### PR TITLE
NEO-1791: does not escape semicolon in outgoing PUT command to BlackPearl

### DIFF
--- a/ds3/networking/headers.go
+++ b/ds3/networking/headers.go
@@ -12,14 +12,14 @@
 package networking
 
 import (
-    "fmt"
-    "time"
     "crypto/hmac"
     "crypto/sha1"
     "encoding/base64"
     "errors"
+    "fmt"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "net/url"
+    "time"
 )
 
 // Http Headers
@@ -81,7 +81,7 @@ func (fields *signatureFields) BuildAuthHeaderValue(creds *Credentials) (string)
         fields.ContentType,
         fields.Date,
         fields.CanonicalizedAmzHeaders,
-        urlPath.EscapedPath(),
+        customEscapePath(urlPath),
         fields.CanonicalizedSubResources,
     )
 

--- a/ds3/networking/httpRequestBuilder.go
+++ b/ds3/networking/httpRequestBuilder.go
@@ -141,7 +141,19 @@ func (builder *HttpRequestBuilder) buildUrl(conn *ConnectionInfo) string {
     var httpUrl = *conn.Endpoint
     httpUrl.Path = builder.signatureFields.Path
     httpUrl.RawQuery = encodeQueryParams(builder.queryParams)
+
+    // Perform a custom percent encoding of the path to ensure ; and + are percent encoded as BP expects
+    httpUrl.RawPath = customEscapePath(httpUrl)
+
     return httpUrl.String()
+}
+
+// Returns the percent encoded path of the provided URL in a format that is congruent with BP.
+// This uses the standard path escaping plus it explicitly percent encodes ; and + since the
+// http library does not encode them by default.
+func customEscapePath(httpUrl url.URL) string {
+    replacer := strings.NewReplacer(";", "%3B", "+", "%2B")
+    return replacer.Replace(httpUrl.EscapedPath())
 }
 
 func (builder *HttpRequestBuilder) maybeAddSignatureQueryParams() {

--- a/ds3/networking/httpRequestBuilder_test.go
+++ b/ds3/networking/httpRequestBuilder_test.go
@@ -2,7 +2,7 @@ package networking
 
 import (
     "fmt"
-    "github.com/SpectraLogic/core_go/test_helpers"
+    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
     "net/url"
     "testing"
 )
@@ -35,7 +35,7 @@ func TestBuildUrlEscapingPath(t *testing.T) {
     const bucketName = "myBucket"
 
     endPoint, err := url.Parse("http://sm2u-1-10g.eng.sldomain.com")
-    test_helpers.FatalOnError(t, err, "unable to parse endpoint")
+    ds3Testing.AssertNilError(t, err)
 
     connectionInfo := &ConnectionInfo{
         Endpoint: endPoint,
@@ -52,6 +52,6 @@ func TestBuildUrlEscapingPath(t *testing.T) {
 
         expectedObjectName := fmt.Sprintf("object%swithsymbol", testCase.encoded)
         expected := fmt.Sprintf("%s/%s/%s", endPoint.String(), bucketName, expectedObjectName)
-        test_helpers.AssertEqual(t, expected, encodedUrl, fmt.Sprintf("encoding symbol %s", testCase.input))
+        ds3Testing.AssertString(t, fmt.Sprintf("encoding symbol %s", testCase.input), expected, encodedUrl)
     }
 }

--- a/ds3/networking/httpRequestBuilder_test.go
+++ b/ds3/networking/httpRequestBuilder_test.go
@@ -1,0 +1,57 @@
+package networking
+
+import (
+    "fmt"
+    "github.com/SpectraLogic/core_go/test_helpers"
+    "net/url"
+    "testing"
+)
+
+func TestBuildUrlEscapingPath(t *testing.T) {
+    testCases := []struct {
+        input string
+        encoded string
+    }{
+        {input:"-", encoded:"-"},
+        {input:".", encoded:"."},
+        {input:"_", encoded:"_"},
+        {input:"~", encoded:"~"},
+        {input:"$", encoded:"$"},
+        {input:",", encoded:","},
+        {input:"&", encoded:"&"},
+        {input:"=", encoded:"="},
+        {input:"@", encoded:"@"},
+        {input:":", encoded:":"},
+        {input:"/", encoded:"/"},
+        {input:";", encoded:"%3B"},
+        {input:"+", encoded:"%2B"},
+        {input:"?", encoded:"%3F"},
+        {input:" ", encoded:"%20"},
+        {input:"%", encoded:"%25"},
+        {input:"#", encoded:"%23"},
+        {input:"'", encoded:"%27"},
+    }
+
+    const bucketName = "myBucket"
+
+    endPoint, err := url.Parse("http://sm2u-1-10g.eng.sldomain.com")
+    test_helpers.FatalOnError(t, err, "unable to parse endpoint")
+
+    connectionInfo := &ConnectionInfo{
+        Endpoint: endPoint,
+    }
+
+    for _, testCase := range testCases {
+        objectName := fmt.Sprintf("object%swithsymbol", testCase.input)
+
+        requestBuilder := NewHttpRequestBuilder().
+            WithHttpVerb("PUT").
+            WithPath("/" + bucketName + "/" + objectName)
+
+        encodedUrl := requestBuilder.buildUrl(connectionInfo)
+
+        expectedObjectName := fmt.Sprintf("object%swithsymbol", testCase.encoded)
+        expected := fmt.Sprintf("%s/%s/%s", endPoint.String(), bucketName, expectedObjectName)
+        test_helpers.AssertEqual(t, expected, encodedUrl, fmt.Sprintf("encoding symbol %s", testCase.input))
+    }
+}


### PR DESCRIPTION
Even though `;` is a valid character in a URL according to the RFC spec, it does not play well with BP. Adding percent encoding for `;` and `+` in the path part of the URL.