### PR TITLE
Moved query param creation

### DIFF
--- a/src/ds3/models/abortMultipartRequest.go
+++ b/src/ds3/models/abortMultipartRequest.go
@@ -10,13 +10,18 @@ type AbortMultipartRequest struct {
     bucketName string
     objectName string
     uploadId string
+    queryParams *url.Values
 }
 
 func NewAbortMultipartRequest(bucketName string, objectName string, uploadId string) *AbortMultipartRequest {
+    queryParams := &url.Values{}
+    queryParams.Set("", uploadId)
+
     return &AbortMultipartRequest{
         bucketName: bucketName,
         objectName: objectName,
         uploadId: uploadId,
+        queryParams: queryParams,
     }
 }
 
@@ -29,7 +34,7 @@ func (abortMultipartRequest *AbortMultipartRequest) Path() string {
 }
 
 func (abortMultipartRequest *AbortMultipartRequest) QueryParams() *url.Values {
-    return &url.Values{"uploadId": []string{abortMultipartRequest.uploadId}}
+    return abortMultipartRequest.queryParams
 }
 
 func (AbortMultipartRequest) Header() *http.Header {

--- a/src/ds3/models/bulkGetRequest.go
+++ b/src/ds3/models/bulkGetRequest.go
@@ -9,10 +9,18 @@ import (
 type BulkGetRequest struct {
     bucketName string
     content networking.SizedReadCloser
+    queryParams *url.Values
 }
 
 func NewBulkGetRequest(bucketName string, objects []Object) *BulkGetRequest {
-    return &BulkGetRequest{bucketName, buildObjectListStream(objects)}
+    queryParams := &url.Values{}
+    queryParams.Set("operation", "start_bulk_get")
+
+    return &BulkGetRequest{
+        bucketName: bucketName,
+        content: buildObjectListStream(objects),
+        queryParams: queryParams,
+    }
 }
 
 func (BulkGetRequest) Verb() networking.HttpVerb {
@@ -23,8 +31,8 @@ func (bulkGetRequest *BulkGetRequest) Path() string {
     return "/_rest_/buckets/" + bulkGetRequest.bucketName
 }
 
-func (BulkGetRequest) QueryParams() *url.Values {
-    return &url.Values{"operation": []string{"start_bulk_get"}}
+func (bulkGetRequest *BulkGetRequest) QueryParams() *url.Values {
+    return bulkGetRequest.queryParams
 }
 
 func (BulkGetRequest) Header() *http.Header {

--- a/src/ds3/models/bulkPutRequest.go
+++ b/src/ds3/models/bulkPutRequest.go
@@ -9,10 +9,18 @@ import (
 type BulkPutRequest struct {
     bucketName string
     content networking.SizedReadCloser
+    queryParams *url.Values
 }
 
 func NewBulkPutRequest(bucketName string, objects []Object) *BulkPutRequest {
-    return &BulkPutRequest{bucketName, buildObjectListStream(objects)}
+    queryParams := &url.Values{}
+    queryParams.Set("operation", "start_bulk_put")
+
+    return &BulkPutRequest{
+        bucketName: bucketName,
+        content: buildObjectListStream(objects),
+        queryParams: queryParams,
+    }
 }
 
 func (BulkPutRequest) Verb() networking.HttpVerb {
@@ -23,8 +31,8 @@ func (bulkPutRequest *BulkPutRequest) Path() string {
     return "/_rest_/buckets/" + bulkPutRequest.bucketName
 }
 
-func (BulkPutRequest) QueryParams() *url.Values {
-    return &url.Values{"operation": []string{"start_bulk_put"}}
+func (bulkPutRequest *BulkPutRequest) QueryParams() *url.Values {
+    return bulkPutRequest.queryParams
 }
 
 func (BulkPutRequest) Header() *http.Header {

--- a/src/ds3/models/completeMultipartRequest.go
+++ b/src/ds3/models/completeMultipartRequest.go
@@ -12,6 +12,7 @@ type CompleteMultipartRequest struct {
     objectName string
     uploadId string
     parts []Part
+    queryParams *url.Values
 }
 
 type CompleteMultipartUpload struct {
@@ -24,11 +25,15 @@ type Part struct {
 }
 
 func NewCompleteMultipartRequest(bucketName string, objectName string, uploadId string, parts []Part) *CompleteMultipartRequest {
+    queryParams := &url.Values{}
+    queryParams.Set("uploadId", uploadId)
+
     return &CompleteMultipartRequest{
         bucketName: bucketName,
         objectName: objectName,
         uploadId: uploadId,
         parts: parts,
+        queryParams: queryParams,
     }
 }
 
@@ -41,7 +46,7 @@ func (completeMultipartRequest *CompleteMultipartRequest) Path() string {
 }
 
 func (completeMultipartRequest *CompleteMultipartRequest) QueryParams() *url.Values {
-    return &url.Values{"uploadId": []string{completeMultipartRequest.uploadId}}
+    return completeMultipartRequest.queryParams
 }
 
 func (CompleteMultipartRequest) Header() *http.Header {

--- a/src/ds3/models/deleteBucketRequest.go
+++ b/src/ds3/models/deleteBucketRequest.go
@@ -8,11 +8,13 @@ import (
 
 type DeleteBucketRequest struct {
     bucketName string
+    queryParams *url.Values
 }
 
 func NewDeleteBucketRequest(bucketName string) *DeleteBucketRequest {
     return &DeleteBucketRequest{
         bucketName: bucketName,
+        queryParams: &url.Values{},
     }
 }
 
@@ -25,7 +27,7 @@ func (deleteBucketRequest *DeleteBucketRequest) Path() string {
 }
 
 func (deleteBucketRequest *DeleteBucketRequest) QueryParams() *url.Values {
-    return new(url.Values)
+    return deleteBucketRequest.queryParams
 }
 
 func (DeleteBucketRequest) Header() *http.Header {

--- a/src/ds3/models/deleteObjectRequest.go
+++ b/src/ds3/models/deleteObjectRequest.go
@@ -9,10 +9,14 @@ import (
 type DeleteObjectRequest struct {
     bucketName string
     objectName string
+    queryParams *url.Values
 }
 
 func NewDeleteObjectRequest(bucketName string, objectName string) *DeleteObjectRequest {
-    return &DeleteObjectRequest{bucketName, objectName}
+    return &DeleteObjectRequest{
+        bucketName: bucketName,
+        objectName: objectName,
+        queryParams: &url.Values{},}
 }
 
 func (DeleteObjectRequest) Verb() networking.HttpVerb {
@@ -24,7 +28,7 @@ func (deleteObjectRequest *DeleteObjectRequest) Path() string {
 }
 
 func (deleteObjectRequest *DeleteObjectRequest) QueryParams() *url.Values {
-    return new(url.Values)
+    return deleteObjectRequest.queryParams
 }
 
 func (DeleteObjectRequest) Header() *http.Header {

--- a/src/ds3/models/getBucketRequest.go
+++ b/src/ds3/models/getBucketRequest.go
@@ -12,26 +12,31 @@ type GetBucketRequest struct {
     marker string
     prefix string
     maxKeys int
+    queryParams *url.Values
 }
 
 func NewGetBucketRequest(bucketName string) *GetBucketRequest {
     return &GetBucketRequest{
         bucketName: bucketName,
+        queryParams: &url.Values{},
     }
 }
 
 func (getBucketRequest *GetBucketRequest) WithMarker(marker string) *GetBucketRequest {
     getBucketRequest.marker = marker
+    getBucketRequest.queryParams.Set("marker", marker)
     return getBucketRequest
 }
 
 func (getBucketRequest *GetBucketRequest) WithPrefix(prefix string) *GetBucketRequest {
     getBucketRequest.prefix = prefix
+    getBucketRequest.queryParams.Set("prefix", prefix)
     return getBucketRequest
 }
 
 func (getBucketRequest *GetBucketRequest) WithMaxKeys(maxKeys int) *GetBucketRequest {
     getBucketRequest.maxKeys = maxKeys
+    getBucketRequest.queryParams.Set("max-keys", strconv.Itoa(getBucketRequest.maxKeys))
     return getBucketRequest
 }
 
@@ -44,17 +49,7 @@ func (getBucketRequest *GetBucketRequest) Path() string {
 }
 
 func (getBucketRequest *GetBucketRequest) QueryParams() *url.Values {
-    values := make(url.Values)
-    if getBucketRequest.marker != "" {
-        values.Add("marker", getBucketRequest.marker)
-    }
-    if getBucketRequest.prefix != "" {
-        values.Add("prefix", getBucketRequest.prefix)
-    }
-    if getBucketRequest.maxKeys > 0 {
-        values.Add("max-keys", strconv.Itoa(getBucketRequest.maxKeys))
-    }
-    return &values
+    return getBucketRequest.queryParams
 }
 
 func (GetBucketRequest) Header() *http.Header {

--- a/src/ds3/models/getObjectRequest.go
+++ b/src/ds3/models/getObjectRequest.go
@@ -12,6 +12,7 @@ type GetObjectRequest struct {
     objectName string
     rangeHeader *rangeHeader
     checksum networking.Checksum
+    queryParams *url.Values
 }
 
 type rangeHeader struct {
@@ -23,6 +24,7 @@ func NewGetObjectRequest(bucketName string, objectName string) *GetObjectRequest
         bucketName: bucketName,
         objectName: objectName,
         checksum:   networking.NewNoneChecksum(), //Default checksum type of None
+        queryParams: &url.Values{},
     }
 }
 
@@ -45,8 +47,8 @@ func (getObjectRequest *GetObjectRequest) Path() string {
     return "/" + getObjectRequest.bucketName + "/" + getObjectRequest.objectName
 }
 
-func (GetObjectRequest) QueryParams() *url.Values {
-    return new(url.Values)
+func (getObjectRequest GetObjectRequest) QueryParams() *url.Values {
+    return getObjectRequest.queryParams
 }
 
 func (getObjectRequest GetObjectRequest) Header() *http.Header {

--- a/src/ds3/models/getServiceRequest.go
+++ b/src/ds3/models/getServiceRequest.go
@@ -6,10 +6,14 @@ import (
     "ds3/networking"
 )
 
-type GetServiceRequest struct {}
+type GetServiceRequest struct {
+    queryParams *url.Values
+}
 
 func NewGetServiceRequest() *GetServiceRequest {
-    return &GetServiceRequest{}
+    return &GetServiceRequest{
+        queryParams: &url.Values{},
+    }
 }
 
 func (GetServiceRequest) Verb() networking.HttpVerb {
@@ -20,8 +24,8 @@ func (GetServiceRequest) Path() string {
     return "/"
 }
 
-func (GetServiceRequest) QueryParams() *url.Values {
-    return new(url.Values)
+func (getServiceRequest *GetServiceRequest) QueryParams() *url.Values {
+    return getServiceRequest.queryParams
 }
 
 func (GetServiceRequest) Header() *http.Header {

--- a/src/ds3/models/initiateMultipartRequest.go
+++ b/src/ds3/models/initiateMultipartRequest.go
@@ -9,12 +9,17 @@ import (
 type InitiateMultipartRequest struct {
     bucketName string
     objectName string
+    queryParams *url.Values
 }
 
 func NewInitiateMultipartRequest(bucketName string, objectName string) *InitiateMultipartRequest {
+    queryParams := &url.Values{}
+    queryParams.Set("uploads", "")
+
     return &InitiateMultipartRequest{
         bucketName: bucketName,
         objectName: objectName,
+        queryParams: queryParams,
     }
 }
 
@@ -27,7 +32,7 @@ func (initiateMultipartRequest *InitiateMultipartRequest) Path() string {
 }
 
 func (initiateMultipartRequest *InitiateMultipartRequest) QueryParams() *url.Values {
-    return &url.Values{"uploads": []string{""}}
+    return initiateMultipartRequest.queryParams
 }
 
 func (InitiateMultipartRequest) Header() *http.Header {

--- a/src/ds3/models/listMultipartRequest.go
+++ b/src/ds3/models/listMultipartRequest.go
@@ -6,10 +6,17 @@ import (
     "ds3/networking"
 )
 
-type ListMultipartRequest struct { }
+type ListMultipartRequest struct {
+    queryParams *url.Values
+}
 
 func NewListMultipartRequest() *ListMultipartRequest {
-    return &ListMultipartRequest{}
+    queryParams := &url.Values{}
+    queryParams.Set("uploads", "")
+
+    return &ListMultipartRequest{
+        queryParams: queryParams,
+    }
 }
 
 func (ListMultipartRequest) Verb() networking.HttpVerb {
@@ -20,8 +27,8 @@ func (ListMultipartRequest) Path() string {
     return "/"
 }
 
-func (ListMultipartRequest) QueryParams() *url.Values {
-    return &url.Values{"uploads": []string{""}}
+func (listMultipartRequest *ListMultipartRequest) QueryParams() *url.Values {
+    return listMultipartRequest.queryParams
 }
 
 func (ListMultipartRequest) Header() *http.Header {

--- a/src/ds3/models/listPartsRequest.go
+++ b/src/ds3/models/listPartsRequest.go
@@ -10,13 +10,18 @@ type ListPartsRequest struct {
     bucketName string
     objectName string
     uploadId string
+    queryParams *url.Values
 }
 
 func NewListPartsRequest(bucketName string, objectName string, uploadId string) *ListPartsRequest {
+    queryParams := &url.Values{}
+    queryParams.Set("uploadId", uploadId)
+
     return &ListPartsRequest{
         bucketName: bucketName,
         objectName: objectName,
         uploadId: uploadId,
+        queryParams: queryParams,
     }
 }
 
@@ -29,7 +34,7 @@ func (listPartsRequest *ListPartsRequest) Path() string {
 }
 
 func (listPartsRequest *ListPartsRequest) QueryParams() *url.Values {
-    return &url.Values{"uploadId": []string{listPartsRequest.uploadId}}
+    return listPartsRequest.queryParams
 }
 
 func (ListPartsRequest) Header() *http.Header {

--- a/src/ds3/models/putBucketRequest.go
+++ b/src/ds3/models/putBucketRequest.go
@@ -8,11 +8,13 @@ import (
 
 type PutBucketRequest struct {
     bucketName string
+    queryParams *url.Values
 }
 
 func NewPutBucketRequest(bucketName string) *PutBucketRequest {
     return &PutBucketRequest{
         bucketName: bucketName,
+        queryParams: &url.Values{},
     }
 }
 
@@ -25,7 +27,7 @@ func (putBucketRequest *PutBucketRequest) Path() string {
 }
 
 func (putBucketRequest *PutBucketRequest) QueryParams() *url.Values {
-    return new(url.Values)
+    return putBucketRequest.queryParams
 }
 
 func (PutBucketRequest) Header() *http.Header {

--- a/src/ds3/models/putObjectRequest.go
+++ b/src/ds3/models/putObjectRequest.go
@@ -11,6 +11,7 @@ type PutObjectRequest struct {
     objectName string
     content networking.SizedReadCloser
     checksum networking.Checksum
+    queryParams *url.Values
 }
 
 func NewPutObjectRequest(bucketName string, objectName string, content networking.SizedReadCloser) *PutObjectRequest {
@@ -19,6 +20,7 @@ func NewPutObjectRequest(bucketName string, objectName string, content networkin
         objectName:objectName,
         content:content,
         checksum: networking.NewNoneChecksum(), //Default checksum type of None
+        queryParams: &url.Values{},
     }
 }
 
@@ -36,8 +38,8 @@ func (putObjectRequest *PutObjectRequest) Path() string {
     return "/" + putObjectRequest.bucketName + "/" + putObjectRequest.objectName
 }
 
-func (PutObjectRequest) QueryParams() *url.Values {
-    return new(url.Values)
+func (putObjectRequest *PutObjectRequest) QueryParams() *url.Values {
+    return putObjectRequest.queryParams
 }
 
 func (PutObjectRequest) Header() *http.Header {

--- a/src/ds3/models/putPartRequest.go
+++ b/src/ds3/models/putPartRequest.go
@@ -13,6 +13,7 @@ type PutPartRequest struct {
     partNumber int
     uploadId string
     content networking.SizedReadCloser
+    queryParams *url.Values
 }
 
 func NewPutPartRequest(
@@ -22,7 +23,18 @@ func NewPutPartRequest(
     uploadId string,
     content networking.SizedReadCloser,
 ) *PutPartRequest {
-    return &PutPartRequest{bucketName, objectName, partNumber, uploadId, content}
+    queryParams := &url.Values{}
+    queryParams.Set("partNumber", strconv.Itoa(partNumber))
+    queryParams.Set("uploadId", uploadId)
+
+    return &PutPartRequest{
+        bucketName: bucketName,
+        objectName: objectName,
+        partNumber: partNumber,
+        uploadId: uploadId,
+        content: content,
+        queryParams: queryParams,
+    }
 }
 
 func (PutPartRequest) Verb() networking.HttpVerb {
@@ -34,10 +46,7 @@ func (putPartRequest *PutPartRequest) Path() string {
 }
 
 func (putPartRequest *PutPartRequest) QueryParams() *url.Values {
-    return &url.Values{
-        "partNumber": []string{strconv.Itoa(putPartRequest.partNumber)},
-        "uploadId": []string{putPartRequest.uploadId},
-    }
+    return putPartRequest.queryParams
 }
 
 func (PutPartRequest) Header() *http.Header {


### PR DESCRIPTION
The request handlers' query params were originally created and set within the getter function for query params.  I moved the initalization of query params into the request constructor, and moved the setting of querry parameters to relevant locations (within constructor and with-constructors).