### PR TITLE
Updated response handler status code handling as prep for autogening

### DIFF
--- a/src/ds3/ds3Client_test.go
+++ b/src/ds3/ds3Client_test.go
@@ -90,7 +90,7 @@ func TestGetBadService(t *testing.T) {
     if err == nil {
         t.Error("Expected an error but didn't get one.")
     } else {
-        expectedError := "Received a status code of 400 when 200 was expected. Could not parse the response for additional information."
+        expectedError := "Received a status code of 400 when [200] was expected. Could not parse the response for additional information."
         actualError := err.Error()
         if actualError != expectedError {
             t.Errorf("Expected a different error message than received: '%s'", actualError)
@@ -241,7 +241,7 @@ func TestGetBadBucket(t *testing.T) {
     if err == nil {
         t.Error("Expected an error but got nil.")
     } else {
-        expectedError := "Received a status code of 400 when 200 was expected. Could not parse the response for additional information."
+        expectedError := "Received a status code of 400 when [200] was expected. Could not parse the response for additional information."
         actualError := err.Error()
         if actualError != expectedError {
             t.Errorf("Expected a different error message than received: '%s'", actualError)

--- a/src/ds3/models/abortMultipartResponse.go
+++ b/src/ds3/models/abortMultipartResponse.go
@@ -9,15 +9,10 @@ type AbortMultipartResponse struct {}
 func NewAbortMultipartResponse(webResponse networking.WebResponse) (*AbortMultipartResponse, error) {
     expectedStatusCodes := []int { 204 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 204:
         return &AbortMultipartResponse{}, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/abortMultipartResponse.go
+++ b/src/ds3/models/abortMultipartResponse.go
@@ -1,17 +1,24 @@
 package models
 
 import (
-    "net/http"
     "ds3/networking"
 )
 
 type AbortMultipartResponse struct {}
 
 func NewAbortMultipartResponse(webResponse networking.WebResponse) (*AbortMultipartResponse, error) {
-    if err := checkStatusCode(webResponse, http.StatusNoContent); err != nil {
+    expectedStatusCodes := []int { 204 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
-    } else {
+    }
+
+    switch code := webResponse.StatusCode(); code {
+    case 204:
         return &AbortMultipartResponse{}, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }
 

--- a/src/ds3/models/badStatusCodeError.go
+++ b/src/ds3/models/badStatusCodeError.go
@@ -6,7 +6,7 @@ import (
 )
 
 type BadStatusCodeError struct {
-    ExpectedStatusCode int
+    ExpectedStatusCode []int
     ActualStatusCode int
     ErrorBody *Error
 }
@@ -18,7 +18,7 @@ type Error struct {
     RequestId string
 }
 
-func buildBadStatusCodeError(webResponse networking.WebResponse, expectedStatusCode int) *BadStatusCodeError {
+func buildBadStatusCodeError(webResponse networking.WebResponse, expectedStatusCodes []int) *BadStatusCodeError {
     var errorBody Error
     var errorBodyPtr *Error
 
@@ -30,7 +30,7 @@ func buildBadStatusCodeError(webResponse networking.WebResponse, expectedStatusC
 
     // Return the bad status code entity.
     return &BadStatusCodeError{
-        expectedStatusCode,
+        expectedStatusCodes,
         webResponse.StatusCode(),
         errorBodyPtr,
     }
@@ -39,14 +39,14 @@ func buildBadStatusCodeError(webResponse networking.WebResponse, expectedStatusC
 func (err BadStatusCodeError) Error() string {
     if err.ErrorBody != nil {
         return fmt.Sprintf(
-            "Received a status code of %d when %d was expected. Error message: \"%s\"",
+            "Received a status code of %d when %v was expected. Error message: \"%s\"",
             err.ActualStatusCode,
             err.ExpectedStatusCode,
             err.ErrorBody.Message,
         )
     } else {
         return fmt.Sprintf(
-            "Received a status code of %d when %d was expected. Could not parse the response for additional information.",
+            "Received a status code of %d when %v was expected. Could not parse the response for additional information.",
             err.ActualStatusCode,
             err.ExpectedStatusCode,
         )

--- a/src/ds3/models/bulk.go
+++ b/src/ds3/models/bulk.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-    "net/http"
     "ds3/networking"
 )
 
@@ -27,7 +26,7 @@ type bulkObject struct {
 func getObjectsFromBulkResponse(webResponse networking.WebResponse) ([][]Object, error) {
     // Parse the master object list response body.
     var mol masterobjectlist
-    if err := readResponseBody(webResponse, http.StatusOK, &mol); err != nil {
+    if err := readResponseBody(webResponse, &mol); err != nil {
         return nil, err
     }
 

--- a/src/ds3/models/bulkGetResponse.go
+++ b/src/ds3/models/bulkGetResponse.go
@@ -11,16 +11,11 @@ type BulkGetResponse struct {
 func NewBulkGetResponse(webResponse networking.WebResponse) (*BulkGetResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         objects, err := getObjectsFromBulkResponse(webResponse)
         return &BulkGetResponse{objects}, err
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 

--- a/src/ds3/models/bulkGetResponse.go
+++ b/src/ds3/models/bulkGetResponse.go
@@ -9,7 +9,20 @@ type BulkGetResponse struct {
 }
 
 func NewBulkGetResponse(webResponse networking.WebResponse) (*BulkGetResponse, error) {
-    objects, err := getObjectsFromBulkResponse(webResponse)
-    return &BulkGetResponse{objects}, err
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
+        return nil, err
+    }
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
+        objects, err := getObjectsFromBulkResponse(webResponse)
+        return &BulkGetResponse{objects}, err
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+    }
+
 }
 

--- a/src/ds3/models/bulkPutResponse.go
+++ b/src/ds3/models/bulkPutResponse.go
@@ -11,16 +11,11 @@ type BulkPutResponse struct {
 func NewBulkPutResponse(webResponse networking.WebResponse) (*BulkPutResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         objects, err := getObjectsFromBulkResponse(webResponse)
         return &BulkPutResponse{objects}, err
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 

--- a/src/ds3/models/bulkPutResponse.go
+++ b/src/ds3/models/bulkPutResponse.go
@@ -9,7 +9,20 @@ type BulkPutResponse struct {
 }
 
 func NewBulkPutResponse(webResponse networking.WebResponse) (*BulkPutResponse, error) {
-    objects, err := getObjectsFromBulkResponse(webResponse)
-    return &BulkPutResponse{objects}, err
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
+        return nil, err
+    }
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
+        objects, err := getObjectsFromBulkResponse(webResponse)
+        return &BulkPutResponse{objects}, err
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+    }
+
 }
 

--- a/src/ds3/models/completeMultipartResponse.go
+++ b/src/ds3/models/completeMultipartResponse.go
@@ -15,10 +15,6 @@ type CompleteMultipartResponse struct {
 func NewCompleteMultipartResponse(webResponse networking.WebResponse) (*CompleteMultipartResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         var body CompleteMultipartResponse
@@ -28,7 +24,6 @@ func NewCompleteMultipartResponse(webResponse networking.WebResponse) (*Complete
         body.ETag = strings.Trim(body.ETag, "\"")
         return &body, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/completeMultipartResponse.go
+++ b/src/ds3/models/completeMultipartResponse.go
@@ -2,7 +2,6 @@ package models
 
 import (
     "strings"
-    "net/http"
     "ds3/networking"
 )
 
@@ -14,12 +13,24 @@ type CompleteMultipartResponse struct {
 }
 
 func NewCompleteMultipartResponse(webResponse networking.WebResponse) (*CompleteMultipartResponse, error) {
-    var body CompleteMultipartResponse
-    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
     }
-    body.ETag = strings.Trim(body.ETag, "\"")
-    return &body, nil
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
+        var body CompleteMultipartResponse
+        if err := readResponseBody(webResponse, &body); err != nil {
+            return nil, err
+        }
+        body.ETag = strings.Trim(body.ETag, "\"")
+        return &body, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+    }
 }
 
 

--- a/src/ds3/models/deleteBucketResponse.go
+++ b/src/ds3/models/deleteBucketResponse.go
@@ -9,15 +9,10 @@ type DeleteBucketResponse struct {}
 func NewDeleteBucketResponse(webResponse networking.WebResponse) (*DeleteBucketResponse, error) {
     expectedStatusCodes := []int { 204 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 204:
         return &DeleteBucketResponse{}, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/deleteBucketResponse.go
+++ b/src/ds3/models/deleteBucketResponse.go
@@ -1,17 +1,23 @@
 package models
 
 import (
-    "net/http"
     "ds3/networking"
 )
 
 type DeleteBucketResponse struct {}
 
 func NewDeleteBucketResponse(webResponse networking.WebResponse) (*DeleteBucketResponse, error) {
-    if err := checkStatusCode(webResponse, http.StatusNoContent); err != nil {
+    expectedStatusCodes := []int { 204 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
-    } else {
+    }
+
+    switch code := webResponse.StatusCode(); code {
+    case 204:
         return &DeleteBucketResponse{}, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }
-

--- a/src/ds3/models/deleteObjectResponse.go
+++ b/src/ds3/models/deleteObjectResponse.go
@@ -1,18 +1,23 @@
 package models
 
 import (
-    "net/http"
     "ds3/networking"
 )
 
 type DeleteObjectResponse struct {}
 
 func NewDeleteObjectResponse(webResponse networking.WebResponse) (*DeleteObjectResponse, error) {
-    if err := checkStatusCode(webResponse, http.StatusNoContent); err != nil {
+    expectedStatusCodes := []int { 204 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
-    } else {
+    }
+
+    switch code := webResponse.StatusCode(); code {
+    case 204:
         return &DeleteObjectResponse{}, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }
-
-

--- a/src/ds3/models/deleteObjectResponse.go
+++ b/src/ds3/models/deleteObjectResponse.go
@@ -9,15 +9,10 @@ type DeleteObjectResponse struct {}
 func NewDeleteObjectResponse(webResponse networking.WebResponse) (*DeleteObjectResponse, error) {
     expectedStatusCodes := []int { 204 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 204:
         return &DeleteObjectResponse{}, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/deleteObjectsResponse.go
+++ b/src/ds3/models/deleteObjectsResponse.go
@@ -22,10 +22,6 @@ type DeleteError struct {
 func NewDeleteObjectsResponse(webResponse networking.WebResponse) (*DeleteObjectsResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         var body DeleteObjectsResponse //DeleteResult
@@ -34,7 +30,6 @@ func NewDeleteObjectsResponse(webResponse networking.WebResponse) (*DeleteObject
         }
         return &body, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/deleteObjectsResponse.go
+++ b/src/ds3/models/deleteObjectsResponse.go
@@ -2,7 +2,6 @@ package models
 
 import (
     "ds3/networking"
-    "net/http"
 )
 
 type DeleteObjectsResponse struct {
@@ -21,9 +20,21 @@ type DeleteError struct {
 }
 
 func NewDeleteObjectsResponse(webResponse networking.WebResponse) (*DeleteObjectsResponse, error) {
-    var body DeleteObjectsResponse //DeleteResult
-    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
     }
-    return &body, nil
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
+        var body DeleteObjectsResponse //DeleteResult
+        if err := readResponseBody(webResponse, &body); err != nil {
+            return nil, err
+        }
+        return &body, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+    }
 }

--- a/src/ds3/models/getBucketResponse.go
+++ b/src/ds3/models/getBucketResponse.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-    "net/http"
     "ds3/networking"
 )
 
@@ -18,10 +17,21 @@ type GetBucketResponse struct {
 }
 
 func NewGetBucketResponse(webResponse networking.WebResponse) (*GetBucketResponse, error) {
-    var body GetBucketResponse
-    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
     }
-    return &body, nil
-}
 
+    switch code := webResponse.StatusCode(); code {
+    case 200:
+        var body GetBucketResponse
+        if err := readResponseBody(webResponse, &body); err != nil {
+            return nil, err
+        }
+        return &body, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+    }
+}

--- a/src/ds3/models/getBucketResponse.go
+++ b/src/ds3/models/getBucketResponse.go
@@ -19,10 +19,6 @@ type GetBucketResponse struct {
 func NewGetBucketResponse(webResponse networking.WebResponse) (*GetBucketResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         var body GetBucketResponse
@@ -31,7 +27,6 @@ func NewGetBucketResponse(webResponse networking.WebResponse) (*GetBucketRespons
         }
         return &body, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/getObjectResponse.go
+++ b/src/ds3/models/getObjectResponse.go
@@ -2,7 +2,6 @@ package models
 
 import (
     "io"
-    "net/http"
     "ds3/networking"
 )
 
@@ -11,9 +10,18 @@ type GetObjectResponse struct {
 }
 
 func NewGetObjectResponse(webResponse networking.WebResponse) (*GetObjectResponse, error) {
-    if err := checkStatusCode(webResponse, http.StatusOK); err != nil {
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
     }
-    return &GetObjectResponse{webResponse.Body()}, nil
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
+        return &GetObjectResponse{webResponse.Body()}, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+    }
 }
 

--- a/src/ds3/models/getObjectResponse.go
+++ b/src/ds3/models/getObjectResponse.go
@@ -12,15 +12,10 @@ type GetObjectResponse struct {
 func NewGetObjectResponse(webResponse networking.WebResponse) (*GetObjectResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         return &GetObjectResponse{webResponse.Body()}, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/getServiceResponse.go
+++ b/src/ds3/models/getServiceResponse.go
@@ -17,10 +17,6 @@ type Bucket struct {
 func NewGetServiceResponse(webResponse networking.WebResponse) (*GetServiceResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         var body GetServiceResponse
@@ -29,7 +25,6 @@ func NewGetServiceResponse(webResponse networking.WebResponse) (*GetServiceRespo
         }
         return &body, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/getServiceResponse.go
+++ b/src/ds3/models/getServiceResponse.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-    "net/http"
     "ds3/networking"
 )
 
@@ -16,10 +15,21 @@ type Bucket struct {
 }
 
 func NewGetServiceResponse(webResponse networking.WebResponse) (*GetServiceResponse, error) {
-    var body GetServiceResponse
-    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
     }
-    return &body, nil
-}
 
+    switch code := webResponse.StatusCode(); code {
+    case 200:
+        var body GetServiceResponse
+        if err := readResponseBody(webResponse, &body); err != nil {
+            return nil, err
+        }
+        return &body, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+    }
+}

--- a/src/ds3/models/initiateMultipartResponse.go
+++ b/src/ds3/models/initiateMultipartResponse.go
@@ -13,10 +13,6 @@ type InitiateMultipartResponse struct {
 func NewInitiateMultipartResponse(webResponse networking.WebResponse) (*InitiateMultipartResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         var body InitiateMultipartResponse
@@ -25,7 +21,6 @@ func NewInitiateMultipartResponse(webResponse networking.WebResponse) (*Initiate
         }
         return &body, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/initiateMultipartResponse.go
+++ b/src/ds3/models/initiateMultipartResponse.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-    "net/http"
     "ds3/networking"
 )
 
@@ -12,10 +11,22 @@ type InitiateMultipartResponse struct {
 }
 
 func NewInitiateMultipartResponse(webResponse networking.WebResponse) (*InitiateMultipartResponse, error) {
-    var body InitiateMultipartResponse
-    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
     }
-    return &body, nil
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
+        var body InitiateMultipartResponse
+        if err := readResponseBody(webResponse, &body); err != nil {
+            return nil, err
+        }
+        return &body, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+    }
 }
 

--- a/src/ds3/models/listMultipartResponse.go
+++ b/src/ds3/models/listMultipartResponse.go
@@ -27,10 +27,6 @@ type Upload struct {
 func NewListMultipartResponse(webResponse networking.WebResponse) (*ListMultipartResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         var body ListMultipartResponse
@@ -39,7 +35,6 @@ func NewListMultipartResponse(webResponse networking.WebResponse) (*ListMultipar
         }
         return &body, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/listMultipartResponse.go
+++ b/src/ds3/models/listMultipartResponse.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-    "net/http"
     "ds3/networking"
 )
 
@@ -26,11 +25,21 @@ type Upload struct {
 }
 
 func NewListMultipartResponse(webResponse networking.WebResponse) (*ListMultipartResponse, error) {
-    var body ListMultipartResponse
-    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
     }
-    return &body, nil
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
+        var body ListMultipartResponse
+        if err := readResponseBody(webResponse, &body); err != nil {
+            return nil, err
+        }
+        return &body, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+    }
 }
-
-

--- a/src/ds3/models/listPartsResponse.go
+++ b/src/ds3/models/listPartsResponse.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-    "net/http"
     "ds3/networking"
 )
 
@@ -27,10 +26,22 @@ type UploadedPart struct {
 }
 
 func NewListPartsResponse(webResponse networking.WebResponse) (*ListPartsResponse, error) {
-    var body ListPartsResponse
-    if err := readResponseBody(webResponse, http.StatusOK, &body); err != nil {
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
     }
-    return &body, nil
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
+        var body ListPartsResponse
+        if err := readResponseBody(webResponse, &body); err != nil {
+            return nil, err
+        }
+        return &body, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+    }
 }
 

--- a/src/ds3/models/listPartsResponse.go
+++ b/src/ds3/models/listPartsResponse.go
@@ -28,10 +28,6 @@ type UploadedPart struct {
 func NewListPartsResponse(webResponse networking.WebResponse) (*ListPartsResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         var body ListPartsResponse
@@ -40,7 +36,6 @@ func NewListPartsResponse(webResponse networking.WebResponse) (*ListPartsRespons
         }
         return &body, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/putBucketResponse.go
+++ b/src/ds3/models/putBucketResponse.go
@@ -1,17 +1,24 @@
 package models
 
 import (
-    "net/http"
     "ds3/networking"
 )
 
 type PutBucketResponse struct {}
 
 func NewPutBucketResponse(webResponse networking.WebResponse) (*PutBucketResponse, error) {
-    if err := checkStatusCode(webResponse, http.StatusOK); err != nil {
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
-    } else {
+    }
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
         return &PutBucketResponse{}, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }
 

--- a/src/ds3/models/putBucketResponse.go
+++ b/src/ds3/models/putBucketResponse.go
@@ -9,15 +9,10 @@ type PutBucketResponse struct {}
 func NewPutBucketResponse(webResponse networking.WebResponse) (*PutBucketResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         return &PutBucketResponse{}, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/putObjectResponse.go
+++ b/src/ds3/models/putObjectResponse.go
@@ -1,17 +1,24 @@
 package models
 
 import (
-    "net/http"
     "ds3/networking"
 )
 
 type PutObjectResponse struct {}
 
 func NewPutObjectResponse(webResponse networking.WebResponse) (*PutObjectResponse, error) {
-    if err := checkStatusCode(webResponse, http.StatusOK); err != nil {
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
-    } else {
+    }
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
         return &PutObjectResponse{}, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }
 

--- a/src/ds3/models/putObjectResponse.go
+++ b/src/ds3/models/putObjectResponse.go
@@ -9,15 +9,10 @@ type PutObjectResponse struct {}
 func NewPutObjectResponse(webResponse networking.WebResponse) (*PutObjectResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         return &PutObjectResponse{}, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/putPartResponse.go
+++ b/src/ds3/models/putPartResponse.go
@@ -2,7 +2,6 @@ package models
 
 import (
     "strings"
-    "net/http"
     "ds3/networking"
 )
 
@@ -11,15 +10,22 @@ type PutPartResponse struct {
 }
 
 func NewPutPartResponse(webResponse networking.WebResponse) (*PutPartResponse, error) {
-    if err := checkStatusCode(webResponse, http.StatusOK); err != nil {
+    expectedStatusCodes := []int { 200 }
+
+    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
         return nil, err
-    } else {
+    }
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
         etags := (*webResponse.Header())["etag"]
         var etag string
         if len(etags) > 0 {
             etag = strings.Trim(etags[0], "\"")
         }
         return &PutPartResponse{etag}, nil
+    default:
+        //Should never get here
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }
-

--- a/src/ds3/models/putPartResponse.go
+++ b/src/ds3/models/putPartResponse.go
@@ -12,10 +12,6 @@ type PutPartResponse struct {
 func NewPutPartResponse(webResponse networking.WebResponse) (*PutPartResponse, error) {
     expectedStatusCodes := []int { 200 }
 
-    if err := checkStatusCode(webResponse, expectedStatusCodes); err != nil {
-        return nil, err
-    }
-
     switch code := webResponse.StatusCode(); code {
     case 200:
         etags := (*webResponse.Header())["etag"]
@@ -25,7 +21,6 @@ func NewPutPartResponse(webResponse networking.WebResponse) (*PutPartResponse, e
         }
         return &PutPartResponse{etag}, nil
     default:
-        //Should never get here
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }

--- a/src/ds3/models/responseHandling.go
+++ b/src/ds3/models/responseHandling.go
@@ -7,16 +7,6 @@ import (
     "ds3/networking"
 )
 
-func checkStatusCode(webResponse networking.WebResponse, expectedStatusCodes []int) error {
-    code := webResponse.StatusCode()
-    for _, expectedCode := range expectedStatusCodes {
-        if code == expectedCode {
-            return nil
-        }
-    }
-    return buildBadStatusCodeError(webResponse, expectedStatusCodes)
-}
-
 func readResponseBody(webResponse networking.WebResponse, parsedBody interface{}) error {
     // Clean up the response body.
     body := webResponse.Body()

--- a/src/ds3/models/responseHandling.go
+++ b/src/ds3/models/responseHandling.go
@@ -7,23 +7,20 @@ import (
     "ds3/networking"
 )
 
-func checkStatusCode(webResponse networking.WebResponse, expectedStatusCode int) error {
-    if webResponse.StatusCode() == expectedStatusCode {
-        return nil
-    } else {
-        return buildBadStatusCodeError(webResponse, expectedStatusCode)
+func checkStatusCode(webResponse networking.WebResponse, expectedStatusCodes []int) error {
+    code := webResponse.StatusCode()
+    for _, expectedCode := range expectedStatusCodes {
+        if code == expectedCode {
+            return nil
+        }
     }
+    return buildBadStatusCodeError(webResponse, expectedStatusCodes)
 }
 
-func readResponseBody(webResponse networking.WebResponse, expectedStatusCode int, parsedBody interface{}) error {
+func readResponseBody(webResponse networking.WebResponse, parsedBody interface{}) error {
     // Clean up the response body.
     body := webResponse.Body()
     defer body.Close()
-
-    // Check the status code.
-    if err := checkStatusCode(webResponse, expectedStatusCode); err != nil {
-        return err
-    }
 
     // Parse the response
     return parseResponseBody(body, parsedBody)


### PR DESCRIPTION
**Changes**
- Updated `checkStatusCode` to take multiple status codes so that a response handler can properly handle a 200 and 204 properly (for example)
- Updated response handling to use a switch statement for status codes to determine proper parsing. This was done in preparation for generating response handlers which have multiple non-error response codes