### PR TITLE
In Close(), actually close the reader if it implements io.ReadCloser -- JIRA NEO-537

### DIFF
--- a/helpers/channels/ds3OjectReadCloserDecorator.go
+++ b/helpers/channels/ds3OjectReadCloserDecorator.go
@@ -11,6 +11,10 @@ func NewDs3ObjectReadCloserDecorator(reader io.Reader) io.ReadCloser {
 }
 
 func (Ds3ObjectReadCloser Ds3ObjectReadCloser) Close() error {
+	readCloser, isReadCloser := Ds3ObjectReadCloser.Reader.(io.ReadCloser)
+	if isReadCloser && readCloser != nil {
+		return readCloser.Close()
+	}
 	return nil
 }
 


### PR DESCRIPTION
If we don't close the file, files are left open our command edits.  This ensures they are closed when we close them.