### PR TITLE
Use an http.Transport with sensible defaults

### DIFF
--- a/ds3/ds3Client.go
+++ b/ds3/ds3Client.go
@@ -3,6 +3,7 @@ package ds3
 import (
     "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
     "net/url"
+    "time"
     "github.com/SpectraLogic/ds3_go_sdk/sdk_log"
 )
 
@@ -72,6 +73,16 @@ func (clientBuilder *ClientBuilder) WithIgnoreServerCertificate(ignoreServerCert
 
 func (clientBuilder *ClientBuilder) WithLogger(logger sdk_log.Logger) *ClientBuilder {
     clientBuilder.logger = logger
+    return clientBuilder
+}
+
+func (clientBuilder *ClientBuilder) WithMaxIdleConnsPerHost(count int) *ClientBuilder {
+    clientBuilder.connectionInfo.MaxIdleConnsPerHost = count
+    return clientBuilder
+}
+
+func (clientBuilder *ClientBuilder) WithIdleConnTimeout(timeout time.Duration) *ClientBuilder {
+    clientBuilder.connectionInfo.IdleConnTimeout = timeout
     return clientBuilder
 }
 

--- a/ds3/networking/net.go
+++ b/ds3/networking/net.go
@@ -4,6 +4,7 @@ import (
     "crypto/tls"
     "net/http"
     "net/url"
+    "time"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
@@ -12,6 +13,8 @@ type ConnectionInfo struct {
     Credentials             *Credentials
     Proxy                   *url.URL
     IgnoreServerCertificate bool
+    MaxIdleConnsPerHost     int
+    IdleConnTimeout         time.Duration
 }
 
 type Credentials struct {
@@ -28,16 +31,35 @@ type SendNetwork struct {
     transport *http.Transport
 }
 
+// Default idle connection timeout that's applied to the transport.
+// Beats BlackPearl's 60s Tomcat keepAliveTimeout so the client always
+// closes idle conns first and never races a server-side FIN.
+const DEFAULT_IDLE_CONN_TIMEOUT = 30 * time.Second
+
 func NewSendNetwork(connectionInfo *ConnectionInfo) Network {
-    sendNetwork := &SendNetwork{
-        transport: &http.Transport{
-            Proxy: http.ProxyURL(connectionInfo.Proxy),
-        },
+    transport := http.DefaultTransport.(*http.Transport).Clone()
+    transport.IdleConnTimeout = DEFAULT_IDLE_CONN_TIMEOUT
+
+    if connectionInfo.Proxy != nil {
+        transport.Proxy = http.ProxyURL(connectionInfo.Proxy)
     }
     if connectionInfo.IgnoreServerCertificate {
-        sendNetwork.transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+        transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
     }
-    return sendNetwork
+    if connectionInfo.MaxIdleConnsPerHost > 0 {
+        transport.MaxIdleConnsPerHost = connectionInfo.MaxIdleConnsPerHost
+    }
+    if connectionInfo.IdleConnTimeout > 0 {
+        transport.IdleConnTimeout = connectionInfo.IdleConnTimeout
+    }
+
+    // Pin HTTP/1.1: BlackPearl's Tomcat h2 connector trips a 64 KB
+    // stream-window stall on streaming PUTs (RMS-10959). The C SDK
+    // (libds3v5) does the same.
+    transport.ForceAttemptHTTP2 = false
+    transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
+
+    return &SendNetwork{transport: transport}
 }
 
 func (sendNetwork *SendNetwork) Invoke(httpRequest *http.Request) (models.WebResponse, error) {


### PR DESCRIPTION
Replace the bare http.Transport literal in ds3.Client. Cloning http.DefaultTransport gives us a 30s dial timeout, OS-level TCP keepalive, TLS handshake / Expect-100-continue timeouts, and HTTPS_PROXY env-var fallback that the bare literal lacked.

Default IdleConnTimeout to 30s (DEFAULT_IDLE_CONN_TIMEOUT). This SDK only ever talks to BlackPearl, whose Tomcat connector closes idle keep-alive conns after 60s; the cloned 90s default would always lose that race and leave the next request hitting a half-closed socket.

Pin HTTP/1.1 (ForceAttemptHTTP2=false plus a non-nil empty TLSNextProto): BlackPearl's Tomcat HTTP/2 connector trips a 64 KB stream-window stall on streaming PUTs (RMS-10959). The DS3 C SDK (libds3v5) takes the same posture for the same reason.

Add ClientBuilder.WithMaxIdleConnsPerHost and WithIdleConnTimeout for app-specific overrides. MaxIdleConnsPerHost intentionally has no SDK default — the right value depends on the app's concurrency profile (Vail's differs from a CLI's), so the cloned stdlib fallback (2) applies unless an app sets it.