### PR TITLE
OTHER: adding retry around bulk get when a blob only partially transfers

### DIFF
--- a/ds3_integration/utils/testUtils.go
+++ b/ds3_integration/utils/testUtils.go
@@ -60,7 +60,7 @@ func VerifyBookContent(t *testing.T, bookName string, actual io.ReadCloser) {
     verifyContent(t, expected, actual)
 }
 
-func VerifyPartialFile(t *testing.T, filePath string, length int64, offset int64, actual io.ReadCloser) {
+func VerifyPartialFile(t *testing.T, filePath string, length int64, offset int64, actual io.Reader) {
     f, err := os.Open(filePath)
     ds3Testing.AssertNilError(t, err)
 
@@ -73,7 +73,7 @@ func VerifyPartialFile(t *testing.T, filePath string, length int64, offset int64
     verifyPartialContent(t, *expected, actual, length)
 }
 
-func verifyPartialContent(t *testing.T, expected []byte, actual io.ReadCloser, length int64) {
+func verifyPartialContent(t *testing.T, expected []byte, actual io.Reader, length int64) {
     content, err := getNBytesFromReader(actual, length)
     ds3Testing.AssertNilError(t, err)
 


### PR DESCRIPTION
If the blob is not retrieved in its entirety, then ranged naked gets are used to retrieve the remaining portion of the blob. This retry only applies to blobs where no range was specified.