### PR TITLE
Simple updates from Go review session

### DIFF
--- a/src/ds3/ds3_mocks_test.go
+++ b/src/ds3/ds3_mocks_test.go
@@ -52,7 +52,7 @@ func (mockedNet *mockedNet) Returning(statusCode int, response string, headers *
     return &Client{mockedNet}
 }
 
-func (mockedNet *mockedNet) Invoke(ds3Request networking.Ds3Request) (networking.Ds3Response, error) {
+func (mockedNet *mockedNet) Invoke(ds3Request networking.Ds3Request) (networking.WebResponse, error) {
     // Verify the verb.
     verb := ds3Request.Verb()
     if verb != mockedNet.verb {
@@ -98,7 +98,7 @@ func (mockedNet *mockedNet) Invoke(ds3Request networking.Ds3Request) (networking
         }
     }
 
-    // Return the net.Ds3Response interface, which we just made mockedNet also implement.
+    // Return the net.WebResponse interface, which we just made mockedNet also implement.
     return mockedNet, nil
 }
 

--- a/src/ds3/models/abortMultipartResponse.go
+++ b/src/ds3/models/abortMultipartResponse.go
@@ -7,8 +7,8 @@ import (
 
 type AbortMultipartResponse struct {}
 
-func NewAbortMultipartResponse(ds3Response networking.Ds3Response) (*AbortMultipartResponse, error) {
-    if err := checkStatusCode(ds3Response, http.StatusNoContent); err != nil {
+func NewAbortMultipartResponse(webResponse networking.WebResponse) (*AbortMultipartResponse, error) {
+    if err := checkStatusCode(webResponse, http.StatusNoContent); err != nil {
         return nil, err
     } else {
         return &AbortMultipartResponse{}, nil

--- a/src/ds3/models/badStatusCodeError.go
+++ b/src/ds3/models/badStatusCodeError.go
@@ -18,12 +18,12 @@ type Error struct {
     RequestId string
 }
 
-func buildBadStatusCodeError(ds3Response networking.Ds3Response, expectedStatusCode int) *BadStatusCodeError {
+func buildBadStatusCodeError(webResponse networking.WebResponse, expectedStatusCode int) *BadStatusCodeError {
     var errorBody Error
     var errorBodyPtr *Error
 
     // Parse the body and if it worked then use the structure.
-    err := parseResponseBody(ds3Response.Body(), &errorBody)
+    err := parseResponseBody(webResponse.Body(), &errorBody)
     if err == nil {
         errorBodyPtr = &errorBody
     }
@@ -31,7 +31,7 @@ func buildBadStatusCodeError(ds3Response networking.Ds3Response, expectedStatusC
     // Return the bad status code entity.
     return &BadStatusCodeError{
         expectedStatusCode,
-        ds3Response.StatusCode(),
+        webResponse.StatusCode(),
         errorBodyPtr,
     }
 }

--- a/src/ds3/models/bulk.go
+++ b/src/ds3/models/bulk.go
@@ -45,10 +45,10 @@ func buildObjectListStream(ds3Objects []Object) networking.SizedReadCloser {
 }
 
 // Parses the DS3 specific bulk command response.
-func getObjectsFromBulkResponse(ds3Response networking.Ds3Response) ([][]Object, error) {
+func getObjectsFromBulkResponse(webResponse networking.WebResponse) ([][]Object, error) {
     // Parse the master object list response body.
     var mol masterobjectlist
-    if err := readResponseBody(ds3Response, http.StatusOK, &mol); err != nil {
+    if err := readResponseBody(webResponse, http.StatusOK, &mol); err != nil {
         return nil, err
     }
 

--- a/src/ds3/models/bulkGetResponse.go
+++ b/src/ds3/models/bulkGetResponse.go
@@ -8,8 +8,8 @@ type BulkGetResponse struct {
     Objects [][]Object
 }
 
-func NewBulkGetResponse(ds3Response networking.Ds3Response) (*BulkGetResponse, error) {
-    objects, err := getObjectsFromBulkResponse(ds3Response)
+func NewBulkGetResponse(webResponse networking.WebResponse) (*BulkGetResponse, error) {
+    objects, err := getObjectsFromBulkResponse(webResponse)
     return &BulkGetResponse{objects}, err
 }
 

--- a/src/ds3/models/bulkPutResponse.go
+++ b/src/ds3/models/bulkPutResponse.go
@@ -8,8 +8,8 @@ type BulkPutResponse struct {
     Objects [][]Object
 }
 
-func NewBulkPutResponse(ds3Response networking.Ds3Response) (*BulkPutResponse, error) {
-    objects, err := getObjectsFromBulkResponse(ds3Response)
+func NewBulkPutResponse(webResponse networking.WebResponse) (*BulkPutResponse, error) {
+    objects, err := getObjectsFromBulkResponse(webResponse)
     return &BulkPutResponse{objects}, err
 }
 

--- a/src/ds3/models/completeMultipartResponse.go
+++ b/src/ds3/models/completeMultipartResponse.go
@@ -13,9 +13,9 @@ type CompleteMultipartResponse struct {
     ETag string
 }
 
-func NewCompleteMultipartResponse(ds3Response networking.Ds3Response) (*CompleteMultipartResponse, error) {
+func NewCompleteMultipartResponse(webResponse networking.WebResponse) (*CompleteMultipartResponse, error) {
     var body CompleteMultipartResponse
-    if err := readResponseBody(ds3Response, http.StatusOK, &body); err != nil {
+    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
         return nil, err
     }
     body.ETag = strings.Trim(body.ETag, "\"")

--- a/src/ds3/models/deleteBucketResponse.go
+++ b/src/ds3/models/deleteBucketResponse.go
@@ -7,8 +7,8 @@ import (
 
 type DeleteBucketResponse struct {}
 
-func NewDeleteBucketResponse(ds3Response networking.Ds3Response) (*DeleteBucketResponse, error) {
-    if err := checkStatusCode(ds3Response, http.StatusNoContent); err != nil {
+func NewDeleteBucketResponse(webResponse networking.WebResponse) (*DeleteBucketResponse, error) {
+    if err := checkStatusCode(webResponse, http.StatusNoContent); err != nil {
         return nil, err
     } else {
         return &DeleteBucketResponse{}, nil

--- a/src/ds3/models/deleteObjectResponse.go
+++ b/src/ds3/models/deleteObjectResponse.go
@@ -7,8 +7,8 @@ import (
 
 type DeleteObjectResponse struct {}
 
-func NewDeleteObjectResponse(ds3Response networking.Ds3Response) (*DeleteObjectResponse, error) {
-    if err := checkStatusCode(ds3Response, http.StatusNoContent); err != nil {
+func NewDeleteObjectResponse(webResponse networking.WebResponse) (*DeleteObjectResponse, error) {
+    if err := checkStatusCode(webResponse, http.StatusNoContent); err != nil {
         return nil, err
     } else {
         return &DeleteObjectResponse{}, nil

--- a/src/ds3/models/getBucketResponse.go
+++ b/src/ds3/models/getBucketResponse.go
@@ -17,9 +17,9 @@ type GetBucketResponse struct {
     Prefix string
 }
 
-func NewGetBucketResponse(ds3Response networking.Ds3Response) (*GetBucketResponse, error) {
+func NewGetBucketResponse(webResponse networking.WebResponse) (*GetBucketResponse, error) {
     var body GetBucketResponse
-    if err := readResponseBody(ds3Response, http.StatusOK, &body); err != nil {
+    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
         return nil, err
     }
     return &body, nil

--- a/src/ds3/models/getObjectResponse.go
+++ b/src/ds3/models/getObjectResponse.go
@@ -10,10 +10,10 @@ type GetObjectResponse struct {
     Content io.ReadCloser
 }
 
-func NewGetObjectResponse(ds3Response networking.Ds3Response) (*GetObjectResponse, error) {
-    if err := checkStatusCode(ds3Response, http.StatusOK); err != nil {
+func NewGetObjectResponse(webResponse networking.WebResponse) (*GetObjectResponse, error) {
+    if err := checkStatusCode(webResponse, http.StatusOK); err != nil {
         return nil, err
     }
-    return &GetObjectResponse{ds3Response.Body()}, nil
+    return &GetObjectResponse{webResponse.Body()}, nil
 }
 

--- a/src/ds3/models/getServiceResponse.go
+++ b/src/ds3/models/getServiceResponse.go
@@ -15,9 +15,9 @@ type Bucket struct {
     CreationDate string
 }
 
-func NewGetServiceResponse(ds3Response networking.Ds3Response) (*GetServiceResponse, error) {
+func NewGetServiceResponse(webResponse networking.WebResponse) (*GetServiceResponse, error) {
     var body GetServiceResponse
-    if err := readResponseBody(ds3Response, http.StatusOK, &body); err != nil {
+    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
         return nil, err
     }
     return &body, nil

--- a/src/ds3/models/initiateMultipartResponse.go
+++ b/src/ds3/models/initiateMultipartResponse.go
@@ -11,9 +11,9 @@ type InitiateMultipartResponse struct {
     UploadId string
 }
 
-func NewInitiateMultipartResponse(ds3Response networking.Ds3Response) (*InitiateMultipartResponse, error) {
+func NewInitiateMultipartResponse(webResponse networking.WebResponse) (*InitiateMultipartResponse, error) {
     var body InitiateMultipartResponse
-    if err := readResponseBody(ds3Response, http.StatusOK, &body); err != nil {
+    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
         return nil, err
     }
     return &body, nil

--- a/src/ds3/models/listMultipartResponse.go
+++ b/src/ds3/models/listMultipartResponse.go
@@ -25,9 +25,9 @@ type Upload struct {
     Initiated string
 }
 
-func NewListMultipartResponse(ds3Response networking.Ds3Response) (*ListMultipartResponse, error) {
+func NewListMultipartResponse(webResponse networking.WebResponse) (*ListMultipartResponse, error) {
     var body ListMultipartResponse
-    if err := readResponseBody(ds3Response, http.StatusOK, &body); err != nil {
+    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
         return nil, err
     }
     return &body, nil

--- a/src/ds3/models/listPartsResponse.go
+++ b/src/ds3/models/listPartsResponse.go
@@ -26,9 +26,9 @@ type UploadedPart struct {
     Size int64
 }
 
-func NewListPartsResponse(ds3Response networking.Ds3Response) (*ListPartsResponse, error) {
+func NewListPartsResponse(webResponse networking.WebResponse) (*ListPartsResponse, error) {
     var body ListPartsResponse
-    if err := readResponseBody(ds3Response, http.StatusOK, &body); err != nil {
+    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
         return nil, err
     }
     return &body, nil

--- a/src/ds3/models/putBucketResponse.go
+++ b/src/ds3/models/putBucketResponse.go
@@ -7,8 +7,8 @@ import (
 
 type PutBucketResponse struct {}
 
-func NewPutBucketResponse(ds3Response networking.Ds3Response) (*PutBucketResponse, error) {
-    if err := checkStatusCode(ds3Response, http.StatusOK); err != nil {
+func NewPutBucketResponse(webResponse networking.WebResponse) (*PutBucketResponse, error) {
+    if err := checkStatusCode(webResponse, http.StatusOK); err != nil {
         return nil, err
     } else {
         return &PutBucketResponse{}, nil

--- a/src/ds3/models/putObjectResponse.go
+++ b/src/ds3/models/putObjectResponse.go
@@ -7,8 +7,8 @@ import (
 
 type PutObjectResponse struct {}
 
-func NewPutObjectResponse(ds3Response networking.Ds3Response) (*PutObjectResponse, error) {
-    if err := checkStatusCode(ds3Response, http.StatusOK); err != nil {
+func NewPutObjectResponse(webResponse networking.WebResponse) (*PutObjectResponse, error) {
+    if err := checkStatusCode(webResponse, http.StatusOK); err != nil {
         return nil, err
     } else {
         return &PutObjectResponse{}, nil

--- a/src/ds3/models/putPartResponse.go
+++ b/src/ds3/models/putPartResponse.go
@@ -10,11 +10,11 @@ type PutPartResponse struct {
     ETag string
 }
 
-func NewPutPartResponse(ds3Response networking.Ds3Response) (*PutPartResponse, error) {
-    if err := checkStatusCode(ds3Response, http.StatusOK); err != nil {
+func NewPutPartResponse(webResponse networking.WebResponse) (*PutPartResponse, error) {
+    if err := checkStatusCode(webResponse, http.StatusOK); err != nil {
         return nil, err
     } else {
-        etags := (*ds3Response.Header())["etag"]
+        etags := (*webResponse.Header())["etag"]
         var etag string
         if len(etags) > 0 {
             etag = strings.Trim(etags[0], "\"")

--- a/src/ds3/models/responseHandling.go
+++ b/src/ds3/models/responseHandling.go
@@ -7,21 +7,21 @@ import (
     "ds3/networking"
 )
 
-func checkStatusCode(response networking.Ds3Response, expectedStatusCode int) error {
-    if response.StatusCode() == expectedStatusCode {
+func checkStatusCode(webResponse networking.WebResponse, expectedStatusCode int) error {
+    if webResponse.StatusCode() == expectedStatusCode {
         return nil
     } else {
-        return buildBadStatusCodeError(response, expectedStatusCode)
+        return buildBadStatusCodeError(webResponse, expectedStatusCode)
     }
 }
 
-func readResponseBody(ds3Response networking.Ds3Response, expectedStatusCode int, parsedBody interface{}) error {
+func readResponseBody(webResponse networking.WebResponse, expectedStatusCode int, parsedBody interface{}) error {
     // Clean up the response body.
-    body := ds3Response.Body()
+    body := webResponse.Body()
     defer body.Close()
 
     // Check the status code.
-    if err := checkStatusCode(ds3Response, expectedStatusCode); err != nil {
+    if err := checkStatusCode(webResponse, expectedStatusCode); err != nil {
         return err
     }
 

--- a/src/ds3/networking/ds3request.go
+++ b/src/ds3/networking/ds3request.go
@@ -23,8 +23,7 @@ type Ds3Request interface {
 type SizedReadCloser interface {
     io.Reader
     io.Closer
-    io.Seeker
-    Size() int64
+    Size() (int64, error)
 }
 
 type HttpVerb int
@@ -75,7 +74,7 @@ func (bytesSizedReadCloser *bytesSizedReadCloser) Seek(offset int64, whence int)
     return bytesSizedReadCloser.reader.Seek(offset, whence)
 }
 
-func (bytesSizedReadCloser *bytesSizedReadCloser) Size() int64 {
-    return bytesSizedReadCloser.size
+func (bytesSizedReadCloser *bytesSizedReadCloser) Size() (int64, error) {
+    return bytesSizedReadCloser.size, nil
 }
 

--- a/src/ds3/networking/ds3response.go
+++ b/src/ds3/networking/ds3response.go
@@ -6,7 +6,7 @@ import (
     "net/http"
 )
 
-type Ds3Response interface {
+type WebResponse interface {
     StatusCode() int
     Body() io.ReadCloser
     Header() *http.Header

--- a/src/ds3/networking/headers.go
+++ b/src/ds3/networking/headers.go
@@ -33,12 +33,12 @@ func setRequestHeaders(httpRequest *http.Request, creds Credentials, ds3Request 
 }
 
 type signatureFields struct {
-    Verb string
-    ContentMd5 string
-    ContentType string
-    Date string
+    Verb                    string
+    ContentHash             string
+    ContentType             string
+    Date                    string
     CanonicalizedAmzHeaders string
-    Path string
+    Path                    string
 }
 
 func buildAuthHeaderValue(creds Credentials, fields signatureFields) string {
@@ -46,7 +46,7 @@ func buildAuthHeaderValue(creds Credentials, fields signatureFields) string {
     stringToSign := fmt.Sprintf(
         "%s\n%s\n%s\n%s\n%s%s",
         fields.Verb,
-        fields.ContentMd5,
+        fields.ContentHash,
         fields.ContentType,
         fields.Date,
         fields.CanonicalizedAmzHeaders,

--- a/src/ds3_cli/commands/fileSizeReadCloser.go
+++ b/src/ds3_cli/commands/fileSizeReadCloser.go
@@ -3,35 +3,36 @@ package commands
 import "os"
 
 // Implements the SizedReadCloser interface for a file.
-type fileSizeReadCloser struct {
+// Decorates an os.File and adds a Size function which determines the length of the file
+type fileWithSizeDecorator struct {
     file *os.File
 }
 
-func readFile(path string) (*fileSizeReadCloser, error) {
+func readFile(path string) (*fileWithSizeDecorator, error) {
     content, fileErr := os.Open(path)
     if fileErr != nil {
         return nil, fileErr
     }
-    return &fileSizeReadCloser{content}, nil
+    return &fileWithSizeDecorator{content}, nil
 }
 
-func (fileSizeReadCloser *fileSizeReadCloser) Size() int64 {
-    fi, err := fileSizeReadCloser.file.Stat()
+func (fileWithSizeDecorator *fileWithSizeDecorator) Size() (int64, error) {
+    fi, err := fileWithSizeDecorator.file.Stat()
     if err != nil {
-        panic(err)
+        return 0, err
     }
-    return fi.Size()
+    return fi.Size(), nil
 }
 
-func (fileSizeReadCloser *fileSizeReadCloser) Read(p []byte) (int, error) {
-    return fileSizeReadCloser.file.Read(p)
+func (fileWithSizeDecorator *fileWithSizeDecorator) Read(p []byte) (int, error) {
+    return fileWithSizeDecorator.file.Read(p)
 }
 
-func (fileSizeReadCloser *fileSizeReadCloser) Seek(offset int64, whence int) (int64, error) {
-    return fileSizeReadCloser.file.Seek(offset, whence)
+func (fileWithSizeDecorator *fileWithSizeDecorator) Seek(offset int64, whence int) (int64, error) {
+    return fileWithSizeDecorator.file.Seek(offset, whence)
 }
 
-func (fileSizeReadCloser *fileSizeReadCloser) Close() error {
-    return fileSizeReadCloser.file.Close()
+func (fileWithSizeDecorator *fileWithSizeDecorator) Close() error {
+    return fileWithSizeDecorator.file.Close()
 }
 


### PR DESCRIPTION
**Changes**
- Renamed `Ds3Response` -> `WebResponse`
- Renamed `ContentMd5` -> `ContentHash` in header's `signatureFields` struct
- Renamed `fileSizeReadCloser` -> `fileWithSizeDecorator`
- Removed `io.Seeker` from `SizedReadCloser` interface
- Added error to return of `SizeReadCloser` interface and removed panic from `fileWithSizeDecorator` implementation

**TODO**
- Create Network decorators for network retry and 307 retry (and remove retry from network code)
- In headers, have `ContentHash` set via a header and passed to the `signatureFields`