### PR TITLE
DO NOT MERGE: Looking for feedback on prototype for unmarshaling refactor

### DIFF
--- a/src/ds3/ds3Client_test.go
+++ b/src/ds3/ds3Client_test.go
@@ -1573,8 +1573,8 @@ func TestGetTapeSpectraS3(t *testing.T) {
     ds3Testing.AssertNonNilStringPtr(t, "LastModified", "2015-08-21T16:14:30.714", tape.LastModified)
     ds3Testing.AssertStringPtrIsNil(t, "LastVerified", tape.LastVerified)
     ds3Testing.AssertNonNilStringPtr(t, "PartitionId", "4f8a5cbb-9837-41d9-afd1-cebed41f18f7", tape.PartitionId)
-    if *tape.PreviousState != models.UNDEFINED {
-        t.Fatalf("Expected previous state '%d' but was '%d'.", models.UNDEFINED, *tape.PreviousState)
+    if tape.PreviousState != nil {
+        t.Fatalf("Expected previous state '%d' but was '%d'.", "nil", *tape.PreviousState)
     }
     ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "HP-W130501213", tape.SerialNumber)
     ds3Testing.AssertString(t, "State", models.TAPE_STATE_NORMAL.String(), tape.State.String())

--- a/src/ds3/ds3Client_test.go
+++ b/src/ds3/ds3Client_test.go
@@ -1503,8 +1503,8 @@ func TestGetTapesSpectraS3(t *testing.T) {
     ds3Testing.AssertNonNilStringPtr(t, "LastModified", "2015-08-21T16:14:30.714", tape.LastModified)
     ds3Testing.AssertStringPtrIsNil(t, "LastVerified", tape.LastVerified)
     ds3Testing.AssertNonNilStringPtr(t, "PartitionId", "4f8a5cbb-9837-41d9-afd1-cebed41f18f7", tape.PartitionId)
-    if *tape.PreviousState != models.UNDEFINED {
-        t.Fatalf("Expected previous state '%d' but was '%d'.", models.UNDEFINED, *tape.PreviousState)
+    if tape.PreviousState != nil {
+        t.Fatalf("Expected previous state '%d' but was '%d'.", "nil", *tape.PreviousState)
     }
     ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "HP-W130501213", tape.SerialNumber)
     ds3Testing.AssertString(t, "State", models.TAPE_STATE_NORMAL.String(), tape.State.String())

--- a/src/ds3/models/getJobsSpectraS3Response.go
+++ b/src/ds3/models/getJobsSpectraS3Response.go
@@ -23,13 +23,17 @@ type GetJobsSpectraS3Response struct {
     Headers *http.Header
 }
 
+func (getJobsSpectraS3Response *GetJobsSpectraS3Response) parse(webResponse networking.WebResponse) error {
+    return parseResponsePayload2(webResponse, &getJobsSpectraS3Response.JobList)
+}
+
 func NewGetJobsSpectraS3Response(webResponse networking.WebResponse) (*GetJobsSpectraS3Response, error) {
     expectedStatusCodes := []int { 200 }
 
     switch code := webResponse.StatusCode(); code {
     case 200:
         var body GetJobsSpectraS3Response
-        if err := readResponseBody(webResponse, &body.JobList); err != nil {
+        if err := body.parse(webResponse); err != nil {
             return nil, err
         }
         body.Headers = webResponse.Header()

--- a/src/ds3/models/getTapeSpectraS3Response.go
+++ b/src/ds3/models/getTapeSpectraS3Response.go
@@ -23,13 +23,17 @@ type GetTapeSpectraS3Response struct {
     Headers *http.Header
 }
 
+func (getTapeSpectraS3Response *GetTapeSpectraS3Response) parse(webResponse networking.WebResponse) error {
+    return parseResponsePayload2(webResponse, &getTapeSpectraS3Response.Tape)
+}
+
 func NewGetTapeSpectraS3Response(webResponse networking.WebResponse) (*GetTapeSpectraS3Response, error) {
     expectedStatusCodes := []int { 200 }
 
     switch code := webResponse.StatusCode(); code {
     case 200:
         var body GetTapeSpectraS3Response
-        if err := readResponseBody(webResponse, &body.Tape); err != nil {
+        if err := body.parse(webResponse); err != nil {
             return nil, err
         }
         body.Headers = webResponse.Header()

--- a/src/ds3/models/getTapesSpectraS3Response.go
+++ b/src/ds3/models/getTapesSpectraS3Response.go
@@ -23,13 +23,17 @@ type GetTapesSpectraS3Response struct {
     Headers *http.Header
 }
 
+func (getTapesSpectraS3Response *GetTapesSpectraS3Response) parse(webResponse networking.WebResponse) error {
+    return parseResponsePayload2(webResponse, &getTapesSpectraS3Response.TapeList)
+}
+
 func NewGetTapesSpectraS3Response(webResponse networking.WebResponse) (*GetTapesSpectraS3Response, error) {
     expectedStatusCodes := []int { 200 }
 
     switch code := webResponse.StatusCode(); code {
     case 200:
         var body GetTapesSpectraS3Response
-        if err := readResponseBody(webResponse, &body.TapeList); err != nil {
+        if err := body.parse(webResponse); err != nil {
             return nil, err
         }
         body.Headers = webResponse.Header()

--- a/src/ds3/models/responseHandling.go
+++ b/src/ds3/models/responseHandling.go
@@ -1,3 +1,5 @@
+//TODO delete once replaced with responseHandlingUtil
+
 package models
 
 import (

--- a/src/ds3/models/responseHandlingUtil.go
+++ b/src/ds3/models/responseHandlingUtil.go
@@ -7,7 +7,7 @@ import (
 )
 
 type modelParser interface {
-    parse(node *XmlNode) error
+    parse(node *XmlNode, aggErr *AggregateError)
 }
 
 //todo update name and test
@@ -23,7 +23,9 @@ func parseResponsePayload2(webResponse networking.WebResponse, parsedBody modelP
     }
 
     // Parse the response
-    return parsedBody.parse(root)
+    var aggErr AggregateError
+    parsedBody.parse(root, &aggErr)
+    return aggErr.GetErrors()
 }
 
 // Converts the contents of the reader into an xml node tree

--- a/src/ds3/models/responseHandlingUtil.go
+++ b/src/ds3/models/responseHandlingUtil.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+    "ds3/networking"
+    "encoding/xml"
+    "io"
+)
+
+type modelParser interface {
+    parse(node *XmlNode) error
+}
+
+//todo update name and test
+func parseResponsePayload2(webResponse networking.WebResponse, parsedBody modelParser) error {
+    // Clean up the response body.
+    body := webResponse.Body()
+    defer body.Close()
+
+    // Create the xml tree
+    root, err := parseXmlTree(body)
+    if err != nil {
+        return err
+    }
+
+    // Parse the response
+    return parsedBody.parse(root)
+}
+
+// Converts the contents of the reader into an xml node tree
+func parseXmlTree(reader io.ReadCloser) (*XmlNode, error) {
+
+    var xmlNode XmlNode
+    dec := xml.NewDecoder(reader)
+    xmlTreeErr := dec.Decode(&xmlNode)
+    if xmlTreeErr != nil {
+        return nil, xmlTreeErr
+    }
+
+    return &xmlNode, nil
+}

--- a/src/ds3/models/testParsers.go
+++ b/src/ds3/models/testParsers.go
@@ -2,26 +2,190 @@ package models
 
 import (
     "strconv"
+    "log"
+    "fmt"
+    "reflect"
 )
 
-//TODO test parser- hand implemented
+// TODO move to separate file
 
-func (tape *Tape) parse(node *XmlNode) error {
+type AggregateError struct {
+    Errors []error
+}
+
+func (aggregateError *AggregateError) Error() string {
+    msg := fmt.Sprintf("Multiple errors occured: %d\n", len(aggregateError.Errors))
+
+    for i, err := range aggregateError.Errors {
+        msg += fmt.Sprintf("%d) %s\n", i, err.Error())
+    }
+
+    return msg
+}
+
+// Returns the aggregate error if at least one error exists,
+// else returns nil
+func (aggregateError *AggregateError) GetErrors() error {
+    if len (aggregateError.Errors) == 0 {
+        return nil
+    }
+    return aggregateError
+}
+
+func (aggregateError *AggregateError) Append(err error) {
+    if err != nil {
+        aggregateError.Errors = append(aggregateError.Errors, err)
+    }
+}
+
+//TODO test parsers- hand implemented
+
+func (jobList *JobList) parse(node *XmlNode, aggErr *AggregateError) {
+    // No attributes to parse
+
+    // Parse children nodes
+    for _, child := range node.Children {
+        switch child.XMLName.Local {
+        case "Job":
+            var job Job
+            job.parse(&child, aggErr)
+            jobList.Jobs = append(jobList.Jobs, job)
+        }
+    }
+}
+
+func (job *Job) parse(node *XmlNode, aggErr *AggregateError) {
+    // Parse attributes
+    for _, attr := range node.Attrs {
+        switch attr.Name.Local {
+        case "Aggregating":
+            job.Aggregating = parseBoolFromString(attr.Value, aggErr)
+        case "BucketName":
+            job.BucketName = parseNullableStringFromString(attr.Value)
+        case "CachedSizeInBytes":
+            job.CachedSizeInBytes = parseInt64FromString(attr.Value, aggErr)
+        case "ChunkClientProcessingOrderGuarantee":
+            parseEnumFromString(attr.Value, &job.ChunkClientProcessingOrderGuarantee, aggErr)
+        case "CompletedSizeInBytes":
+            job.CompletedSizeInBytes = parseInt64FromString(attr.Value, aggErr)
+        case "EntirelyInCache":
+            job.EntirelyInCache = parseBoolFromString(attr.Value, aggErr)
+        case "JobId":
+            job.JobId = attr.Value
+        case "Naked":
+            job.Naked = parseBoolFromString(attr.Value, aggErr)
+        case "Name":
+            job.Name = parseNullableStringFromString(attr.Value)
+        case "OriginalSizeInBytes":
+            job.OriginalSizeInBytes = parseInt64FromString(attr.Value, aggErr)
+        case "Priority":
+            parseEnumFromString(attr.Value, &job.Priority, aggErr)
+        case "RequestType":
+            parseEnumFromString(attr.Value, &job.RequestType, aggErr)
+        case "StartDate":
+            job.StartDate = attr.Value
+        case "Status":
+            parseEnumFromString(attr.Value, &job.Status, aggErr)
+        case "UserId":
+            job.UserId = attr.Value
+        case "UserName":
+            job.UserName = parseNullableStringFromString(attr.Value)
+        }
+    }
+
+    // Parse children nodes
+    for _, child := range node.Children {
+        switch child.XMLName.Local {
+        case "Nodes":
+            var jobNode JobNode
+            var list modelSlice = parseDs3ObjectList("Node", child.Children, &jobNode, aggErr)
+            for _, n := range list {
+                if v, ok := n.(*JobNode); ok {
+                    job.Nodes = append(job.Nodes, *v)
+                }
+            }
+        }
+    }
+}
+
+type modelSlice []modelParser
+
+// TODO Convert to generic function using reflection that works for any modelParser type
+func parseDs3ObjectList(tagName string, xmlNodes []XmlNode, model modelParser, aggErr *AggregateError) modelSlice {
+    var list modelSlice
+
+    for _, curXmlNode := range xmlNodes {
+        if curXmlNode.XMLName.Local == tagName {
+            v := reflect.ValueOf(model)
+            curResult := v.Interface().(modelParser)
+            curResult.parse(&curXmlNode, aggErr)
+            list = append(list, curResult)
+        } else {
+            // TODO possibly change from logging to appending to aggregate error
+            log.Printf("WARNING: Discovered unexpected tag '%s' when expected tag '%s'.\n", curXmlNode.XMLName.Local, tagName)
+        }
+    }
+    return list
+}
+
+// TODO Convert to generic function using reflection that works for any modelParser type
+func parseJobNodeList(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []JobNode {
+    var result []JobNode
+    for _, curXmlNode := range xmlNodes {
+        if curXmlNode.XMLName.Local == tagName {
+            var curResult JobNode
+            curResult.parse(&curXmlNode, aggErr)
+            result = append(result, curResult)
+        } else {
+            // TODO possibly change from logging to appending to aggregate error
+            log.Printf("WARNING: Discovered unexpected tag '%s' when expected tag '%s'.\n", curXmlNode.XMLName.Local, tagName)
+        }
+    }
+    return result
+}
+
+func (jobNode *JobNode) parse(node *XmlNode, aggErr *AggregateError) {
+    // Parse attributes
+    for _, attr := range node.Attrs {
+        switch attr.Name.Local {
+        case "EndPoint":
+            jobNode.EndPoint = parseNullableStringFromString(attr.Value)
+        case "HttpPort":
+            jobNode.HttpPort = parseNullableIntFromString(attr.Value, aggErr)
+        case "HttpsPort":
+            jobNode.HttpsPort = parseNullableIntFromString(attr.Value, aggErr)
+        case "Id":
+            jobNode.Id = attr.Value
+        }
+    }
+
+    // No children nodes
+}
+
+func (tapeList *TapeList) parse(node *XmlNode, aggErr *AggregateError) {
+    // No attributes to parse
+
+    // Parse children nodes
+    for _, child := range node.Children {
+        switch child.XMLName.Local {
+        case "Tape":
+            var tape Tape
+            tape.parse(&child, aggErr)
+            tapeList.Tapes = append(tapeList.Tapes, tape)
+        }
+    }
+}
+
+func (tape *Tape) parse(node *XmlNode, aggErr *AggregateError) {
     // No attributes to parse for Tape object
 
     // Parse children nodes
-    var err error
     for _, child := range node.Children {
         switch child.XMLName.Local {
         case "AssignedToStorageDomain":
-            if tape.AssignedToStorageDomain, err = parseBool(child.Content); err != nil {
-                return err
-            }
+            tape.AssignedToStorageDomain = parseBool(child.Content, aggErr)
         case "AvailableRawCapacity":
-            var err error
-            if tape.AvailableRawCapacity, err = parseNullableInt(child.Content); err != nil {
-                return err
-            }
+            tape.AvailableRawCapacity = parseNullableInt64(child.Content, aggErr)
         case "BarCode":
             tape.BarCode = parseNullableString(child.Content)
         case "BucketId":
@@ -37,9 +201,7 @@ func (tape *Tape) parse(node *XmlNode) error {
         case "EjectPending":
             tape.EjectPending = parseNullableString(child.Content)
         case "FullOfData":
-            if tape.FullOfData, err = parseBool(child.Content); err != nil {
-                return err
-            }
+            tape.FullOfData = parseBool(child.Content, aggErr)
         case "Id":
             tape.Id = parseString(child.Content)
         case "LastAccessed":
@@ -55,41 +217,25 @@ func (tape *Tape) parse(node *XmlNode) error {
         case "PartitionId":
             tape.PartitionId = parseNullableString(child.Content)
         case "PreviousState":
-            if err := parseNullableEnum(child.Content, tape.PreviousState); err != nil {
-                return err
-            }
+            parseNullableEnum(child.Content, tape.PreviousState, aggErr)
         case "SerialNumber":
             tape.SerialNumber = parseNullableString(child.Content)
         case "State":
-            if err := parseEnum(child.Content, &tape.State); err != nil {
-                return err
-            }
+            parseEnum(child.Content, &tape.State, aggErr)
         case "StorageDomainId":
             tape.StorageDomainId = parseNullableString(child.Content)
         case "TakeOwnershipPending":
-            if tape.TakeOwnershipPending, err = parseBool(child.Content); err != nil {
-                return err
-            }
+            tape.TakeOwnershipPending = parseBool(child.Content, aggErr)
         case "TotalRawCapacity":
-            if tape.TotalRawCapacity, err = parseNullableInt(child.Content); err != nil {
-                return err
-            }
+            tape.TotalRawCapacity = parseNullableInt64(child.Content, aggErr)
         case "Type":
-            if err := parseEnum(child.Content, &tape.Type); err != nil {
-                return err
-            }
+            parseEnum(child.Content, &tape.Type, aggErr)
         case "VerifyPending":
-            if err := parseNullableEnum(child.Content, tape.VerifyPending); err != nil {
-                return err
-            }
+            parseNullableEnum(child.Content, tape.VerifyPending, aggErr)
         case "WriteProtected":
-            if tape.WriteProtected, err = parseBool(child.Content); err != nil {
-                return err
-            }
+            tape.WriteProtected = parseBool(child.Content, aggErr)
         }
     }
-
-    return nil
 }
 
 // Interface defined for spectra defined enums
@@ -99,15 +245,18 @@ type Ds3Enum interface {
     UnmarshalText(text []byte) error
 }
 
-func parseEnum(content []byte, param Ds3Enum) error {
-    return param.UnmarshalText(content)
+func parseEnum(content []byte, param Ds3Enum, aggErr *AggregateError) {
+    err := param.UnmarshalText(content)
+    if err != nil {
+        aggErr.Append(err)
+    }
 }
 
-func parseNullableEnum(content []byte, param Ds3Enum) error {
-    if len(content) == 0 {
-        return nil
+func parseNullableEnum(content []byte, param Ds3Enum, aggErr *AggregateError) {
+    if len(content) > 0 {
+        parseEnum(content, param, aggErr)
     }
-    return parseEnum(content, param)
+
 }
 
 // Parses a string value
@@ -125,33 +274,127 @@ func parseNullableString(content []byte) *string {
 }
 
 // Parses an int64 value and expects a value to exist
-func parseInt(content []byte) (int64, error) {
-    return strconv.ParseInt(string(content), 10, 64)
+func parseInt(content []byte, aggErr *AggregateError) int {
+    result, err :=  strconv.Atoi(string(content))
+    if err != nil {
+        aggErr.Append(err)
+    }
+    return result
 }
 
-func parseNullableInt(content []byte) (*int64, error) {
+func parseNullableInt(content []byte, aggErr *AggregateError) *int {
     if len(content) == 0 {
-        return nil, nil
+        return nil
     }
-    result, err := parseInt(content)
+    result := parseInt(content, aggErr)
+    return &result
+}
+
+// Parses an int64 value and expects a value to exist
+func parseInt64(content []byte, aggErr *AggregateError) int64 {
+    result, err := strconv.ParseInt(string(content), 10, 64)
     if err != nil {
-        return nil, err
+        aggErr.Append(err)
     }
-    return &result, nil
+    return result
+}
+
+func parseNullableInt64(content []byte, aggErr *AggregateError) *int64 {
+    if len(content) == 0 {
+        return nil
+    }
+    result := parseInt64(content, aggErr)
+    return &result
 }
 
 // Parses a boolean value and expects a value
-func parseBool(content []byte) (bool, error) {
-    return strconv.ParseBool(string(content))
+func parseBool(content []byte, aggErr *AggregateError) bool {
+    result, err := strconv.ParseBool(string(content))
+    if err != nil {
+        aggErr.Append(err)
+    }
+    return result
 }
 
-func parseNullableBool(content []byte) (*bool, error) {
+func parseNullableBool(content []byte, aggErr *AggregateError) *bool {
     if len(content) == 0 {
-        return nil, nil
+        return nil
     }
-    result, err := parseBool(content)
+    result := parseBool(content, aggErr)
+    return &result
+}
+
+// TODO ----------------------------- parsing attributes from strings
+
+func parseEnumFromString(content string, param Ds3Enum, aggErr *AggregateError) {
+    err := param.UnmarshalText([]byte(content))
     if err != nil {
-        return nil, err
+        aggErr.Append(err)
     }
-    return &result, nil
+}
+
+func parseNullableEnumFromString(content string, param Ds3Enum, aggErr *AggregateError) {
+    if len(content) > 0 {
+        parseEnumFromString(content, param, aggErr)
+    }
+}
+
+// Parses a string, where no bytes is converted to nil
+func parseNullableStringFromString(content string) *string {
+    if len(content) == 0 {
+        return nil
+    }
+    result := content
+    return &result
+}
+
+// Parses an int value and expects a value to exist
+func parseIntFromString(content string, aggErr *AggregateError) int {
+    result, err :=  strconv.Atoi(content)
+    if err != nil {
+        aggErr.Append(err)
+    }
+    return result
+}
+
+func parseNullableIntFromString(content string, aggErr *AggregateError) *int {
+    if len(content) == 0 {
+        return nil
+    }
+    result := parseIntFromString(content, aggErr)
+    return &result
+}
+
+// Parses an int64 value and expects a value to exist
+func parseInt64FromString(content string, aggErr *AggregateError) int64 {
+    result, err := strconv.ParseInt(content, 10, 64)
+    if err != nil {
+        aggErr.Append(err)
+    }
+    return result
+}
+
+func parseNullableInt64FromString(content string, aggErr *AggregateError) *int64 {
+    if len(content) == 0 {
+        return nil
+    }
+    result := parseInt64FromString(content, aggErr)
+    return &result
+}
+
+// Parses a boolean value and expects a value
+func parseBoolFromString(content string, aggErr *AggregateError) bool {
+    result, err := strconv.ParseBool(content)
+    if err != nil {
+        aggErr.Append(err)
+    }
+    return result
+}
+
+func parseNullableBoolFromString(content string, aggErr *AggregateError) *bool {
+    if len(content) == 0 {
+        return nil
+    }
+    result := parseBoolFromString(content, aggErr)
+    return &result
 }

--- a/src/ds3/models/testParsers.go
+++ b/src/ds3/models/testParsers.go
@@ -1,0 +1,157 @@
+package models
+
+import (
+    "strconv"
+)
+
+//TODO test parser- hand implemented
+
+func (tape *Tape) parse(node *XmlNode) error {
+    // No attributes to parse for Tape object
+
+    // Parse children nodes
+    var err error
+    for _, child := range node.Children {
+        switch child.XMLName.Local {
+        case "AssignedToStorageDomain":
+            if tape.AssignedToStorageDomain, err = parseBool(child.Content); err != nil {
+                return err
+            }
+        case "AvailableRawCapacity":
+            var err error
+            if tape.AvailableRawCapacity, err = parseNullableInt(child.Content); err != nil {
+                return err
+            }
+        case "BarCode":
+            tape.BarCode = parseNullableString(child.Content)
+        case "BucketId":
+            tape.BucketId = parseNullableString(child.Content)
+        case "DescriptionForIdentification":
+            tape.DescriptionForIdentification = parseNullableString(child.Content)
+        case "EjectDate":
+            tape.EjectDate = parseNullableString(child.Content)
+        case "EjectLabel":
+            tape.EjectLabel = parseNullableString(child.Content)
+        case "EjectLocation":
+            tape.EjectLocation = parseNullableString(child.Content)
+        case "EjectPending":
+            tape.EjectPending = parseNullableString(child.Content)
+        case "FullOfData":
+            if tape.FullOfData, err = parseBool(child.Content); err != nil {
+                return err
+            }
+        case "Id":
+            tape.Id = parseString(child.Content)
+        case "LastAccessed":
+            tape.LastAccessed = parseNullableString(child.Content)
+        case "LastCheckpoint":
+            tape.LastCheckpoint = parseNullableString(child.Content)
+        case "LastModified":
+            tape.LastModified = parseNullableString(child.Content)
+        case "LastVerified":
+            tape.LastVerified = parseNullableString(child.Content)
+        case "PartiallyVerifiedEndOfTape":
+            tape.PartiallyVerifiedEndOfTape = parseNullableString(child.Content)
+        case "PartitionId":
+            tape.PartitionId = parseNullableString(child.Content)
+        case "PreviousState":
+            if err := parseNullableEnum(child.Content, tape.PreviousState); err != nil {
+                return err
+            }
+        case "SerialNumber":
+            tape.SerialNumber = parseNullableString(child.Content)
+        case "State":
+            if err := parseEnum(child.Content, &tape.State); err != nil {
+                return err
+            }
+        case "StorageDomainId":
+            tape.StorageDomainId = parseNullableString(child.Content)
+        case "TakeOwnershipPending":
+            if tape.TakeOwnershipPending, err = parseBool(child.Content); err != nil {
+                return err
+            }
+        case "TotalRawCapacity":
+            if tape.TotalRawCapacity, err = parseNullableInt(child.Content); err != nil {
+                return err
+            }
+        case "Type":
+            if err := parseEnum(child.Content, &tape.Type); err != nil {
+                return err
+            }
+        case "VerifyPending":
+            if err := parseNullableEnum(child.Content, tape.VerifyPending); err != nil {
+                return err
+            }
+        case "WriteProtected":
+            if tape.WriteProtected, err = parseBool(child.Content); err != nil {
+                return err
+            }
+        }
+    }
+
+    return nil
+}
+
+// Interface defined for spectra defined enums
+// Used for generic parsing of enums
+// within: parseEnum and parseNullableEnum
+type Ds3Enum interface {
+    UnmarshalText(text []byte) error
+}
+
+func parseEnum(content []byte, param Ds3Enum) error {
+    return param.UnmarshalText(content)
+}
+
+func parseNullableEnum(content []byte, param Ds3Enum) error {
+    if len(content) == 0 {
+        return nil
+    }
+    return parseEnum(content, param)
+}
+
+// Parses a string value
+func parseString(content []byte) string {
+    return string(content)
+}
+
+// Parses a string, where no bytes is converted to nil
+func parseNullableString(content []byte) *string {
+    if len(content) == 0 {
+        return nil
+    }
+    result := parseString(content)
+    return &result
+}
+
+// Parses an int64 value and expects a value to exist
+func parseInt(content []byte) (int64, error) {
+    return strconv.ParseInt(string(content), 10, 64)
+}
+
+func parseNullableInt(content []byte) (*int64, error) {
+    if len(content) == 0 {
+        return nil, nil
+    }
+    result, err := parseInt(content)
+    if err != nil {
+        return nil, err
+    }
+    return &result, nil
+}
+
+// Parses a boolean value and expects a value
+func parseBool(content []byte) (bool, error) {
+    return strconv.ParseBool(string(content))
+}
+
+func parseNullableBool(content []byte) (*bool, error) {
+    if len(content) == 0 {
+        return nil, nil
+    }
+    result, err := parseBool(content)
+    if err != nil {
+        return nil, err
+    }
+    return &result, nil
+}

--- a/src/ds3/models/xmlTree.go
+++ b/src/ds3/models/xmlTree.go
@@ -1,0 +1,34 @@
+// Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+// this file except in compliance with the License. A copy of the License is located at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file.
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// This code is auto-generated, do not modify
+
+package models
+
+import (
+    "encoding/xml"
+)
+
+type XmlNode struct {
+    XMLName  xml.Name
+    Attrs    []xml.Attr `xml:"-"`
+    Content  []byte     `xml:",chardata"`
+    Children []XmlNode     `xml:",any"`
+}
+
+// Uses the Go library to unmarshal XML into a simple node structure
+func (xmlNode *XmlNode) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+    xmlNode.Attrs = start.Attr
+
+    type n XmlNode
+
+    return d.DecodeElement((*n)(xmlNode), &start)
+}

--- a/src/ds3_utils/ds3Testing/assertUtil.go
+++ b/src/ds3_utils/ds3Testing/assertUtil.go
@@ -67,7 +67,7 @@ func AssertNonNilStringPtr(t *testing.T, label string, expected string, actual *
 
 // Asserts if a specified string pointer is nil. If not, Fatal.
 func AssertStringPtrIsNil(t *testing.T, label string, actual *string) {
-    if actual != nil && *actual != "" { //TODO remove empty string comparison once parsing null elements is fixed
+    if actual != nil {
         t.Fatalf("Expected %s to be 'nil' but was '%s'.", label, *actual)
     }
 }


### PR DESCRIPTION
This outlines a new method of unmarshaling xml using the `GetTapeSpectraS3` command.

Steps
1) Uses go library to unmarshal payload into an xml tree structure.  Reference `xmlTree.go` and `responseHandlingUtil.go`
2) Created parse function for all defined types that maps the XmlNode onto the type. Reference `testParsers.go`
3) Created parse slice function for parsing lists of objects.  This will be generated for all types that are represented as a list.  This removes nexted for loops from parsing code. Reference `parseJobNodeSlice` in `testParsers.go`
4) Created aggregate error that collects all parsing related errors and returns the aggregate at the end. This provides a best effort parsing. This simplified the if-else statements surrounding error returns.