### PR TITLE
Fixing request payloads new design

### DIFF
--- a/src/ds3/models/clearSuspectBlobAzureTargetsSpectraS3Request.go
+++ b/src/ds3/models/clearSuspectBlobAzureTargetsSpectraS3Request.go
@@ -20,13 +20,16 @@ import (
 )
 
 type ClearSuspectBlobAzureTargetsSpectraS3Request struct {
+    content networking.ReaderWithSizeDecorator
     queryParams *url.Values
 }
 
-func NewClearSuspectBlobAzureTargetsSpectraS3Request() *ClearSuspectBlobAzureTargetsSpectraS3Request {
+//TODO special case in autogen and add unit test
+func NewClearSuspectBlobAzureTargetsSpectraS3Request(ids []string) *ClearSuspectBlobAzureTargetsSpectraS3Request {
     queryParams := &url.Values{}
 
     return &ClearSuspectBlobAzureTargetsSpectraS3Request{
+        content: buildIdListPayload(ids),
         queryParams: queryParams,
     }
 }
@@ -57,6 +60,6 @@ func (ClearSuspectBlobAzureTargetsSpectraS3Request) Header() *http.Header {
     return &http.Header{}
 }
 
-func (ClearSuspectBlobAzureTargetsSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return nil
+func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return clearSuspectBlobAzureTargetsSpectraS3Request.content
 }

--- a/src/ds3/models/clearSuspectBlobPoolsSpectraS3Request.go
+++ b/src/ds3/models/clearSuspectBlobPoolsSpectraS3Request.go
@@ -20,13 +20,16 @@ import (
 )
 
 type ClearSuspectBlobPoolsSpectraS3Request struct {
+    content networking.ReaderWithSizeDecorator
     queryParams *url.Values
 }
 
-func NewClearSuspectBlobPoolsSpectraS3Request() *ClearSuspectBlobPoolsSpectraS3Request {
+//TODO special case in autogen and add unit test
+func NewClearSuspectBlobPoolsSpectraS3Request(ids []string) *ClearSuspectBlobPoolsSpectraS3Request {
     queryParams := &url.Values{}
 
     return &ClearSuspectBlobPoolsSpectraS3Request{
+        content: buildIdListPayload(ids),
         queryParams: queryParams,
     }
 }
@@ -57,6 +60,6 @@ func (ClearSuspectBlobPoolsSpectraS3Request) Header() *http.Header {
     return &http.Header{}
 }
 
-func (ClearSuspectBlobPoolsSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return nil
+func (clearSuspectBlobPoolsSpectraS3Request *ClearSuspectBlobPoolsSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return clearSuspectBlobPoolsSpectraS3Request.content
 }

--- a/src/ds3/models/clearSuspectBlobS3TargetsSpectraS3Request.go
+++ b/src/ds3/models/clearSuspectBlobS3TargetsSpectraS3Request.go
@@ -20,13 +20,16 @@ import (
 )
 
 type ClearSuspectBlobS3TargetsSpectraS3Request struct {
+    content networking.ReaderWithSizeDecorator
     queryParams *url.Values
 }
 
-func NewClearSuspectBlobS3TargetsSpectraS3Request() *ClearSuspectBlobS3TargetsSpectraS3Request {
+//TODO special case in autogen and add unit test
+func NewClearSuspectBlobS3TargetsSpectraS3Request(ids []string) *ClearSuspectBlobS3TargetsSpectraS3Request {
     queryParams := &url.Values{}
 
     return &ClearSuspectBlobS3TargetsSpectraS3Request{
+        content: buildIdListPayload(ids),
         queryParams: queryParams,
     }
 }
@@ -57,6 +60,6 @@ func (ClearSuspectBlobS3TargetsSpectraS3Request) Header() *http.Header {
     return &http.Header{}
 }
 
-func (ClearSuspectBlobS3TargetsSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+func (clearSuspectBlobS3TargetsSpectraS3Request *ClearSuspectBlobS3TargetsSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
     return nil
 }

--- a/src/ds3/models/clearSuspectBlobTapesSpectraS3Request.go
+++ b/src/ds3/models/clearSuspectBlobTapesSpectraS3Request.go
@@ -20,13 +20,16 @@ import (
 )
 
 type ClearSuspectBlobTapesSpectraS3Request struct {
+    content networking.ReaderWithSizeDecorator
     queryParams *url.Values
 }
 
-func NewClearSuspectBlobTapesSpectraS3Request() *ClearSuspectBlobTapesSpectraS3Request {
+//TODO special case in autogen and add unit test
+func NewClearSuspectBlobTapesSpectraS3Request(ids []string) *ClearSuspectBlobTapesSpectraS3Request {
     queryParams := &url.Values{}
 
     return &ClearSuspectBlobTapesSpectraS3Request{
+        content: buildIdListPayload(ids),
         queryParams: queryParams,
     }
 }

--- a/src/ds3/models/ejectStorageDomainBlobsSpectraS3Request.go
+++ b/src/ds3/models/ejectStorageDomainBlobsSpectraS3Request.go
@@ -28,7 +28,8 @@ type EjectStorageDomainBlobsSpectraS3Request struct {
     queryParams *url.Values
 }
 
-func NewEjectStorageDomainBlobsSpectraS3Request(bucketId string, objects []Ds3Object, storageDomainId string) *EjectStorageDomainBlobsSpectraS3Request {
+//TODO update autogen and add unit test
+func NewEjectStorageDomainBlobsSpectraS3Request(bucketId string, objects []string, storageDomainId string) *EjectStorageDomainBlobsSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "eject")
     queryParams.Set("blobs", "")
@@ -38,7 +39,7 @@ func NewEjectStorageDomainBlobsSpectraS3Request(bucketId string, objects []Ds3Ob
     return &EjectStorageDomainBlobsSpectraS3Request{
         bucketId: bucketId,
         storageDomainId: storageDomainId,
-        content: buildDs3ObjectListStream(objects),
+        content: buildDs3ObjectStreamFromNames(objects),
         queryParams: queryParams,
     }
 }

--- a/src/ds3/models/getBlobsOnAzureTargetSpectraS3Request.go
+++ b/src/ds3/models/getBlobsOnAzureTargetSpectraS3Request.go
@@ -21,17 +21,16 @@ import (
 
 type GetBlobsOnAzureTargetSpectraS3Request struct {
     azureTarget string
-    content networking.ReaderWithSizeDecorator
     queryParams *url.Values
 }
 
-func NewGetBlobsOnAzureTargetSpectraS3Request(azureTarget string, objects []Ds3Object) *GetBlobsOnAzureTargetSpectraS3Request {
+//TODO stop special casing in autogen
+func NewGetBlobsOnAzureTargetSpectraS3Request(azureTarget string) *GetBlobsOnAzureTargetSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "get_physical_placement")
 
     return &GetBlobsOnAzureTargetSpectraS3Request{
         azureTarget: azureTarget,
-        content: buildDs3ObjectListStream(objects),
         queryParams: queryParams,
     }
 }
@@ -58,6 +57,6 @@ func (GetBlobsOnAzureTargetSpectraS3Request) Header() *http.Header {
     return &http.Header{}
 }
 
-func (getBlobsOnAzureTargetSpectraS3Request *GetBlobsOnAzureTargetSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return getBlobsOnAzureTargetSpectraS3Request.content
+func (GetBlobsOnAzureTargetSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return nil
 }

--- a/src/ds3/models/getBlobsOnDs3TargetSpectraS3Request.go
+++ b/src/ds3/models/getBlobsOnDs3TargetSpectraS3Request.go
@@ -20,18 +20,17 @@ import (
 )
 
 type GetBlobsOnDs3TargetSpectraS3Request struct {
-    content networking.ReaderWithSizeDecorator
     ds3Target string
     queryParams *url.Values
 }
 
-func NewGetBlobsOnDs3TargetSpectraS3Request(ds3Target string, objects []Ds3Object) *GetBlobsOnDs3TargetSpectraS3Request {
+//TODO stop special casing in autogen
+func NewGetBlobsOnDs3TargetSpectraS3Request(ds3Target string) *GetBlobsOnDs3TargetSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "get_physical_placement")
 
     return &GetBlobsOnDs3TargetSpectraS3Request{
         ds3Target: ds3Target,
-        content: buildDs3ObjectListStream(objects),
         queryParams: queryParams,
     }
 }
@@ -58,6 +57,6 @@ func (GetBlobsOnDs3TargetSpectraS3Request) Header() *http.Header {
     return &http.Header{}
 }
 
-func (getBlobsOnDs3TargetSpectraS3Request *GetBlobsOnDs3TargetSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return getBlobsOnDs3TargetSpectraS3Request.content
+func (GetBlobsOnDs3TargetSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return nil
 }

--- a/src/ds3/models/getBlobsOnPoolSpectraS3Request.go
+++ b/src/ds3/models/getBlobsOnPoolSpectraS3Request.go
@@ -20,18 +20,17 @@ import (
 )
 
 type GetBlobsOnPoolSpectraS3Request struct {
-    content networking.ReaderWithSizeDecorator
     pool string
     queryParams *url.Values
 }
 
-func NewGetBlobsOnPoolSpectraS3Request(objects []Ds3Object, pool string) *GetBlobsOnPoolSpectraS3Request {
+//TODO stop special casing in autogen
+func NewGetBlobsOnPoolSpectraS3Request(pool string) *GetBlobsOnPoolSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "get_physical_placement")
 
     return &GetBlobsOnPoolSpectraS3Request{
         pool: pool,
-        content: buildDs3ObjectListStream(objects),
         queryParams: queryParams,
     }
 }
@@ -58,6 +57,6 @@ func (GetBlobsOnPoolSpectraS3Request) Header() *http.Header {
     return &http.Header{}
 }
 
-func (getBlobsOnPoolSpectraS3Request *GetBlobsOnPoolSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return getBlobsOnPoolSpectraS3Request.content
+func (GetBlobsOnPoolSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return nil
 }

--- a/src/ds3/models/getBlobsOnS3TargetSpectraS3Request.go
+++ b/src/ds3/models/getBlobsOnS3TargetSpectraS3Request.go
@@ -20,18 +20,17 @@ import (
 )
 
 type GetBlobsOnS3TargetSpectraS3Request struct {
-    content networking.ReaderWithSizeDecorator
     s3Target string
     queryParams *url.Values
 }
 
-func NewGetBlobsOnS3TargetSpectraS3Request(objects []Ds3Object, s3Target string) *GetBlobsOnS3TargetSpectraS3Request {
+//TODO stop special casing in autogen
+func NewGetBlobsOnS3TargetSpectraS3Request(s3Target string) *GetBlobsOnS3TargetSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "get_physical_placement")
 
     return &GetBlobsOnS3TargetSpectraS3Request{
         s3Target: s3Target,
-        content: buildDs3ObjectListStream(objects),
         queryParams: queryParams,
     }
 }
@@ -58,6 +57,6 @@ func (GetBlobsOnS3TargetSpectraS3Request) Header() *http.Header {
     return &http.Header{}
 }
 
-func (getBlobsOnS3TargetSpectraS3Request *GetBlobsOnS3TargetSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return getBlobsOnS3TargetSpectraS3Request.content
+func (GetBlobsOnS3TargetSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return nil
 }

--- a/src/ds3/models/getBlobsOnTapeSpectraS3Request.go
+++ b/src/ds3/models/getBlobsOnTapeSpectraS3Request.go
@@ -20,18 +20,17 @@ import (
 )
 
 type GetBlobsOnTapeSpectraS3Request struct {
-    content networking.ReaderWithSizeDecorator
     tapeId string
     queryParams *url.Values
 }
 
-func NewGetBlobsOnTapeSpectraS3Request(objects []Ds3Object, tapeId string) *GetBlobsOnTapeSpectraS3Request {
+//TODO stop special casing in autogen
+func NewGetBlobsOnTapeSpectraS3Request(tapeId string) *GetBlobsOnTapeSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "get_physical_placement")
 
     return &GetBlobsOnTapeSpectraS3Request{
         tapeId: tapeId,
-        content: buildDs3ObjectListStream(objects),
         queryParams: queryParams,
     }
 }
@@ -59,5 +58,5 @@ func (GetBlobsOnTapeSpectraS3Request) Header() *http.Header {
 }
 
 func (getBlobsOnTapeSpectraS3Request *GetBlobsOnTapeSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return getBlobsOnTapeSpectraS3Request.content
+    return nil
 }

--- a/src/ds3/models/getBulkJobSpectraS3Request.go
+++ b/src/ds3/models/getBulkJobSpectraS3Request.go
@@ -31,13 +31,25 @@ type GetBulkJobSpectraS3Request struct {
     queryParams *url.Values
 }
 
-func NewGetBulkJobSpectraS3Request(bucketName string, objects []Ds3Object) *GetBulkJobSpectraS3Request {
+//TODO update autogen to add second constructor
+func NewGetBulkJobSpectraS3Request(bucketName string, objectNames []string) *GetBulkJobSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "start_bulk_get")
 
     return &GetBulkJobSpectraS3Request{
         bucketName: bucketName,
-        content: buildDs3ObjectListStream(objects),
+        content: buildDs3ObjectStreamFromNames(objectNames),
+        queryParams: queryParams,
+    }
+}
+
+func NewGetBulkJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *GetBulkJobSpectraS3Request {
+    queryParams := &url.Values{}
+    queryParams.Set("operation", "start_bulk_get")
+
+    return &GetBulkJobSpectraS3Request{
+        bucketName: bucketName,
+        content: buildDs3GetObjectListStream(objects),
         queryParams: queryParams,
     }
 }

--- a/src/ds3/models/getPhysicalPlacementForObjectsSpectraS3Request.go
+++ b/src/ds3/models/getPhysicalPlacementForObjectsSpectraS3Request.go
@@ -26,13 +26,14 @@ type GetPhysicalPlacementForObjectsSpectraS3Request struct {
     queryParams *url.Values
 }
 
-func NewGetPhysicalPlacementForObjectsSpectraS3Request(bucketName string, objects []Ds3Object) *GetPhysicalPlacementForObjectsSpectraS3Request {
+//TODO update special casing in autogen
+func NewGetPhysicalPlacementForObjectsSpectraS3Request(bucketName string, objectNames []string) *GetPhysicalPlacementForObjectsSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "get_physical_placement")
 
     return &GetPhysicalPlacementForObjectsSpectraS3Request{
         bucketName: bucketName,
-        content: buildDs3ObjectListStream(objects),
+        content: buildDs3ObjectStreamFromNames(objectNames),
         queryParams: queryParams,
     }
 }

--- a/src/ds3/models/getPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request.go
+++ b/src/ds3/models/getPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request.go
@@ -26,14 +26,15 @@ type GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request struct {
     queryParams *url.Values
 }
 
-func NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName string, objects []Ds3Object) *GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
+//TODO update special casing in autogen
+func NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName string, objectNames []string) *GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "get_physical_placement")
     queryParams.Set("full_details", "")
 
     return &GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
         bucketName: bucketName,
-        content: buildDs3ObjectListStream(objects),
+        content: buildDs3ObjectStreamFromNames(objectNames),
         queryParams: queryParams,
     }
 }

--- a/src/ds3/models/markSuspectBlobAzureTargetsAsDegradedSpectraS3Request.go
+++ b/src/ds3/models/markSuspectBlobAzureTargetsAsDegradedSpectraS3Request.go
@@ -20,13 +20,16 @@ import (
 )
 
 type MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request struct {
+    content networking.ReaderWithSizeDecorator
     queryParams *url.Values
 }
 
-func NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request() *MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request {
+//TODO special case request payload and add unit test
+func NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(ids []string) *MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request {
     queryParams := &url.Values{}
 
     return &MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request{
+        content: buildIdListPayload(ids),
         queryParams: queryParams,
     }
 }
@@ -57,6 +60,6 @@ func (MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request) Header() *http.Head
     return &http.Header{}
 }
 
-func (MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return nil
+func (markSuspectBlobAzureTargetsAsDegradedSpectraS3Request *MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return markSuspectBlobAzureTargetsAsDegradedSpectraS3Request.content
 }

--- a/src/ds3/models/markSuspectBlobDs3TargetsAsDegradedSpectraS3Request.go
+++ b/src/ds3/models/markSuspectBlobDs3TargetsAsDegradedSpectraS3Request.go
@@ -20,13 +20,16 @@ import (
 )
 
 type MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request struct {
+    content networking.ReaderWithSizeDecorator
     queryParams *url.Values
 }
 
-func NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request() *MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request {
+//TODO special case request payload and add unit test
+func NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(ids []string) *MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request {
     queryParams := &url.Values{}
 
     return &MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request{
+        content: buildIdListPayload(ids),
         queryParams: queryParams,
     }
 }
@@ -57,6 +60,6 @@ func (MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request) Header() *http.Header
     return &http.Header{}
 }
 
-func (MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return nil
+func (markSuspectBlobDs3TargetsAsDegradedSpectraS3Request *MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return markSuspectBlobDs3TargetsAsDegradedSpectraS3Request.content
 }

--- a/src/ds3/models/markSuspectBlobPoolsAsDegradedSpectraS3Request.go
+++ b/src/ds3/models/markSuspectBlobPoolsAsDegradedSpectraS3Request.go
@@ -20,13 +20,16 @@ import (
 )
 
 type MarkSuspectBlobPoolsAsDegradedSpectraS3Request struct {
+    content networking.ReaderWithSizeDecorator
     queryParams *url.Values
 }
 
-func NewMarkSuspectBlobPoolsAsDegradedSpectraS3Request() *MarkSuspectBlobPoolsAsDegradedSpectraS3Request {
+//TODO special case request payload and add unit test
+func NewMarkSuspectBlobPoolsAsDegradedSpectraS3Request(ids []string) *MarkSuspectBlobPoolsAsDegradedSpectraS3Request {
     queryParams := &url.Values{}
 
     return &MarkSuspectBlobPoolsAsDegradedSpectraS3Request{
+        content: buildIdListPayload(ids),
         queryParams: queryParams,
     }
 }
@@ -57,6 +60,6 @@ func (MarkSuspectBlobPoolsAsDegradedSpectraS3Request) Header() *http.Header {
     return &http.Header{}
 }
 
-func (MarkSuspectBlobPoolsAsDegradedSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return nil
+func (markSuspectBlobPoolsAsDegradedSpectraS3Request *MarkSuspectBlobPoolsAsDegradedSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return markSuspectBlobPoolsAsDegradedSpectraS3Request.content
 }

--- a/src/ds3/models/markSuspectBlobS3TargetsAsDegradedSpectraS3Request.go
+++ b/src/ds3/models/markSuspectBlobS3TargetsAsDegradedSpectraS3Request.go
@@ -20,13 +20,16 @@ import (
 )
 
 type MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request struct {
+    content networking.ReaderWithSizeDecorator
     queryParams *url.Values
 }
 
-func NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Request() *MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request {
+//TODO special case request payload and add unit test
+func NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(ids []string) *MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request {
     queryParams := &url.Values{}
 
     return &MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request{
+        content: buildIdListPayload(ids),
         queryParams: queryParams,
     }
 }
@@ -57,6 +60,6 @@ func (MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request) Header() *http.Header 
     return &http.Header{}
 }
 
-func (MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return nil
+func (markSuspectBlobS3TargetsAsDegradedSpectraS3Request *MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return markSuspectBlobS3TargetsAsDegradedSpectraS3Request.content
 }

--- a/src/ds3/models/markSuspectBlobTapesAsDegradedSpectraS3Request.go
+++ b/src/ds3/models/markSuspectBlobTapesAsDegradedSpectraS3Request.go
@@ -20,13 +20,16 @@ import (
 )
 
 type MarkSuspectBlobTapesAsDegradedSpectraS3Request struct {
+    content networking.ReaderWithSizeDecorator
     queryParams *url.Values
 }
 
-func NewMarkSuspectBlobTapesAsDegradedSpectraS3Request() *MarkSuspectBlobTapesAsDegradedSpectraS3Request {
+//TODO special case request payload and add unit test
+func NewMarkSuspectBlobTapesAsDegradedSpectraS3Request(ids []string) *MarkSuspectBlobTapesAsDegradedSpectraS3Request {
     queryParams := &url.Values{}
 
     return &MarkSuspectBlobTapesAsDegradedSpectraS3Request{
+        content: buildIdListPayload(ids),
         queryParams: queryParams,
     }
 }
@@ -57,6 +60,6 @@ func (MarkSuspectBlobTapesAsDegradedSpectraS3Request) Header() *http.Header {
     return &http.Header{}
 }
 
-func (MarkSuspectBlobTapesAsDegradedSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return nil
+func (markSuspectBlobTapesAsDegradedSpectraS3Request *MarkSuspectBlobTapesAsDegradedSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return markSuspectBlobTapesAsDegradedSpectraS3Request.content
 }

--- a/src/ds3/models/putBulkJobSpectraS3Request.go
+++ b/src/ds3/models/putBulkJobSpectraS3Request.go
@@ -33,13 +33,14 @@ type PutBulkJobSpectraS3Request struct {
     queryParams *url.Values
 }
 
-func NewPutBulkJobSpectraS3Request(bucketName string, objects []Ds3Object) *PutBulkJobSpectraS3Request {
+//TODO update autogen special casing
+func NewPutBulkJobSpectraS3Request(bucketName string, objects []Ds3PutObject) *PutBulkJobSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "start_bulk_put")
 
     return &PutBulkJobSpectraS3Request{
         bucketName: bucketName,
-        content: buildDs3ObjectListStream(objects),
+        content: buildDs3PutObjectListStream(objects),
         queryParams: queryParams,
     }
 }

--- a/src/ds3/models/requestPayloadUtils.go
+++ b/src/ds3/models/requestPayloadUtils.go
@@ -1,3 +1,14 @@
+// Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+// this file except in compliance with the License. A copy of the License is located at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file.
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
 package models
 
 import (
@@ -14,21 +25,115 @@ type Part struct {
     ETag string
 }
 
-type ds3ObjectList struct {
+// Converts the parts list into a request payload stream of format:
+// <CompleteMultipartUpload><Part><PartNumber>partNumber</PartNumber><ETag>eTag</ETag></Part>...</CompleteMultipartUpload>
+func buildPartsListStream(parts []Part) networking.ReaderWithSizeDecorator {
+    completeMultipartUpload := CompleteMultipartUpload{ Parts:parts }
+    return marshalRequestPayload(completeMultipartUpload)
+}
+
+
+type ds3PutObjectList struct {
     XMLName xml.Name
-    Ds3Objects []Ds3Object `xml:"object"`
+    Ds3PutObjects []Ds3PutObject `xml:"Object"`
 }
 
-type Ds3Object struct {
-    Name string `xml:"name,attr"`
-    Size int64 `xml:"size,attr"`
+type Ds3PutObject struct {
+    Name string `xml:"Name,attr"`
+    Size int64 `xml:"Size,attr"`
 }
 
-func newDs3ObjectList(ds3objects []Ds3Object) *ds3ObjectList {
-    return &ds3ObjectList{
-        XMLName: xml.Name{Local:"objects"},
-        Ds3Objects: ds3objects,
+func newDs3PutObjectList(ds3PutObjects []Ds3PutObject) *ds3PutObjectList {
+    return &ds3PutObjectList{
+        XMLName: xml.Name{Local:"Objects"},
+        Ds3PutObjects: ds3PutObjects,
     }
+}
+
+// Converts the ds3 put object list into a request payload stream of format:
+// <Objects><Object Name="o1" Size="2048"></Object><Object Name="o2" Size="2048"></Object>...</Objects>
+func buildDs3PutObjectListStream(ds3PutObjects []Ds3PutObject) networking.ReaderWithSizeDecorator {
+    // Build the ds3 put object list entity.
+    objects := newDs3PutObjectList(ds3PutObjects)
+    return marshalRequestPayload(objects)
+}
+
+type Ds3GetObject struct {
+    Name string `xml:"Name,attr"`
+    Length *int64 `xml:"Length,attr,omitempty"`
+    Offset *int64 `xml:"Offset,attr,omitempty"`
+}
+
+type ds3GetObjectList struct {
+    XMLName xml.Name
+    Ds3GetObjects []Ds3GetObject `xml:"Object"`
+}
+
+func NewDs3GetObject(name string) Ds3GetObject {
+    return Ds3GetObject{Name:name}
+}
+
+func newDs3GetObjectList(ds3GetObjects []Ds3GetObject) *ds3GetObjectList {
+    return &ds3GetObjectList{
+        XMLName: xml.Name{Local:"Objects"},
+        Ds3GetObjects: ds3GetObjects,
+    }
+}
+
+// Creates a Ds3GetObject used for partial objects
+func NewPartialDs3GetObject(name string, length int64, offset int64) Ds3GetObject {
+    return Ds3GetObject{
+        Name:name,
+        Length:&length,
+        Offset:&offset,
+    }
+}
+
+// Converts string list into Ds3Object and marshals to request payload stream of format:
+// <Objects><Object Name="o1"></Object><Object Name="o2"></Object>...</Objects>
+func buildDs3ObjectStreamFromNames(objectNames []string) networking.ReaderWithSizeDecorator {
+    // Build the ds3 get object list entity.
+    var objects []Ds3GetObject
+    for _, name := range objectNames {
+        objects = append(objects, NewDs3GetObject(name))
+    }
+
+    objectList := newDs3GetObjectList(objects)
+
+    return marshalRequestPayload(objectList)
+}
+
+// Converts the ds3 get object list into a request payload stream of format:
+// <Objects><Object Name="o1" Length="2" Offset="3"></Object><Object Name="o2" Length="3" offset="4"></Object>...</Objects>
+func buildDs3GetObjectListStream(ds3GetObjects []Ds3GetObject) networking.ReaderWithSizeDecorator {
+    // Build the ds3 get object list entity.
+    objects := newDs3GetObjectList(ds3GetObjects)
+    return marshalRequestPayload(objects)
+}
+
+type Ds3VerifyObject struct {
+    Name string `xml:"Name,attr"`
+    Length int64 `xml:"Length,attr"`
+}
+
+type ds3VerifyObjectList struct {
+    XMLName xml.Name
+    Ds3VerifyObjects []Ds3VerifyObject `xml:"Object"`
+}
+
+func newDs3VerifyObjectList(ds3VerifyObjects []Ds3VerifyObject) *ds3VerifyObjectList {
+    return &ds3VerifyObjectList{
+        XMLName: xml.Name{Local:"Objects"},
+        Ds3VerifyObjects: ds3VerifyObjects,
+    }
+}
+
+// Converts the ds3 put object list into a request payload stream of format:
+// <Objects><Object Name="o1" Length="2048"></Object><Object Name="o2" Length="2048"></Object>...</Objects>
+func buildDs3VerifyObjectListStream(ds3VerifyObjects []Ds3VerifyObject) networking.ReaderWithSizeDecorator {
+    // Build the ds3 put object list entity.
+    objects := newDs3VerifyObjectList(ds3VerifyObjects)
+    return marshalRequestPayload(objects)
 }
 
 type deleteObjectList struct {
@@ -51,20 +156,30 @@ func newDeleteObjectList(objectNames []string) *deleteObjectList {
     }
 }
 
-// Converts the ds3 object list into a request payload stream.
-func buildDs3ObjectListStream(ds3Objects []Ds3Object) networking.ReaderWithSizeDecorator {
-    // Build the ds3 object list entity.
-    objects := newDs3ObjectList(ds3Objects)
+// Converts a list of object names into a request payload stream for delete objects of format:
+// <Delete><Object><Key>o1</Key></Object><Object><Key>o2</Key></Object>...</Delete>
+func buildDeleteObjectsPayload(objectNames []string) networking.ReaderWithSizeDecorator {
+    deleteObjects := newDeleteObjectList(objectNames)
+    return marshalRequestPayload(deleteObjects)
+}
 
-    // Create an xml document from the entity.
-    xmlBytes, err := xml.Marshal(objects)
-    if err != nil {
-        //Should never happen
-        panic(err)
+type idList struct {
+    XMLName xml.Name
+    IdList []string `xml:"Id"`
+}
+
+func newIdList(objectNames []string) *idList {
+    return &idList{
+        XMLName: xml.Name{Local:"Ids"},
+        IdList:objectNames,
     }
+}
 
-    // Create a ByteReaderWithSizeDecorator which the network layer expects.
-    return networking.BuildByteReaderWithSizeDecorator(xmlBytes)
+// Converts a list of ids into a request payload stream of format:
+// <Ids><Id>id1</Id><Id>id2</Id>...</Ids>
+func buildIdListPayload(ids []string) networking.ReaderWithSizeDecorator {
+    idList := newIdList(ids)
+    return marshalRequestPayload(idList)
 }
 
 // Converts a string request payload into a request payload stream.
@@ -72,23 +187,8 @@ func buildStreamFromString(payload string) networking.ReaderWithSizeDecorator {
     return networking.BuildByteReaderWithSizeDecorator([]byte(payload))
 }
 
-// Converts the parts list into a request payload stream.
-func buildPartsListStream(parts []Part) networking.ReaderWithSizeDecorator {
-    // Create an xml document from the entity.
-    xmlBytes, err := xml.Marshal(CompleteMultipartUpload{parts})
-    if err != nil {
-        //Should never happen
-        panic(err)
-    }
-
-    // Create a ReaderWithSizeDecorator which the network layer expects.
-    return networking.BuildByteReaderWithSizeDecorator(xmlBytes)
-}
-
-// Converts a list of object names into a request payload stream for delete objects
-func buildDeleteObjectsPayload(objectNames []string) networking.ReaderWithSizeDecorator {
-    deleteObjects := newDeleteObjectList(objectNames)
-    xmlBytes, err := xml.Marshal(deleteObjects)
+func marshalRequestPayload(model interface{}) networking.ReaderWithSizeDecorator {
+    xmlBytes, err := xml.Marshal(model)
     if err != nil {
         // Should never happen
         panic(err)

--- a/src/ds3/models/requestPayloadUtils_test.go
+++ b/src/ds3/models/requestPayloadUtils_test.go
@@ -1,0 +1,122 @@
+// Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+// this file except in compliance with the License. A copy of the License is located at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file.
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package models
+
+import (
+    "testing"
+    "io/ioutil"
+    "ds3/networking"
+)
+
+func verifyStreamContent(t *testing.T, contentStream networking.ReaderWithSizeDecorator, expected string) {
+    bs, readErr := ioutil.ReadAll(contentStream)
+    if readErr != nil {
+        t.Fatalf("Unexpected error: '%s'.", readErr.Error())
+    }
+    result := string(bs)
+    if result != expected {
+        t.Fatalf("Expected '%s' but got '%s'.", expected, result)
+    }
+}
+
+func TestBuildPartsListStream(t *testing.T) {
+    expected := "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>eTag1</ETag></Part><Part><PartNumber>2</PartNumber><ETag>eTag2</ETag></Part><Part><PartNumber>3</PartNumber><ETag>eTag3</ETag></Part></CompleteMultipartUpload>"
+
+    parts := []Part{
+        {PartNumber:1, ETag:"eTag1"},
+        {PartNumber:2, ETag:"eTag2"},
+        {PartNumber:3, ETag:"eTag3"},
+    }
+
+    contentStream := buildPartsListStream(parts)
+
+    defer contentStream.Close()
+    verifyStreamContent(t, contentStream, expected)
+}
+
+func TestBuildDs3PutObjectListStream(t *testing.T) {
+    expected := "<Objects><Object Name=\"o1\" Size=\"1\"></Object><Object Name=\"o2\" Size=\"2\"></Object><Object Name=\"o3\" Size=\"3\"></Object></Objects>"
+
+    ds3PutObjects := []Ds3PutObject{
+        {Name:"o1", Size:1},
+        {Name:"o2", Size:2},
+        {Name:"o3", Size:3},
+    }
+
+    contentStream := buildDs3PutObjectListStream(ds3PutObjects)
+
+    defer contentStream.Close()
+    verifyStreamContent(t, contentStream, expected)
+}
+
+func TestBuildDs3ObjectStreamFromNames(t *testing.T) {
+    expected := "<Objects><Object Name=\"o1\"></Object><Object Name=\"o2\"></Object><Object Name=\"o3\"></Object></Objects>"
+
+    names := []string {"o1", "o2", "o3"}
+
+    contentStream := buildDs3ObjectStreamFromNames(names)
+
+    defer contentStream.Close()
+    verifyStreamContent(t, contentStream, expected)
+}
+
+func TestBuildDs3GetObjectListStream(t *testing.T) {
+    expected := "<Objects><Object Name=\"o1\" Length=\"10\" Offset=\"1\"></Object><Object Name=\"o2\" Length=\"20\" Offset=\"2\"></Object><Object Name=\"o3\" Length=\"30\" Offset=\"3\"></Object></Objects>"
+
+    ds3GetObjects := []Ds3GetObject {
+        NewPartialDs3GetObject("o1", 10, 1),
+        NewPartialDs3GetObject("o2", 20, 2),
+        NewPartialDs3GetObject("o3", 30, 3),
+    }
+
+    contentStream := buildDs3GetObjectListStream(ds3GetObjects)
+
+    defer contentStream.Close()
+    verifyStreamContent(t, contentStream, expected)
+}
+
+func TestBuildDs3VerifyObjectListStream(t *testing.T) {
+    expected := "<Objects><Object Name=\"o1\" Length=\"1\"></Object><Object Name=\"o2\" Length=\"2\"></Object><Object Name=\"o3\" Length=\"3\"></Object></Objects>"
+
+    ds3VerifyObjects := []Ds3VerifyObject {
+        {Name:"o1", Length:1},
+        {Name:"o2", Length:2},
+        {Name:"o3", Length:3},
+    }
+
+    contentStream := buildDs3VerifyObjectListStream(ds3VerifyObjects)
+
+    defer contentStream.Close()
+    verifyStreamContent(t, contentStream, expected)
+}
+
+func TestBuildDeleteObjectsPayload(t *testing.T) {
+    expected := "<Delete><Object><Key>o1</Key></Object><Object><Key>o2</Key></Object><Object><Key>o3</Key></Object></Delete>"
+
+    names := []string {"o1", "o2", "o3"}
+
+    contentStream := buildDeleteObjectsPayload(names)
+
+    defer contentStream.Close()
+    verifyStreamContent(t, contentStream, expected)
+}
+
+func TestBuildIdListPayload(t *testing.T) {
+    expected := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
+
+    ids := []string{"id1", "id2", "id3"}
+
+    contentStream := buildIdListPayload(ids)
+
+    defer contentStream.Close()
+    verifyStreamContent(t, contentStream, expected)
+}

--- a/src/ds3/models/verifyBulkJobSpectraS3Request.go
+++ b/src/ds3/models/verifyBulkJobSpectraS3Request.go
@@ -29,13 +29,13 @@ type VerifyBulkJobSpectraS3Request struct {
     queryParams *url.Values
 }
 
-func NewVerifyBulkJobSpectraS3Request(bucketName string, objects []Ds3Object) *VerifyBulkJobSpectraS3Request {
+func NewVerifyBulkJobSpectraS3Request(bucketName string, objects []Ds3VerifyObject) *VerifyBulkJobSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "start_bulk_verify")
 
     return &VerifyBulkJobSpectraS3Request{
         bucketName: bucketName,
-        content: buildDs3ObjectListStream(objects),
+        content: buildDs3VerifyObjectListStream(objects),
         queryParams: queryParams,
     }
 }

--- a/src/ds3/models/verifyPhysicalPlacementForObjectsSpectraS3Request.go
+++ b/src/ds3/models/verifyPhysicalPlacementForObjectsSpectraS3Request.go
@@ -26,13 +26,14 @@ type VerifyPhysicalPlacementForObjectsSpectraS3Request struct {
     queryParams *url.Values
 }
 
-func NewVerifyPhysicalPlacementForObjectsSpectraS3Request(bucketName string, objects []Ds3Object) *VerifyPhysicalPlacementForObjectsSpectraS3Request {
+//TODO update request payload type to []string and conversion to stream
+func NewVerifyPhysicalPlacementForObjectsSpectraS3Request(bucketName string, objectNames []string) *VerifyPhysicalPlacementForObjectsSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "verify_physical_placement")
 
     return &VerifyPhysicalPlacementForObjectsSpectraS3Request{
         bucketName: bucketName,
-        content: buildDs3ObjectListStream(objects),
+        content: buildDs3ObjectStreamFromNames(objectNames),
         queryParams: queryParams,
     }
 }

--- a/src/ds3/models/verifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request.go
+++ b/src/ds3/models/verifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request.go
@@ -26,14 +26,15 @@ type VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request struct {
     queryParams *url.Values
 }
 
-func NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName string, objects []Ds3Object) *VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
+//TODO update request payload type to []string and conversion to stream
+func NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName string, objectNames []string) *VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "verify_physical_placement")
     queryParams.Set("full_details", "")
 
     return &VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
         bucketName: bucketName,
-        content: buildDs3ObjectListStream(objects),
+        content: buildDs3ObjectStreamFromNames(objectNames),
         queryParams: queryParams,
     }
 }

--- a/src/ds3_cli/commands/bulkGet.go
+++ b/src/ds3_cli/commands/bulkGet.go
@@ -21,8 +21,13 @@ func bulkGet(client *ds3.Client, args *Arguments) error {
         return err
     }
 
+    var ds3GetObjects []models.Ds3GetObject
+    for _, obj := range objects {
+        ds3GetObjects = append(ds3GetObjects, models.NewDs3GetObject(obj.Name))
+    }
+
     // Run request.
-    response, err := client.GetBulkJobSpectraS3(models.NewGetBulkJobSpectraS3Request(args.Bucket, objects))
+    response, err := client.GetBulkJobSpectraS3(models.NewGetBulkJobSpectraS3RequestWithPartialObjects(args.Bucket, ds3GetObjects))
     if err != nil {
         return err
     }

--- a/src/ds3_cli/commands/bulkPut.go
+++ b/src/ds3_cli/commands/bulkPut.go
@@ -23,9 +23,9 @@ func bulkPut(client *ds3.Client, args *Arguments) error {
     }
 
     // Create object entities that we can query with for each file.
-    objects := make([]models.Ds3Object, len(files))
+    objects := make([]models.Ds3PutObject, len(files))
     for i, file := range files {
-        objects[i] = models.Ds3Object{Name: file.path, Size: file.size}
+        objects[i] = models.Ds3PutObject{Name: file.path, Size: file.size}
     }
 
     // Run request.

--- a/src/ds3_cli/commands/getBucketObjects.go
+++ b/src/ds3_cli/commands/getBucketObjects.go
@@ -9,7 +9,7 @@ import (
 // Gets all objects in a bucket, performing multiple requests if the results
 // are paged. Also supports limiting to an arbitrary number of keys independent
 // of page size.
-func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Ds3Object, error) {
+func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Ds3PutObject, error) {
     // Validate arguments.
     if args.Bucket == "" {
         return nil, errors.New("Must specify a bucket name when doing get_bucket.")
@@ -22,7 +22,7 @@ func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Ds3Object, 
     }
 
     // Do a do...while pattern to do as many requests as needed.
-    var results []models.Ds3Object
+    var results []models.Ds3PutObject
     marker := ""
     for {
         // Build the request.
@@ -36,7 +36,7 @@ func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Ds3Object, 
 
         // Output the results.
         for _, obj := range response.ListBucketResult.Objects {
-            ds3object := models.Ds3Object{Name:*obj.Key, Size:obj.Size}
+            ds3object := models.Ds3PutObject{Name:*obj.Key, Size:obj.Size}
             results = append(results, ds3object)
         }
 

--- a/src/ds3_integration/utils/testUtils.go
+++ b/src/ds3_integration/utils/testUtils.go
@@ -29,13 +29,12 @@ func VerifyBookContent(t *testing.T, bookName string, content io.ReadCloser) {
     }
 }
 
-func ConvertObjectsIntoDs3Objects(objects []models.Contents) []models.Ds3Object {
-    var ds3Objects []models.Ds3Object
+func ConvertObjectsIntoObjectNameList(objects []models.Contents) []string {
+    var objectNames []string
     for _, obj := range objects{
-        curDs3Object := models.Ds3Object{ Name:*obj.Key, Size:obj.Size, }
-        ds3Objects = append(ds3Objects, curDs3Object)
+        objectNames = append(objectNames, *obj.Key)
     }
-    return ds3Objects
+    return objectNames
 }
 
 //Puts the test books onto the BP
@@ -102,14 +101,14 @@ func GetResourceBooks() (map[string]networking.ReaderWithSizeDecorator, error) {
     return result, nil
 }
 
-func ConvertBooksToDs3Objects(books map[string]networking.ReaderWithSizeDecorator) ([]models.Ds3Object, error) {
-    var ds3Objects []models.Ds3Object
+func ConvertBooksToDs3Objects(books map[string]networking.ReaderWithSizeDecorator) ([]models.Ds3PutObject, error) {
+    var ds3Objects []models.Ds3PutObject
     for title, stream := range books {
         size, err := stream.Size()
         if err != nil {
             return nil, err
         }
-        var curObj models.Ds3Object = models.Ds3Object{
+        var curObj models.Ds3PutObject = models.Ds3PutObject{
             Name:title,
             Size:size,
         }


### PR DESCRIPTION
**Changes**
- Divided `Ds3Object` into `Ds3PutObject`, `Ds3GetObject` and `Ds3VerifyObject` to properly represent request payloads.
- Simplified request payloads to use `[]string` whenever possible
- Added second constructor for `GetBulkJobSpectraS3Request` so that users can either specify request payload of `[]string` or `[]Ds3GetObject` for partial objects
- Added new request payload code for `<ids><id>id</id>...</ids>` which has appeared in 4.0
- Removed erroneous request payloads from some commands that have no payload

**Future Work**
- Update autogen to correctly generate all modified request handlers in this PR