### PR TITLE
SA-189: Fixed parsing of CommonPrefixes

### DIFF
--- a/src/ds3/models/listBucketResultParser.go
+++ b/src/ds3/models/listBucketResultParser.go
@@ -19,7 +19,9 @@ func (listBucketResult *ListBucketResult) parse(xmlNode *XmlNode, aggErr *Aggreg
     for _, child := range xmlNode.Children {
         switch child.XMLName.Local {
         case "CommonPrefixes":
-            listBucketResult.CommonPrefixes = parseStringSlice("Prefix", child.Children, aggErr)
+            var prefixes []string
+            prefixes = parseStringSlice("Prefix", child.Children, aggErr)
+            listBucketResult.CommonPrefixes = append(listBucketResult.CommonPrefixes, prefixes...)
         case "CreationDate":
             listBucketResult.CreationDate = parseNullableString(child.Content)
         case "Delimiter":

--- a/src/ds3/models/listMultiPartUploadsResultParser.go
+++ b/src/ds3/models/listMultiPartUploadsResultParser.go
@@ -21,7 +21,9 @@ func (listMultiPartUploadsResult *ListMultiPartUploadsResult) parse(xmlNode *Xml
         case "Bucket":
             listMultiPartUploadsResult.Bucket = parseNullableString(child.Content)
         case "CommonPrefixes":
-            listMultiPartUploadsResult.CommonPrefixes = parseStringSlice("Prefix", child.Children, aggErr)
+            var prefixes []string
+            prefixes = parseStringSlice("Prefix", child.Children, aggErr)
+            listMultiPartUploadsResult.CommonPrefixes = append(listMultiPartUploadsResult.CommonPrefixes, prefixes...)
         case "Delimiter":
             listMultiPartUploadsResult.Delimiter = parseNullableString(child.Content)
         case "KeyMarker":

--- a/src/ds3/models/responseParsingUtil.go
+++ b/src/ds3/models/responseParsingUtil.go
@@ -256,7 +256,7 @@ func parseStringSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError
             var curResult string = string(curXmlNode.Content)
             result = append(result, curResult)
         } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing Job struct.\n", curXmlNode.XMLName.Local, tagName)
+            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing string slice.\n", curXmlNode.XMLName.Local, tagName)
         }
     }
     return result


### PR DESCRIPTION
**Changes**
- Added unit test for parsing response payload with common prefixes
- Fixed how common prefixes is parsed
- Fixed inaccurate log message