### PR TITLE
SDKPM-45: Created robust setup and teardown for integration tests

### DIFF
--- a/src/ds3_integration/smoke_test.go
+++ b/src/ds3_integration/smoke_test.go
@@ -26,19 +26,21 @@ import (
 
 var client *ds3.Client
 var testBucket = "GoIntegrationTestBucket"
+var envTestNameSpace = "GoIntegrationSmokeTest"
 var defaultUser = "Administrator"
 
 func TestMain(m *testing.M) {
     var err error
     var exitVal int
-    client, err = testutils.SetupTestEnv(testBucket)
+    var ids *testutils.TestIds
+    client, ids, err = testutils.SetupTestEnv(testBucket, defaultUser, envTestNameSpace)
     if err != nil {
         log.Printf("Unable to setup test environment '%s'.", err.Error())
         exitVal = 1
     } else {
         exitVal = m.Run()
     }
-    testutils.TeardownTestEnv(client, testBucket)
+    testutils.TeardownTestEnv(client, ids, testBucket)
     os.Exit(exitVal)
 }
 


### PR DESCRIPTION
The setup and teardown is based off of the Java integration setup and teardown code regarding what constitutes a robust environment.

**Tests**
All tests are passing. Tests run successfully if there is a default data policy, and if there is not a default data policy associated with the default user. If there exists a default data policy before running the tests, it is restored once tests are complete.