### PR TITLE
Fixing panic in put helper if file does not exist

### DIFF
--- a/helpers/putProducer.go
+++ b/helpers/putProducer.go
@@ -64,6 +64,7 @@ func (producer *putProducer) transferOperationBuilder(info putObjectInfo, aggErr
         if err != nil {
             aggErr.Append(err)
             log.Printf("ERROR could not get reader for object with name='%s' offset=%d length=%d", info.blob.Name(), info.blob.Offset(), info.blob.Length())
+            return
         }
         defer info.channelBuilder.OnDone(reader)
 


### PR DESCRIPTION
In the transfer blob operation, if we fail to get a reader, we should exit early. Previously we continued execution, and this caused a panic when we attempted to close the nil reader.