### PR TITLE
Adding JobId as return value in helper put and get functions

### DIFF
--- a/helpers/getTransfernator.go
+++ b/helpers/getTransfernator.go
@@ -63,13 +63,13 @@ func createPartialGetObjects(getObject helperModels.GetObject) []ds3Models.Ds3Ge
     return partialObjects
 }
 
-func (transceiver *getTransceiver) transfer() error {
+func (transceiver *getTransceiver) transfer() (string, error) {
     // create bulk get job
     bulkGet := newBulkGetRequest(transceiver.BucketName, transceiver.ReadObjects, transceiver.Strategy.Options)
 
     bulkGetResponse, err := transceiver.Client.GetBulkJobSpectraS3(bulkGet)
     if err != nil {
-        return err
+        return "", err
     }
 
     // init queue, producer and consumer
@@ -86,5 +86,5 @@ func (transceiver *getTransceiver) transfer() error {
     go consumer.run()
     waitGroup.Wait()
 
-    return aggErr.GetErrors()
+    return bulkGetResponse.MasterObjectList.JobId, aggErr.GetErrors()
 }

--- a/helpers/helpersImpl.go
+++ b/helpers/helpersImpl.go
@@ -8,8 +8,18 @@ import (
 type HelperInterface interface {
     //ListObjectsFromBucket(bucketName string) []ds3Models.S3Object
     //ListObjectsFromDirectory(directoryName string) []helperModels.PutObject
-    PutObjects(bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (error)
-    GetObjects(bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (error)
+
+    // Puts the specified list of objects on the Black Pearl in the specified bucket.
+    // Returns the Black Pearl bulk put Job ID and any errors that may have occurred.
+    // A job ID will be returned if a BP job was successfully created, regardless of
+    // whether additional errors occur.
+    PutObjects(bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (string, error)
+
+    // Retrieves the list of objects from the specified bucket on the Black Pearl.
+    // Returns the Black Pearl bulk get Job ID and any errors that may have occurred.
+    // A job ID will be returned if a BP job was successfully created, regardless of
+    // whether additional errors occur.
+    GetObjects(bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (string, error)
 }
 
 type HelperImpl struct {
@@ -30,12 +40,12 @@ func (helper *HelperImpl) ListObjectsFromDirectory(directoryName string) []helpe
 }
 */
 
-func (helper *HelperImpl) PutObjects(bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (error) {
+func (helper *HelperImpl) PutObjects(bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (string, error) {
     transceiver := newPutTransceiver(bucketName, &objects, &strategy, helper.client)
     return transceiver.transfer()
 }
 
-func (helper *HelperImpl) GetObjects(bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (error) {
+func (helper *HelperImpl) GetObjects(bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (string, error) {
     transceiver := newGetTransceiver(bucketName, &objects, &strategy, helper.client)
     return transceiver.transfer()
 }

--- a/helpers/putTransceiver.go
+++ b/helpers/putTransceiver.go
@@ -61,13 +61,13 @@ func newBulkPutRequest(bucketName string, writeObjects *[]helperModels.PutObject
     return bulkPut
 }
 
-func (transceiver *putTransceiver) transfer() error {
+func (transceiver *putTransceiver) transfer() (string, error) {
     // create bulk put job
     bulkPut := newBulkPutRequest(transceiver.BucketName, transceiver.WriteObjects, transceiver.Strategy.Options)
 
     bulkPutResponse, err := transceiver.Client.PutBulkJobSpectraS3(bulkPut)
     if err != nil {
-        return err
+        return "", err
     }
 
     // init queue, producer and consumer
@@ -85,7 +85,7 @@ func (transceiver *putTransceiver) transfer() error {
     go consumer.run()
     waitGroup.Wait()
 
-    return aggErr.GetErrors()
+    return bulkPutResponse.MasterObjectList.JobId, aggErr.GetErrors()
 }
 
 /*

--- a/helpers_integration/helpersImpl_test.go
+++ b/helpers_integration/helpersImpl_test.go
@@ -45,8 +45,11 @@ func TestPutBulk(t *testing.T) {
     writeObjects, err := getTestBooksAsWriteObjects()
     ds3Testing.AssertNilError(t, err)
 
-    err = helper.PutObjects(testBucket, *writeObjects, strategy)
+    jobId, err := helper.PutObjects(testBucket, *writeObjects, strategy)
     ds3Testing.AssertNilError(t, err)
+    if jobId == "" {
+        t.Error("expected to get a BP job ID, but instead got nothing")
+    }
 
     // verify all books are on BP
     getBucket, getBucketErr := client.GetBucket(ds3Models.NewGetBucketRequest(testBucket))
@@ -75,8 +78,11 @@ func TestPutBulkBlobSpanningChunksRandomAccess(t *testing.T) {
 
     ds3Testing.AssertNilError(t, err)
 
-    err = helper.PutObjects(testBucket, writeObjects, strategy)
+    jobId, err := helper.PutObjects(testBucket, writeObjects, strategy)
     ds3Testing.AssertNilError(t, err)
+    if jobId == "" {
+        t.Error("expected to get a BP job ID, but instead got nothing")
+    }
 
 
     testutils.VerifyFilesOnBP(t, testBucket, []string {LargeBookTitle}, LargeBookPath, client)
@@ -96,8 +102,11 @@ func TestPutBulkBlobSpanningChunksStreamAccess(t *testing.T) {
 
     ds3Testing.AssertNilError(t, err)
 
-    err = helper.PutObjects(testBucket, writeObjects, strategy)
+    jobId, err := helper.PutObjects(testBucket, writeObjects, strategy)
     ds3Testing.AssertNilError(t, err)
+    if jobId == "" {
+        t.Error("expected to get a BP job ID, but instead got nothing")
+    }
 
     testutils.VerifyFilesOnBP(t, testBucket, []string {LargeBookTitle}, LargeBookPath, client)
 }
@@ -142,8 +151,11 @@ func TestGetBulk(t *testing.T) {
         {Name: testutils.BookTitles[3], ChannelBuilder: channels.NewWriteChannelBuilder(file3.Name())},
     }
 
-    err = helper.GetObjects(testBucket, readObjects, strategy)
+    jobId, err := helper.GetObjects(testBucket, readObjects, strategy)
     ds3Testing.AssertNilError(t, err)
+    if jobId == "" {
+        t.Error("expected to get a BP job ID, but instead got nothing")
+    }
 
     utils.VerifyBookContent(testutils.BookTitles[0], file0)
     utils.VerifyBookContent(testutils.BookTitles[1], file1)
@@ -172,8 +184,11 @@ func TestGetBulkBlobSpanningChunksRandomAccess(t *testing.T) {
         {Name: LargeBookTitle, ChannelBuilder: channels.NewWriteChannelBuilder(file.Name())},
     }
 
-    err = helper.GetObjects(testBucket, readObjects, strategy)
+    jobId, err := helper.GetObjects(testBucket, readObjects, strategy)
     ds3Testing.AssertNilError(t, err)
+    if jobId == "" {
+        t.Error("expected to get a BP job ID, but instead got nothing")
+    }
 
     err = VerifyLargeBookContent(file)
     ds3Testing.AssertNilError(t, err)
@@ -207,8 +222,11 @@ func TestGetBulkPartialObjectRandomAccess(t *testing.T) {
         {Name: LargeBookTitle, ChannelBuilder: channels.NewPartialObjectChannelBuilder(file.Name(), ranges), Ranges: ranges},
     }
 
-    err = helper.GetObjects(testBucket, readObjects, strategy)
+    jobId, err := helper.GetObjects(testBucket, readObjects, strategy)
     ds3Testing.AssertNilError(t, err)
+    if jobId == "" {
+        t.Error("expected to get a BP job ID, but instead got nothing")
+    }
 
     file.Seek(0, io.SeekStart)
     testutils.VerifyPartialFile(t, LargeBookPath + LargeBookTitle, 101, 0, file)

--- a/helpers_integration/largeFileTestUtil.go
+++ b/helpers_integration/largeFileTestUtil.go
@@ -46,5 +46,6 @@ func LoadLargeFile(bucket string, client *ds3.Client) error {
     var writeObjects []helperModels.PutObject
     writeObjects = append(writeObjects, *writeObj)
 
-    return helper.PutObjects(bucket, writeObjects, newTestTransferStrategy())
+    _, err = helper.PutObjects(bucket, writeObjects, newTestTransferStrategy())
+    return err
 }


### PR DESCRIPTION
Returning the JobId will make diagnosing problems easier in the future.