### PR TITLE
GOSDK-26: On archive helpers can hang indefinetely using streaming strategy if blob fails

### DIFF
--- a/helpers/channels/fatalErrorHandler.go
+++ b/helpers/channels/fatalErrorHandler.go
@@ -1,0 +1,32 @@
+package channels
+
+import "sync"
+
+// Implements the fatal error handling in channel builders.
+// This is used to track if a file has encountered a fatal error such that
+// future blobs for a given file should not be processed.
+type FatalErrorHandler struct {
+    errLock sync.RWMutex
+    fatalError error
+}
+
+func (errHandler *FatalErrorHandler) HasFatalError() bool {
+    errHandler.errLock.RLock()
+    defer errHandler.errLock.RUnlock()
+
+    return errHandler.fatalError != nil
+}
+
+func (errHandler *FatalErrorHandler) SetFatalError(err error) {
+    errHandler.errLock.Lock()
+    defer errHandler.errLock.Unlock()
+
+    errHandler.fatalError = err
+}
+
+func (errHandler *FatalErrorHandler) GetFatalError() error {
+    errHandler.errLock.RLock()
+    defer errHandler.errLock.RUnlock()
+
+    return errHandler.fatalError
+}

--- a/helpers/channels/fatalErrorHandler.go
+++ b/helpers/channels/fatalErrorHandler.go
@@ -17,11 +17,15 @@ func (errHandler *FatalErrorHandler) HasFatalError() bool {
     return errHandler.fatalError != nil
 }
 
+// Captures the first fatal error that occurs.
+// In a multi-threaded environment, all subsequent errors will be ignored.
 func (errHandler *FatalErrorHandler) SetFatalError(err error) {
     errHandler.errLock.Lock()
     defer errHandler.errLock.Unlock()
 
-    errHandler.fatalError = err
+    if errHandler.fatalError == nil {
+        errHandler.fatalError = err
+    }
 }
 
 func (errHandler *FatalErrorHandler) GetFatalError() error {

--- a/helpers/channels/objectReadChannelBuilder.go
+++ b/helpers/channels/objectReadChannelBuilder.go
@@ -1,9 +1,9 @@
 package channels
 
 import (
+    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
     "io"
     "os"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
 )
 
 const defaultPermissions = 0
@@ -12,6 +12,7 @@ const defaultPermissions = 0
 // This channel functions as a random-access and can be used concurrently.
 type ObjectReadChannelBuilder struct {
     name string
+    FatalErrorHandler
 }
 
 func NewReadChannelBuilder(name string) helperModels.ReadChannelBuilder {

--- a/helpers/channels/objectReadChannelDecorator.go
+++ b/helpers/channels/objectReadChannelDecorator.go
@@ -7,6 +7,7 @@ import (
 
 type ObjectReadChannelDecorator struct {
 	readCloser io.ReadCloser
+	FatalErrorHandler
 }
 
 func NewObjectReadChannelDecorator(reader io.Reader) models.ReadChannelBuilder {

--- a/helpers/channels/objectWriteChannelBuilder.go
+++ b/helpers/channels/objectWriteChannelBuilder.go
@@ -11,6 +11,7 @@ import (
 // are not writing to the same location within the file.
 type ObjectWriteChannelBuilder struct {
     name string
+    FatalErrorHandler
 }
 
 func NewWriteChannelBuilder(name string) helperModels.WriteChannelBuilder {

--- a/helpers/channels/partialObjectWriteChannelBuilder.go
+++ b/helpers/channels/partialObjectWriteChannelBuilder.go
@@ -11,6 +11,7 @@ type PartialObjectWriteChannelBuilder struct {
     name string
     // map of object ranges to destination offset for start of range
     rangeMap partialObjectRangeMap
+    FatalErrorHandler
 }
 
 func NewPartialObjectChannelBuilder(name string, objRanges []ds3Models.Range) helperModels.WriteChannelBuilder {

--- a/helpers/models/channelBuilder.go
+++ b/helpers/models/channelBuilder.go
@@ -2,15 +2,22 @@ package models
 
 import "io"
 
+type ChannelErrorHandler interface {
+    HasFatalError() bool // Determines if a fatal error has happened while transferring a file, i.e. don't transfer more blobs for this file.
+    SetFatalError(err error) // Sets a fatal error for the associated file. This will stop future blobs from being sent from this channel.
+}
+
 type ReadChannelBuilder interface {
     IsChannelAvailable(offset int64) bool
     GetChannel(offset int64) (io.ReadCloser, error)
     OnDone(reader io.ReadCloser) // Determines what a given blob does when it finishes transferring
+    ChannelErrorHandler
 }
 
 type WriteChannelBuilder interface {
     IsChannelAvailable(offset int64) bool
     GetChannel(offset int64) (io.WriteCloser, error)
     OnDone(writer io.WriteCloser) // Determines what a given blob does when it finishes transferring
+    ChannelErrorHandler
 }
 

--- a/helpers_integration/largeFileTestUtil.go
+++ b/helpers_integration/largeFileTestUtil.go
@@ -36,6 +36,8 @@ func VerifyLargeBookContent(content io.ReadCloser) error {
 }
 
 func LoadLargeFile(bucket string, client *ds3.Client) error {
+    fmt.Printf("Loading large file to BP")
+    defer fmt.Printf("Finished loading large file to BP")
     helper := helpers.NewHelpers(client)
 
     writeObj, err := getTestWriteObjectRandomAccess(LargeBookTitle, LargeBookPath + LargeBookTitle)

--- a/helpers_integration/testReadChannels.go
+++ b/helpers_integration/testReadChannels.go
@@ -1,6 +1,7 @@
 package helpers_integration
 
 import (
+    "github.com/SpectraLogic/ds3_go_sdk/helpers/channels"
     "sync"
     "io"
     "log"
@@ -12,6 +13,7 @@ import (
 type testStreamAccessReadChannelBuilder struct {
     f *os.File
     channelCounter channelCounter
+    channels.FatalErrorHandler
 }
 
 // Used as a thread safe counter to keep track of the current number of channels in use for a given ReadChannelBuilder
@@ -42,7 +44,7 @@ func (builder *testStreamAccessReadChannelBuilder) GetChannel(offset int64) (io.
     if builder.channelCounter.currentCount() > 0 {
         return nil, errors.New("ERROR: channel is not currently available")
     }
-    log.Printf("DEBUG: incrementing channel semaphore with length %d", builder.channelCounter.currentCount()) //todo delete
+    log.Printf("DEBUG: incrementing channel semaphore with length %d", builder.channelCounter.currentCount())
     builder.channelCounter.increment()
     return builder.f, nil
 }
@@ -50,10 +52,10 @@ func (builder *testStreamAccessReadChannelBuilder) GetChannel(offset int64) (io.
 func (builder *testStreamAccessReadChannelBuilder) IsChannelAvailable(offset int64) bool {
     curOffset, _ := builder.f.Seek(0, io.SeekCurrent)
     if curOffset != offset || builder.channelCounter.currentCount() > 0 {
-        log.Printf("DEBUG: channel is not available. Offset expected=%d actual=%d. Semaphore expected=0 actual=%d", offset, curOffset, builder.channelCounter.currentCount()) //todo delete
+        log.Printf("DEBUG: channel is not available. Offset expected=%d actual=%d. Semaphore expected=0 actual=%d", offset, curOffset, builder.channelCounter.currentCount())
         return false
     }
-    log.Print("DEBUG: channel deamed available\n") //todo delete
+    log.Print("DEBUG: channel deamed available\n")
     return true
 }
 

--- a/helpers_integration/testWriteChannels.go
+++ b/helpers_integration/testWriteChannels.go
@@ -1,0 +1,69 @@
+package helpers_integration
+
+import (
+    "errors"
+    "fmt"
+    "github.com/SpectraLogic/ds3_go_sdk/helpers/channels"
+    "io"
+    "log"
+    "os"
+)
+
+type testStreamAccessWriteChannelBuilder struct {
+    f *os.File
+    channelCounter channelCounter
+    channels.FatalErrorHandler
+}
+
+func (builder *testStreamAccessWriteChannelBuilder) IsChannelAvailable(offset int64) bool {
+    curOffset, _ := builder.f.Seek(0, io.SeekCurrent)
+    if curOffset != offset || builder.channelCounter.currentCount() > 0 {
+        log.Printf("DEBUG: channel is not available. Offset expected Offset expected=%d actual=%d. Semaphore expected=0 actual=%d\n", offset, curOffset, builder.channelCounter.currentCount())
+        return false
+    }
+    log.Printf("DEBUG: channel is available\n")
+    return true
+}
+
+func (builder *testStreamAccessWriteChannelBuilder) GetChannel(offset int64) (io.WriteCloser, error) {
+    if builder.channelCounter.currentCount() > 0 {
+        return nil, errors.New("ERROR: channel is not currently available")
+    }
+    builder.channelCounter.increment()
+    return builder.f, nil
+}
+
+func (builder *testStreamAccessWriteChannelBuilder) OnDone(writer io.WriteCloser) {
+    if builder.channelCounter.currentCount() == 0 {
+        log.Printf("ERROR: cannot perform OnDone as no channels currently allocated")
+        return
+    }
+    builder.channelCounter.decrement()
+}
+
+// test channel that will fail to get channel
+type testStreamAccessWriteFailOnFirstBlob struct {
+    channelCounter
+    channels.FatalErrorHandler
+}
+
+func (builder *testStreamAccessWriteFailOnFirstBlob) IsChannelAvailable(offset int64) bool {
+    if offset != 0 {
+        log.Printf("DEBUG: channel is not available at offset=%d. Semaphore expected=0 actual=%d\n", offset, builder.channelCounter.currentCount())
+        return false
+    }
+    log.Printf("DEBUG: channel is available\n")
+    return true
+}
+
+func (builder testStreamAccessWriteFailOnFirstBlob) GetChannel(offset int64) (io.WriteCloser, error) {
+    return nil, fmt.Errorf("unable to get channel")
+}
+
+func (builder *testStreamAccessWriteFailOnFirstBlob) OnDone(writer io.WriteCloser) {
+    if builder.channelCounter.currentCount() == 0 {
+        log.Printf("ERROR: cannot perform OnDone as no channels currently allocated")
+        return
+    }
+    builder.channelCounter.decrement()
+}


### PR DESCRIPTION
Extending channel builders to include a fatal error tracker. Now, if a fatal error happens on one blob, then channel builder is notified and future blobs associated with the same file are not transferred.