### PR TITLE
Client feature fixes

### DIFF
--- a/ds3/buildclient/buildClient.go
+++ b/ds3/buildclient/buildClient.go
@@ -50,7 +50,7 @@ func createClient(args *commands.Arguments) (*ds3.Client, error) {
     
     // Parse endpoint.
     endpoint := args.Endpoint
-    if !strings.HasPrefix(endpoint, "http://") || !strings.HasPrefix(endpoint, "https://") {
+    if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
         endpoint = "https://" + endpoint
     }
 

--- a/ds3_cli/commands/args.go
+++ b/ds3_cli/commands/args.go
@@ -10,6 +10,7 @@ import (
 type Arguments struct {
     Endpoint, Proxy string
     AccessKey, SecretKey string
+    IgnoreServerCertificate bool
     Command string
     Bucket string
     Key string
@@ -21,6 +22,7 @@ type Arguments struct {
 func ParseArgs() (*Arguments, error) {
     // Parse command line arguments.
     endpointParam := flag.String("endpoint", "", "Specifies the url to the DS3 server.")
+    ignoreServerCertParam := flag.Bool("ignore_server_cert", false, "Specifies whether to ignore the server's certificate.")
     accessKeyParam := flag.String("access_key", "", "Specifies the access_key for the DS3 user.")
     secretKeyParam := flag.String("secret_key", "", "Specifies the secret_key for the DS3 user.")
     proxyParam := flag.String("proxy", "", "Specifies the HTTP proxy to route through.")
@@ -36,6 +38,7 @@ func ParseArgs() (*Arguments, error) {
     // Build the arguments object.
     args := Arguments{
         Endpoint: paramOrEnv(*endpointParam, "DS3_ENDPOINT"),
+        IgnoreServerCertificate: *ignoreServerCertParam,
         AccessKey: paramOrEnv(*accessKeyParam, "DS3_ACCESS_KEY"),
         SecretKey: paramOrEnv(*secretKeyParam, "DS3_SECRET_KEY"),
         Proxy: paramOrEnv(*proxyParam, "DS3_PROXY"),

--- a/ds3_cli/commands/getBucketObjects.go
+++ b/ds3_cli/commands/getBucketObjects.go
@@ -45,7 +45,7 @@ func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Ds3PutObjec
         remainingKeys -= len(response.ListBucketResult.Objects)
 
         // Take note of the next marker to get.
-        //marker = *response.ListBucketResult.NextMarker
+        marker = *response.ListBucketResult.NextMarker
 
         // Take care of the do...while.
         if response.ListBucketResult.Truncated == false || remainingKeys <= 0 {

--- a/ds3_cli/commands/getBucketObjects.go
+++ b/ds3_cli/commands/getBucketObjects.go
@@ -45,7 +45,7 @@ func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Ds3PutObjec
         remainingKeys -= len(response.ListBucketResult.Objects)
 
         // Take note of the next marker to get.
-        marker = *response.ListBucketResult.NextMarker
+        //marker = *response.ListBucketResult.NextMarker
 
         // Take care of the do...while.
         if response.ListBucketResult.Truncated == false || remainingKeys <= 0 {


### PR DESCRIPTION
Add client argument/option to ignore server certs. Support for the option was already in the  base just not added into the higher client functions.

Also added the feature that the client builder will prepend "https://" to the endpoint IP if it doesn't exist. This can be omitted, but ds3_java_cli does this as well.

I'm having an issue with the marker in getBucketObjects but will open that up separately.