### PR TITLE
SA-205: Fixed request payload for Verify Bulk and fixed minor bug in unit test

### DIFF
--- a/src/ds3/ds3Client_test.go
+++ b/src/ds3/ds3Client_test.go
@@ -557,7 +557,7 @@ func TestBulkGetWithSimpleDs3GetObjets(t *testing.T) {
     )
 }
 
-func TestBulkGetWithPartialDs3GetObjets(t *testing.T) {
+func TestBulkGetWithPartialDs3GetObjects(t *testing.T) {
     objects := []models.Ds3GetObject {
         models.NewPartialDs3GetObject("file1", 10, 100),
         models.NewPartialDs3GetObject("file2", 20, 200),
@@ -588,6 +588,42 @@ func TestBulkGetWithObjectNames(t *testing.T) {
         &stringRequest,
         func(client *Client) ([]models.Objects, error) {
             request, err := client.GetBulkJobSpectraS3(models.NewGetBulkJobSpectraS3Request("bucketName", objects))
+            return request.MasterObjectList.Objects, err
+        },
+    )
+}
+
+func TestBulkVerifyWithPartialDs3GetObjects(t *testing.T) {
+    objects := []models.Ds3GetObject {
+        models.NewPartialDs3GetObject("file1", 10, 100),
+        models.NewPartialDs3GetObject("file2", 20, 200),
+        models.NewPartialDs3GetObject("file3", 30, 300),
+    }
+
+    stringRequest := "<Objects><Object Name=\"file1\" Length=\"10\" Offset=\"100\"></Object><Object Name=\"file2\" Length=\"20\" Offset=\"200\"></Object><Object Name=\"file3\" Length=\"30\" Offset=\"300\"></Object></Objects>"
+
+    runBulkGetTest(
+        t,
+        "start_bulk_verify",
+        &stringRequest,
+        func(client *Client) ([]models.Objects, error) {
+            request, err := client.VerifyBulkJobSpectraS3(models.NewVerifyBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
+            return request.MasterObjectList.Objects, err
+        },
+    )
+}
+
+func TestBulkVerifyWithObjectNames(t *testing.T) {
+    objects := []string {"file1", "file2", "file3"}
+
+    stringRequest := "<Objects><Object Name=\"file1\"></Object><Object Name=\"file2\"></Object><Object Name=\"file3\"></Object></Objects>"
+
+    runBulkGetTest(
+        t,
+        "start_bulk_verify",
+        &stringRequest,
+        func(client *Client) ([]models.Objects, error) {
+            request, err := client.VerifyBulkJobSpectraS3(models.NewVerifyBulkJobSpectraS3Request("bucketName", objects))
             return request.MasterObjectList.Objects, err
         },
     )
@@ -1642,7 +1678,7 @@ func TestGetPhysicalPlacementForObjectsSpectraS3(t *testing.T) {
 
 func TestGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3(t *testing.T) {
     expectedRequest := "<Objects><Object Name=\"obj1\"></Object><Object Name=\"obj2\"></Object><Object Name=\"obj3\"></Object></Objects>"
-    responsePayload := "<Data><AzureTargets/><Ds3Targets/><Pools/><S3Targets/><Tapes/></Data>"
+    responsePayload := "<Data><Object Bucket=\"b1\" Id=\"a2897bbd-3e0b-4c0f-83d7-29e1e7669bdd\" InCache=\"false\" Latest=\"true\" Length=\"10\" Name=\"o4\" Offset=\"0\" Version=\"1\"><PhysicalPlacement><AzureTargets/><Ds3Targets/><Pools/><S3Targets/><Tapes/></PhysicalPlacement></Object></Data>"
 
     // Create and run the mocked client.
     bucketName := "BucketName"

--- a/src/ds3/models/requestPayloadUtils.go
+++ b/src/ds3/models/requestPayloadUtils.go
@@ -111,31 +111,6 @@ func buildDs3GetObjectListStream(ds3GetObjects []Ds3GetObject) networking.Reader
     return marshalRequestPayload(objects)
 }
 
-type Ds3VerifyObject struct {
-    Name string `xml:"Name,attr"`
-    Length int64 `xml:"Length,attr"`
-}
-
-type ds3VerifyObjectList struct {
-    XMLName xml.Name
-    Ds3VerifyObjects []Ds3VerifyObject `xml:"Object"`
-}
-
-func newDs3VerifyObjectList(ds3VerifyObjects []Ds3VerifyObject) *ds3VerifyObjectList {
-    return &ds3VerifyObjectList{
-        XMLName: xml.Name{Local:"Objects"},
-        Ds3VerifyObjects: ds3VerifyObjects,
-    }
-}
-
-// Converts the ds3 put object list into a request payload stream of format:
-// <Objects><Object Name="o1" Length="2048"></Object><Object Name="o2" Length="2048"></Object>...</Objects>
-func buildDs3VerifyObjectListStream(ds3VerifyObjects []Ds3VerifyObject) networking.ReaderWithSizeDecorator {
-    // Build the ds3 put object list entity.
-    objects := newDs3VerifyObjectList(ds3VerifyObjects)
-    return marshalRequestPayload(objects)
-}
-
 type deleteObjectList struct {
     XMLName xml.Name
     Objects []deleteObject `xml:"Object"`

--- a/src/ds3/models/requestPayloadUtils_test.go
+++ b/src/ds3/models/requestPayloadUtils_test.go
@@ -84,21 +84,6 @@ func TestBuildDs3GetObjectListStream(t *testing.T) {
     verifyStreamContent(t, contentStream, expected)
 }
 
-func TestBuildDs3VerifyObjectListStream(t *testing.T) {
-    expected := "<Objects><Object Name=\"o1\" Length=\"1\"></Object><Object Name=\"o2\" Length=\"2\"></Object><Object Name=\"o3\" Length=\"3\"></Object></Objects>"
-
-    ds3VerifyObjects := []Ds3VerifyObject {
-        {Name:"o1", Length:1},
-        {Name:"o2", Length:2},
-        {Name:"o3", Length:3},
-    }
-
-    contentStream := buildDs3VerifyObjectListStream(ds3VerifyObjects)
-
-    defer contentStream.Close()
-    verifyStreamContent(t, contentStream, expected)
-}
-
 func TestBuildDeleteObjectsPayload(t *testing.T) {
     expected := "<Delete><Object><Key>o1</Key></Object><Object><Key>o2</Key></Object><Object><Key>o3</Key></Object></Delete>"
 

--- a/src/ds3/models/verifyBulkJobSpectraS3Request.go
+++ b/src/ds3/models/verifyBulkJobSpectraS3Request.go
@@ -29,13 +29,24 @@ type VerifyBulkJobSpectraS3Request struct {
     queryParams *url.Values
 }
 
-func NewVerifyBulkJobSpectraS3Request(bucketName string, objects []Ds3VerifyObject) *VerifyBulkJobSpectraS3Request {
+func NewVerifyBulkJobSpectraS3Request(bucketName string, objectNames []string) *VerifyBulkJobSpectraS3Request {
     queryParams := &url.Values{}
     queryParams.Set("operation", "start_bulk_verify")
 
     return &VerifyBulkJobSpectraS3Request{
         bucketName: bucketName,
-        content: buildDs3VerifyObjectListStream(objects),
+        content: buildDs3ObjectStreamFromNames(objectNames),
+        queryParams: queryParams,
+    }
+}
+
+func NewVerifyBulkJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *VerifyBulkJobSpectraS3Request {
+    queryParams := &url.Values{}
+    queryParams.Set("operation", "start_bulk_verify")
+
+    return &VerifyBulkJobSpectraS3Request{
+        bucketName: bucketName,
+        content: buildDs3GetObjectListStream(objects),
         queryParams: queryParams,
     }
 }


### PR DESCRIPTION
**Changes**
- Fixed request payload for Verify Bulk to accept either a 'objectNames []string' or `objects []Ds3GetObject`
- Deleted erroneous `Ds3VerifyObject`
- Fixed unit test which was printing warnings due to incorrect expected response payload