### PR TITLE
Incorrect authorization header calculation

### DIFF
--- a/ds3/networking/canonicalHeaders.go
+++ b/ds3/networking/canonicalHeaders.go
@@ -1,0 +1,12 @@
+package networking
+
+// Used to correctly sort headers when creating the stringToSign for the authorization header.
+type CanonicalHeader struct{
+	key string // key is assumed to be lower cased
+	values []string
+}
+type CanonicalHeaders []CanonicalHeader
+
+func (p CanonicalHeaders) Len() int           { return len(p) }
+func (p CanonicalHeaders) Less(i, j int) bool { return p[i].key < p[j].key }
+func (p CanonicalHeaders) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/ds3/networking/headers_test.go
+++ b/ds3/networking/headers_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestBuildAuthHeaderValue(t *testing.T) {
-    expected := "AWS access:1JbBTxv5KRFKbvju7w27c2J6bKk="
+    expected := "AWS access:gmW4yg/tw02UYleIqGn5ebvKbr8="
 
     fields := signatureFields{
         Verb:"PUT",

--- a/ds3/networking/httpRequestBuilder.go
+++ b/ds3/networking/httpRequestBuilder.go
@@ -207,33 +207,31 @@ func (builder *HttpRequestBuilder) maybeAddSignatureQueryParams() {
 }
 
 func (builder *HttpRequestBuilder) maybeAddAmazonCanonicalHeaders() {
-	headerKeys := make([]string, 0)
+	var canonicalHeaders CanonicalHeaders
 
 	for key, value := range *builder.headers {
 		lowerCaseKey := strings.ToLower(key)
 		if strings.HasPrefix(lowerCaseKey, models.AMZ_META_HEADER) && len(value) > 0 {
-			headerKeys = append(headerKeys, key)
+            canonicalHeaders = append(canonicalHeaders, CanonicalHeader{
+                key:   lowerCaseKey,
+                values: value,
+            })
 		}
 	}
 
-	if len(headerKeys) == 0 {
+	if len(canonicalHeaders) == 0 {
 		return
 	}
 
-	sort.Strings(headerKeys)
+	sort.Sort(canonicalHeaders)
 
 	var stringBuilder strings.Builder
 
-	var httpHeaders map[string][]string = *builder.headers
-
-	for _, headerKey := range headerKeys {
-		lowerCaseKey := strings.ToLower(headerKey)
-		headerValue := httpHeaders[headerKey]
-
-		if len(headerValue) > 0 {
-			stringBuilder.WriteString(lowerCaseKey)
+	for _, header := range canonicalHeaders {
+		if len(header.values) > 0 {
+			stringBuilder.WriteString(header.key)
 			stringBuilder.WriteString(":")
-			stringBuilder.WriteString(strings.Join(headerValue, ","))
+			stringBuilder.WriteString(strings.Join(header.values, ","))
 			stringBuilder.WriteString("\n")
 		}
 	}

--- a/ds3_integration/smoke_test.go
+++ b/ds3_integration/smoke_test.go
@@ -176,8 +176,8 @@ func TestDeleteBucketNonEmpty(t *testing.T) {
     putObjErr := testutils.PutObjectLogError(t, client, bucketName, beowulf, book)
     ds3Testing.AssertNilError(t, putObjErr)
 
-    //Attempt to delete non-empty bucket
-    deleteErr := testutils.DeleteBucket(client, bucketName)
+    //Attempt to delete non-empty bucket without force
+    _, deleteErr := client.DeleteBucketSpectraS3(models.NewDeleteBucketSpectraS3Request(bucketName))
     ds3Testing.AssertBadStatusCodeError(t, 409, deleteErr)
 }
 
@@ -544,7 +544,11 @@ func TestPuttingZeroLengthObject(t *testing.T) {
 
     zeroBytes := make([]byte, 0)
 
-    putObjectRequest := models.NewPutObjectRequest(bucketName, objectName, ds3.BuildByteReaderWithSizeDecorator(zeroBytes))
+    putObjectRequest := models.NewPutObjectRequest(bucketName, objectName, ds3.BuildByteReaderWithSizeDecorator(zeroBytes)).
+        WithMetaData("_c", "C").
+        WithMetaData("d", "D").
+        WithMetaData("_a", "A").
+        WithMetaData("b", "B")
 
     _, err = client.PutObject(putObjectRequest)
 


### PR DESCRIPTION
The authorization header was being calculated incorrectly due to incorrect sorting on amz headers when there existed a header that started with an underscore. The `http.Header` implementation automatically camel cases headers. We were sorting the header keys before lower casing them when calculating the authorization header. Since underscore sorts differently when compared to upper and lower cased alpha characters, this created an incorrect sort order in the stringToSign. Fixed sorting to take place after lower casing header keys. 

Also fixed two stale tests that were failing due to unrelated issues.