### PR TITLE
Separated request and response models in preparation for autogen

### DIFF
--- a/src/ds3/ds3Client_test.go
+++ b/src/ds3/ds3Client_test.go
@@ -325,7 +325,7 @@ func TestPutObject(t *testing.T) {
         PutObject(models.NewPutObjectRequest(
             "bucketName",
             "object",
-        networking.BuildSizedReadCloser([]byte(stringResponse)),
+        networking.BuildByteReaderWithSizeDecorator([]byte(stringResponse)),
         ))
 
     // Check the error result.
@@ -343,7 +343,7 @@ func TestBulkPut(t *testing.T) {
     runBulkTest(
         t,
         "start_bulk_put",
-        func(client *Client, objects []models.Object) ([][]models.Object, error) {
+        func(client *Client, objects []models.Ds3Object) ([][]models.Object, error) {
             request, err := client.BulkPut(models.NewBulkPutRequest("bucketName", objects))
             return request.Objects, err
         },
@@ -354,14 +354,14 @@ func TestBulkGet(t *testing.T) {
     runBulkTest(
         t,
         "start_bulk_get",
-        func(client *Client, objects []models.Object) ([][]models.Object, error) {
+        func(client *Client, objects []models.Ds3Object) ([][]models.Object, error) {
             request, err := client.BulkGet(models.NewBulkGetRequest("bucketName", objects))
             return request.Objects, err
         },
     )
 }
 
-type bulkTest func(*Client, []models.Object) ([][]models.Object, error)
+type bulkTest func(*Client, []models.Ds3Object) ([][]models.Object, error)
 
 func runBulkTest(t *testing.T, operation string, callToTest bulkTest) {
     keys := []string { "file2", "file1", "file3" }
@@ -370,10 +370,10 @@ func runBulkTest(t *testing.T, operation string, callToTest bulkTest) {
     stringRequest := "<objects><object name=\"file1\" size=\"256\"></object><object name=\"file2\" size=\"1202\"></object><object name=\"file3\" size=\"2523\"></object></objects>"
     stringResponse := "<masterobjectlist><objects><object name='file2' size='1202'/><object name='file1' size='256'/><object name='file3' size='2523'/></objects></masterobjectlist>"
 
-    inputObjects := []models.Object {
-        {Key: "file1", Size: 256 },
-        {Key: "file2", Size: 1202 },
-        {Key: "file3", Size: 2523 },
+    inputObjects := []models.Ds3Object {
+        {Name: "file1", Size: 256 },
+        {Name: "file2", Size: 1202 },
+        {Name: "file3", Size: 2523 },
     }
 
     // Create and run the mocked client.
@@ -464,7 +464,7 @@ func TestPutPart(t *testing.T) {
             "object",
             partNumber,
             uploadId,
-            networking.BuildSizedReadCloser([]byte(content)),
+            networking.BuildByteReaderWithSizeDecorator([]byte(content)),
         ))
 
     // Check the error result.

--- a/src/ds3/ds3Mocks_test.go
+++ b/src/ds3/ds3Mocks_test.go
@@ -107,7 +107,7 @@ func (mockedNet *mockedNet) StatusCode() int {
 }
 
 func (mockedNet *mockedNet) Body() io.ReadCloser {
-    return networking.BuildSizedReadCloser([]byte(mockedNet.response))
+    return networking.BuildByteReaderWithSizeDecorator([]byte(mockedNet.response))
 }
 
 func (mockedNet *mockedNet) Header() *http.Header {

--- a/src/ds3/models/bulk.go
+++ b/src/ds3/models/bulk.go
@@ -6,42 +6,54 @@ import (
     "ds3/networking"
 )
 
-// Represents the XML document for both the bulk request and response data for
+// Represents the XML document for the bulk response data for
 // bulk gets and bulk puts.
+//TODO delete: will be auto-generated
 type masterobjectlist struct {
     ObjectLists []objects `xml:"objects"`
 }
 
+//TODO delete: will be auto-generated
 type objects struct {
-    Objects []object `xml:"object"`
+    Objects []bulkObject `xml:"object"`
 }
 
-type object struct {
+//TODO delete: will be auto-generated
+type bulkObject struct {
+    Name string `xml:"name,attr"`
+    Size int64 `xml:"size,attr"`
+}
+
+type ds3ObjectList struct {
+    XMLName xml.Name
+    Ds3Objects []Ds3Object `xml:"object"`
+}
+
+func newDs3ObjectList(ds3objects []Ds3Object) *ds3ObjectList {
+    return &ds3ObjectList{
+        XMLName: xml.Name{Local:"objects"},
+        Ds3Objects: ds3objects,
+    }
+}
+
+type Ds3Object struct {
     Name string `xml:"name,attr"`
     Size int64 `xml:"size,attr"`
 }
 
 // Converts the ds3 object list to an object we can send in our request.
-func buildObjectListStream(ds3Objects []Object) networking.ReaderWithSizeDecorator {
-    // Create an array of objects to put into the master object list.
-    molObjects := make([]object, len(ds3Objects))
-
-    // Copy the important ds3 object contents into the master object list objects.
-    for i, obj := range ds3Objects {
-        molObjects[i] = object{obj.Key, obj.Size}
-    }
-
-    // Build the mast object list entity.
-    mol := objects{molObjects}
+func buildDs3ObjectListStream(ds3Objects []Ds3Object) networking.ReaderWithSizeDecorator {
+    // Build the ds3 object list entity.
+    objects := newDs3ObjectList(ds3Objects)
 
     // Create an xml document from the entity.
-    xmlBytes, err := xml.Marshal(mol)
+    xmlBytes, err := xml.Marshal(objects)
     if err != nil {
         panic(err)
     }
 
-    // Create a ReaderWithSizeDecorator which the network layer expects.
-    return networking.BuildSizedReadCloser(xmlBytes)
+    // Create a ByteReaderWithSizeDecorator which the network layer expects.
+    return networking.BuildByteReaderWithSizeDecorator(xmlBytes)
 }
 
 // Parses the DS3 specific bulk command response.

--- a/src/ds3/models/bulkGetRequest.go
+++ b/src/ds3/models/bulkGetRequest.go
@@ -12,13 +12,13 @@ type BulkGetRequest struct {
     queryParams *url.Values
 }
 
-func NewBulkGetRequest(bucketName string, objects []Object) *BulkGetRequest {
+func NewBulkGetRequest(bucketName string, objects []Ds3Object) *BulkGetRequest {
     queryParams := &url.Values{}
     queryParams.Set("operation", "start_bulk_get")
 
     return &BulkGetRequest{
         bucketName: bucketName,
-        content: buildObjectListStream(objects),
+        content: buildDs3ObjectListStream(objects),
         queryParams: queryParams,
     }
 }

--- a/src/ds3/models/bulkPutRequest.go
+++ b/src/ds3/models/bulkPutRequest.go
@@ -12,13 +12,13 @@ type BulkPutRequest struct {
     queryParams *url.Values
 }
 
-func NewBulkPutRequest(bucketName string, objects []Object) *BulkPutRequest {
+func NewBulkPutRequest(bucketName string, objects []Ds3Object) *BulkPutRequest {
     queryParams := &url.Values{}
     queryParams.Set("operation", "start_bulk_put")
 
     return &BulkPutRequest{
         bucketName: bucketName,
-        content: buildObjectListStream(objects),
+        content: buildDs3ObjectListStream(objects),
         queryParams: queryParams,
     }
 }

--- a/src/ds3/models/completeMultipartRequest.go
+++ b/src/ds3/models/completeMultipartRequest.go
@@ -61,7 +61,7 @@ func (completeMultipartRequest *CompleteMultipartRequest) GetContentStream() net
     }
 
     // Create a ReaderWithSizeDecorator which the network layer expects.
-    return networking.BuildSizedReadCloser(xmlBytes)
+    return networking.BuildByteReaderWithSizeDecorator(xmlBytes)
 }
 
 func (CompleteMultipartRequest) GetChecksum() networking.Checksum {

--- a/src/ds3/networking/ds3Request.go
+++ b/src/ds3/networking/ds3Request.go
@@ -78,7 +78,7 @@ type byteReaderWithSizeDecorator struct {
     size int64
 }
 
-func BuildSizedReadCloser(contentBytes []byte) ReaderWithSizeDecorator {
+func BuildByteReaderWithSizeDecorator(contentBytes []byte) ReaderWithSizeDecorator {
     return &byteReaderWithSizeDecorator{
         bytes.NewReader(contentBytes),
         int64(len(contentBytes)),

--- a/src/ds3_cli/commands/bulkPut.go
+++ b/src/ds3_cli/commands/bulkPut.go
@@ -23,9 +23,9 @@ func bulkPut(client *ds3.Client, args *Arguments) error {
     }
 
     // Create object entities that we can query with for each file.
-    objects := make([]models.Object, len(files))
+    objects := make([]models.Ds3Object, len(files))
     for i, file := range files {
-        objects[i] = models.Object{Key: file.path, Size: file.size}
+        objects[i] = models.Ds3Object{Name: file.path, Size: file.size}
     }
 
     // Run request.

--- a/src/ds3_cli/commands/getBucket.go
+++ b/src/ds3_cli/commands/getBucket.go
@@ -22,7 +22,7 @@ func getBucket(client *ds3.Client, args *Arguments) error {
         return err
     }
     for _, obj := range objects {
-        fmt.Println(obj.Key)
+        fmt.Println(obj.Name)
     }
     return nil
 }

--- a/src/ds3_cli/commands/getBucketObjects.go
+++ b/src/ds3_cli/commands/getBucketObjects.go
@@ -9,7 +9,7 @@ import (
 // Gets all objects in a bucket, performing multiple requests if the results
 // are paged. Also supports limiting to an arbitrary number of keys independent
 // of page size.
-func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Object, error) {
+func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Ds3Object, error) {
     // Validate arguments.
     if args.Bucket == "" {
         return nil, errors.New("Must specify a bucket name when doing get_bucket.")
@@ -22,7 +22,7 @@ func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Object, err
     }
 
     // Do a do...while pattern to do as many requests as needed.
-    var results []models.Object
+    var results []models.Ds3Object
     marker := ""
     for {
         // Build the request.
@@ -36,7 +36,8 @@ func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Object, err
 
         // Output the results.
         for _, obj := range response.Contents {
-            results = append(results, obj)
+            ds3object := models.Ds3Object{Name:obj.Key, Size:obj.Size}
+            results = append(results, ds3object)
         }
 
         // Subtract the number of keys that we got from the number of keys that

--- a/src/ds3_integration/utils/testUtils.go
+++ b/src/ds3_integration/utils/testUtils.go
@@ -40,7 +40,7 @@ func PutObjectLogError(t *testing.T, client *ds3.Client, bucketName string, obje
 
 // Puts the specified object. Returns an error if not successful.
 func PutObject(client *ds3.Client, bucketName string, objectName string, data []byte) (error) {
-    putObjectResponse, putErr := client.PutObject(models.NewPutObjectRequest(bucketName, objectName, networking.BuildSizedReadCloser(data)))
+    putObjectResponse, putErr := client.PutObject(models.NewPutObjectRequest(bucketName, objectName, networking.BuildByteReaderWithSizeDecorator(data)))
     if putErr != nil {
         return putErr
     }


### PR DESCRIPTION
**Changes**
- Separated request and response payload models for bulk requests.
- Renamed models to conform with Java and Net SDK names
- Renamed `BuildSizedReadCloser` -> `BuildByteReaderWithSizeDecorator` which was missed when the associated struct name was updated.
