### PR TITLE
OTHER: fixing race condition queueing things for processing

### DIFF
--- a/helpers/blobQueue.go
+++ b/helpers/blobQueue.go
@@ -3,6 +3,7 @@ package helpers
 import (
     "errors"
     helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+    "reflect"
 )
 
 // A queue that manages descriptions of blobs
@@ -25,6 +26,12 @@ func NewBlobDescriptionQueue() BlobDescriptionQueue {
 }
 
 func (queue *blobDescriptionQueueImpl) Push(description *helperModels.BlobDescription) {
+    // verify that this blob isn't already in the queue before adding it
+    for _, existingBlob := range queue.queue {
+        if reflect.DeepEqual(*existingBlob, *description) {
+            return
+        }
+    }
     queue.queue = append(queue.queue, description)
 }
 


### PR DESCRIPTION
Cherry-pick (#101)

This only happens in streaming strategy combined with very small blob size on the BP bucket. There existed the possibility that a blob would be added to the queue twice. This explicitly prevents the double queuing of blobs.