### PR TITLE
GOSDK-23: The SDK breaks canonical MIME encoding of http headers

### DIFF
--- a/ds3/models/ds3Response.go
+++ b/ds3/models/ds3Response.go
@@ -2,7 +2,6 @@ package models
 
 import (
     "io"
-    "strings"
     "net/http"
 )
 
@@ -29,13 +28,10 @@ func (wrappedHttpResponse *WrappedHttpResponse) Body() io.ReadCloser {
 }
 
 func (wrappedHttpResponse *WrappedHttpResponse) Header() *http.Header {
-    // The HTTP spec says headers keys are case insensitive, so we'll just
-    // to lower them before processing the response so we can always get the
-    // right thing.
     result := make(http.Header)
     header := wrappedHttpResponse.rawResponse.Header
     for k, v := range header {
-        result[strings.ToLower(k)] = v
+        result[k] = v
     }
     return &result
 }


### PR DESCRIPTION
Removing the to lower call on all headers which was messing with the MIME encoding.