### PR TITLE
Fix for jira neo 996.  BP GetObject() does not return an entire object

### DIFF
--- a/helpers/channels/objectWriteChannelBuilder.go
+++ b/helpers/channels/objectWriteChannelBuilder.go
@@ -22,10 +22,11 @@ func (builder *ObjectWriteChannelBuilder) IsChannelAvailable(offset int64) bool 
 }
 
 func (builder *ObjectWriteChannelBuilder) GetChannel(offset int64) (io.WriteCloser, error) {
-    f, err := os.OpenFile(builder.name, os.O_WRONLY, defaultPermissions)
+    f, err := os.OpenFile(builder.name, os.O_WRONLY | os.O_CREATE, os.ModePerm)
     if err != nil {
         return nil, err
     }
+
     f.Seek(offset, io.SeekStart)
     return f, nil
 }


### PR DESCRIPTION
If the original file had been blobbed.  Using a bulk get per object restored.  Making write channel builder create the file if it doesn't exist.