### PR TITLE
Implemented command with string response payload

### DIFF
--- a/src/ds3/ds3Client_test.go
+++ b/src/ds3/ds3Client_test.go
@@ -316,6 +316,33 @@ func TestGetObjectRange(t *testing.T) {
     }
 }
 
+func TestGetJobToReplicateSpectraS3(t *testing.T) {
+    stringResponse := "object contents"
+
+    // Create and run the mocked client.
+    request := models.NewGetJobToReplicateSpectraS3Request("23a876ec-2fac-4dc8-b8e6-98d6026e7f4a")
+
+    expectedParams := &url.Values{"replicate": []string{""}}
+    response, err := mockedClient(t).
+        Expecting(networking.GET, "/_rest_/job/23a876ec-2fac-4dc8-b8e6-98d6026e7f4a", expectedParams, nil).
+        Returning(200, stringResponse, nil).
+        GetJobToReplicateSpectraS3(request)
+
+    // Check the error result.
+    if err != nil {
+        t.Errorf("Unexpected error '%s'.", err.Error())
+    }
+
+    // Check the response value.
+    if response == nil {
+        t.Error("Response was unexpectedly nil.")
+    } else {
+        if response.Content != stringResponse {
+            t.Errorf("Unexpected response: expected '%s' but was '%s'", stringResponse, response.Content)
+        }
+    }
+}
+
 func TestPutObject(t *testing.T) {
     stringResponse := "object contents"
 

--- a/src/ds3/ds3Gets.go
+++ b/src/ds3/ds3Gets.go
@@ -74,3 +74,17 @@ func (client *Client) ListMultipart(request *models.ListMultipartRequest) (*mode
     return models.NewListMultipartResponse(response)
 }
 
+func (client *Client) GetJobToReplicateSpectraS3(request *models.GetJobToReplicateSpectraS3Request) (*models.GetJobToReplicateSpectraS3Response, error) {
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)
+    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)
+
+    // Invoke the HTTP request.
+    response, requestErr := httpRedirectDecorator.Invoke(request)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewGetJobToReplicateSpectraS3Response(response)
+}
+

--- a/src/ds3/models/getJobToReplicateSpectraS3Request.go
+++ b/src/ds3/models/getJobToReplicateSpectraS3Request.go
@@ -1,0 +1,46 @@
+package models
+
+import (
+    "net/url"
+    "net/http"
+    "ds3/networking"
+)
+
+type GetJobToReplicateSpectraS3Request struct {
+    jobId string
+    queryParams *url.Values
+}
+
+func NewGetJobToReplicateSpectraS3Request(jobId string) *GetJobToReplicateSpectraS3Request {
+    queryParams := &url.Values{}
+    queryParams.Set("replicate", "")
+
+    return &GetJobToReplicateSpectraS3Request{
+        jobId: jobId,
+        queryParams: queryParams,
+    }
+}
+
+func (GetJobToReplicateSpectraS3Request) Verb() networking.HttpVerb {
+    return networking.GET
+}
+
+func (getJobToReplicateSpectraS3Request *GetJobToReplicateSpectraS3Request) Path() string {
+    return "/_rest_/job/" + getJobToReplicateSpectraS3Request.jobId
+}
+
+func (getJobToReplicateSpectraS3Request *GetJobToReplicateSpectraS3Request) QueryParams() *url.Values {
+    return getJobToReplicateSpectraS3Request.queryParams
+}
+
+func (GetJobToReplicateSpectraS3Request) Header() *http.Header {
+    return &http.Header{}
+}
+
+func (GetJobToReplicateSpectraS3Request) GetChecksum() networking.Checksum {
+    return networking.NewNoneChecksum()
+}
+
+func (GetJobToReplicateSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return nil
+}

--- a/src/ds3/models/getJobToReplicateSpectraS3Response.go
+++ b/src/ds3/models/getJobToReplicateSpectraS3Response.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+    "ds3/networking"
+)
+
+type GetJobToReplicateSpectraS3Response struct {
+    Content string
+}
+
+func NewGetJobToReplicateSpectraS3Response(webResponse networking.WebResponse) (*GetJobToReplicateSpectraS3Response, error) {
+    expectedStatusCodes := []int { 200 }
+
+    switch code := webResponse.StatusCode(); code {
+    case 200:
+        content, err := getResponseBodyAsString(webResponse)
+        if err != nil {
+            return nil, err
+        }
+        return &GetJobToReplicateSpectraS3Response{Content: content}, nil
+    default:
+        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+    }
+}

--- a/src/ds3/models/responseHandling.go
+++ b/src/ds3/models/responseHandling.go
@@ -31,3 +31,17 @@ func parseResponseBody(reader io.ReadCloser, body interface{}) error {
     return nil
 }
 
+func getResponseBodyAsString(webResponse networking.WebResponse) (string, error) {
+    // Clean up the response body.
+    body := webResponse.Body()
+    defer body.Close()
+
+    // Get the bytes or forward the error
+    bytes, err := ioutil.ReadAll(body)
+    if err != nil {
+        return "", err
+    }
+
+    // Convert the bytes into a string
+    return string(bytes), nil
+}


### PR DESCRIPTION
Implemented `GetJobToReplicateSpectraS3` command as prototype for how to generate responses with string response payloads