### PR TITLE
Network decorators

### DIFF
--- a/src/ds3/ds3.go
+++ b/src/ds3/ds3.go
@@ -7,6 +7,7 @@ import (
 
 type Client struct {
     netLayer networking.Network
+    clientPolicy *ClientPolicy
 }
 
 type ClientBuilder struct {
@@ -46,6 +47,9 @@ func (clientBuilder *ClientBuilder) WithNetworkRetryCount(count int) *ClientBuil
 }
 
 func (clientBuilder *ClientBuilder) BuildClient() *Client {
-    return &Client{networking.NewHttpNetwork(clientBuilder.connectionInfo)}
+    return &Client{
+        networking.NewHttpNetwork(clientBuilder.connectionInfo),
+        clientBuilder.clientPolicy,
+    }
 }
 

--- a/src/ds3/ds3.go
+++ b/src/ds3/ds3.go
@@ -11,7 +11,12 @@ type Client struct {
 
 type ClientBuilder struct {
     connectionInfo *networking.ConnectionInfo
-    connectionPolicy *networking.ConnectionPolicy
+    clientPolicy *ClientPolicy
+}
+
+type ClientPolicy struct {
+    maxRetries int // Maximum number of times to attempt sending a request amidst network issues
+    maxRedirect int // Maximum number of times to attempt redirect retries
 }
 
 func NewClientBuilder(endpoint *url.URL, creds networking.Credentials) *ClientBuilder {
@@ -20,7 +25,9 @@ func NewClientBuilder(endpoint *url.URL, creds networking.Credentials) *ClientBu
             Endpoint: *endpoint,
             Creds: creds,
             Proxy: nil},
-        &networking.ConnectionPolicy{RedirectRetryCount: 5}}
+        &ClientPolicy{
+            maxRetries: 5,
+            maxRedirect: 5}}
 }
 
 func (clientBuilder *ClientBuilder) WithProxy(proxy *url.URL) *ClientBuilder {
@@ -29,11 +36,16 @@ func (clientBuilder *ClientBuilder) WithProxy(proxy *url.URL) *ClientBuilder {
 }
 
 func (clientBuilder *ClientBuilder) WithRedirectRetryCount(count int) *ClientBuilder {
-    clientBuilder.connectionPolicy.RedirectRetryCount = count
+    clientBuilder.clientPolicy.maxRedirect = count
+    return clientBuilder
+}
+
+func (clientBuilder *ClientBuilder) WithNetworkRetryCount(count int) *ClientBuilder {
+    clientBuilder.clientPolicy.maxRetries = count
     return clientBuilder
 }
 
 func (clientBuilder *ClientBuilder) BuildClient() *Client {
-    return &Client{networking.NewHttpNetwork(clientBuilder.connectionInfo, clientBuilder.connectionPolicy)}
+    return &Client{networking.NewHttpNetwork(clientBuilder.connectionInfo)}
 }
 

--- a/src/ds3/ds3_mocks_test.go
+++ b/src/ds3/ds3_mocks_test.go
@@ -49,7 +49,7 @@ func (mockedNet *mockedNet) Returning(statusCode int, response string, headers *
     mockedNet.statusCode = statusCode
     mockedNet.response = response
     mockedNet.headers = headers
-    return &Client{mockedNet}
+    return &Client{mockedNet, &ClientPolicy{5, 5}}
 }
 
 func (mockedNet *mockedNet) Invoke(ds3Request networking.Ds3Request) (networking.WebResponse, error) {

--- a/src/ds3/networking/httpredirect.go
+++ b/src/ds3/networking/httpredirect.go
@@ -1,0 +1,47 @@
+package networking
+
+import (
+    "errors"
+    "fmt"
+)
+
+type httpRedirectPolicy struct {
+    maxRedirect int
+}
+
+type HttpTempRedirectDecorator struct {
+    network *Network
+    policy *httpRedirectPolicy
+}
+
+
+// Decorator for Network which handles 307 redirect retries
+func NewHttpTempRedirectDecorator(network *Network, maxRedirect int) (Network) {
+    return &HttpTempRedirectDecorator{
+        network: network,
+        policy: &httpRedirectPolicy{maxRedirect: maxRedirect},
+    }
+}
+
+func (tempRedirectDecorator *HttpTempRedirectDecorator) Invoke(request Ds3Request) (WebResponse, error) {
+    // Handle as many 307's as we're allowed.
+    for i := 0; i <= tempRedirectDecorator.policy.maxRedirect; i++ {
+        ds3Response, err := (*tempRedirectDecorator.network).Invoke(request)
+
+        // If request was performed successfully then return response.
+        if err == nil {
+            return ds3Response, nil
+        }
+
+        // If there was a non-redirect error then return.
+        if _, ok := err.(TemporaryRedirectError); ok == false {
+            return nil, err
+        }
+    }
+
+    // We had as many 307 redirects as we were allowed to use.
+    return nil, errors.New(fmt.Sprintf(
+        "The server is busy. Retried the max number of %d times.",
+        tempRedirectDecorator.policy.maxRedirect,
+    ))
+}

--- a/src/ds3/networking/networkerrors.go
+++ b/src/ds3/networking/networkerrors.go
@@ -1,0 +1,17 @@
+package networking
+
+import "fmt"
+
+// Error denoting a request has returned a temporary redirect status code
+type TemporaryRedirectError int
+
+func (temporaryRedirectError TemporaryRedirectError) Error() string {
+    return fmt.Sprintf("Temporary Redirect, received status code %d", temporaryRedirectError)
+}
+
+// Denotes an error occurred during attempt to perform request
+type RoundTripError string
+
+func (roundTripError RoundTripError) Error() string {
+    return string(roundTripError)
+}

--- a/src/ds3/networking/networkretry.go
+++ b/src/ds3/networking/networkretry.go
@@ -1,0 +1,53 @@
+package networking
+
+import (
+    "errors"
+    "fmt"
+    "log"
+)
+
+type networkRetryPolicy struct {
+    maxRetries int
+}
+
+// Decorator for Network which handles network related retries
+type NetworkRetryDecorator struct {
+    network *Network
+    policy *networkRetryPolicy
+}
+
+func NewNetworkRetryDecorator(network *Network, maxRetires int) (Network) {
+    return &NetworkRetryDecorator{
+        network: network,
+        policy: &networkRetryPolicy{ maxRetries: maxRetires},
+    }
+}
+
+func (networkRetryDecorator *NetworkRetryDecorator) Invoke(request Ds3Request) (WebResponse, error) {
+    // Handle as many Network related retries as we're allowed.
+    var lastErr error
+    for i := 0; i <= networkRetryDecorator.policy.maxRetries; i++ {
+        ds3Response, err := (*networkRetryDecorator.network).Invoke(request)
+
+        // If request was performed successfully then return response.
+        if err == nil {
+            return ds3Response, nil
+        }
+
+        // If there was a non-network error then return.
+        if _, ok := err.(RoundTripError); ok == false {
+            return nil, err
+        }
+
+        // Log the network error, and try again if max retries has not been attempted
+        log.Printf("Encountered network error '%s'.", err.Error())
+        lastErr = err
+    }
+
+    // We had as many network related retries as we're allowed to use.
+    return nil, errors.New(fmt.Sprintf(
+        "Cannot send request. Retried the max number of %d times. Error: `%s`.",
+        networkRetryDecorator.policy.maxRetries,
+        lastErr.Error(),
+    ))
+}


### PR DESCRIPTION
**Changes**
- `HttpRedirectDecorator` wraps a `Network` and handles 307 redirects.
- `NetworkRetryDecorator` wraps a `Network` and handles retries due to network related issues.
- Removed retry logic from `httpNetwork`.