### PR TITLE
Adding travis yml and updating tests to work with go test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ go:
   - 1.9.x
   - master
 
+go_import_path: spectra
+
 script:
   - go test ./ds3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+go:
+  - 1.8.x
+  - 1.9.x
+  - master
+
+script:
+  - go test ./ds3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
   - 1.9.x
   - master
 
-go_import_path: spectra
+go_import_path: spectra/ds3_go_sdk
 
 script:
   - go test ./ds3

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ In the ds3_go_sdk you create a `Client` instance through the setting of the foll
 
 Examples
 --------
-All examples are listed in the [samples](samples/) module.
+All examples are listed in the [samples](samples/) module. All samples can be run from [samples main](samples/samples.go).
 
-* [How to use get service to list buckets](samples/getServiceSample.go)
-* [How to create a bucket](samples/getBucketSample.go)
-* [How to get a single object using a naked S3 get](samples/getObjectSample.go)
-* [How to use bulk put to send multiple files to the BP efficiently](samples/putBulkSample.go)
-* [How to use bulk get to retrieve multiple files from the BP efficiently](samples/getBulkSample.go)
+* [How to use get service to list buckets](samples/functions/getServiceSample.go)
+* [How to create a bucket](samples/functions/getBucketSample.go)
+* [How to get a single object using a naked S3 get](samples/functions/getObjectSample.go)
+* [How to use bulk put to send multiple files to the BP efficiently](samples/functions/putBulkSample.go)
+* [How to use bulk get to retrieve multiple files from the BP efficiently](samples/functions/getBulkSample.go)
 
 Running Tests with GB
 ---------------------

--- a/ds3/ds3Client_test.go
+++ b/ds3/ds3Client_test.go
@@ -834,19 +834,19 @@ func TestDeleteObjects(t *testing.T) {
     }
 
     if response.DeleteResult.DeletedObjects == nil {
-        t.Fatalf("Expected '%s' but got 'nil'", expectedDeleted)
+        t.Fatalf("Expected '%v' but got 'nil'", expectedDeleted)
     }
 
     if !reflect.DeepEqual(response.DeleteResult.DeletedObjects, expectedDeleted) {
-        t.Fatalf("Expected '%s' but got '%s'", expectedDeleted, response.DeleteResult.DeletedObjects)
+        t.Fatalf("Expected '%v' but got '%v'", expectedDeleted, response.DeleteResult.DeletedObjects)
     }
 
     if response.DeleteResult.Errors == nil {
-        t.Fatalf("Expected '%s' but got 'nil'", expectedErrors)
+        t.Fatalf("Expected '%v' but got 'nil'", expectedErrors)
     }
 
     if !reflect.DeepEqual(response.DeleteResult.Errors, expectedErrors) {
-        t.Fatalf("Expected '%s' but got '%s'", expectedErrors, response.DeleteResult.Errors)
+        t.Fatalf("Expected '%v' but got '%v'", expectedErrors, response.DeleteResult.Errors)
     }
 }
 
@@ -1393,7 +1393,7 @@ func TestGetTapesSpectraS3(t *testing.T) {
     ds3Testing.AssertStringPtrIsNil(t, "LastVerified", tape.LastVerified)
     ds3Testing.AssertNonNilStringPtr(t, "PartitionId", "4f8a5cbb-9837-41d9-afd1-cebed41f18f7", tape.PartitionId)
     if tape.PreviousState != nil {
-        t.Fatalf("Expected previous state '%d' but was '%d'.", "nil", *tape.PreviousState)
+        t.Fatalf("Expected previous state '%s' but was '%s'.", "nil", tape.PreviousState.String())
     }
     ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "HP-W130501213", tape.SerialNumber)
     ds3Testing.AssertString(t, "State", models.TAPE_STATE_NORMAL.String(), tape.State.String())
@@ -1459,7 +1459,7 @@ func TestGetTapeSpectraS3(t *testing.T) {
     ds3Testing.AssertStringPtrIsNil(t, "LastVerified", tape.LastVerified)
     ds3Testing.AssertNonNilStringPtr(t, "PartitionId", "4f8a5cbb-9837-41d9-afd1-cebed41f18f7", tape.PartitionId)
     if tape.PreviousState != nil {
-        t.Fatalf("Expected previous state '%d' but was '%d'.", "nil", *tape.PreviousState)
+        t.Fatalf("Expected previous state '%s' but was '%s'.", "nil", tape.PreviousState.String())
     }
     ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "HP-W130501213", tape.SerialNumber)
     ds3Testing.AssertString(t, "State", models.TAPE_STATE_NORMAL.String(), tape.State.String())

--- a/samples/functions/getBucketSample.go
+++ b/samples/functions/getBucketSample.go
@@ -9,7 +9,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-package main
+package functions
 
 import (
     "log"
@@ -21,7 +21,9 @@ import (
 
 // Demonstrates how to get a list of S3 objects in a bucket. Assumes that the target
 // bucket already exists and has files, i.e. run putBulkSample.go first.
-func main() {
+func GetBucketSample() {
+    fmt.Println("---- Get Bucket Sample ----")
+
     // Create the client from environment variables.
     client, err := buildclient.FromEnv()
     if err != nil {

--- a/samples/functions/getBulkSample.go
+++ b/samples/functions/getBulkSample.go
@@ -9,7 +9,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-package main
+package functions
 
 import (
     "spectra/ds3_go_sdk/ds3/buildclient"
@@ -17,11 +17,14 @@ import (
     "spectra/ds3_go_sdk/ds3/models"
     "spectra/ds3_go_sdk/samples/utils"
     "time"
+    "fmt"
 )
 
 // Demonstrates how to perform a bulk get. Assumes that the target bucket already exists
 // and has files, i.e. run putBulkSample.go first.
-func main() {
+func GetBulkSample() {
+    fmt.Println("---- Get Bulk Sample ----")
+
     // Create a client from environment variables.
     client, err := buildclient.FromEnv()
     if err != nil {
@@ -87,6 +90,7 @@ func main() {
                     if err != nil {
                         log.Fatal(err)
                     }
+                    fmt.Printf("Retrived: %s offset=%d length%d\n", *curObj.Name, curObj.Offset, curObj.Length)
                 }
                 curChunkCount++
             }

--- a/samples/functions/getObjectSample.go
+++ b/samples/functions/getObjectSample.go
@@ -9,35 +9,36 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-package main
+package functions
 
 import (
     "log"
     "spectra/ds3_go_sdk/ds3/models"
     "spectra/ds3_go_sdk/ds3/buildclient"
-    "fmt"
     "spectra/ds3_go_sdk/samples/utils"
+    "fmt"
 )
 
-func main() {
+// Demonstrates how to get an object within a bucket. Assumes that the
+// target bucket already exists and has the specified file.
+// i.e. run putBulkSample.go first.
+func GetObjectSample() {
+    fmt.Println("---- Get Object Sample ----")
+
     // Create the client from environment variables.
     client, err := buildclient.FromEnv()
     if err != nil {
         log.Fatal(err)
     }
 
-    // Create the get service request. All requests to a DS3 appliance start this way.
-    request := models.NewGetServiceRequest()
-
-    // Perform the Get Service call by using the client and invoking the desired command.
-    response, err := client.GetService(request)
+    // Grab the first book defined in utils.BookNames
+    getObjRequest := models.NewGetObjectRequest(utils.BucketName, utils.BookNames[0])
+    getObjResponse, err := client.GetObject(getObjRequest)
     if err != nil {
         log.Fatal(err)
     }
 
-    // Printing contents of get service.
-    fmt.Println("Buckets:")
-    for i, bucket := range response.ListAllMyBucketsResult.Buckets {
-        fmt.Printf("%d) Name: %s; CreationDate: %s\n", i + 1, utils.ToSafeString(bucket.Name), utils.ToSafeString(bucket.CreationDate))
-    }
+    // Verify that the contents of the book were retrieved correctly.
+    utils.VerifyBookContent(utils.BookNames[0], getObjResponse.Content)
+    fmt.Printf("Retrieved: %s\n", utils.BookNames[0])
 }

--- a/samples/functions/getServiceSample.go
+++ b/samples/functions/getServiceSample.go
@@ -9,32 +9,37 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-package main
+package functions
 
 import (
     "log"
     "spectra/ds3_go_sdk/ds3/models"
     "spectra/ds3_go_sdk/ds3/buildclient"
+    "fmt"
     "spectra/ds3_go_sdk/samples/utils"
 )
 
-// Demonstrates how to get an object within a bucket. Assumes that the
-// target bucket already exists and has the specified file.
-// i.e. run putBulkSample.go first.
-func main() {
+func GetServiceSample() {
+    fmt.Println("---- Get Service Sample ----")
+
     // Create the client from environment variables.
     client, err := buildclient.FromEnv()
     if err != nil {
         log.Fatal(err)
     }
 
-    // Grab the first book defined in utils.BookNames
-    getObjRequest := models.NewGetObjectRequest(utils.BucketName, utils.BookNames[0])
-    getObjResponse, err := client.GetObject(getObjRequest)
+    // Create the get service request. All requests to a DS3 appliance start this way.
+    request := models.NewGetServiceRequest()
+
+    // Perform the Get Service call by using the client and invoking the desired command.
+    response, err := client.GetService(request)
     if err != nil {
         log.Fatal(err)
     }
 
-    // Verify that the contents of the book were retrieved correctly.
-    utils.VerifyBookContent(utils.BookNames[0], getObjResponse.Content)
+    // Printing contents of get service.
+    fmt.Println("Buckets:")
+    for i, bucket := range response.ListAllMyBucketsResult.Buckets {
+        fmt.Printf("%d) Name: %s; CreationDate: %s\n", i + 1, utils.ToSafeString(bucket.Name), utils.ToSafeString(bucket.CreationDate))
+    }
 }

--- a/samples/functions/putBulkSample.go
+++ b/samples/functions/putBulkSample.go
@@ -9,7 +9,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-package main
+package functions
 
 import (
     "log"
@@ -18,9 +18,12 @@ import (
     "os"
     "time"
     "spectra/ds3_go_sdk/samples/utils"
+    "fmt"
 )
 
-func main() {
+func PutBulkSample() {
+    fmt.Println("---- Put Bulk Sample ----")
+
     // Create a client from environment variables.
     client, err := buildclient.FromEnv()
     if err != nil {
@@ -87,7 +90,7 @@ func main() {
                         log.Fatal(err)
                     }
 
-                    putObjRequest := models.NewPutObjectRequest(utils.BucketName, *curObj.Name, *reader).
+                    putObjRequest := models.NewPutObjectRequest(utils.BucketName, *curObj.Name, reader).
                         WithJob(chunksReadyResponse.MasterObjectList.JobId).
                         WithOffset(curObj.Offset)
 
@@ -95,6 +98,7 @@ func main() {
                     if err != nil {
                         log.Fatal(err)
                     }
+                    fmt.Printf("Sent: %s offset=%d length=%d\n", *curObj.Name, curObj.Offset, curObj.Length)
                 }
                 curChunkCount++
             }

--- a/samples/samples.go
+++ b/samples/samples.go
@@ -1,0 +1,38 @@
+// Copyright 2014-2018 Spectra Logic Corporation. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+// this file except in compliance with the License. A copy of the License is located at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file.
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package main
+
+import "spectra/ds3_go_sdk/samples/functions"
+
+// Runs the various sample code. Each sample is self contained and can be run separately.
+func main() {
+
+    // Lists all existing buckets on the BP.
+    // Source code: getServiceSample.go
+    functions.GetServiceSample()
+
+    // Creates a bucket on the BP and puts sample files in the bucket.
+    // Source code: putBulkSample.go
+    functions.PutBulkSample()
+
+    // Gets a list of S3 objects in a bucket.
+    // Source code: getBucketSample.go
+    functions.GetBucketSample()
+
+    // Retrieve an object from a bucket.
+    // Source code: getObjectSample.go
+    functions.GetObjectSample()
+
+    // Retrieves several objects from a bucket on the BP.
+    // Source code: getBulkSample.go
+    functions.GetBulkSample()
+}

--- a/samples/utils/sampleUtils.go
+++ b/samples/utils/sampleUtils.go
@@ -22,7 +22,7 @@ import (
 )
 
 const BucketName = "GoPutBulkBucket"
-const ResourceFolder = "./src/samples/resources/"
+const ResourceFolder = "./samples/resources/"
 var BookNames = []string{"beowulf.txt", "sherlock_holmes.txt", "tale_of_two_cities.txt", "ulysses.txt"}
 
 // Loads a book from resources folder.


### PR DESCRIPTION
- Adding travis yml file to enable unit tests in ds3 package to run on PRs. Unit tests are run with `go test` tool.
- Updated some improper format in tests that `go test` failed to compile with.