### PR TITLE
OTHER: making all items in helper strategies public so that they can be set

### DIFF
--- a/helpers/getTransfernator.go
+++ b/helpers/getTransfernator.go
@@ -40,8 +40,11 @@ func newBulkGetRequest(bucketName string, readObjects *[]helperModels.GetObject,
     if options.ImplicitJobIdResolution != nil {
         bulkGet.WithImplicitJobIdResolution(*options.ImplicitJobIdResolution)
     }
-    if options.priority != ds3Models.UNDEFINED {
-        bulkGet.WithPriority(options.priority)
+    if options.Priority != ds3Models.UNDEFINED {
+        bulkGet.WithPriority(options.Priority)
+    }
+    if options.Name != nil {
+        bulkGet.WithName(*options.Name)
     }
 
     return bulkGet

--- a/helpers/readTransferStrategy.go
+++ b/helpers/readTransferStrategy.go
@@ -12,8 +12,8 @@ type ReadBulkJobOptions struct {
     Aggregating *bool
     ChunkClientProcessingOrderGuarantee models.JobChunkClientProcessingOrderGuarantee
     ImplicitJobIdResolution *bool
-    name *string
-    priority models.Priority
+    Name *string
+    Priority models.Priority
 }
 
 // Strategy for how to blob objects for writing


### PR DESCRIPTION
It was a typo that some were package private.