### PR TITLE
Authorization digest

### DIFF
--- a/ds3/networking/httpRequestBuilder.go
+++ b/ds3/networking/httpRequestBuilder.go
@@ -118,7 +118,7 @@ func (builder *HttpRequestBuilder) Build(conn *ConnectionInfo) (*http.Request, e
 
     builder.signatureFields.Date = getCurrentTime()
 
-	builder.maybeAddAmazonCanonicalHeaders()
+    builder.maybeAddAmazonCanonicalHeaders()
 
     authHeaderVal := builder.signatureFields.BuildAuthHeaderValue(conn.Credentials)
 

--- a/ds3/networking/networking_test.go
+++ b/ds3/networking/networking_test.go
@@ -15,7 +15,6 @@ import (
     "testing"
     "net/url"
     "spectra/ds3_go_sdk/ds3_utils/ds3Testing"
-	"fmt"
 	"strings"
 )
 
@@ -50,8 +49,6 @@ func TestBuildingAuthorizationDigestWithMetadata(t *testing.T) {
 		Build(&connectionInfo)
 
 	amazonHeaders := httpRequestBuilder.signatureFields.CanonicalizedAmzHeaders
-
-	fmt.Println(amazonHeaders)
 
 	ds3Testing.AssertBool(t, "expected amazonHeader to have something in it", true, len(amazonHeaders) > 0)
 

--- a/ds3/networking/networking_test.go
+++ b/ds3/networking/networking_test.go
@@ -15,6 +15,8 @@ import (
     "testing"
     "net/url"
     "spectra/ds3_go_sdk/ds3_utils/ds3Testing"
+	"fmt"
+	"strings"
 )
 
 func TestEncodeQueryParams(t *testing.T) {
@@ -28,4 +30,31 @@ func TestEncodeQueryParams(t *testing.T) {
     result := encodeQueryParams(queryParams)
 
     ds3Testing.AssertString(t, "Encoded Query Params", expected, result)
+}
+
+func TestBuildingAuthorizationDigestWithMetadata(t *testing.T) {
+	httpRequestBuilder := NewHttpRequestBuilder()
+
+	endpointUrl, err := url.Parse("https://google.com")
+	ds3Testing.AssertNilError(t, err)
+
+	const gracie = "Gracie"
+	const eskimo = "Eskimo"
+
+	connectionInfo := ConnectionInfo{
+		Endpoint:    endpointUrl,
+		Credentials: &Credentials{AccessId: gracie, Key: eskimo},
+		Proxy:       nil}
+
+	httpRequestBuilder.WithHeader(AmazonMetadataPrefix + gracie, eskimo).
+		Build(&connectionInfo)
+
+	amazonHeaders := httpRequestBuilder.signatureFields.CanonicalizedAmzHeaders
+
+	fmt.Println(amazonHeaders)
+
+	ds3Testing.AssertBool(t, "expected amazonHeader to have something in it", true, len(amazonHeaders) > 0)
+
+	expected := AmazonMetadataPrefix + strings.ToLower(gracie) + ":" + eskimo + "\n"
+	ds3Testing.AssertBool(t, "amazonHeader string isn't what we expected", true, strings.Compare(amazonHeaders, expected) == 0)
 }


### PR DESCRIPTION
Adding http headers that start with x-amz-meta- to authorization digest.  BP looks at header fields in addition to some other stuff to compute the digest signature.