### PR TITLE
Added network decorators in client code

### DIFF
--- a/src/ds3/ds3Client.go
+++ b/src/ds3/ds3Client.go
@@ -20,6 +20,9 @@ type ClientPolicy struct {
     maxRedirect int // Maximum number of times to attempt redirect retries
 }
 
+const DEFAULT_MAX_RETRIES = 5
+const DEFAULT_MAX_REDIRECTS = 5
+
 func NewClientBuilder(endpoint *url.URL, creds networking.Credentials) *ClientBuilder {
     return &ClientBuilder{
         &networking.ConnectionInfo{
@@ -27,8 +30,8 @@ func NewClientBuilder(endpoint *url.URL, creds networking.Credentials) *ClientBu
             Creds: creds,
             Proxy: nil},
         &ClientPolicy{
-            maxRetries: 5,
-            maxRedirect: 5}}
+            maxRetries: DEFAULT_MAX_RETRIES,
+            maxRedirect: DEFAULT_MAX_REDIRECTS}}
 }
 
 func (clientBuilder *ClientBuilder) WithProxy(proxy *url.URL) *ClientBuilder {

--- a/src/ds3/ds3Deletes.go
+++ b/src/ds3/ds3Deletes.go
@@ -1,10 +1,15 @@
 package ds3
 
-import "ds3/models"
+import (
+    "ds3/models"
+    "ds3/networking"
+)
 
 func (client *Client) DeleteBucket(request *models.DeleteBucketRequest) (*models.DeleteBucketResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -14,8 +19,10 @@ func (client *Client) DeleteBucket(request *models.DeleteBucketRequest) (*models
 }
 
 func (client *Client) DeleteObject(request *models.DeleteObjectRequest) (*models.DeleteObjectResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -25,8 +32,10 @@ func (client *Client) DeleteObject(request *models.DeleteObjectRequest) (*models
 }
 
 func (client *Client) AbortMultipart(request *models.AbortMultipartRequest) (*models.AbortMultipartResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -36,8 +45,10 @@ func (client *Client) AbortMultipart(request *models.AbortMultipartRequest) (*mo
 }
 
 func (client *Client) DeleteObjects(request *models.DeleteObjectsRequest) (*models.DeleteObjectsResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }

--- a/src/ds3/ds3Gets.go
+++ b/src/ds3/ds3Gets.go
@@ -1,10 +1,16 @@
 package ds3
 
-import "ds3/models"
+import (
+    "ds3/models"
+    networking "ds3/networking"
+)
 
 func (client *Client) GetService(request *models.GetServiceRequest) (*models.GetServiceResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := httpRedirectDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -14,8 +20,11 @@ func (client *Client) GetService(request *models.GetServiceRequest) (*models.Get
 }
 
 func (client *Client) GetBucket(request *models.GetBucketRequest) (*models.GetBucketResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := httpRedirectDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -25,8 +34,10 @@ func (client *Client) GetBucket(request *models.GetBucketRequest) (*models.GetBu
 }
 
 func (client *Client) GetObject(request *models.GetObjectRequest) (*models.GetObjectResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -36,8 +47,11 @@ func (client *Client) GetObject(request *models.GetObjectRequest) (*models.GetOb
 }
 
 func (client *Client) ListParts(request *models.ListPartsRequest) (*models.ListPartsResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := httpRedirectDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -47,8 +61,11 @@ func (client *Client) ListParts(request *models.ListPartsRequest) (*models.ListP
 }
 
 func (client *Client) ListMultipart(request *models.ListMultipartRequest) (*models.ListMultipartResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := httpRedirectDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }

--- a/src/ds3/ds3Posts.go
+++ b/src/ds3/ds3Posts.go
@@ -1,10 +1,15 @@
 package ds3
 
-import "ds3/models"
+import (
+    "ds3/models"
+    "ds3/networking"
+)
 
 func (client *Client) InitiateMultipart(request *models.InitiateMultipartRequest) (*models.InitiateMultipartResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -14,8 +19,10 @@ func (client *Client) InitiateMultipart(request *models.InitiateMultipartRequest
 }
 
 func (client *Client) CompleteMultipart(request *models.CompleteMultipartRequest) (*models.CompleteMultipartResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }

--- a/src/ds3/ds3Puts.go
+++ b/src/ds3/ds3Puts.go
@@ -1,10 +1,15 @@
 package ds3
 
-import "ds3/models"
+import (
+    "ds3/models"
+    "ds3/networking"
+)
 
 func (client *Client) PutBucket(request *models.PutBucketRequest) (*models.PutBucketResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -14,8 +19,10 @@ func (client *Client) PutBucket(request *models.PutBucketRequest) (*models.PutBu
 }
 
 func (client *Client) PutObject(request *models.PutObjectRequest) (*models.PutObjectResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -25,8 +32,10 @@ func (client *Client) PutObject(request *models.PutObjectRequest) (*models.PutOb
 }
 
 func (client *Client) BulkGet(request *models.BulkGetRequest) (*models.BulkGetResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -36,8 +45,10 @@ func (client *Client) BulkGet(request *models.BulkGetRequest) (*models.BulkGetRe
 }
 
 func (client *Client) BulkPut(request *models.BulkPutRequest) (*models.BulkPutResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }
@@ -47,8 +58,10 @@ func (client *Client) BulkPut(request *models.BulkPutRequest) (*models.BulkPutRe
 }
 
 func (client *Client) PutPart(request *models.PutPartRequest) (*models.PutPartResponse, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+
     // Invoke the HTTP request.
-    response, requestErr := client.netLayer.Invoke(request)
+    response, requestErr := networkRetryDecorator.Invoke(request)
     if requestErr != nil {
         return nil, requestErr
     }


### PR DESCRIPTION
**Changes**
- Made default max retries and max redirects constant rather than magic numbers
- Added network decorator `NetworkRetryDecorator` to all client commands
- Added network decorator `HttpTempRedirect` to all client commands of type GET except `GetObject`