### PR TITLE
Added unit tests for all requests with payloads

### DIFF
--- a/src/ds3/models/clearSuspectBlobS3TargetsSpectraS3Request.go
+++ b/src/ds3/models/clearSuspectBlobS3TargetsSpectraS3Request.go
@@ -61,5 +61,5 @@ func (ClearSuspectBlobS3TargetsSpectraS3Request) Header() *http.Header {
 }
 
 func (clearSuspectBlobS3TargetsSpectraS3Request *ClearSuspectBlobS3TargetsSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return nil
+    return clearSuspectBlobS3TargetsSpectraS3Request.content
 }

--- a/src/ds3/models/clearSuspectBlobTapesSpectraS3Request.go
+++ b/src/ds3/models/clearSuspectBlobTapesSpectraS3Request.go
@@ -60,6 +60,6 @@ func (ClearSuspectBlobTapesSpectraS3Request) Header() *http.Header {
     return &http.Header{}
 }
 
-func (ClearSuspectBlobTapesSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
-    return nil
+func (clearSuspectBlobTapesSpectraS3Request *ClearSuspectBlobTapesSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
+    return clearSuspectBlobTapesSpectraS3Request.content
 }

--- a/src/ds3_utils/ds3Testing/assertUtil.go
+++ b/src/ds3_utils/ds3Testing/assertUtil.go
@@ -26,7 +26,7 @@ func AssertNonNilBoolPtr(t *testing.T, label string, expected bool, actual *bool
 }
 
 // Asserts if a specified bool pointer is nil. If not, Fatal.
-func AssertBoolPtrIsNil(t *testing.T, label bool, actual *bool) {
+func AssertBoolPtrIsNil(t *testing.T, label string, actual *bool) {
     if actual != nil {
         t.Fatalf("Expected %s to be 'nil' but was '%t'.", label, *actual)
     }


### PR DESCRIPTION
**Changes**
- Added unit tests for all requests with payloads
  - Test `TestVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3` is commented out as there is a bug during response parsing which causes a panic. This test will be uncommented once the parsing bug is fixed.
- Fixed bug in assert util 
- Fixed get stream content in some manually modified request files in preparation for autogen fixes
