### PR TITLE
VAIL-8539: Add support for Go contexts

### DIFF
--- a/ds3/ds3Client_test.go
+++ b/ds3/ds3Client_test.go
@@ -12,6 +12,7 @@
 package ds3
 
 import (
+    "context"
     "testing"
     "strconv"
     "net/url"
@@ -55,7 +56,7 @@ func TestGetService(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/", &url.Values{}, &http.Header{}, nil).
         Returning(200, stringResponse, nil).
-        GetService(models.NewGetServiceRequest())
+        GetService(context.Background(), models.NewGetServiceRequest())
 
     // Validate the error contents.
     ds3Testing.AssertNilError(t, err)
@@ -81,7 +82,7 @@ func TestGetBadService(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/", &url.Values{}, &http.Header{}, nil).
         Returning(400, "", nil).
-        GetService(models.NewGetServiceRequest())
+        GetService(context.Background(), models.NewGetServiceRequest())
 
     // Check the response.
     if response != nil {
@@ -119,7 +120,7 @@ func TestGetBucket(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/remoteTest16", &url.Values{}, &http.Header{}, nil).
         Returning(200, stringResponse, nil).
-        GetBucket(models.NewGetBucketRequest("remoteTest16"))
+        GetBucket(context.Background(), models.NewGetBucketRequest("remoteTest16"))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -173,7 +174,7 @@ func TestGetBucketWithCommonPrefixes(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/" + bucketName, queryParams, &http.Header{}, nil).
         Returning(200, stringResponse, nil).
-        GetBucket(models.NewGetBucketRequest(bucketName).WithDelimiter(delimiter))
+        GetBucket(context.Background(), models.NewGetBucketRequest(bucketName).WithDelimiter(delimiter))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -214,7 +215,7 @@ func TestPutBucket(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_PUT, "/bucketName", &url.Values{}, &http.Header{}, nil).
         Returning(200, "", nil).
-        PutBucket(models.NewPutBucketRequest("bucketName"))
+        PutBucket(context.Background(), models.NewPutBucketRequest("bucketName"))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -230,7 +231,7 @@ func TestDeleteBucket(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_DELETE, "/bucketName", &url.Values{}, &http.Header{}, nil).
         Returning(204, "", nil).
-        DeleteBucket(models.NewDeleteBucketRequest("bucketName"))
+        DeleteBucket(context.Background(), models.NewDeleteBucketRequest("bucketName"))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -250,7 +251,7 @@ func TestDeleteFolderRecursivelySpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_DELETE, "/_rest_/folder/FolderName", queryParams, &http.Header{}, nil).
             Returning(204, "", nil).
-            DeleteFolderRecursivelySpectraS3(models.NewDeleteFolderRecursivelySpectraS3Request(bucketId, folderName))
+            DeleteFolderRecursivelySpectraS3(context.Background(), models.NewDeleteFolderRecursivelySpectraS3Request(bucketId, folderName))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -266,7 +267,7 @@ func TestDeleteObject(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_DELETE, "/bucketName/my/file.txt", &url.Values{}, &http.Header{}, nil).
         Returning(204, "", nil).
-        DeleteObject(models.NewDeleteObjectRequest("bucketName", "my/file.txt"))
+        DeleteObject(context.Background(), models.NewDeleteObjectRequest("bucketName", "my/file.txt"))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -282,7 +283,7 @@ func TestGetBadBucket(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/remoteTest16", &url.Values{}, &http.Header{}, nil).
         Returning(400, "", nil).
-        GetBucket(models.NewGetBucketRequest("remoteTest16"))
+        GetBucket(context.Background(), models.NewGetBucketRequest("remoteTest16"))
 
     // Check the error result.
     if err == nil {
@@ -305,7 +306,7 @@ func TestGetObject(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/bucketName/object", &url.Values{}, &http.Header{}, nil).
         Returning(200, stringResponse, nil).
-        GetObject(models.NewGetObjectRequest("bucketName", "object"))
+        GetObject(context.Background(), models.NewGetObjectRequest("bucketName", "object"))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -333,7 +334,7 @@ func TestGetPartialObject(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/bucketName/object", &url.Values{}, requestHeaders, nil).
         Returning(206, stringResponse, nil).
-        GetObject(models.NewGetObjectRequest("bucketName", "object").
+        GetObject(context.Background(), models.NewGetObjectRequest("bucketName", "object").
             WithRanges(
                 models.Range{Start: 1, End: 5},
                 models.Range{Start: 7, End: 8},
@@ -366,7 +367,7 @@ func TestGetObjectRange(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/bucketName/object", &url.Values{}, requestHeaders, nil).
         Returning(200, stringResponse, &http.Header{"Range": []string{"bytes=20-179"}}).
-        GetObject(request)
+        GetObject(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -399,7 +400,7 @@ func TestGetObjectsDetailsSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_GET, "/_rest_/object", queryParams, &http.Header{}, nil).
             Returning(200, stringResponse, responseHeaders).
-            GetObjectsDetailsSpectraS3(request)
+            GetObjectsDetailsSpectraS3(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -441,7 +442,7 @@ func TestGetJobToReplicateSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/_rest_/job/23a876ec-2fac-4dc8-b8e6-98d6026e7f4a", expectedParams, &http.Header{}, nil).
         Returning(200, stringResponse, nil).
-        GetJobToReplicateSpectraS3(request)
+        GetJobToReplicateSpectraS3(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -460,7 +461,7 @@ func TestPutObject(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_PUT, "/bucketName/object", &url.Values{}, &http.Header{}, nil).
         Returning(200, "", nil).
-        PutObject(models.NewPutObjectRequest(
+        PutObject(context.Background(), models.NewPutObjectRequest(
             "bucketName",
             "object",
             BuildByteReaderWithSizeDecorator([]byte(stringResponse)),
@@ -497,7 +498,7 @@ func TestPutObjectWithMetaData(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_PUT, "/bucketName/object", &url.Values{}, expectedMetaData, nil).
             Returning(200, "", nil).
-            PutObject(request)
+            PutObject(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -513,7 +514,7 @@ func TestBulkPut(t *testing.T) {
         t,
         "start_bulk_put",
         func(client *Client, objects []models.Ds3PutObject) ([]models.Objects, error) {
-            request, err := client.PutBulkJobSpectraS3(models.NewPutBulkJobSpectraS3Request("bucketName", objects))
+            request, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request("bucketName", objects))
             return request.MasterObjectList.Objects, err
         },
     )
@@ -579,7 +580,7 @@ func TestBulkGetWithSimpleDs3GetObjets(t *testing.T) {
         "start_bulk_get",
         &stringRequest,
         func(client *Client) ([]models.Objects, error) {
-            request, err := client.GetBulkJobSpectraS3(models.NewGetBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
+            request, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
             return request.MasterObjectList.Objects, err
         },
     )
@@ -599,7 +600,7 @@ func TestBulkGetWithPartialDs3GetObjects(t *testing.T) {
         "start_bulk_get",
         &stringRequest,
         func(client *Client) ([]models.Objects, error) {
-            request, err := client.GetBulkJobSpectraS3(models.NewGetBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
+            request, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
             return request.MasterObjectList.Objects, err
         },
     )
@@ -615,7 +616,7 @@ func TestBulkGetWithObjectNames(t *testing.T) {
         "start_bulk_get",
         &stringRequest,
         func(client *Client) ([]models.Objects, error) {
-            request, err := client.GetBulkJobSpectraS3(models.NewGetBulkJobSpectraS3Request("bucketName", objects))
+            request, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3Request("bucketName", objects))
             return request.MasterObjectList.Objects, err
         },
     )
@@ -635,7 +636,7 @@ func TestBulkVerifyWithPartialDs3GetObjects(t *testing.T) {
         "start_bulk_verify",
         &stringRequest,
         func(client *Client) ([]models.Objects, error) {
-            request, err := client.VerifyBulkJobSpectraS3(models.NewVerifyBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
+            request, err := client.VerifyBulkJobSpectraS3(context.Background(), models.NewVerifyBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
             return request.MasterObjectList.Objects, err
         },
     )
@@ -651,7 +652,7 @@ func TestBulkVerifyWithObjectNames(t *testing.T) {
         "start_bulk_verify",
         &stringRequest,
         func(client *Client) ([]models.Objects, error) {
-            request, err := client.VerifyBulkJobSpectraS3(models.NewVerifyBulkJobSpectraS3Request("bucketName", objects))
+            request, err := client.VerifyBulkJobSpectraS3(context.Background(), models.NewVerifyBulkJobSpectraS3Request("bucketName", objects))
             return request.MasterObjectList.Objects, err
         },
     )
@@ -704,7 +705,7 @@ func TestInitiateMultipart(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_POST, "/bucketName/object", qs, &http.Header{}, nil).
         Returning(200, stringResponse, nil).
-        InitiateMultiPartUpload(models.NewInitiateMultiPartUploadRequest(
+        InitiateMultiPartUpload(context.Background(), models.NewInitiateMultiPartUploadRequest(
             "bucketName",
             "object",
         ))
@@ -738,7 +739,7 @@ func TestPutPart(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_PUT, "/bucketName/object", qs, &http.Header{}, &content).
         Returning(200, "", responseHeaders).
-        PutMultiPartUploadPart(models.NewPutMultiPartUploadPartRequest(
+        PutMultiPartUploadPart(context.Background(), models.NewPutMultiPartUploadPartRequest(
             "bucketName",
             "object",
             BuildByteReaderWithSizeDecorator([]byte(content)),
@@ -773,7 +774,7 @@ func TestCompleteMultipart(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_POST, "/bucketName/object", qs, &http.Header{}, &expectedRequest).
         Returning(200, expectedResponse, &http.Header{"etag": []string{etag}}).
-        CompleteMultiPartUpload(models.NewCompleteMultiPartUploadRequest(
+        CompleteMultiPartUpload(context.Background(), models.NewCompleteMultiPartUploadRequest(
             bucket,
             key,
             []models.Part{
@@ -825,7 +826,7 @@ func TestDeleteObjects(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_POST, "/bucketName", qs, &http.Header{}, &expectedRequest).
         Returning(200, expectedResponse, &http.Header{}).
-        DeleteObjects(models.NewDeleteObjectsRequest(bucket, objectNames))
+        DeleteObjects(context.Background(), models.NewDeleteObjectsRequest(bucket, objectNames))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -870,7 +871,7 @@ func TestAllocateJobChunkSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_PUT, "/_rest_/job_chunk/203f6886-b058-4f7c-a012-8779176453b1", qp, &http.Header{}, nil).
             Returning(200, responseString, nil).
-            AllocateJobChunkSpectraS3(request)
+            AllocateJobChunkSpectraS3(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1000,7 +1001,7 @@ func TestGetJobChunksReadyForClientProcessingSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_GET, "/_rest_/job_chunk", qp, &http.Header{}, nil).
             Returning(200, test_master_object_list_xml, nil).
-            GetJobChunksReadyForClientProcessingSpectraS3(request)
+            GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1017,7 +1018,7 @@ func TestGetJobSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_GET, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
             Returning(200, test_master_object_list_xml, nil).
-            GetJobSpectraS3(request)
+            GetJobSpectraS3(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1035,7 +1036,7 @@ func TestModifyJobSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_PUT, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
             Returning(200, test_master_object_list_xml, nil).
-            ModifyJobSpectraS3(request)
+            ModifyJobSpectraS3(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1065,7 +1066,7 @@ func TestGetJobsSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_GET, "/_rest_/job", &url.Values{}, &http.Header{}, nil).
             Returning(200, responseString, nil).
-            GetJobsSpectraS3(models.NewGetJobsSpectraS3Request())
+            GetJobsSpectraS3(context.Background(), models.NewGetJobsSpectraS3Request())
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1148,7 +1149,7 @@ func TestCancelJobSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_DELETE, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", qp, &http.Header{}, nil).
             Returning(204, "", nil).
-            CancelJobSpectraS3(request)
+            CancelJobSpectraS3(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1166,7 +1167,7 @@ func TestDeleteTapeDriveSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_DELETE, "/_rest_/tape_drive/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
             Returning(204, "", nil).
-            DeleteTapeDriveSpectraS3(request)
+            DeleteTapeDriveSpectraS3(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1184,7 +1185,7 @@ func TestDeleteTapePartitionSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_DELETE, "/_rest_/tape_partition/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
             Returning(204, "", nil).
-            DeleteTapePartitionSpectraS3(request)
+            DeleteTapePartitionSpectraS3(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1200,7 +1201,7 @@ func TestVerifySystemHealthSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_GET, "/_rest_/system_health", &url.Values{}, &http.Header{}, nil).
             Returning(200, responsePayload, nil).
-            VerifySystemHealthSpectraS3(models.NewVerifySystemHealthSpectraS3Request())
+            VerifySystemHealthSpectraS3(context.Background(), models.NewVerifySystemHealthSpectraS3Request())
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1221,7 +1222,7 @@ func TestGetSystemInformationSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_GET, "/_rest_/system_information", &url.Values{}, &http.Header{}, nil).
             Returning(200, responsePayload, nil).
-            GetSystemInformationSpectraS3(models.NewGetSystemInformationSpectraS3Request())
+            GetSystemInformationSpectraS3(context.Background(), models.NewGetSystemInformationSpectraS3Request())
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1247,7 +1248,7 @@ func TestGetTapeLibrariesSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_GET, "/_rest_/tape_library", &url.Values{}, &http.Header{}, nil).
             Returning(200, responsePayload, responseHeaders).
-            GetTapeLibrariesSpectraS3(models.NewGetTapeLibrariesSpectraS3Request())
+            GetTapeLibrariesSpectraS3(context.Background(), models.NewGetTapeLibrariesSpectraS3Request())
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1285,7 +1286,7 @@ func TestGetTapeLibrarySpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_GET, "/_rest_/tape_library/" + id, &url.Values{}, &http.Header{}, nil).
             Returning(200, responsePayload, nil).
-            GetTapeLibrarySpectraS3(models.NewGetTapeLibrarySpectraS3Request(id))
+            GetTapeLibrarySpectraS3(context.Background(), models.NewGetTapeLibrarySpectraS3Request(id))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1310,7 +1311,7 @@ func TestGetTapeDriveSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_GET, "/_rest_/tape_drive/" + id, &url.Values{}, &http.Header{}, nil).
             Returning(200, responsePayload, nil).
-            GetTapeDriveSpectraS3(models.NewGetTapeDriveSpectraS3Request(id))
+            GetTapeDriveSpectraS3(context.Background(), models.NewGetTapeDriveSpectraS3Request(id))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1363,7 +1364,7 @@ func TestGetTapesSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
             Expecting(HTTP_VERB_GET, "/_rest_/tape", &url.Values{}, &http.Header{}, nil).
             Returning(200, responsePayload, responseHeaders).
-            GetTapesSpectraS3(models.NewGetTapesSpectraS3Request())
+            GetTapesSpectraS3(context.Background(), models.NewGetTapesSpectraS3Request())
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1414,7 +1415,7 @@ func TestDeletePermanentlyLostTapeSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_DELETE, "/_rest_/tape/" + id, &url.Values{}, &http.Header{}, nil).
         Returning(204, "", nil).
-        DeletePermanentlyLostTapeSpectraS3(request)
+        DeletePermanentlyLostTapeSpectraS3(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1433,7 +1434,7 @@ func TestGetTapeSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/_rest_/tape/" + id, &url.Values{}, &http.Header{}, nil).
         Returning(200, responsePayload, nil).
-        GetTapeSpectraS3(request)
+        GetTapeSpectraS3(context.Background(), request)
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1479,7 +1480,7 @@ func TestClearSuspectBlobAzureTargetsSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_azure_target", &url.Values{}, &http.Header{}, &expectedRequest).
         Returning(204, "", nil).
-        ClearSuspectBlobAzureTargetsSpectraS3(models.NewClearSuspectBlobAzureTargetsSpectraS3Request(ids))
+        ClearSuspectBlobAzureTargetsSpectraS3(context.Background(), models.NewClearSuspectBlobAzureTargetsSpectraS3Request(ids))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1499,7 +1500,7 @@ func TestClearSuspectBlobPoolsSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_pool", &url.Values{}, &http.Header{}, &expectedRequest).
         Returning(204, "", nil).
-        ClearSuspectBlobPoolsSpectraS3(models.NewClearSuspectBlobPoolsSpectraS3Request(ids))
+        ClearSuspectBlobPoolsSpectraS3(context.Background(), models.NewClearSuspectBlobPoolsSpectraS3Request(ids))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1519,7 +1520,7 @@ func TestClearSuspectBlobS3TargetsSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_s3_target", &url.Values{}, &http.Header{}, &expectedRequest).
         Returning(204, "", nil).
-        ClearSuspectBlobS3TargetsSpectraS3(models.NewClearSuspectBlobS3TargetsSpectraS3Request(ids))
+        ClearSuspectBlobS3TargetsSpectraS3(context.Background(), models.NewClearSuspectBlobS3TargetsSpectraS3Request(ids))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1540,7 +1541,7 @@ func TestClearSuspectBlobDs3TargetsSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_ds3_target", &url.Values{}, &http.Header{}, &expectedRequest).
         Returning(204, "", nil).
-        ClearSuspectBlobDs3TargetsSpectraS3(models.NewClearSuspectBlobDs3TargetsSpectraS3Request(ids))
+        ClearSuspectBlobDs3TargetsSpectraS3(context.Background(), models.NewClearSuspectBlobDs3TargetsSpectraS3Request(ids))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1560,7 +1561,7 @@ func TestClearSuspectBlobTapesSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_tape", &url.Values{}, &http.Header{}, &expectedRequest).
         Returning(204, "", nil).
-        ClearSuspectBlobTapesSpectraS3(models.NewClearSuspectBlobTapesSpectraS3Request(ids))
+        ClearSuspectBlobTapesSpectraS3(context.Background(), models.NewClearSuspectBlobTapesSpectraS3Request(ids))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1589,7 +1590,7 @@ func TestEjectStorageDomainBlobsSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_PUT, "/_rest_/tape", qp, &http.Header{}, &expectedRequest).
         Returning(204, "", nil).
-        EjectStorageDomainBlobsSpectraS3(models.NewEjectStorageDomainBlobsSpectraS3Request(bucketId, storageDomainId, objectNames))
+        EjectStorageDomainBlobsSpectraS3(context.Background(), models.NewEjectStorageDomainBlobsSpectraS3Request(bucketId, storageDomainId, objectNames))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1606,7 +1607,7 @@ func TestGetBlobsOnAzureTargetSpectraS3(t *testing.T) {
         t,
         "/_rest_/azure_target/" + target,
         func(client *Client) (models.BulkObjectList, error) {
-            request, err := client.GetBlobsOnAzureTargetSpectraS3(models.NewGetBlobsOnAzureTargetSpectraS3Request(target))
+            request, err := client.GetBlobsOnAzureTargetSpectraS3(context.Background(), models.NewGetBlobsOnAzureTargetSpectraS3Request(target))
             return request.BulkObjectList, err
         },
     )
@@ -1618,7 +1619,7 @@ func TestGetBlobsOnDs3TargetSpectraS3(t *testing.T) {
         t,
         "/_rest_/ds3_target/" + target,
         func(client *Client) (models.BulkObjectList, error) {
-            request, err := client.GetBlobsOnDs3TargetSpectraS3(models.NewGetBlobsOnDs3TargetSpectraS3Request(target))
+            request, err := client.GetBlobsOnDs3TargetSpectraS3(context.Background(), models.NewGetBlobsOnDs3TargetSpectraS3Request(target))
             return request.BulkObjectList, err
         },
     )
@@ -1630,7 +1631,7 @@ func TestGetBlobsOnPoolSpectraS3(t *testing.T) {
         t,
         "/_rest_/pool/" + target,
         func(client *Client) (models.BulkObjectList, error) {
-            request, err := client.GetBlobsOnPoolSpectraS3(models.NewGetBlobsOnPoolSpectraS3Request(target))
+            request, err := client.GetBlobsOnPoolSpectraS3(context.Background(), models.NewGetBlobsOnPoolSpectraS3Request(target))
             return request.BulkObjectList, err
         },
     )
@@ -1642,7 +1643,7 @@ func TestGetBlobsOnS3TargetSpectraS3(t *testing.T) {
         t,
         "/_rest_/s3_target/" + target,
         func(client *Client) (models.BulkObjectList, error) {
-            request, err := client.GetBlobsOnS3TargetSpectraS3(models.NewGetBlobsOnS3TargetSpectraS3Request(target))
+            request, err := client.GetBlobsOnS3TargetSpectraS3(context.Background(), models.NewGetBlobsOnS3TargetSpectraS3Request(target))
             return request.BulkObjectList, err
         },
     )
@@ -1654,7 +1655,7 @@ func TestGetBlobsOnTapeSpectraS3(t *testing.T) {
         t,
         "/_rest_/tape/" + target,
         func(client *Client) (models.BulkObjectList, error) {
-            request, err := client.GetBlobsOnTapeSpectraS3(models.NewGetBlobsOnTapeSpectraS3Request(target))
+            request, err := client.GetBlobsOnTapeSpectraS3(context.Background(), models.NewGetBlobsOnTapeSpectraS3Request(target))
             return request.BulkObjectList, err
         },
     )
@@ -1715,7 +1716,7 @@ func TestGetPhysicalPlacementForObjectsSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_PUT, "/_rest_/bucket/" + bucketName, qp, &http.Header{}, &expectedRequest).
         Returning(200, responsePayload, nil).
-        GetPhysicalPlacementForObjectsSpectraS3(models.NewGetPhysicalPlacementForObjectsSpectraS3Request(bucketName, objectNames))
+        GetPhysicalPlacementForObjectsSpectraS3(context.Background(), models.NewGetPhysicalPlacementForObjectsSpectraS3Request(bucketName, objectNames))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1742,7 +1743,7 @@ func TestGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_PUT, "/_rest_/bucket/" + bucketName, qp, &http.Header{}, &expectedRequest).
         Returning(200, responsePayload, nil).
-        GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3(models.NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName, objectNames))
+        GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3(context.Background(), models.NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName, objectNames))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1758,7 +1759,7 @@ func TestMarkSuspectBlobAzureTargetsAsDegradedSpectraS3(t *testing.T) {
         t,
         "/_rest_/suspect_blob_azure_target",
         func(client *Client, ids []string) error {
-            _, err := client.MarkSuspectBlobAzureTargetsAsDegradedSpectraS3(models.NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(ids))
+            _, err := client.MarkSuspectBlobAzureTargetsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(ids))
             return err
         },
     )
@@ -1769,7 +1770,7 @@ func TestMarkSuspectBlobDs3TargetsAsDegradedSpectraS3(t *testing.T) {
         t,
         "/_rest_/suspect_blob_ds3_target",
         func(client *Client, ids []string) error {
-            _, err := client.MarkSuspectBlobDs3TargetsAsDegradedSpectraS3(models.NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(ids))
+            _, err := client.MarkSuspectBlobDs3TargetsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(ids))
             return err
         },
     )
@@ -1780,7 +1781,7 @@ func TestMarkSuspectBlobPoolsAsDegradedSpectraS3(t *testing.T) {
         t,
         "/_rest_/suspect_blob_pool",
         func(client *Client, ids []string) error {
-            _, err := client.MarkSuspectBlobPoolsAsDegradedSpectraS3(models.NewMarkSuspectBlobPoolsAsDegradedSpectraS3Request(ids))
+            _, err := client.MarkSuspectBlobPoolsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobPoolsAsDegradedSpectraS3Request(ids))
             return err
         },
     )
@@ -1791,7 +1792,7 @@ func TestMarkSuspectBlobS3TargetsAsDegradedSpectraS3(t *testing.T) {
         t,
         "/_rest_/suspect_blob_s3_target",
         func(client *Client, ids []string) error {
-            _, err := client.MarkSuspectBlobS3TargetsAsDegradedSpectraS3(models.NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(ids))
+            _, err := client.MarkSuspectBlobS3TargetsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(ids))
             return err
         },
     )
@@ -1802,7 +1803,7 @@ func TestMarkSuspectBlobTapesAsDegradedSpectraS3(t *testing.T) {
         t,
         "/_rest_/suspect_blob_tape",
         func(client *Client, ids []string) error {
-            _, err := client.MarkSuspectBlobTapesAsDegradedSpectraS3(models.NewMarkSuspectBlobTapesAsDegradedSpectraS3Request(ids))
+            _, err := client.MarkSuspectBlobTapesAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobTapesAsDegradedSpectraS3Request(ids))
             return err
         },
     )
@@ -1839,7 +1840,7 @@ func TestVerifyPhysicalPlacementForObjectsSpectraS3(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/_rest_/bucket/" + bucketName, qp, &http.Header{}, &expectedRequest).
         Returning(200, responsePayload, nil).
-        VerifyPhysicalPlacementForObjectsSpectraS3(models.NewVerifyPhysicalPlacementForObjectsSpectraS3Request(bucketName, objectNames))
+        VerifyPhysicalPlacementForObjectsSpectraS3(context.Background(), models.NewVerifyPhysicalPlacementForObjectsSpectraS3Request(bucketName, objectNames))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1867,7 +1868,7 @@ func TestVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3(t *testing.T)
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_GET, "/_rest_/bucket/" + bucketName, qp, &http.Header{}, &expectedRequest).
         Returning(200, responsePayload, nil).
-        VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3(models.NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName, objectNames))
+        VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3(context.Background(), models.NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName, objectNames))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)
@@ -1946,7 +1947,7 @@ func TestHeadObject(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_HEAD, "/" + bucketName + "/" + objectName, &url.Values{}, &http.Header{}, nil).
         Returning(200, "", responseHeaders).
-        HeadObject(models.NewHeadObjectRequest(bucketName, objectName))
+        HeadObject(context.Background(), models.NewHeadObjectRequest(bucketName, objectName))
 
     ds3Testing.AssertNilError(t, err)
 
@@ -1977,7 +1978,7 @@ func TestStageObjectsJob(t *testing.T) {
     response, err := mockedClient(t).
         Expecting(HTTP_VERB_PUT, "/_rest_/bucket/" + bucketName, qp, &http.Header{}, &expectedRequest).
         Returning(200, responsePayload, nil).
-        StageObjectsJobSpectraS3(models.NewStageObjectsJobSpectraS3RequestWithPartialObjects(bucketName, objects))
+        StageObjectsJobSpectraS3(context.Background(), models.NewStageObjectsJobSpectraS3RequestWithPartialObjects(bucketName, objects))
 
     // Check the error result.
     ds3Testing.AssertNilError(t, err)

--- a/ds3/ds3Deletes.go
+++ b/ds3/ds3Deletes.go
@@ -14,17 +14,18 @@
 package ds3
 
 import (
+    "context"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
 )
 
-func (client *Client) AbortMultiPartUpload(request *models.AbortMultiPartUploadRequest) (*models.AbortMultiPartUploadResponse, error) {
+func (client *Client) AbortMultiPartUpload(ctx context.Context, request *models.AbortMultiPartUploadRequest) (*models.AbortMultiPartUploadResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/" + request.BucketName + "/" + request.ObjectName).
         WithQueryParam("upload_id", request.UploadId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -42,12 +43,12 @@ func (client *Client) AbortMultiPartUpload(request *models.AbortMultiPartUploadR
     return models.NewAbortMultiPartUploadResponse(response)
 }
 
-func (client *Client) DeleteBucket(request *models.DeleteBucketRequest) (*models.DeleteBucketResponse, error) {
+func (client *Client) DeleteBucket(ctx context.Context, request *models.DeleteBucketRequest) (*models.DeleteBucketResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/" + request.BucketName).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -65,13 +66,13 @@ func (client *Client) DeleteBucket(request *models.DeleteBucketRequest) (*models
     return models.NewDeleteBucketResponse(response)
 }
 
-func (client *Client) DeleteObject(request *models.DeleteObjectRequest) (*models.DeleteObjectResponse, error) {
+func (client *Client) DeleteObject(ctx context.Context, request *models.DeleteObjectRequest) (*models.DeleteObjectResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/" + request.BucketName + "/" + request.ObjectName).
         WithOptionalQueryParam("version_id", request.VersionId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -89,12 +90,12 @@ func (client *Client) DeleteObject(request *models.DeleteObjectRequest) (*models
     return models.NewDeleteObjectResponse(response)
 }
 
-func (client *Client) DeleteBucketAclSpectraS3(request *models.DeleteBucketAclSpectraS3Request) (*models.DeleteBucketAclSpectraS3Response, error) {
+func (client *Client) DeleteBucketAclSpectraS3(ctx context.Context, request *models.DeleteBucketAclSpectraS3Request) (*models.DeleteBucketAclSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/bucket_acl/" + request.BucketAcl).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -112,12 +113,12 @@ func (client *Client) DeleteBucketAclSpectraS3(request *models.DeleteBucketAclSp
     return models.NewDeleteBucketAclSpectraS3Response(response)
 }
 
-func (client *Client) DeleteDataPolicyAclSpectraS3(request *models.DeleteDataPolicyAclSpectraS3Request) (*models.DeleteDataPolicyAclSpectraS3Response, error) {
+func (client *Client) DeleteDataPolicyAclSpectraS3(ctx context.Context, request *models.DeleteDataPolicyAclSpectraS3Request) (*models.DeleteDataPolicyAclSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/data_policy_acl/" + request.DataPolicyAcl).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -135,13 +136,13 @@ func (client *Client) DeleteDataPolicyAclSpectraS3(request *models.DeleteDataPol
     return models.NewDeleteDataPolicyAclSpectraS3Response(response)
 }
 
-func (client *Client) DeleteBucketSpectraS3(request *models.DeleteBucketSpectraS3Request) (*models.DeleteBucketSpectraS3Response, error) {
+func (client *Client) DeleteBucketSpectraS3(ctx context.Context, request *models.DeleteBucketSpectraS3Request) (*models.DeleteBucketSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/bucket/" + request.BucketName).
         WithOptionalVoidQueryParam("force", request.Force).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -159,12 +160,12 @@ func (client *Client) DeleteBucketSpectraS3(request *models.DeleteBucketSpectraS
     return models.NewDeleteBucketSpectraS3Response(response)
 }
 
-func (client *Client) DeleteAzureDataReplicationRuleSpectraS3(request *models.DeleteAzureDataReplicationRuleSpectraS3Request) (*models.DeleteAzureDataReplicationRuleSpectraS3Response, error) {
+func (client *Client) DeleteAzureDataReplicationRuleSpectraS3(ctx context.Context, request *models.DeleteAzureDataReplicationRuleSpectraS3Request) (*models.DeleteAzureDataReplicationRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/azure_data_replication_rule/" + request.AzureDataReplicationRule).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -182,12 +183,12 @@ func (client *Client) DeleteAzureDataReplicationRuleSpectraS3(request *models.De
     return models.NewDeleteAzureDataReplicationRuleSpectraS3Response(response)
 }
 
-func (client *Client) DeleteDataPersistenceRuleSpectraS3(request *models.DeleteDataPersistenceRuleSpectraS3Request) (*models.DeleteDataPersistenceRuleSpectraS3Response, error) {
+func (client *Client) DeleteDataPersistenceRuleSpectraS3(ctx context.Context, request *models.DeleteDataPersistenceRuleSpectraS3Request) (*models.DeleteDataPersistenceRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/data_persistence_rule/" + request.DataPersistenceRuleId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -205,12 +206,12 @@ func (client *Client) DeleteDataPersistenceRuleSpectraS3(request *models.DeleteD
     return models.NewDeleteDataPersistenceRuleSpectraS3Response(response)
 }
 
-func (client *Client) DeleteDataPolicySpectraS3(request *models.DeleteDataPolicySpectraS3Request) (*models.DeleteDataPolicySpectraS3Response, error) {
+func (client *Client) DeleteDataPolicySpectraS3(ctx context.Context, request *models.DeleteDataPolicySpectraS3Request) (*models.DeleteDataPolicySpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/data_policy/" + request.DataPolicyId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -228,12 +229,12 @@ func (client *Client) DeleteDataPolicySpectraS3(request *models.DeleteDataPolicy
     return models.NewDeleteDataPolicySpectraS3Response(response)
 }
 
-func (client *Client) DeleteDs3DataReplicationRuleSpectraS3(request *models.DeleteDs3DataReplicationRuleSpectraS3Request) (*models.DeleteDs3DataReplicationRuleSpectraS3Response, error) {
+func (client *Client) DeleteDs3DataReplicationRuleSpectraS3(ctx context.Context, request *models.DeleteDs3DataReplicationRuleSpectraS3Request) (*models.DeleteDs3DataReplicationRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/ds3_data_replication_rule/" + request.Ds3DataReplicationRule).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -251,12 +252,12 @@ func (client *Client) DeleteDs3DataReplicationRuleSpectraS3(request *models.Dele
     return models.NewDeleteDs3DataReplicationRuleSpectraS3Response(response)
 }
 
-func (client *Client) DeleteS3DataReplicationRuleSpectraS3(request *models.DeleteS3DataReplicationRuleSpectraS3Request) (*models.DeleteS3DataReplicationRuleSpectraS3Response, error) {
+func (client *Client) DeleteS3DataReplicationRuleSpectraS3(ctx context.Context, request *models.DeleteS3DataReplicationRuleSpectraS3Request) (*models.DeleteS3DataReplicationRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/s3_data_replication_rule/" + request.S3DataReplicationRule).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -274,14 +275,14 @@ func (client *Client) DeleteS3DataReplicationRuleSpectraS3(request *models.Delet
     return models.NewDeleteS3DataReplicationRuleSpectraS3Response(response)
 }
 
-func (client *Client) ClearSuspectBlobAzureTargetsSpectraS3(request *models.ClearSuspectBlobAzureTargetsSpectraS3Request) (*models.ClearSuspectBlobAzureTargetsSpectraS3Response, error) {
+func (client *Client) ClearSuspectBlobAzureTargetsSpectraS3(ctx context.Context, request *models.ClearSuspectBlobAzureTargetsSpectraS3Request) (*models.ClearSuspectBlobAzureTargetsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/suspect_blob_azure_target").
         WithOptionalVoidQueryParam("force", request.Force).
         WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -299,14 +300,14 @@ func (client *Client) ClearSuspectBlobAzureTargetsSpectraS3(request *models.Clea
     return models.NewClearSuspectBlobAzureTargetsSpectraS3Response(response)
 }
 
-func (client *Client) ClearSuspectBlobDs3TargetsSpectraS3(request *models.ClearSuspectBlobDs3TargetsSpectraS3Request) (*models.ClearSuspectBlobDs3TargetsSpectraS3Response, error) {
+func (client *Client) ClearSuspectBlobDs3TargetsSpectraS3(ctx context.Context, request *models.ClearSuspectBlobDs3TargetsSpectraS3Request) (*models.ClearSuspectBlobDs3TargetsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/suspect_blob_ds3_target").
         WithOptionalVoidQueryParam("force", request.Force).
         WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -324,14 +325,14 @@ func (client *Client) ClearSuspectBlobDs3TargetsSpectraS3(request *models.ClearS
     return models.NewClearSuspectBlobDs3TargetsSpectraS3Response(response)
 }
 
-func (client *Client) ClearSuspectBlobPoolsSpectraS3(request *models.ClearSuspectBlobPoolsSpectraS3Request) (*models.ClearSuspectBlobPoolsSpectraS3Response, error) {
+func (client *Client) ClearSuspectBlobPoolsSpectraS3(ctx context.Context, request *models.ClearSuspectBlobPoolsSpectraS3Request) (*models.ClearSuspectBlobPoolsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/suspect_blob_pool").
         WithOptionalVoidQueryParam("force", request.Force).
         WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -349,14 +350,14 @@ func (client *Client) ClearSuspectBlobPoolsSpectraS3(request *models.ClearSuspec
     return models.NewClearSuspectBlobPoolsSpectraS3Response(response)
 }
 
-func (client *Client) ClearSuspectBlobS3TargetsSpectraS3(request *models.ClearSuspectBlobS3TargetsSpectraS3Request) (*models.ClearSuspectBlobS3TargetsSpectraS3Response, error) {
+func (client *Client) ClearSuspectBlobS3TargetsSpectraS3(ctx context.Context, request *models.ClearSuspectBlobS3TargetsSpectraS3Request) (*models.ClearSuspectBlobS3TargetsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/suspect_blob_s3_target").
         WithOptionalVoidQueryParam("force", request.Force).
         WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -374,14 +375,14 @@ func (client *Client) ClearSuspectBlobS3TargetsSpectraS3(request *models.ClearSu
     return models.NewClearSuspectBlobS3TargetsSpectraS3Response(response)
 }
 
-func (client *Client) ClearSuspectBlobTapesSpectraS3(request *models.ClearSuspectBlobTapesSpectraS3Request) (*models.ClearSuspectBlobTapesSpectraS3Response, error) {
+func (client *Client) ClearSuspectBlobTapesSpectraS3(ctx context.Context, request *models.ClearSuspectBlobTapesSpectraS3Request) (*models.ClearSuspectBlobTapesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/suspect_blob_tape").
         WithOptionalVoidQueryParam("force", request.Force).
         WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -399,12 +400,12 @@ func (client *Client) ClearSuspectBlobTapesSpectraS3(request *models.ClearSuspec
     return models.NewClearSuspectBlobTapesSpectraS3Response(response)
 }
 
-func (client *Client) DeleteGroupMemberSpectraS3(request *models.DeleteGroupMemberSpectraS3Request) (*models.DeleteGroupMemberSpectraS3Response, error) {
+func (client *Client) DeleteGroupMemberSpectraS3(ctx context.Context, request *models.DeleteGroupMemberSpectraS3Request) (*models.DeleteGroupMemberSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/group_member/" + request.GroupMember).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -422,12 +423,12 @@ func (client *Client) DeleteGroupMemberSpectraS3(request *models.DeleteGroupMemb
     return models.NewDeleteGroupMemberSpectraS3Response(response)
 }
 
-func (client *Client) DeleteGroupSpectraS3(request *models.DeleteGroupSpectraS3Request) (*models.DeleteGroupSpectraS3Response, error) {
+func (client *Client) DeleteGroupSpectraS3(ctx context.Context, request *models.DeleteGroupSpectraS3Request) (*models.DeleteGroupSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/group/" + request.Group).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -445,13 +446,13 @@ func (client *Client) DeleteGroupSpectraS3(request *models.DeleteGroupSpectraS3R
     return models.NewDeleteGroupSpectraS3Response(response)
 }
 
-func (client *Client) CancelActiveJobSpectraS3(request *models.CancelActiveJobSpectraS3Request) (*models.CancelActiveJobSpectraS3Response, error) {
+func (client *Client) CancelActiveJobSpectraS3(ctx context.Context, request *models.CancelActiveJobSpectraS3Request) (*models.CancelActiveJobSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/active_job/" + request.ActiveJobId).
         WithQueryParam("force", "").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -469,7 +470,7 @@ func (client *Client) CancelActiveJobSpectraS3(request *models.CancelActiveJobSp
     return models.NewCancelActiveJobSpectraS3Response(response)
 }
 
-func (client *Client) CancelAllActiveJobsSpectraS3(request *models.CancelAllActiveJobsSpectraS3Request) (*models.CancelAllActiveJobsSpectraS3Response, error) {
+func (client *Client) CancelAllActiveJobsSpectraS3(ctx context.Context, request *models.CancelAllActiveJobsSpectraS3Request) (*models.CancelAllActiveJobsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
@@ -477,7 +478,7 @@ func (client *Client) CancelAllActiveJobsSpectraS3(request *models.CancelAllActi
         WithQueryParam("force", "").
         WithOptionalQueryParam("bucket_id", request.BucketId).
         WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -495,7 +496,7 @@ func (client *Client) CancelAllActiveJobsSpectraS3(request *models.CancelAllActi
     return models.NewCancelAllActiveJobsSpectraS3Response(response)
 }
 
-func (client *Client) CancelAllJobsSpectraS3(request *models.CancelAllJobsSpectraS3Request) (*models.CancelAllJobsSpectraS3Response, error) {
+func (client *Client) CancelAllJobsSpectraS3(ctx context.Context, request *models.CancelAllJobsSpectraS3Request) (*models.CancelAllJobsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
@@ -503,7 +504,7 @@ func (client *Client) CancelAllJobsSpectraS3(request *models.CancelAllJobsSpectr
         WithQueryParam("force", "").
         WithOptionalQueryParam("bucket_id", request.BucketId).
         WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -521,13 +522,13 @@ func (client *Client) CancelAllJobsSpectraS3(request *models.CancelAllJobsSpectr
     return models.NewCancelAllJobsSpectraS3Response(response)
 }
 
-func (client *Client) CancelJobSpectraS3(request *models.CancelJobSpectraS3Request) (*models.CancelJobSpectraS3Response, error) {
+func (client *Client) CancelJobSpectraS3(ctx context.Context, request *models.CancelJobSpectraS3Request) (*models.CancelJobSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/job/" + request.JobId).
         WithQueryParam("force", "").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -545,12 +546,12 @@ func (client *Client) CancelJobSpectraS3(request *models.CancelJobSpectraS3Reque
     return models.NewCancelJobSpectraS3Response(response)
 }
 
-func (client *Client) ClearAllCanceledJobsSpectraS3(request *models.ClearAllCanceledJobsSpectraS3Request) (*models.ClearAllCanceledJobsSpectraS3Response, error) {
+func (client *Client) ClearAllCanceledJobsSpectraS3(ctx context.Context, request *models.ClearAllCanceledJobsSpectraS3Request) (*models.ClearAllCanceledJobsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/canceled_job").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -568,12 +569,12 @@ func (client *Client) ClearAllCanceledJobsSpectraS3(request *models.ClearAllCanc
     return models.NewClearAllCanceledJobsSpectraS3Response(response)
 }
 
-func (client *Client) ClearAllCompletedJobsSpectraS3(request *models.ClearAllCompletedJobsSpectraS3Request) (*models.ClearAllCompletedJobsSpectraS3Response, error) {
+func (client *Client) ClearAllCompletedJobsSpectraS3(ctx context.Context, request *models.ClearAllCompletedJobsSpectraS3Request) (*models.ClearAllCompletedJobsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/completed_job").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -591,12 +592,12 @@ func (client *Client) ClearAllCompletedJobsSpectraS3(request *models.ClearAllCom
     return models.NewClearAllCompletedJobsSpectraS3Response(response)
 }
 
-func (client *Client) DeleteJobCreationFailureSpectraS3(request *models.DeleteJobCreationFailureSpectraS3Request) (*models.DeleteJobCreationFailureSpectraS3Response, error) {
+func (client *Client) DeleteJobCreationFailureSpectraS3(ctx context.Context, request *models.DeleteJobCreationFailureSpectraS3Request) (*models.DeleteJobCreationFailureSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/job_creation_failed/" + request.JobCreationFailed).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -614,12 +615,12 @@ func (client *Client) DeleteJobCreationFailureSpectraS3(request *models.DeleteJo
     return models.NewDeleteJobCreationFailureSpectraS3Response(response)
 }
 
-func (client *Client) TruncateActiveJobSpectraS3(request *models.TruncateActiveJobSpectraS3Request) (*models.TruncateActiveJobSpectraS3Response, error) {
+func (client *Client) TruncateActiveJobSpectraS3(ctx context.Context, request *models.TruncateActiveJobSpectraS3Request) (*models.TruncateActiveJobSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/active_job/" + request.ActiveJobId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -637,14 +638,14 @@ func (client *Client) TruncateActiveJobSpectraS3(request *models.TruncateActiveJ
     return models.NewTruncateActiveJobSpectraS3Response(response)
 }
 
-func (client *Client) TruncateAllActiveJobsSpectraS3(request *models.TruncateAllActiveJobsSpectraS3Request) (*models.TruncateAllActiveJobsSpectraS3Response, error) {
+func (client *Client) TruncateAllActiveJobsSpectraS3(ctx context.Context, request *models.TruncateAllActiveJobsSpectraS3Request) (*models.TruncateAllActiveJobsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/active_job").
         WithOptionalQueryParam("bucket_id", request.BucketId).
         WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -662,14 +663,14 @@ func (client *Client) TruncateAllActiveJobsSpectraS3(request *models.TruncateAll
     return models.NewTruncateAllActiveJobsSpectraS3Response(response)
 }
 
-func (client *Client) TruncateAllJobsSpectraS3(request *models.TruncateAllJobsSpectraS3Request) (*models.TruncateAllJobsSpectraS3Response, error) {
+func (client *Client) TruncateAllJobsSpectraS3(ctx context.Context, request *models.TruncateAllJobsSpectraS3Request) (*models.TruncateAllJobsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/job").
         WithOptionalQueryParam("bucket_id", request.BucketId).
         WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -687,12 +688,12 @@ func (client *Client) TruncateAllJobsSpectraS3(request *models.TruncateAllJobsSp
     return models.NewTruncateAllJobsSpectraS3Response(response)
 }
 
-func (client *Client) TruncateJobSpectraS3(request *models.TruncateJobSpectraS3Request) (*models.TruncateJobSpectraS3Response, error) {
+func (client *Client) TruncateJobSpectraS3(ctx context.Context, request *models.TruncateJobSpectraS3Request) (*models.TruncateJobSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/job/" + request.JobId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -710,12 +711,12 @@ func (client *Client) TruncateJobSpectraS3(request *models.TruncateJobSpectraS3R
     return models.NewTruncateJobSpectraS3Response(response)
 }
 
-func (client *Client) DeleteAzureTargetFailureNotificationRegistrationSpectraS3(request *models.DeleteAzureTargetFailureNotificationRegistrationSpectraS3Request) (*models.DeleteAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteAzureTargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteAzureTargetFailureNotificationRegistrationSpectraS3Request) (*models.DeleteAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/azure_target_failure_notification_registration/" + request.AzureTargetFailureNotificationRegistration).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -733,12 +734,12 @@ func (client *Client) DeleteAzureTargetFailureNotificationRegistrationSpectraS3(
     return models.NewDeleteAzureTargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteBucketChangesNotificationRegistrationSpectraS3(request *models.DeleteBucketChangesNotificationRegistrationSpectraS3Request) (*models.DeleteBucketChangesNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteBucketChangesNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteBucketChangesNotificationRegistrationSpectraS3Request) (*models.DeleteBucketChangesNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/bucket_changes_notification_registration/" + request.BucketChangesNotificationRegistration).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -756,12 +757,12 @@ func (client *Client) DeleteBucketChangesNotificationRegistrationSpectraS3(reque
     return models.NewDeleteBucketChangesNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteDs3TargetFailureNotificationRegistrationSpectraS3(request *models.DeleteDs3TargetFailureNotificationRegistrationSpectraS3Request) (*models.DeleteDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteDs3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteDs3TargetFailureNotificationRegistrationSpectraS3Request) (*models.DeleteDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/ds3_target_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -779,12 +780,12 @@ func (client *Client) DeleteDs3TargetFailureNotificationRegistrationSpectraS3(re
     return models.NewDeleteDs3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteJobCompletedNotificationRegistrationSpectraS3(request *models.DeleteJobCompletedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCompletedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteJobCompletedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteJobCompletedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCompletedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/job_completed_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -802,12 +803,12 @@ func (client *Client) DeleteJobCompletedNotificationRegistrationSpectraS3(reques
     return models.NewDeleteJobCompletedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteJobCreatedNotificationRegistrationSpectraS3(request *models.DeleteJobCreatedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteJobCreatedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteJobCreatedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/job_created_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -825,12 +826,12 @@ func (client *Client) DeleteJobCreatedNotificationRegistrationSpectraS3(request 
     return models.NewDeleteJobCreatedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteJobCreationFailedNotificationRegistrationSpectraS3(request *models.DeleteJobCreationFailedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteJobCreationFailedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteJobCreationFailedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/job_creation_failed_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -848,12 +849,12 @@ func (client *Client) DeleteJobCreationFailedNotificationRegistrationSpectraS3(r
     return models.NewDeleteJobCreationFailedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteObjectCachedNotificationRegistrationSpectraS3(request *models.DeleteObjectCachedNotificationRegistrationSpectraS3Request) (*models.DeleteObjectCachedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteObjectCachedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteObjectCachedNotificationRegistrationSpectraS3Request) (*models.DeleteObjectCachedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/object_cached_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -871,12 +872,12 @@ func (client *Client) DeleteObjectCachedNotificationRegistrationSpectraS3(reques
     return models.NewDeleteObjectCachedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteObjectLostNotificationRegistrationSpectraS3(request *models.DeleteObjectLostNotificationRegistrationSpectraS3Request) (*models.DeleteObjectLostNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteObjectLostNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteObjectLostNotificationRegistrationSpectraS3Request) (*models.DeleteObjectLostNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/object_lost_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -894,12 +895,12 @@ func (client *Client) DeleteObjectLostNotificationRegistrationSpectraS3(request 
     return models.NewDeleteObjectLostNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteObjectPersistedNotificationRegistrationSpectraS3(request *models.DeleteObjectPersistedNotificationRegistrationSpectraS3Request) (*models.DeleteObjectPersistedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteObjectPersistedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteObjectPersistedNotificationRegistrationSpectraS3Request) (*models.DeleteObjectPersistedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/object_persisted_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -917,12 +918,12 @@ func (client *Client) DeleteObjectPersistedNotificationRegistrationSpectraS3(req
     return models.NewDeleteObjectPersistedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeletePoolFailureNotificationRegistrationSpectraS3(request *models.DeletePoolFailureNotificationRegistrationSpectraS3Request) (*models.DeletePoolFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeletePoolFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeletePoolFailureNotificationRegistrationSpectraS3Request) (*models.DeletePoolFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/pool_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -940,12 +941,12 @@ func (client *Client) DeletePoolFailureNotificationRegistrationSpectraS3(request
     return models.NewDeletePoolFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteS3TargetFailureNotificationRegistrationSpectraS3(request *models.DeleteS3TargetFailureNotificationRegistrationSpectraS3Request) (*models.DeleteS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteS3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteS3TargetFailureNotificationRegistrationSpectraS3Request) (*models.DeleteS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/s3_target_failure_notification_registration/" + request.S3TargetFailureNotificationRegistration).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -963,12 +964,12 @@ func (client *Client) DeleteS3TargetFailureNotificationRegistrationSpectraS3(req
     return models.NewDeleteS3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteStorageDomainFailureNotificationRegistrationSpectraS3(request *models.DeleteStorageDomainFailureNotificationRegistrationSpectraS3Request) (*models.DeleteStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteStorageDomainFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteStorageDomainFailureNotificationRegistrationSpectraS3Request) (*models.DeleteStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/storage_domain_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -986,12 +987,12 @@ func (client *Client) DeleteStorageDomainFailureNotificationRegistrationSpectraS
     return models.NewDeleteStorageDomainFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteSystemFailureNotificationRegistrationSpectraS3(request *models.DeleteSystemFailureNotificationRegistrationSpectraS3Request) (*models.DeleteSystemFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteSystemFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteSystemFailureNotificationRegistrationSpectraS3Request) (*models.DeleteSystemFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/system_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1009,12 +1010,12 @@ func (client *Client) DeleteSystemFailureNotificationRegistrationSpectraS3(reque
     return models.NewDeleteSystemFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteTapeFailureNotificationRegistrationSpectraS3(request *models.DeleteTapeFailureNotificationRegistrationSpectraS3Request) (*models.DeleteTapeFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteTapeFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteTapeFailureNotificationRegistrationSpectraS3Request) (*models.DeleteTapeFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/tape_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1032,12 +1033,12 @@ func (client *Client) DeleteTapeFailureNotificationRegistrationSpectraS3(request
     return models.NewDeleteTapeFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteTapePartitionFailureNotificationRegistrationSpectraS3(request *models.DeleteTapePartitionFailureNotificationRegistrationSpectraS3Request) (*models.DeleteTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) DeleteTapePartitionFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteTapePartitionFailureNotificationRegistrationSpectraS3Request) (*models.DeleteTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/tape_partition_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1055,14 +1056,14 @@ func (client *Client) DeleteTapePartitionFailureNotificationRegistrationSpectraS
     return models.NewDeleteTapePartitionFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) DeleteFolderRecursivelySpectraS3(request *models.DeleteFolderRecursivelySpectraS3Request) (*models.DeleteFolderRecursivelySpectraS3Response, error) {
+func (client *Client) DeleteFolderRecursivelySpectraS3(ctx context.Context, request *models.DeleteFolderRecursivelySpectraS3Request) (*models.DeleteFolderRecursivelySpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/folder/" + request.Folder).
         WithQueryParam("bucket_id", request.BucketId).
         WithQueryParam("recursive", "").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1080,12 +1081,12 @@ func (client *Client) DeleteFolderRecursivelySpectraS3(request *models.DeleteFol
     return models.NewDeleteFolderRecursivelySpectraS3Response(response)
 }
 
-func (client *Client) DeletePermanentlyLostPoolSpectraS3(request *models.DeletePermanentlyLostPoolSpectraS3Request) (*models.DeletePermanentlyLostPoolSpectraS3Response, error) {
+func (client *Client) DeletePermanentlyLostPoolSpectraS3(ctx context.Context, request *models.DeletePermanentlyLostPoolSpectraS3Request) (*models.DeletePermanentlyLostPoolSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/pool/" + request.Pool).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1103,12 +1104,12 @@ func (client *Client) DeletePermanentlyLostPoolSpectraS3(request *models.DeleteP
     return models.NewDeletePermanentlyLostPoolSpectraS3Response(response)
 }
 
-func (client *Client) DeletePoolFailureSpectraS3(request *models.DeletePoolFailureSpectraS3Request) (*models.DeletePoolFailureSpectraS3Response, error) {
+func (client *Client) DeletePoolFailureSpectraS3(ctx context.Context, request *models.DeletePoolFailureSpectraS3Request) (*models.DeletePoolFailureSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/pool_failure/" + request.PoolFailure).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1126,12 +1127,12 @@ func (client *Client) DeletePoolFailureSpectraS3(request *models.DeletePoolFailu
     return models.NewDeletePoolFailureSpectraS3Response(response)
 }
 
-func (client *Client) DeletePoolPartitionSpectraS3(request *models.DeletePoolPartitionSpectraS3Request) (*models.DeletePoolPartitionSpectraS3Response, error) {
+func (client *Client) DeletePoolPartitionSpectraS3(ctx context.Context, request *models.DeletePoolPartitionSpectraS3Request) (*models.DeletePoolPartitionSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/pool_partition/" + request.PoolPartition).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1149,12 +1150,12 @@ func (client *Client) DeletePoolPartitionSpectraS3(request *models.DeletePoolPar
     return models.NewDeletePoolPartitionSpectraS3Response(response)
 }
 
-func (client *Client) DeleteStorageDomainFailureSpectraS3(request *models.DeleteStorageDomainFailureSpectraS3Request) (*models.DeleteStorageDomainFailureSpectraS3Response, error) {
+func (client *Client) DeleteStorageDomainFailureSpectraS3(ctx context.Context, request *models.DeleteStorageDomainFailureSpectraS3Request) (*models.DeleteStorageDomainFailureSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/storage_domain_failure/" + request.StorageDomainFailure).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1172,12 +1173,12 @@ func (client *Client) DeleteStorageDomainFailureSpectraS3(request *models.Delete
     return models.NewDeleteStorageDomainFailureSpectraS3Response(response)
 }
 
-func (client *Client) DeleteStorageDomainMemberSpectraS3(request *models.DeleteStorageDomainMemberSpectraS3Request) (*models.DeleteStorageDomainMemberSpectraS3Response, error) {
+func (client *Client) DeleteStorageDomainMemberSpectraS3(ctx context.Context, request *models.DeleteStorageDomainMemberSpectraS3Request) (*models.DeleteStorageDomainMemberSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/storage_domain_member/" + request.StorageDomainMember).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1195,12 +1196,12 @@ func (client *Client) DeleteStorageDomainMemberSpectraS3(request *models.DeleteS
     return models.NewDeleteStorageDomainMemberSpectraS3Response(response)
 }
 
-func (client *Client) DeleteStorageDomainSpectraS3(request *models.DeleteStorageDomainSpectraS3Request) (*models.DeleteStorageDomainSpectraS3Response, error) {
+func (client *Client) DeleteStorageDomainSpectraS3(ctx context.Context, request *models.DeleteStorageDomainSpectraS3Request) (*models.DeleteStorageDomainSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/storage_domain/" + request.StorageDomain).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1218,12 +1219,12 @@ func (client *Client) DeleteStorageDomainSpectraS3(request *models.DeleteStorage
     return models.NewDeleteStorageDomainSpectraS3Response(response)
 }
 
-func (client *Client) DeletePermanentlyLostTapeSpectraS3(request *models.DeletePermanentlyLostTapeSpectraS3Request) (*models.DeletePermanentlyLostTapeSpectraS3Response, error) {
+func (client *Client) DeletePermanentlyLostTapeSpectraS3(ctx context.Context, request *models.DeletePermanentlyLostTapeSpectraS3Request) (*models.DeletePermanentlyLostTapeSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/tape/" + request.TapeId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1241,12 +1242,12 @@ func (client *Client) DeletePermanentlyLostTapeSpectraS3(request *models.DeleteP
     return models.NewDeletePermanentlyLostTapeSpectraS3Response(response)
 }
 
-func (client *Client) DeleteTapeDensityDirectiveSpectraS3(request *models.DeleteTapeDensityDirectiveSpectraS3Request) (*models.DeleteTapeDensityDirectiveSpectraS3Response, error) {
+func (client *Client) DeleteTapeDensityDirectiveSpectraS3(ctx context.Context, request *models.DeleteTapeDensityDirectiveSpectraS3Request) (*models.DeleteTapeDensityDirectiveSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/tape_density_directive/" + request.TapeDensityDirective).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1264,12 +1265,12 @@ func (client *Client) DeleteTapeDensityDirectiveSpectraS3(request *models.Delete
     return models.NewDeleteTapeDensityDirectiveSpectraS3Response(response)
 }
 
-func (client *Client) DeleteTapeDriveSpectraS3(request *models.DeleteTapeDriveSpectraS3Request) (*models.DeleteTapeDriveSpectraS3Response, error) {
+func (client *Client) DeleteTapeDriveSpectraS3(ctx context.Context, request *models.DeleteTapeDriveSpectraS3Request) (*models.DeleteTapeDriveSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1287,12 +1288,12 @@ func (client *Client) DeleteTapeDriveSpectraS3(request *models.DeleteTapeDriveSp
     return models.NewDeleteTapeDriveSpectraS3Response(response)
 }
 
-func (client *Client) DeleteTapeFailureSpectraS3(request *models.DeleteTapeFailureSpectraS3Request) (*models.DeleteTapeFailureSpectraS3Response, error) {
+func (client *Client) DeleteTapeFailureSpectraS3(ctx context.Context, request *models.DeleteTapeFailureSpectraS3Request) (*models.DeleteTapeFailureSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/tape_failure/" + request.TapeFailure).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1310,12 +1311,12 @@ func (client *Client) DeleteTapeFailureSpectraS3(request *models.DeleteTapeFailu
     return models.NewDeleteTapeFailureSpectraS3Response(response)
 }
 
-func (client *Client) DeleteTapePartitionFailureSpectraS3(request *models.DeleteTapePartitionFailureSpectraS3Request) (*models.DeleteTapePartitionFailureSpectraS3Response, error) {
+func (client *Client) DeleteTapePartitionFailureSpectraS3(ctx context.Context, request *models.DeleteTapePartitionFailureSpectraS3Request) (*models.DeleteTapePartitionFailureSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/tape_partition_failure/" + request.TapePartitionFailure).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1333,12 +1334,12 @@ func (client *Client) DeleteTapePartitionFailureSpectraS3(request *models.Delete
     return models.NewDeleteTapePartitionFailureSpectraS3Response(response)
 }
 
-func (client *Client) DeleteTapePartitionSpectraS3(request *models.DeleteTapePartitionSpectraS3Request) (*models.DeleteTapePartitionSpectraS3Response, error) {
+func (client *Client) DeleteTapePartitionSpectraS3(ctx context.Context, request *models.DeleteTapePartitionSpectraS3Request) (*models.DeleteTapePartitionSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/tape_partition/" + request.TapePartition).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1356,12 +1357,12 @@ func (client *Client) DeleteTapePartitionSpectraS3(request *models.DeleteTapePar
     return models.NewDeleteTapePartitionSpectraS3Response(response)
 }
 
-func (client *Client) DeleteAzureTargetBucketNameSpectraS3(request *models.DeleteAzureTargetBucketNameSpectraS3Request) (*models.DeleteAzureTargetBucketNameSpectraS3Response, error) {
+func (client *Client) DeleteAzureTargetBucketNameSpectraS3(ctx context.Context, request *models.DeleteAzureTargetBucketNameSpectraS3Request) (*models.DeleteAzureTargetBucketNameSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/azure_target_bucket_name/" + request.AzureTargetBucketName).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1379,12 +1380,12 @@ func (client *Client) DeleteAzureTargetBucketNameSpectraS3(request *models.Delet
     return models.NewDeleteAzureTargetBucketNameSpectraS3Response(response)
 }
 
-func (client *Client) DeleteAzureTargetFailureSpectraS3(request *models.DeleteAzureTargetFailureSpectraS3Request) (*models.DeleteAzureTargetFailureSpectraS3Response, error) {
+func (client *Client) DeleteAzureTargetFailureSpectraS3(ctx context.Context, request *models.DeleteAzureTargetFailureSpectraS3Request) (*models.DeleteAzureTargetFailureSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/azure_target_failure/" + request.AzureTargetFailure).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1402,12 +1403,12 @@ func (client *Client) DeleteAzureTargetFailureSpectraS3(request *models.DeleteAz
     return models.NewDeleteAzureTargetFailureSpectraS3Response(response)
 }
 
-func (client *Client) DeleteAzureTargetReadPreferenceSpectraS3(request *models.DeleteAzureTargetReadPreferenceSpectraS3Request) (*models.DeleteAzureTargetReadPreferenceSpectraS3Response, error) {
+func (client *Client) DeleteAzureTargetReadPreferenceSpectraS3(ctx context.Context, request *models.DeleteAzureTargetReadPreferenceSpectraS3Request) (*models.DeleteAzureTargetReadPreferenceSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/azure_target_read_preference/" + request.AzureTargetReadPreference).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1425,12 +1426,12 @@ func (client *Client) DeleteAzureTargetReadPreferenceSpectraS3(request *models.D
     return models.NewDeleteAzureTargetReadPreferenceSpectraS3Response(response)
 }
 
-func (client *Client) DeleteAzureTargetSpectraS3(request *models.DeleteAzureTargetSpectraS3Request) (*models.DeleteAzureTargetSpectraS3Response, error) {
+func (client *Client) DeleteAzureTargetSpectraS3(ctx context.Context, request *models.DeleteAzureTargetSpectraS3Request) (*models.DeleteAzureTargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/azure_target/" + request.AzureTarget).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1448,12 +1449,12 @@ func (client *Client) DeleteAzureTargetSpectraS3(request *models.DeleteAzureTarg
     return models.NewDeleteAzureTargetSpectraS3Response(response)
 }
 
-func (client *Client) DeleteDs3TargetFailureSpectraS3(request *models.DeleteDs3TargetFailureSpectraS3Request) (*models.DeleteDs3TargetFailureSpectraS3Response, error) {
+func (client *Client) DeleteDs3TargetFailureSpectraS3(ctx context.Context, request *models.DeleteDs3TargetFailureSpectraS3Request) (*models.DeleteDs3TargetFailureSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/ds3_target_failure/" + request.Ds3TargetFailure).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1471,12 +1472,12 @@ func (client *Client) DeleteDs3TargetFailureSpectraS3(request *models.DeleteDs3T
     return models.NewDeleteDs3TargetFailureSpectraS3Response(response)
 }
 
-func (client *Client) DeleteDs3TargetReadPreferenceSpectraS3(request *models.DeleteDs3TargetReadPreferenceSpectraS3Request) (*models.DeleteDs3TargetReadPreferenceSpectraS3Response, error) {
+func (client *Client) DeleteDs3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.DeleteDs3TargetReadPreferenceSpectraS3Request) (*models.DeleteDs3TargetReadPreferenceSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/ds3_target_read_preference/" + request.Ds3TargetReadPreference).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1494,12 +1495,12 @@ func (client *Client) DeleteDs3TargetReadPreferenceSpectraS3(request *models.Del
     return models.NewDeleteDs3TargetReadPreferenceSpectraS3Response(response)
 }
 
-func (client *Client) DeleteDs3TargetSpectraS3(request *models.DeleteDs3TargetSpectraS3Request) (*models.DeleteDs3TargetSpectraS3Response, error) {
+func (client *Client) DeleteDs3TargetSpectraS3(ctx context.Context, request *models.DeleteDs3TargetSpectraS3Request) (*models.DeleteDs3TargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/ds3_target/" + request.Ds3Target).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1517,12 +1518,12 @@ func (client *Client) DeleteDs3TargetSpectraS3(request *models.DeleteDs3TargetSp
     return models.NewDeleteDs3TargetSpectraS3Response(response)
 }
 
-func (client *Client) DeleteS3TargetBucketNameSpectraS3(request *models.DeleteS3TargetBucketNameSpectraS3Request) (*models.DeleteS3TargetBucketNameSpectraS3Response, error) {
+func (client *Client) DeleteS3TargetBucketNameSpectraS3(ctx context.Context, request *models.DeleteS3TargetBucketNameSpectraS3Request) (*models.DeleteS3TargetBucketNameSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/s3_target_bucket_name/" + request.S3TargetBucketName).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1540,12 +1541,12 @@ func (client *Client) DeleteS3TargetBucketNameSpectraS3(request *models.DeleteS3
     return models.NewDeleteS3TargetBucketNameSpectraS3Response(response)
 }
 
-func (client *Client) DeleteS3TargetFailureSpectraS3(request *models.DeleteS3TargetFailureSpectraS3Request) (*models.DeleteS3TargetFailureSpectraS3Response, error) {
+func (client *Client) DeleteS3TargetFailureSpectraS3(ctx context.Context, request *models.DeleteS3TargetFailureSpectraS3Request) (*models.DeleteS3TargetFailureSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/s3_target_failure/" + request.S3TargetFailure).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1563,12 +1564,12 @@ func (client *Client) DeleteS3TargetFailureSpectraS3(request *models.DeleteS3Tar
     return models.NewDeleteS3TargetFailureSpectraS3Response(response)
 }
 
-func (client *Client) DeleteS3TargetReadPreferenceSpectraS3(request *models.DeleteS3TargetReadPreferenceSpectraS3Request) (*models.DeleteS3TargetReadPreferenceSpectraS3Response, error) {
+func (client *Client) DeleteS3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.DeleteS3TargetReadPreferenceSpectraS3Request) (*models.DeleteS3TargetReadPreferenceSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/s3_target_read_preference/" + request.S3TargetReadPreference).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1586,12 +1587,12 @@ func (client *Client) DeleteS3TargetReadPreferenceSpectraS3(request *models.Dele
     return models.NewDeleteS3TargetReadPreferenceSpectraS3Response(response)
 }
 
-func (client *Client) DeleteS3TargetSpectraS3(request *models.DeleteS3TargetSpectraS3Request) (*models.DeleteS3TargetSpectraS3Response, error) {
+func (client *Client) DeleteS3TargetSpectraS3(ctx context.Context, request *models.DeleteS3TargetSpectraS3Request) (*models.DeleteS3TargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/s3_target/" + request.S3Target).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1609,12 +1610,12 @@ func (client *Client) DeleteS3TargetSpectraS3(request *models.DeleteS3TargetSpec
     return models.NewDeleteS3TargetSpectraS3Response(response)
 }
 
-func (client *Client) DelegateDeleteUserSpectraS3(request *models.DelegateDeleteUserSpectraS3Request) (*models.DelegateDeleteUserSpectraS3Response, error) {
+func (client *Client) DelegateDeleteUserSpectraS3(ctx context.Context, request *models.DelegateDeleteUserSpectraS3Request) (*models.DelegateDeleteUserSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_DELETE).
         WithPath("/_rest_/user/" + request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err

--- a/ds3/ds3Gets.go
+++ b/ds3/ds3Gets.go
@@ -14,11 +14,12 @@
 package ds3
 
 import (
+    "context"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
 )
 
-func (client *Client) GetObject(request *models.GetObjectRequest) (*models.GetObjectResponse, error) {
+func (client *Client) GetObject(ctx context.Context, request *models.GetObjectRequest) (*models.GetObjectResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -29,7 +30,7 @@ func (client *Client) GetObject(request *models.GetObjectRequest) (*models.GetOb
         WithOptionalQueryParam("version_id", request.VersionId).
         WithChecksum(request.Checksum).
         WithHeaders(request.Metadata).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -48,7 +49,7 @@ func (client *Client) GetObject(request *models.GetObjectRequest) (*models.GetOb
 }
 
 
-func (client *Client) GetBucket(request *models.GetBucketRequest) (*models.GetBucketResponse, error) {
+func (client *Client) GetBucket(ctx context.Context, request *models.GetBucketRequest) (*models.GetBucketResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -58,7 +59,7 @@ func (client *Client) GetBucket(request *models.GetBucketRequest) (*models.GetBu
         WithOptionalQueryParam("max_keys", networking.IntPtrToStrPtr(request.MaxKeys)).
         WithOptionalQueryParam("prefix", request.Prefix).
         WithOptionalVoidQueryParam("versions", request.Versions).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -77,12 +78,12 @@ func (client *Client) GetBucket(request *models.GetBucketRequest) (*models.GetBu
     return models.NewGetBucketResponse(response)
 }
 
-func (client *Client) GetService(request *models.GetServiceRequest) (*models.GetServiceResponse, error) {
+func (client *Client) GetService(ctx context.Context, request *models.GetServiceRequest) (*models.GetServiceResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -101,7 +102,7 @@ func (client *Client) GetService(request *models.GetServiceRequest) (*models.Get
     return models.NewGetServiceResponse(response)
 }
 
-func (client *Client) ListMultiPartUploadParts(request *models.ListMultiPartUploadPartsRequest) (*models.ListMultiPartUploadPartsResponse, error) {
+func (client *Client) ListMultiPartUploadParts(ctx context.Context, request *models.ListMultiPartUploadPartsRequest) (*models.ListMultiPartUploadPartsResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -109,7 +110,7 @@ func (client *Client) ListMultiPartUploadParts(request *models.ListMultiPartUplo
         WithQueryParam("upload_id", request.UploadId).
         WithOptionalQueryParam("max_parts", networking.IntPtrToStrPtr(request.MaxParts)).
         WithOptionalQueryParam("part_number_marker", networking.IntPtrToStrPtr(request.PartNumberMarker)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -128,7 +129,7 @@ func (client *Client) ListMultiPartUploadParts(request *models.ListMultiPartUplo
     return models.NewListMultiPartUploadPartsResponse(response)
 }
 
-func (client *Client) ListMultiPartUploads(request *models.ListMultiPartUploadsRequest) (*models.ListMultiPartUploadsResponse, error) {
+func (client *Client) ListMultiPartUploads(ctx context.Context, request *models.ListMultiPartUploadsRequest) (*models.ListMultiPartUploadsResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -139,7 +140,7 @@ func (client *Client) ListMultiPartUploads(request *models.ListMultiPartUploadsR
         WithOptionalQueryParam("max_uploads", networking.IntPtrToStrPtr(request.MaxUploads)).
         WithOptionalQueryParam("prefix", request.Prefix).
         WithOptionalQueryParam("upload_id_marker", request.UploadIdMarker).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -158,12 +159,12 @@ func (client *Client) ListMultiPartUploads(request *models.ListMultiPartUploadsR
     return models.NewListMultiPartUploadsResponse(response)
 }
 
-func (client *Client) GetBucketAclSpectraS3(request *models.GetBucketAclSpectraS3Request) (*models.GetBucketAclSpectraS3Response, error) {
+func (client *Client) GetBucketAclSpectraS3(ctx context.Context, request *models.GetBucketAclSpectraS3Request) (*models.GetBucketAclSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/bucket_acl/" + request.BucketAcl).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -182,7 +183,7 @@ func (client *Client) GetBucketAclSpectraS3(request *models.GetBucketAclSpectraS
     return models.NewGetBucketAclSpectraS3Response(response)
 }
 
-func (client *Client) GetBucketAclsSpectraS3(request *models.GetBucketAclsSpectraS3Request) (*models.GetBucketAclsSpectraS3Response, error) {
+func (client *Client) GetBucketAclsSpectraS3(ctx context.Context, request *models.GetBucketAclsSpectraS3Request) (*models.GetBucketAclsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -195,7 +196,7 @@ func (client *Client) GetBucketAclsSpectraS3(request *models.GetBucketAclsSpectr
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("permission", networking.InterfaceToStrPtr(request.Permission)).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -214,12 +215,12 @@ func (client *Client) GetBucketAclsSpectraS3(request *models.GetBucketAclsSpectr
     return models.NewGetBucketAclsSpectraS3Response(response)
 }
 
-func (client *Client) GetDataPolicyAclSpectraS3(request *models.GetDataPolicyAclSpectraS3Request) (*models.GetDataPolicyAclSpectraS3Response, error) {
+func (client *Client) GetDataPolicyAclSpectraS3(ctx context.Context, request *models.GetDataPolicyAclSpectraS3Request) (*models.GetDataPolicyAclSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/data_policy_acl/" + request.DataPolicyAcl).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -238,7 +239,7 @@ func (client *Client) GetDataPolicyAclSpectraS3(request *models.GetDataPolicyAcl
     return models.NewGetDataPolicyAclSpectraS3Response(response)
 }
 
-func (client *Client) GetDataPolicyAclsSpectraS3(request *models.GetDataPolicyAclsSpectraS3Request) (*models.GetDataPolicyAclsSpectraS3Response, error) {
+func (client *Client) GetDataPolicyAclsSpectraS3(ctx context.Context, request *models.GetDataPolicyAclsSpectraS3Request) (*models.GetDataPolicyAclsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -250,7 +251,7 @@ func (client *Client) GetDataPolicyAclsSpectraS3(request *models.GetDataPolicyAc
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -269,12 +270,12 @@ func (client *Client) GetDataPolicyAclsSpectraS3(request *models.GetDataPolicyAc
     return models.NewGetDataPolicyAclsSpectraS3Response(response)
 }
 
-func (client *Client) GetBucketSpectraS3(request *models.GetBucketSpectraS3Request) (*models.GetBucketSpectraS3Response, error) {
+func (client *Client) GetBucketSpectraS3(ctx context.Context, request *models.GetBucketSpectraS3Request) (*models.GetBucketSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/bucket/" + request.BucketName).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -293,7 +294,7 @@ func (client *Client) GetBucketSpectraS3(request *models.GetBucketSpectraS3Reque
     return models.NewGetBucketSpectraS3Response(response)
 }
 
-func (client *Client) GetBucketsSpectraS3(request *models.GetBucketsSpectraS3Request) (*models.GetBucketsSpectraS3Response, error) {
+func (client *Client) GetBucketsSpectraS3(ctx context.Context, request *models.GetBucketsSpectraS3Request) (*models.GetBucketsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -305,7 +306,7 @@ func (client *Client) GetBucketsSpectraS3(request *models.GetBucketsSpectraS3Req
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -324,12 +325,12 @@ func (client *Client) GetBucketsSpectraS3(request *models.GetBucketsSpectraS3Req
     return models.NewGetBucketsSpectraS3Response(response)
 }
 
-func (client *Client) GetCacheFilesystemSpectraS3(request *models.GetCacheFilesystemSpectraS3Request) (*models.GetCacheFilesystemSpectraS3Response, error) {
+func (client *Client) GetCacheFilesystemSpectraS3(ctx context.Context, request *models.GetCacheFilesystemSpectraS3Request) (*models.GetCacheFilesystemSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/cache_filesystem/" + request.CacheFilesystem).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -348,7 +349,7 @@ func (client *Client) GetCacheFilesystemSpectraS3(request *models.GetCacheFilesy
     return models.NewGetCacheFilesystemSpectraS3Response(response)
 }
 
-func (client *Client) GetCacheFilesystemsSpectraS3(request *models.GetCacheFilesystemsSpectraS3Request) (*models.GetCacheFilesystemsSpectraS3Response, error) {
+func (client *Client) GetCacheFilesystemsSpectraS3(ctx context.Context, request *models.GetCacheFilesystemsSpectraS3Request) (*models.GetCacheFilesystemsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -358,7 +359,7 @@ func (client *Client) GetCacheFilesystemsSpectraS3(request *models.GetCacheFiles
         WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -377,12 +378,12 @@ func (client *Client) GetCacheFilesystemsSpectraS3(request *models.GetCacheFiles
     return models.NewGetCacheFilesystemsSpectraS3Response(response)
 }
 
-func (client *Client) GetCacheStateSpectraS3(request *models.GetCacheStateSpectraS3Request) (*models.GetCacheStateSpectraS3Response, error) {
+func (client *Client) GetCacheStateSpectraS3(ctx context.Context, request *models.GetCacheStateSpectraS3Request) (*models.GetCacheStateSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/cache_state").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -401,7 +402,7 @@ func (client *Client) GetCacheStateSpectraS3(request *models.GetCacheStateSpectr
     return models.NewGetCacheStateSpectraS3Response(response)
 }
 
-func (client *Client) GetBucketCapacitySummarySpectraS3(request *models.GetBucketCapacitySummarySpectraS3Request) (*models.GetBucketCapacitySummarySpectraS3Response, error) {
+func (client *Client) GetBucketCapacitySummarySpectraS3(ctx context.Context, request *models.GetBucketCapacitySummarySpectraS3Request) (*models.GetBucketCapacitySummarySpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -413,7 +414,7 @@ func (client *Client) GetBucketCapacitySummarySpectraS3(request *models.GetBucke
         WithOptionalQueryParam("pool_type", networking.InterfaceToStrPtr(request.PoolType)).
         WithOptionalQueryParam("tape_state", networking.InterfaceToStrPtr(request.TapeState)).
         WithOptionalQueryParam("tape_type", request.TapeType).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -432,7 +433,7 @@ func (client *Client) GetBucketCapacitySummarySpectraS3(request *models.GetBucke
     return models.NewGetBucketCapacitySummarySpectraS3Response(response)
 }
 
-func (client *Client) GetStorageDomainCapacitySummarySpectraS3(request *models.GetStorageDomainCapacitySummarySpectraS3Request) (*models.GetStorageDomainCapacitySummarySpectraS3Response, error) {
+func (client *Client) GetStorageDomainCapacitySummarySpectraS3(ctx context.Context, request *models.GetStorageDomainCapacitySummarySpectraS3Request) (*models.GetStorageDomainCapacitySummarySpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -443,7 +444,7 @@ func (client *Client) GetStorageDomainCapacitySummarySpectraS3(request *models.G
         WithOptionalQueryParam("pool_type", networking.InterfaceToStrPtr(request.PoolType)).
         WithOptionalQueryParam("tape_state", networking.InterfaceToStrPtr(request.TapeState)).
         WithOptionalQueryParam("tape_type", request.TapeType).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -462,7 +463,7 @@ func (client *Client) GetStorageDomainCapacitySummarySpectraS3(request *models.G
     return models.NewGetStorageDomainCapacitySummarySpectraS3Response(response)
 }
 
-func (client *Client) GetSystemCapacitySummarySpectraS3(request *models.GetSystemCapacitySummarySpectraS3Request) (*models.GetSystemCapacitySummarySpectraS3Response, error) {
+func (client *Client) GetSystemCapacitySummarySpectraS3(ctx context.Context, request *models.GetSystemCapacitySummarySpectraS3Request) (*models.GetSystemCapacitySummarySpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -472,7 +473,7 @@ func (client *Client) GetSystemCapacitySummarySpectraS3(request *models.GetSyste
         WithOptionalQueryParam("pool_type", networking.InterfaceToStrPtr(request.PoolType)).
         WithOptionalQueryParam("tape_state", networking.InterfaceToStrPtr(request.TapeState)).
         WithOptionalQueryParam("tape_type", request.TapeType).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -491,12 +492,12 @@ func (client *Client) GetSystemCapacitySummarySpectraS3(request *models.GetSyste
     return models.NewGetSystemCapacitySummarySpectraS3Response(response)
 }
 
-func (client *Client) GetDataPathBackendSpectraS3(request *models.GetDataPathBackendSpectraS3Request) (*models.GetDataPathBackendSpectraS3Response, error) {
+func (client *Client) GetDataPathBackendSpectraS3(ctx context.Context, request *models.GetDataPathBackendSpectraS3Request) (*models.GetDataPathBackendSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/data_path_backend").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -515,13 +516,13 @@ func (client *Client) GetDataPathBackendSpectraS3(request *models.GetDataPathBac
     return models.NewGetDataPathBackendSpectraS3Response(response)
 }
 
-func (client *Client) GetDataPlannerBlobStoreTasksSpectraS3(request *models.GetDataPlannerBlobStoreTasksSpectraS3Request) (*models.GetDataPlannerBlobStoreTasksSpectraS3Response, error) {
+func (client *Client) GetDataPlannerBlobStoreTasksSpectraS3(ctx context.Context, request *models.GetDataPlannerBlobStoreTasksSpectraS3Request) (*models.GetDataPlannerBlobStoreTasksSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/blob_store_task").
         WithOptionalVoidQueryParam("full_details", request.FullDetails).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -540,12 +541,12 @@ func (client *Client) GetDataPlannerBlobStoreTasksSpectraS3(request *models.GetD
     return models.NewGetDataPlannerBlobStoreTasksSpectraS3Response(response)
 }
 
-func (client *Client) GetAzureDataReplicationRuleSpectraS3(request *models.GetAzureDataReplicationRuleSpectraS3Request) (*models.GetAzureDataReplicationRuleSpectraS3Response, error) {
+func (client *Client) GetAzureDataReplicationRuleSpectraS3(ctx context.Context, request *models.GetAzureDataReplicationRuleSpectraS3Request) (*models.GetAzureDataReplicationRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/azure_data_replication_rule/" + request.AzureDataReplicationRule).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -564,7 +565,7 @@ func (client *Client) GetAzureDataReplicationRuleSpectraS3(request *models.GetAz
     return models.NewGetAzureDataReplicationRuleSpectraS3Response(response)
 }
 
-func (client *Client) GetAzureDataReplicationRulesSpectraS3(request *models.GetAzureDataReplicationRulesSpectraS3Request) (*models.GetAzureDataReplicationRulesSpectraS3Response, error) {
+func (client *Client) GetAzureDataReplicationRulesSpectraS3(ctx context.Context, request *models.GetAzureDataReplicationRulesSpectraS3Request) (*models.GetAzureDataReplicationRulesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -578,7 +579,7 @@ func (client *Client) GetAzureDataReplicationRulesSpectraS3(request *models.GetA
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
         WithOptionalQueryParam("target_id", request.TargetId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -597,12 +598,12 @@ func (client *Client) GetAzureDataReplicationRulesSpectraS3(request *models.GetA
     return models.NewGetAzureDataReplicationRulesSpectraS3Response(response)
 }
 
-func (client *Client) GetDataPersistenceRuleSpectraS3(request *models.GetDataPersistenceRuleSpectraS3Request) (*models.GetDataPersistenceRuleSpectraS3Response, error) {
+func (client *Client) GetDataPersistenceRuleSpectraS3(ctx context.Context, request *models.GetDataPersistenceRuleSpectraS3Request) (*models.GetDataPersistenceRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/data_persistence_rule/" + request.DataPersistenceRuleId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -621,7 +622,7 @@ func (client *Client) GetDataPersistenceRuleSpectraS3(request *models.GetDataPer
     return models.NewGetDataPersistenceRuleSpectraS3Response(response)
 }
 
-func (client *Client) GetDataPersistenceRulesSpectraS3(request *models.GetDataPersistenceRulesSpectraS3Request) (*models.GetDataPersistenceRulesSpectraS3Response, error) {
+func (client *Client) GetDataPersistenceRulesSpectraS3(ctx context.Context, request *models.GetDataPersistenceRulesSpectraS3Request) (*models.GetDataPersistenceRulesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -635,7 +636,7 @@ func (client *Client) GetDataPersistenceRulesSpectraS3(request *models.GetDataPe
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
         WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataPersistenceRuleType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -654,7 +655,7 @@ func (client *Client) GetDataPersistenceRulesSpectraS3(request *models.GetDataPe
     return models.NewGetDataPersistenceRulesSpectraS3Response(response)
 }
 
-func (client *Client) GetDataPoliciesSpectraS3(request *models.GetDataPoliciesSpectraS3Request) (*models.GetDataPoliciesSpectraS3Response, error) {
+func (client *Client) GetDataPoliciesSpectraS3(ctx context.Context, request *models.GetDataPoliciesSpectraS3Request) (*models.GetDataPoliciesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -668,7 +669,7 @@ func (client *Client) GetDataPoliciesSpectraS3(request *models.GetDataPoliciesSp
         WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -687,12 +688,12 @@ func (client *Client) GetDataPoliciesSpectraS3(request *models.GetDataPoliciesSp
     return models.NewGetDataPoliciesSpectraS3Response(response)
 }
 
-func (client *Client) GetDataPolicySpectraS3(request *models.GetDataPolicySpectraS3Request) (*models.GetDataPolicySpectraS3Response, error) {
+func (client *Client) GetDataPolicySpectraS3(ctx context.Context, request *models.GetDataPolicySpectraS3Request) (*models.GetDataPolicySpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/data_policy/" + request.DataPolicyId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -711,12 +712,12 @@ func (client *Client) GetDataPolicySpectraS3(request *models.GetDataPolicySpectr
     return models.NewGetDataPolicySpectraS3Response(response)
 }
 
-func (client *Client) GetDs3DataReplicationRuleSpectraS3(request *models.GetDs3DataReplicationRuleSpectraS3Request) (*models.GetDs3DataReplicationRuleSpectraS3Response, error) {
+func (client *Client) GetDs3DataReplicationRuleSpectraS3(ctx context.Context, request *models.GetDs3DataReplicationRuleSpectraS3Request) (*models.GetDs3DataReplicationRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/ds3_data_replication_rule/" + request.Ds3DataReplicationRule).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -735,7 +736,7 @@ func (client *Client) GetDs3DataReplicationRuleSpectraS3(request *models.GetDs3D
     return models.NewGetDs3DataReplicationRuleSpectraS3Response(response)
 }
 
-func (client *Client) GetDs3DataReplicationRulesSpectraS3(request *models.GetDs3DataReplicationRulesSpectraS3Request) (*models.GetDs3DataReplicationRulesSpectraS3Response, error) {
+func (client *Client) GetDs3DataReplicationRulesSpectraS3(ctx context.Context, request *models.GetDs3DataReplicationRulesSpectraS3Request) (*models.GetDs3DataReplicationRulesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -749,7 +750,7 @@ func (client *Client) GetDs3DataReplicationRulesSpectraS3(request *models.GetDs3
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
         WithOptionalQueryParam("target_id", request.TargetId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -768,12 +769,12 @@ func (client *Client) GetDs3DataReplicationRulesSpectraS3(request *models.GetDs3
     return models.NewGetDs3DataReplicationRulesSpectraS3Response(response)
 }
 
-func (client *Client) GetS3DataReplicationRuleSpectraS3(request *models.GetS3DataReplicationRuleSpectraS3Request) (*models.GetS3DataReplicationRuleSpectraS3Response, error) {
+func (client *Client) GetS3DataReplicationRuleSpectraS3(ctx context.Context, request *models.GetS3DataReplicationRuleSpectraS3Request) (*models.GetS3DataReplicationRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/s3_data_replication_rule/" + request.S3DataReplicationRule).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -792,7 +793,7 @@ func (client *Client) GetS3DataReplicationRuleSpectraS3(request *models.GetS3Dat
     return models.NewGetS3DataReplicationRuleSpectraS3Response(response)
 }
 
-func (client *Client) GetS3DataReplicationRulesSpectraS3(request *models.GetS3DataReplicationRulesSpectraS3Request) (*models.GetS3DataReplicationRulesSpectraS3Response, error) {
+func (client *Client) GetS3DataReplicationRulesSpectraS3(ctx context.Context, request *models.GetS3DataReplicationRulesSpectraS3Request) (*models.GetS3DataReplicationRulesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -807,7 +808,7 @@ func (client *Client) GetS3DataReplicationRulesSpectraS3(request *models.GetS3Da
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
         WithOptionalQueryParam("target_id", request.TargetId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -826,7 +827,7 @@ func (client *Client) GetS3DataReplicationRulesSpectraS3(request *models.GetS3Da
     return models.NewGetS3DataReplicationRulesSpectraS3Response(response)
 }
 
-func (client *Client) GetDegradedAzureDataReplicationRulesSpectraS3(request *models.GetDegradedAzureDataReplicationRulesSpectraS3Request) (*models.GetDegradedAzureDataReplicationRulesSpectraS3Response, error) {
+func (client *Client) GetDegradedAzureDataReplicationRulesSpectraS3(ctx context.Context, request *models.GetDegradedAzureDataReplicationRulesSpectraS3Request) (*models.GetDegradedAzureDataReplicationRulesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -839,7 +840,7 @@ func (client *Client) GetDegradedAzureDataReplicationRulesSpectraS3(request *mod
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
         WithOptionalQueryParam("target_id", request.TargetId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -858,7 +859,7 @@ func (client *Client) GetDegradedAzureDataReplicationRulesSpectraS3(request *mod
     return models.NewGetDegradedAzureDataReplicationRulesSpectraS3Response(response)
 }
 
-func (client *Client) GetDegradedBlobsSpectraS3(request *models.GetDegradedBlobsSpectraS3Request) (*models.GetDegradedBlobsSpectraS3Response, error) {
+func (client *Client) GetDegradedBlobsSpectraS3(ctx context.Context, request *models.GetDegradedBlobsSpectraS3Request) (*models.GetDegradedBlobsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -871,7 +872,7 @@ func (client *Client) GetDegradedBlobsSpectraS3(request *models.GetDegradedBlobs
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("persistence_rule_id", request.PersistenceRuleId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -890,7 +891,7 @@ func (client *Client) GetDegradedBlobsSpectraS3(request *models.GetDegradedBlobs
     return models.NewGetDegradedBlobsSpectraS3Response(response)
 }
 
-func (client *Client) GetDegradedBucketsSpectraS3(request *models.GetDegradedBucketsSpectraS3Request) (*models.GetDegradedBucketsSpectraS3Response, error) {
+func (client *Client) GetDegradedBucketsSpectraS3(ctx context.Context, request *models.GetDegradedBucketsSpectraS3Request) (*models.GetDegradedBucketsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -902,7 +903,7 @@ func (client *Client) GetDegradedBucketsSpectraS3(request *models.GetDegradedBuc
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -921,7 +922,7 @@ func (client *Client) GetDegradedBucketsSpectraS3(request *models.GetDegradedBuc
     return models.NewGetDegradedBucketsSpectraS3Response(response)
 }
 
-func (client *Client) GetDegradedDataPersistenceRulesSpectraS3(request *models.GetDegradedDataPersistenceRulesSpectraS3Request) (*models.GetDegradedDataPersistenceRulesSpectraS3Response, error) {
+func (client *Client) GetDegradedDataPersistenceRulesSpectraS3(ctx context.Context, request *models.GetDegradedDataPersistenceRulesSpectraS3Request) (*models.GetDegradedDataPersistenceRulesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -935,7 +936,7 @@ func (client *Client) GetDegradedDataPersistenceRulesSpectraS3(request *models.G
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
         WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataPersistenceRuleType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -954,7 +955,7 @@ func (client *Client) GetDegradedDataPersistenceRulesSpectraS3(request *models.G
     return models.NewGetDegradedDataPersistenceRulesSpectraS3Response(response)
 }
 
-func (client *Client) GetDegradedDs3DataReplicationRulesSpectraS3(request *models.GetDegradedDs3DataReplicationRulesSpectraS3Request) (*models.GetDegradedDs3DataReplicationRulesSpectraS3Response, error) {
+func (client *Client) GetDegradedDs3DataReplicationRulesSpectraS3(ctx context.Context, request *models.GetDegradedDs3DataReplicationRulesSpectraS3Request) (*models.GetDegradedDs3DataReplicationRulesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -967,7 +968,7 @@ func (client *Client) GetDegradedDs3DataReplicationRulesSpectraS3(request *model
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
         WithOptionalQueryParam("target_id", request.TargetId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -986,7 +987,7 @@ func (client *Client) GetDegradedDs3DataReplicationRulesSpectraS3(request *model
     return models.NewGetDegradedDs3DataReplicationRulesSpectraS3Response(response)
 }
 
-func (client *Client) GetDegradedS3DataReplicationRulesSpectraS3(request *models.GetDegradedS3DataReplicationRulesSpectraS3Request) (*models.GetDegradedS3DataReplicationRulesSpectraS3Response, error) {
+func (client *Client) GetDegradedS3DataReplicationRulesSpectraS3(ctx context.Context, request *models.GetDegradedS3DataReplicationRulesSpectraS3Request) (*models.GetDegradedS3DataReplicationRulesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -999,7 +1000,7 @@ func (client *Client) GetDegradedS3DataReplicationRulesSpectraS3(request *models
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
         WithOptionalQueryParam("target_id", request.TargetId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1018,7 +1019,7 @@ func (client *Client) GetDegradedS3DataReplicationRulesSpectraS3(request *models
     return models.NewGetDegradedS3DataReplicationRulesSpectraS3Response(response)
 }
 
-func (client *Client) GetSuspectBlobAzureTargetsSpectraS3(request *models.GetSuspectBlobAzureTargetsSpectraS3Request) (*models.GetSuspectBlobAzureTargetsSpectraS3Response, error) {
+func (client *Client) GetSuspectBlobAzureTargetsSpectraS3(ctx context.Context, request *models.GetSuspectBlobAzureTargetsSpectraS3Request) (*models.GetSuspectBlobAzureTargetsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1029,7 +1030,7 @@ func (client *Client) GetSuspectBlobAzureTargetsSpectraS3(request *models.GetSus
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1048,7 +1049,7 @@ func (client *Client) GetSuspectBlobAzureTargetsSpectraS3(request *models.GetSus
     return models.NewGetSuspectBlobAzureTargetsSpectraS3Response(response)
 }
 
-func (client *Client) GetSuspectBlobDs3TargetsSpectraS3(request *models.GetSuspectBlobDs3TargetsSpectraS3Request) (*models.GetSuspectBlobDs3TargetsSpectraS3Response, error) {
+func (client *Client) GetSuspectBlobDs3TargetsSpectraS3(ctx context.Context, request *models.GetSuspectBlobDs3TargetsSpectraS3Request) (*models.GetSuspectBlobDs3TargetsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1059,7 +1060,7 @@ func (client *Client) GetSuspectBlobDs3TargetsSpectraS3(request *models.GetSuspe
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1078,7 +1079,7 @@ func (client *Client) GetSuspectBlobDs3TargetsSpectraS3(request *models.GetSuspe
     return models.NewGetSuspectBlobDs3TargetsSpectraS3Response(response)
 }
 
-func (client *Client) GetSuspectBlobPoolsSpectraS3(request *models.GetSuspectBlobPoolsSpectraS3Request) (*models.GetSuspectBlobPoolsSpectraS3Response, error) {
+func (client *Client) GetSuspectBlobPoolsSpectraS3(ctx context.Context, request *models.GetSuspectBlobPoolsSpectraS3Request) (*models.GetSuspectBlobPoolsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1089,7 +1090,7 @@ func (client *Client) GetSuspectBlobPoolsSpectraS3(request *models.GetSuspectBlo
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("pool_id", request.PoolId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1108,7 +1109,7 @@ func (client *Client) GetSuspectBlobPoolsSpectraS3(request *models.GetSuspectBlo
     return models.NewGetSuspectBlobPoolsSpectraS3Response(response)
 }
 
-func (client *Client) GetSuspectBlobS3TargetsSpectraS3(request *models.GetSuspectBlobS3TargetsSpectraS3Request) (*models.GetSuspectBlobS3TargetsSpectraS3Response, error) {
+func (client *Client) GetSuspectBlobS3TargetsSpectraS3(ctx context.Context, request *models.GetSuspectBlobS3TargetsSpectraS3Request) (*models.GetSuspectBlobS3TargetsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1119,7 +1120,7 @@ func (client *Client) GetSuspectBlobS3TargetsSpectraS3(request *models.GetSuspec
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1138,7 +1139,7 @@ func (client *Client) GetSuspectBlobS3TargetsSpectraS3(request *models.GetSuspec
     return models.NewGetSuspectBlobS3TargetsSpectraS3Response(response)
 }
 
-func (client *Client) GetSuspectBlobTapesSpectraS3(request *models.GetSuspectBlobTapesSpectraS3Request) (*models.GetSuspectBlobTapesSpectraS3Response, error) {
+func (client *Client) GetSuspectBlobTapesSpectraS3(ctx context.Context, request *models.GetSuspectBlobTapesSpectraS3Request) (*models.GetSuspectBlobTapesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1149,7 +1150,7 @@ func (client *Client) GetSuspectBlobTapesSpectraS3(request *models.GetSuspectBlo
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("tape_id", request.TapeId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1168,7 +1169,7 @@ func (client *Client) GetSuspectBlobTapesSpectraS3(request *models.GetSuspectBlo
     return models.NewGetSuspectBlobTapesSpectraS3Response(response)
 }
 
-func (client *Client) GetSuspectBucketsSpectraS3(request *models.GetSuspectBucketsSpectraS3Request) (*models.GetSuspectBucketsSpectraS3Response, error) {
+func (client *Client) GetSuspectBucketsSpectraS3(ctx context.Context, request *models.GetSuspectBucketsSpectraS3Request) (*models.GetSuspectBucketsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1180,7 +1181,7 @@ func (client *Client) GetSuspectBucketsSpectraS3(request *models.GetSuspectBucke
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1199,7 +1200,7 @@ func (client *Client) GetSuspectBucketsSpectraS3(request *models.GetSuspectBucke
     return models.NewGetSuspectBucketsSpectraS3Response(response)
 }
 
-func (client *Client) GetSuspectObjectsSpectraS3(request *models.GetSuspectObjectsSpectraS3Request) (*models.GetSuspectObjectsSpectraS3Response, error) {
+func (client *Client) GetSuspectObjectsSpectraS3(ctx context.Context, request *models.GetSuspectObjectsSpectraS3Request) (*models.GetSuspectObjectsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1209,7 +1210,7 @@ func (client *Client) GetSuspectObjectsSpectraS3(request *models.GetSuspectObjec
         WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1228,7 +1229,7 @@ func (client *Client) GetSuspectObjectsSpectraS3(request *models.GetSuspectObjec
     return models.NewGetSuspectObjectsSpectraS3Response(response)
 }
 
-func (client *Client) GetSuspectObjectsWithFullDetailsSpectraS3(request *models.GetSuspectObjectsWithFullDetailsSpectraS3Request) (*models.GetSuspectObjectsWithFullDetailsSpectraS3Response, error) {
+func (client *Client) GetSuspectObjectsWithFullDetailsSpectraS3(ctx context.Context, request *models.GetSuspectObjectsWithFullDetailsSpectraS3Request) (*models.GetSuspectObjectsWithFullDetailsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1236,7 +1237,7 @@ func (client *Client) GetSuspectObjectsWithFullDetailsSpectraS3(request *models.
         WithQueryParam("full_details", "").
         WithOptionalQueryParam("bucket_id", request.BucketId).
         WithOptionalQueryParam("storage_domain", request.StorageDomain).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1255,12 +1256,12 @@ func (client *Client) GetSuspectObjectsWithFullDetailsSpectraS3(request *models.
     return models.NewGetSuspectObjectsWithFullDetailsSpectraS3Response(response)
 }
 
-func (client *Client) GetGroupMemberSpectraS3(request *models.GetGroupMemberSpectraS3Request) (*models.GetGroupMemberSpectraS3Response, error) {
+func (client *Client) GetGroupMemberSpectraS3(ctx context.Context, request *models.GetGroupMemberSpectraS3Request) (*models.GetGroupMemberSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/group_member/" + request.GroupMember).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1279,7 +1280,7 @@ func (client *Client) GetGroupMemberSpectraS3(request *models.GetGroupMemberSpec
     return models.NewGetGroupMemberSpectraS3Response(response)
 }
 
-func (client *Client) GetGroupMembersSpectraS3(request *models.GetGroupMembersSpectraS3Request) (*models.GetGroupMembersSpectraS3Response, error) {
+func (client *Client) GetGroupMembersSpectraS3(ctx context.Context, request *models.GetGroupMembersSpectraS3Request) (*models.GetGroupMembersSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1291,7 +1292,7 @@ func (client *Client) GetGroupMembersSpectraS3(request *models.GetGroupMembersSp
         WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1310,12 +1311,12 @@ func (client *Client) GetGroupMembersSpectraS3(request *models.GetGroupMembersSp
     return models.NewGetGroupMembersSpectraS3Response(response)
 }
 
-func (client *Client) GetGroupSpectraS3(request *models.GetGroupSpectraS3Request) (*models.GetGroupSpectraS3Response, error) {
+func (client *Client) GetGroupSpectraS3(ctx context.Context, request *models.GetGroupSpectraS3Request) (*models.GetGroupSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/group/" + request.Group).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1334,7 +1335,7 @@ func (client *Client) GetGroupSpectraS3(request *models.GetGroupSpectraS3Request
     return models.NewGetGroupSpectraS3Response(response)
 }
 
-func (client *Client) GetGroupsSpectraS3(request *models.GetGroupsSpectraS3Request) (*models.GetGroupsSpectraS3Response, error) {
+func (client *Client) GetGroupsSpectraS3(ctx context.Context, request *models.GetGroupsSpectraS3Request) (*models.GetGroupsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1345,7 +1346,7 @@ func (client *Client) GetGroupsSpectraS3(request *models.GetGroupsSpectraS3Reque
         WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1364,12 +1365,12 @@ func (client *Client) GetGroupsSpectraS3(request *models.GetGroupsSpectraS3Reque
     return models.NewGetGroupsSpectraS3Response(response)
 }
 
-func (client *Client) GetActiveJobSpectraS3(request *models.GetActiveJobSpectraS3Request) (*models.GetActiveJobSpectraS3Response, error) {
+func (client *Client) GetActiveJobSpectraS3(ctx context.Context, request *models.GetActiveJobSpectraS3Request) (*models.GetActiveJobSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/active_job/" + request.ActiveJobId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1388,7 +1389,7 @@ func (client *Client) GetActiveJobSpectraS3(request *models.GetActiveJobSpectraS
     return models.NewGetActiveJobSpectraS3Response(response)
 }
 
-func (client *Client) GetActiveJobsSpectraS3(request *models.GetActiveJobsSpectraS3Request) (*models.GetActiveJobsSpectraS3Response, error) {
+func (client *Client) GetActiveJobsSpectraS3(ctx context.Context, request *models.GetActiveJobsSpectraS3Request) (*models.GetActiveJobsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1406,7 +1407,7 @@ func (client *Client) GetActiveJobsSpectraS3(request *models.GetActiveJobsSpectr
         WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
         WithOptionalQueryParam("truncated", networking.BoolPtrToStrPtr(request.Truncated)).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1425,12 +1426,12 @@ func (client *Client) GetActiveJobsSpectraS3(request *models.GetActiveJobsSpectr
     return models.NewGetActiveJobsSpectraS3Response(response)
 }
 
-func (client *Client) GetCanceledJobSpectraS3(request *models.GetCanceledJobSpectraS3Request) (*models.GetCanceledJobSpectraS3Response, error) {
+func (client *Client) GetCanceledJobSpectraS3(ctx context.Context, request *models.GetCanceledJobSpectraS3Request) (*models.GetCanceledJobSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/canceled_job/" + request.CanceledJob).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1449,7 +1450,7 @@ func (client *Client) GetCanceledJobSpectraS3(request *models.GetCanceledJobSpec
     return models.NewGetCanceledJobSpectraS3Response(response)
 }
 
-func (client *Client) GetCanceledJobsSpectraS3(request *models.GetCanceledJobsSpectraS3Request) (*models.GetCanceledJobsSpectraS3Response, error) {
+func (client *Client) GetCanceledJobsSpectraS3(ctx context.Context, request *models.GetCanceledJobsSpectraS3Request) (*models.GetCanceledJobsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1467,7 +1468,7 @@ func (client *Client) GetCanceledJobsSpectraS3(request *models.GetCanceledJobsSp
         WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
         WithOptionalQueryParam("truncated", networking.BoolPtrToStrPtr(request.Truncated)).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1486,12 +1487,12 @@ func (client *Client) GetCanceledJobsSpectraS3(request *models.GetCanceledJobsSp
     return models.NewGetCanceledJobsSpectraS3Response(response)
 }
 
-func (client *Client) GetCompletedJobSpectraS3(request *models.GetCompletedJobSpectraS3Request) (*models.GetCompletedJobSpectraS3Response, error) {
+func (client *Client) GetCompletedJobSpectraS3(ctx context.Context, request *models.GetCompletedJobSpectraS3Request) (*models.GetCompletedJobSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/completed_job/" + request.CompletedJob).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1510,7 +1511,7 @@ func (client *Client) GetCompletedJobSpectraS3(request *models.GetCompletedJobSp
     return models.NewGetCompletedJobSpectraS3Response(response)
 }
 
-func (client *Client) GetCompletedJobsSpectraS3(request *models.GetCompletedJobsSpectraS3Request) (*models.GetCompletedJobsSpectraS3Response, error) {
+func (client *Client) GetCompletedJobsSpectraS3(ctx context.Context, request *models.GetCompletedJobsSpectraS3Request) (*models.GetCompletedJobsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1527,7 +1528,7 @@ func (client *Client) GetCompletedJobsSpectraS3(request *models.GetCompletedJobs
         WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
         WithOptionalQueryParam("truncated", networking.BoolPtrToStrPtr(request.Truncated)).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1546,12 +1547,12 @@ func (client *Client) GetCompletedJobsSpectraS3(request *models.GetCompletedJobs
     return models.NewGetCompletedJobsSpectraS3Response(response)
 }
 
-func (client *Client) GetJobChunkDaoSpectraS3(request *models.GetJobChunkDaoSpectraS3Request) (*models.GetJobChunkDaoSpectraS3Response, error) {
+func (client *Client) GetJobChunkDaoSpectraS3(ctx context.Context, request *models.GetJobChunkDaoSpectraS3Request) (*models.GetJobChunkDaoSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/job_chunk_dao/" + request.JobChunkDao).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1570,12 +1571,12 @@ func (client *Client) GetJobChunkDaoSpectraS3(request *models.GetJobChunkDaoSpec
     return models.NewGetJobChunkDaoSpectraS3Response(response)
 }
 
-func (client *Client) GetJobChunkSpectraS3(request *models.GetJobChunkSpectraS3Request) (*models.GetJobChunkSpectraS3Response, error) {
+func (client *Client) GetJobChunkSpectraS3(ctx context.Context, request *models.GetJobChunkSpectraS3Request) (*models.GetJobChunkSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/job_chunk/" + request.JobChunkId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1594,7 +1595,7 @@ func (client *Client) GetJobChunkSpectraS3(request *models.GetJobChunkSpectraS3R
     return models.NewGetJobChunkSpectraS3Response(response)
 }
 
-func (client *Client) GetJobChunksReadyForClientProcessingSpectraS3(request *models.GetJobChunksReadyForClientProcessingSpectraS3Request) (*models.GetJobChunksReadyForClientProcessingSpectraS3Response, error) {
+func (client *Client) GetJobChunksReadyForClientProcessingSpectraS3(ctx context.Context, request *models.GetJobChunksReadyForClientProcessingSpectraS3Request) (*models.GetJobChunksReadyForClientProcessingSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1602,7 +1603,7 @@ func (client *Client) GetJobChunksReadyForClientProcessingSpectraS3(request *mod
         WithQueryParam("job", request.Job).
         WithOptionalQueryParam("job_chunk", request.JobChunk).
         WithOptionalQueryParam("preferred_number_of_chunks", networking.IntPtrToStrPtr(request.PreferredNumberOfChunks)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1621,7 +1622,7 @@ func (client *Client) GetJobChunksReadyForClientProcessingSpectraS3(request *mod
     return models.NewGetJobChunksReadyForClientProcessingSpectraS3Response(response)
 }
 
-func (client *Client) GetJobCreationFailuresSpectraS3(request *models.GetJobCreationFailuresSpectraS3Request) (*models.GetJobCreationFailuresSpectraS3Response, error) {
+func (client *Client) GetJobCreationFailuresSpectraS3(ctx context.Context, request *models.GetJobCreationFailuresSpectraS3Request) (*models.GetJobCreationFailuresSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1633,7 +1634,7 @@ func (client *Client) GetJobCreationFailuresSpectraS3(request *models.GetJobCrea
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_name", request.UserName).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1652,12 +1653,12 @@ func (client *Client) GetJobCreationFailuresSpectraS3(request *models.GetJobCrea
     return models.NewGetJobCreationFailuresSpectraS3Response(response)
 }
 
-func (client *Client) GetJobSpectraS3(request *models.GetJobSpectraS3Request) (*models.GetJobSpectraS3Response, error) {
+func (client *Client) GetJobSpectraS3(ctx context.Context, request *models.GetJobSpectraS3Request) (*models.GetJobSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/job/" + request.JobId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1676,13 +1677,13 @@ func (client *Client) GetJobSpectraS3(request *models.GetJobSpectraS3Request) (*
     return models.NewGetJobSpectraS3Response(response)
 }
 
-func (client *Client) GetJobToReplicateSpectraS3(request *models.GetJobToReplicateSpectraS3Request) (*models.GetJobToReplicateSpectraS3Response, error) {
+func (client *Client) GetJobToReplicateSpectraS3(ctx context.Context, request *models.GetJobToReplicateSpectraS3Request) (*models.GetJobToReplicateSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/job/" + request.JobId).
         WithQueryParam("replicate", "").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1701,14 +1702,14 @@ func (client *Client) GetJobToReplicateSpectraS3(request *models.GetJobToReplica
     return models.NewGetJobToReplicateSpectraS3Response(response)
 }
 
-func (client *Client) GetJobsSpectraS3(request *models.GetJobsSpectraS3Request) (*models.GetJobsSpectraS3Response, error) {
+func (client *Client) GetJobsSpectraS3(ctx context.Context, request *models.GetJobsSpectraS3Request) (*models.GetJobsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/job").
         WithOptionalQueryParam("bucket_id", request.BucketId).
         WithOptionalVoidQueryParam("full_details", request.FullDetails).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1727,12 +1728,12 @@ func (client *Client) GetJobsSpectraS3(request *models.GetJobsSpectraS3Request) 
     return models.NewGetJobsSpectraS3Response(response)
 }
 
-func (client *Client) GetNodeSpectraS3(request *models.GetNodeSpectraS3Request) (*models.GetNodeSpectraS3Response, error) {
+func (client *Client) GetNodeSpectraS3(ctx context.Context, request *models.GetNodeSpectraS3Request) (*models.GetNodeSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/node/" + request.Node).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1751,7 +1752,7 @@ func (client *Client) GetNodeSpectraS3(request *models.GetNodeSpectraS3Request) 
     return models.NewGetNodeSpectraS3Response(response)
 }
 
-func (client *Client) GetNodesSpectraS3(request *models.GetNodesSpectraS3Request) (*models.GetNodesSpectraS3Response, error) {
+func (client *Client) GetNodesSpectraS3(ctx context.Context, request *models.GetNodesSpectraS3Request) (*models.GetNodesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1760,7 +1761,7 @@ func (client *Client) GetNodesSpectraS3(request *models.GetNodesSpectraS3Request
         WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1779,12 +1780,12 @@ func (client *Client) GetNodesSpectraS3(request *models.GetNodesSpectraS3Request
     return models.NewGetNodesSpectraS3Response(response)
 }
 
-func (client *Client) GetAzureTargetFailureNotificationRegistrationSpectraS3(request *models.GetAzureTargetFailureNotificationRegistrationSpectraS3Request) (*models.GetAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetAzureTargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetAzureTargetFailureNotificationRegistrationSpectraS3Request) (*models.GetAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/azure_target_failure_notification_registration/" + request.AzureTargetFailureNotificationRegistration).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1803,7 +1804,7 @@ func (client *Client) GetAzureTargetFailureNotificationRegistrationSpectraS3(req
     return models.NewGetAzureTargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetAzureTargetFailureNotificationRegistrationsSpectraS3(request *models.GetAzureTargetFailureNotificationRegistrationsSpectraS3Request) (*models.GetAzureTargetFailureNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetAzureTargetFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetAzureTargetFailureNotificationRegistrationsSpectraS3Request) (*models.GetAzureTargetFailureNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1813,7 +1814,7 @@ func (client *Client) GetAzureTargetFailureNotificationRegistrationsSpectraS3(re
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1832,12 +1833,12 @@ func (client *Client) GetAzureTargetFailureNotificationRegistrationsSpectraS3(re
     return models.NewGetAzureTargetFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetBucketChangesNotificationRegistrationSpectraS3(request *models.GetBucketChangesNotificationRegistrationSpectraS3Request) (*models.GetBucketChangesNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetBucketChangesNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetBucketChangesNotificationRegistrationSpectraS3Request) (*models.GetBucketChangesNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/bucket_changes_notification_registration/" + request.BucketChangesNotificationRegistration).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1856,7 +1857,7 @@ func (client *Client) GetBucketChangesNotificationRegistrationSpectraS3(request 
     return models.NewGetBucketChangesNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetBucketChangesNotificationRegistrationsSpectraS3(request *models.GetBucketChangesNotificationRegistrationsSpectraS3Request) (*models.GetBucketChangesNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetBucketChangesNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetBucketChangesNotificationRegistrationsSpectraS3Request) (*models.GetBucketChangesNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1866,7 +1867,7 @@ func (client *Client) GetBucketChangesNotificationRegistrationsSpectraS3(request
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1885,7 +1886,7 @@ func (client *Client) GetBucketChangesNotificationRegistrationsSpectraS3(request
     return models.NewGetBucketChangesNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetBucketHistorySpectraS3(request *models.GetBucketHistorySpectraS3Request) (*models.GetBucketHistorySpectraS3Response, error) {
+func (client *Client) GetBucketHistorySpectraS3(ctx context.Context, request *models.GetBucketHistorySpectraS3Request) (*models.GetBucketHistorySpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1896,7 +1897,7 @@ func (client *Client) GetBucketHistorySpectraS3(request *models.GetBucketHistory
         WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1915,12 +1916,12 @@ func (client *Client) GetBucketHistorySpectraS3(request *models.GetBucketHistory
     return models.NewGetBucketHistorySpectraS3Response(response)
 }
 
-func (client *Client) GetDs3TargetFailureNotificationRegistrationSpectraS3(request *models.GetDs3TargetFailureNotificationRegistrationSpectraS3Request) (*models.GetDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetDs3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetDs3TargetFailureNotificationRegistrationSpectraS3Request) (*models.GetDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/ds3_target_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1939,7 +1940,7 @@ func (client *Client) GetDs3TargetFailureNotificationRegistrationSpectraS3(reque
     return models.NewGetDs3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetDs3TargetFailureNotificationRegistrationsSpectraS3(request *models.GetDs3TargetFailureNotificationRegistrationsSpectraS3Request) (*models.GetDs3TargetFailureNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetDs3TargetFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetDs3TargetFailureNotificationRegistrationsSpectraS3Request) (*models.GetDs3TargetFailureNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -1949,7 +1950,7 @@ func (client *Client) GetDs3TargetFailureNotificationRegistrationsSpectraS3(requ
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1968,12 +1969,12 @@ func (client *Client) GetDs3TargetFailureNotificationRegistrationsSpectraS3(requ
     return models.NewGetDs3TargetFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetJobCompletedNotificationRegistrationSpectraS3(request *models.GetJobCompletedNotificationRegistrationSpectraS3Request) (*models.GetJobCompletedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetJobCompletedNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetJobCompletedNotificationRegistrationSpectraS3Request) (*models.GetJobCompletedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/job_completed_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1992,7 +1993,7 @@ func (client *Client) GetJobCompletedNotificationRegistrationSpectraS3(request *
     return models.NewGetJobCompletedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetJobCompletedNotificationRegistrationsSpectraS3(request *models.GetJobCompletedNotificationRegistrationsSpectraS3Request) (*models.GetJobCompletedNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetJobCompletedNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetJobCompletedNotificationRegistrationsSpectraS3Request) (*models.GetJobCompletedNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2002,7 +2003,7 @@ func (client *Client) GetJobCompletedNotificationRegistrationsSpectraS3(request 
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2021,12 +2022,12 @@ func (client *Client) GetJobCompletedNotificationRegistrationsSpectraS3(request 
     return models.NewGetJobCompletedNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetJobCreatedNotificationRegistrationSpectraS3(request *models.GetJobCreatedNotificationRegistrationSpectraS3Request) (*models.GetJobCreatedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetJobCreatedNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetJobCreatedNotificationRegistrationSpectraS3Request) (*models.GetJobCreatedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/job_created_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2045,7 +2046,7 @@ func (client *Client) GetJobCreatedNotificationRegistrationSpectraS3(request *mo
     return models.NewGetJobCreatedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetJobCreatedNotificationRegistrationsSpectraS3(request *models.GetJobCreatedNotificationRegistrationsSpectraS3Request) (*models.GetJobCreatedNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetJobCreatedNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetJobCreatedNotificationRegistrationsSpectraS3Request) (*models.GetJobCreatedNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2055,7 +2056,7 @@ func (client *Client) GetJobCreatedNotificationRegistrationsSpectraS3(request *m
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2074,12 +2075,12 @@ func (client *Client) GetJobCreatedNotificationRegistrationsSpectraS3(request *m
     return models.NewGetJobCreatedNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetJobCreationFailedNotificationRegistrationSpectraS3(request *models.GetJobCreationFailedNotificationRegistrationSpectraS3Request) (*models.GetJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetJobCreationFailedNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetJobCreationFailedNotificationRegistrationSpectraS3Request) (*models.GetJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/job_creation_failed_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2098,7 +2099,7 @@ func (client *Client) GetJobCreationFailedNotificationRegistrationSpectraS3(requ
     return models.NewGetJobCreationFailedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetJobCreationFailedNotificationRegistrationsSpectraS3(request *models.GetJobCreationFailedNotificationRegistrationsSpectraS3Request) (*models.GetJobCreationFailedNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetJobCreationFailedNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetJobCreationFailedNotificationRegistrationsSpectraS3Request) (*models.GetJobCreationFailedNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2108,7 +2109,7 @@ func (client *Client) GetJobCreationFailedNotificationRegistrationsSpectraS3(req
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2127,12 +2128,12 @@ func (client *Client) GetJobCreationFailedNotificationRegistrationsSpectraS3(req
     return models.NewGetJobCreationFailedNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetObjectCachedNotificationRegistrationSpectraS3(request *models.GetObjectCachedNotificationRegistrationSpectraS3Request) (*models.GetObjectCachedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetObjectCachedNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetObjectCachedNotificationRegistrationSpectraS3Request) (*models.GetObjectCachedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/object_cached_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2151,7 +2152,7 @@ func (client *Client) GetObjectCachedNotificationRegistrationSpectraS3(request *
     return models.NewGetObjectCachedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetObjectCachedNotificationRegistrationsSpectraS3(request *models.GetObjectCachedNotificationRegistrationsSpectraS3Request) (*models.GetObjectCachedNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetObjectCachedNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetObjectCachedNotificationRegistrationsSpectraS3Request) (*models.GetObjectCachedNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2161,7 +2162,7 @@ func (client *Client) GetObjectCachedNotificationRegistrationsSpectraS3(request 
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2180,12 +2181,12 @@ func (client *Client) GetObjectCachedNotificationRegistrationsSpectraS3(request 
     return models.NewGetObjectCachedNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetObjectLostNotificationRegistrationSpectraS3(request *models.GetObjectLostNotificationRegistrationSpectraS3Request) (*models.GetObjectLostNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetObjectLostNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetObjectLostNotificationRegistrationSpectraS3Request) (*models.GetObjectLostNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/object_lost_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2204,7 +2205,7 @@ func (client *Client) GetObjectLostNotificationRegistrationSpectraS3(request *mo
     return models.NewGetObjectLostNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetObjectLostNotificationRegistrationsSpectraS3(request *models.GetObjectLostNotificationRegistrationsSpectraS3Request) (*models.GetObjectLostNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetObjectLostNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetObjectLostNotificationRegistrationsSpectraS3Request) (*models.GetObjectLostNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2214,7 +2215,7 @@ func (client *Client) GetObjectLostNotificationRegistrationsSpectraS3(request *m
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2233,12 +2234,12 @@ func (client *Client) GetObjectLostNotificationRegistrationsSpectraS3(request *m
     return models.NewGetObjectLostNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetObjectPersistedNotificationRegistrationSpectraS3(request *models.GetObjectPersistedNotificationRegistrationSpectraS3Request) (*models.GetObjectPersistedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetObjectPersistedNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetObjectPersistedNotificationRegistrationSpectraS3Request) (*models.GetObjectPersistedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/object_persisted_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2257,7 +2258,7 @@ func (client *Client) GetObjectPersistedNotificationRegistrationSpectraS3(reques
     return models.NewGetObjectPersistedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetObjectPersistedNotificationRegistrationsSpectraS3(request *models.GetObjectPersistedNotificationRegistrationsSpectraS3Request) (*models.GetObjectPersistedNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetObjectPersistedNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetObjectPersistedNotificationRegistrationsSpectraS3Request) (*models.GetObjectPersistedNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2267,7 +2268,7 @@ func (client *Client) GetObjectPersistedNotificationRegistrationsSpectraS3(reque
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2286,12 +2287,12 @@ func (client *Client) GetObjectPersistedNotificationRegistrationsSpectraS3(reque
     return models.NewGetObjectPersistedNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetPoolFailureNotificationRegistrationSpectraS3(request *models.GetPoolFailureNotificationRegistrationSpectraS3Request) (*models.GetPoolFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetPoolFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetPoolFailureNotificationRegistrationSpectraS3Request) (*models.GetPoolFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/pool_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2310,7 +2311,7 @@ func (client *Client) GetPoolFailureNotificationRegistrationSpectraS3(request *m
     return models.NewGetPoolFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetPoolFailureNotificationRegistrationsSpectraS3(request *models.GetPoolFailureNotificationRegistrationsSpectraS3Request) (*models.GetPoolFailureNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetPoolFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetPoolFailureNotificationRegistrationsSpectraS3Request) (*models.GetPoolFailureNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2320,7 +2321,7 @@ func (client *Client) GetPoolFailureNotificationRegistrationsSpectraS3(request *
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2339,12 +2340,12 @@ func (client *Client) GetPoolFailureNotificationRegistrationsSpectraS3(request *
     return models.NewGetPoolFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetS3TargetFailureNotificationRegistrationSpectraS3(request *models.GetS3TargetFailureNotificationRegistrationSpectraS3Request) (*models.GetS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetS3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetS3TargetFailureNotificationRegistrationSpectraS3Request) (*models.GetS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/s3_target_failure_notification_registration/" + request.S3TargetFailureNotificationRegistration).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2363,7 +2364,7 @@ func (client *Client) GetS3TargetFailureNotificationRegistrationSpectraS3(reques
     return models.NewGetS3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetS3TargetFailureNotificationRegistrationsSpectraS3(request *models.GetS3TargetFailureNotificationRegistrationsSpectraS3Request) (*models.GetS3TargetFailureNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetS3TargetFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetS3TargetFailureNotificationRegistrationsSpectraS3Request) (*models.GetS3TargetFailureNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2373,7 +2374,7 @@ func (client *Client) GetS3TargetFailureNotificationRegistrationsSpectraS3(reque
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2392,12 +2393,12 @@ func (client *Client) GetS3TargetFailureNotificationRegistrationsSpectraS3(reque
     return models.NewGetS3TargetFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetStorageDomainFailureNotificationRegistrationSpectraS3(request *models.GetStorageDomainFailureNotificationRegistrationSpectraS3Request) (*models.GetStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetStorageDomainFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetStorageDomainFailureNotificationRegistrationSpectraS3Request) (*models.GetStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/storage_domain_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2416,7 +2417,7 @@ func (client *Client) GetStorageDomainFailureNotificationRegistrationSpectraS3(r
     return models.NewGetStorageDomainFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetStorageDomainFailureNotificationRegistrationsSpectraS3(request *models.GetStorageDomainFailureNotificationRegistrationsSpectraS3Request) (*models.GetStorageDomainFailureNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetStorageDomainFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetStorageDomainFailureNotificationRegistrationsSpectraS3Request) (*models.GetStorageDomainFailureNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2426,7 +2427,7 @@ func (client *Client) GetStorageDomainFailureNotificationRegistrationsSpectraS3(
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2445,12 +2446,12 @@ func (client *Client) GetStorageDomainFailureNotificationRegistrationsSpectraS3(
     return models.NewGetStorageDomainFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetSystemFailureNotificationRegistrationSpectraS3(request *models.GetSystemFailureNotificationRegistrationSpectraS3Request) (*models.GetSystemFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetSystemFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetSystemFailureNotificationRegistrationSpectraS3Request) (*models.GetSystemFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/system_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2469,7 +2470,7 @@ func (client *Client) GetSystemFailureNotificationRegistrationSpectraS3(request 
     return models.NewGetSystemFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetSystemFailureNotificationRegistrationsSpectraS3(request *models.GetSystemFailureNotificationRegistrationsSpectraS3Request) (*models.GetSystemFailureNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetSystemFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetSystemFailureNotificationRegistrationsSpectraS3Request) (*models.GetSystemFailureNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2479,7 +2480,7 @@ func (client *Client) GetSystemFailureNotificationRegistrationsSpectraS3(request
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2498,12 +2499,12 @@ func (client *Client) GetSystemFailureNotificationRegistrationsSpectraS3(request
     return models.NewGetSystemFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetTapeFailureNotificationRegistrationSpectraS3(request *models.GetTapeFailureNotificationRegistrationSpectraS3Request) (*models.GetTapeFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetTapeFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetTapeFailureNotificationRegistrationSpectraS3Request) (*models.GetTapeFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/tape_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2522,7 +2523,7 @@ func (client *Client) GetTapeFailureNotificationRegistrationSpectraS3(request *m
     return models.NewGetTapeFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetTapeFailureNotificationRegistrationsSpectraS3(request *models.GetTapeFailureNotificationRegistrationsSpectraS3Request) (*models.GetTapeFailureNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetTapeFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetTapeFailureNotificationRegistrationsSpectraS3Request) (*models.GetTapeFailureNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2532,7 +2533,7 @@ func (client *Client) GetTapeFailureNotificationRegistrationsSpectraS3(request *
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2551,12 +2552,12 @@ func (client *Client) GetTapeFailureNotificationRegistrationsSpectraS3(request *
     return models.NewGetTapeFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetTapePartitionFailureNotificationRegistrationSpectraS3(request *models.GetTapePartitionFailureNotificationRegistrationSpectraS3Request) (*models.GetTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) GetTapePartitionFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetTapePartitionFailureNotificationRegistrationSpectraS3Request) (*models.GetTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/tape_partition_failure_notification_registration/" + request.NotificationId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2575,7 +2576,7 @@ func (client *Client) GetTapePartitionFailureNotificationRegistrationSpectraS3(r
     return models.NewGetTapePartitionFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) GetTapePartitionFailureNotificationRegistrationsSpectraS3(request *models.GetTapePartitionFailureNotificationRegistrationsSpectraS3Request) (*models.GetTapePartitionFailureNotificationRegistrationsSpectraS3Response, error) {
+func (client *Client) GetTapePartitionFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetTapePartitionFailureNotificationRegistrationsSpectraS3Request) (*models.GetTapePartitionFailureNotificationRegistrationsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2585,7 +2586,7 @@ func (client *Client) GetTapePartitionFailureNotificationRegistrationsSpectraS3(
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2604,13 +2605,13 @@ func (client *Client) GetTapePartitionFailureNotificationRegistrationsSpectraS3(
     return models.NewGetTapePartitionFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
-func (client *Client) GetBlobPersistenceSpectraS3(request *models.GetBlobPersistenceSpectraS3Request) (*models.GetBlobPersistenceSpectraS3Response, error) {
+func (client *Client) GetBlobPersistenceSpectraS3(ctx context.Context, request *models.GetBlobPersistenceSpectraS3Request) (*models.GetBlobPersistenceSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/blob_persistence").
         WithReadCloser(buildStreamFromString(request.RequestPayload)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2629,13 +2630,13 @@ func (client *Client) GetBlobPersistenceSpectraS3(request *models.GetBlobPersist
     return models.NewGetBlobPersistenceSpectraS3Response(response)
 }
 
-func (client *Client) GetObjectDetailsSpectraS3(request *models.GetObjectDetailsSpectraS3Request) (*models.GetObjectDetailsSpectraS3Response, error) {
+func (client *Client) GetObjectDetailsSpectraS3(ctx context.Context, request *models.GetObjectDetailsSpectraS3Request) (*models.GetObjectDetailsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/object/" + request.ObjectName).
         WithQueryParam("bucket_id", request.BucketId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2654,7 +2655,7 @@ func (client *Client) GetObjectDetailsSpectraS3(request *models.GetObjectDetails
     return models.NewGetObjectDetailsSpectraS3Response(response)
 }
 
-func (client *Client) GetObjectsDetailsSpectraS3(request *models.GetObjectsDetailsSpectraS3Request) (*models.GetObjectsDetailsSpectraS3Response, error) {
+func (client *Client) GetObjectsDetailsSpectraS3(ctx context.Context, request *models.GetObjectsDetailsSpectraS3Request) (*models.GetObjectsDetailsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2669,7 +2670,7 @@ func (client *Client) GetObjectsDetailsSpectraS3(request *models.GetObjectsDetai
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("start_date", networking.Int64PtrToStrPtr(request.StartDate)).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.S3ObjectType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2688,7 +2689,7 @@ func (client *Client) GetObjectsDetailsSpectraS3(request *models.GetObjectsDetai
     return models.NewGetObjectsDetailsSpectraS3Response(response)
 }
 
-func (client *Client) GetObjectsWithFullDetailsSpectraS3(request *models.GetObjectsWithFullDetailsSpectraS3Request) (*models.GetObjectsWithFullDetailsSpectraS3Response, error) {
+func (client *Client) GetObjectsWithFullDetailsSpectraS3(ctx context.Context, request *models.GetObjectsWithFullDetailsSpectraS3Request) (*models.GetObjectsWithFullDetailsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2705,7 +2706,7 @@ func (client *Client) GetObjectsWithFullDetailsSpectraS3(request *models.GetObje
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("start_date", networking.Int64PtrToStrPtr(request.StartDate)).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.S3ObjectType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2724,7 +2725,7 @@ func (client *Client) GetObjectsWithFullDetailsSpectraS3(request *models.GetObje
     return models.NewGetObjectsWithFullDetailsSpectraS3Response(response)
 }
 
-func (client *Client) VerifyPhysicalPlacementForObjectsSpectraS3(request *models.VerifyPhysicalPlacementForObjectsSpectraS3Request) (*models.VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {
+func (client *Client) VerifyPhysicalPlacementForObjectsSpectraS3(ctx context.Context, request *models.VerifyPhysicalPlacementForObjectsSpectraS3Request) (*models.VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2732,7 +2733,7 @@ func (client *Client) VerifyPhysicalPlacementForObjectsSpectraS3(request *models
         WithOptionalQueryParam("storage_domain", request.StorageDomain).
         WithQueryParam("operation", "verify_physical_placement").
         WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2751,7 +2752,7 @@ func (client *Client) VerifyPhysicalPlacementForObjectsSpectraS3(request *models
     return models.NewVerifyPhysicalPlacementForObjectsSpectraS3Response(response)
 }
 
-func (client *Client) VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3(request *models.VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request) (*models.VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response, error) {
+func (client *Client) VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3(ctx context.Context, request *models.VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request) (*models.VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2760,7 +2761,7 @@ func (client *Client) VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3(
         WithOptionalQueryParam("storage_domain", request.StorageDomain).
         WithQueryParam("operation", "verify_physical_placement").
         WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2779,13 +2780,13 @@ func (client *Client) VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3(
     return models.NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response(response)
 }
 
-func (client *Client) GetBlobsOnPoolSpectraS3(request *models.GetBlobsOnPoolSpectraS3Request) (*models.GetBlobsOnPoolSpectraS3Response, error) {
+func (client *Client) GetBlobsOnPoolSpectraS3(ctx context.Context, request *models.GetBlobsOnPoolSpectraS3Request) (*models.GetBlobsOnPoolSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/pool/" + request.Pool).
         WithQueryParam("operation", "get_physical_placement").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2804,7 +2805,7 @@ func (client *Client) GetBlobsOnPoolSpectraS3(request *models.GetBlobsOnPoolSpec
     return models.NewGetBlobsOnPoolSpectraS3Response(response)
 }
 
-func (client *Client) GetPoolFailuresSpectraS3(request *models.GetPoolFailuresSpectraS3Request) (*models.GetPoolFailuresSpectraS3Response, error) {
+func (client *Client) GetPoolFailuresSpectraS3(ctx context.Context, request *models.GetPoolFailuresSpectraS3Request) (*models.GetPoolFailuresSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2816,7 +2817,7 @@ func (client *Client) GetPoolFailuresSpectraS3(request *models.GetPoolFailuresSp
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("pool_id", request.PoolId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.PoolFailureType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2835,12 +2836,12 @@ func (client *Client) GetPoolFailuresSpectraS3(request *models.GetPoolFailuresSp
     return models.NewGetPoolFailuresSpectraS3Response(response)
 }
 
-func (client *Client) GetPoolPartitionSpectraS3(request *models.GetPoolPartitionSpectraS3Request) (*models.GetPoolPartitionSpectraS3Response, error) {
+func (client *Client) GetPoolPartitionSpectraS3(ctx context.Context, request *models.GetPoolPartitionSpectraS3Request) (*models.GetPoolPartitionSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/pool_partition/" + request.PoolPartition).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2859,7 +2860,7 @@ func (client *Client) GetPoolPartitionSpectraS3(request *models.GetPoolPartition
     return models.NewGetPoolPartitionSpectraS3Response(response)
 }
 
-func (client *Client) GetPoolPartitionsSpectraS3(request *models.GetPoolPartitionsSpectraS3Request) (*models.GetPoolPartitionsSpectraS3Response, error) {
+func (client *Client) GetPoolPartitionsSpectraS3(ctx context.Context, request *models.GetPoolPartitionsSpectraS3Request) (*models.GetPoolPartitionsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2870,7 +2871,7 @@ func (client *Client) GetPoolPartitionsSpectraS3(request *models.GetPoolPartitio
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.PoolType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2889,12 +2890,12 @@ func (client *Client) GetPoolPartitionsSpectraS3(request *models.GetPoolPartitio
     return models.NewGetPoolPartitionsSpectraS3Response(response)
 }
 
-func (client *Client) GetPoolSpectraS3(request *models.GetPoolSpectraS3Request) (*models.GetPoolSpectraS3Response, error) {
+func (client *Client) GetPoolSpectraS3(ctx context.Context, request *models.GetPoolSpectraS3Request) (*models.GetPoolSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/pool/" + request.Pool).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2913,7 +2914,7 @@ func (client *Client) GetPoolSpectraS3(request *models.GetPoolSpectraS3Request) 
     return models.NewGetPoolSpectraS3Response(response)
 }
 
-func (client *Client) GetPoolsSpectraS3(request *models.GetPoolsSpectraS3Request) (*models.GetPoolsSpectraS3Response, error) {
+func (client *Client) GetPoolsSpectraS3(ctx context.Context, request *models.GetPoolsSpectraS3Request) (*models.GetPoolsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2933,7 +2934,7 @@ func (client *Client) GetPoolsSpectraS3(request *models.GetPoolsSpectraS3Request
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
         WithOptionalQueryParam("storage_domain_member_id", request.StorageDomainMemberId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.PoolType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2952,7 +2953,7 @@ func (client *Client) GetPoolsSpectraS3(request *models.GetPoolsSpectraS3Request
     return models.NewGetPoolsSpectraS3Response(response)
 }
 
-func (client *Client) GetStorageDomainFailuresSpectraS3(request *models.GetStorageDomainFailuresSpectraS3Request) (*models.GetStorageDomainFailuresSpectraS3Response, error) {
+func (client *Client) GetStorageDomainFailuresSpectraS3(ctx context.Context, request *models.GetStorageDomainFailuresSpectraS3Request) (*models.GetStorageDomainFailuresSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -2964,7 +2965,7 @@ func (client *Client) GetStorageDomainFailuresSpectraS3(request *models.GetStora
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.StorageDomainFailureType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -2983,12 +2984,12 @@ func (client *Client) GetStorageDomainFailuresSpectraS3(request *models.GetStora
     return models.NewGetStorageDomainFailuresSpectraS3Response(response)
 }
 
-func (client *Client) GetStorageDomainMemberSpectraS3(request *models.GetStorageDomainMemberSpectraS3Request) (*models.GetStorageDomainMemberSpectraS3Response, error) {
+func (client *Client) GetStorageDomainMemberSpectraS3(ctx context.Context, request *models.GetStorageDomainMemberSpectraS3Request) (*models.GetStorageDomainMemberSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/storage_domain_member/" + request.StorageDomainMember).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3007,7 +3008,7 @@ func (client *Client) GetStorageDomainMemberSpectraS3(request *models.GetStorage
     return models.NewGetStorageDomainMemberSpectraS3Response(response)
 }
 
-func (client *Client) GetStorageDomainMembersSpectraS3(request *models.GetStorageDomainMembersSpectraS3Request) (*models.GetStorageDomainMembersSpectraS3Response, error) {
+func (client *Client) GetStorageDomainMembersSpectraS3(ctx context.Context, request *models.GetStorageDomainMembersSpectraS3Request) (*models.GetStorageDomainMembersSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3022,7 +3023,7 @@ func (client *Client) GetStorageDomainMembersSpectraS3(request *models.GetStorag
         WithOptionalQueryParam("tape_partition_id", request.TapePartitionId).
         WithOptionalQueryParam("tape_type", request.TapeType).
         WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3041,12 +3042,12 @@ func (client *Client) GetStorageDomainMembersSpectraS3(request *models.GetStorag
     return models.NewGetStorageDomainMembersSpectraS3Response(response)
 }
 
-func (client *Client) GetStorageDomainSpectraS3(request *models.GetStorageDomainSpectraS3Request) (*models.GetStorageDomainSpectraS3Response, error) {
+func (client *Client) GetStorageDomainSpectraS3(ctx context.Context, request *models.GetStorageDomainSpectraS3Request) (*models.GetStorageDomainSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/storage_domain/" + request.StorageDomain).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3065,7 +3066,7 @@ func (client *Client) GetStorageDomainSpectraS3(request *models.GetStorageDomain
     return models.NewGetStorageDomainSpectraS3Response(response)
 }
 
-func (client *Client) GetStorageDomainsSpectraS3(request *models.GetStorageDomainsSpectraS3Request) (*models.GetStorageDomainsSpectraS3Response, error) {
+func (client *Client) GetStorageDomainsSpectraS3(ctx context.Context, request *models.GetStorageDomainsSpectraS3Request) (*models.GetStorageDomainsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3082,7 +3083,7 @@ func (client *Client) GetStorageDomainsSpectraS3(request *models.GetStorageDomai
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("secure_media_allocation", networking.BoolPtrToStrPtr(request.SecureMediaAllocation)).
         WithOptionalQueryParam("write_optimization", networking.InterfaceToStrPtr(request.WriteOptimization)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3101,7 +3102,7 @@ func (client *Client) GetStorageDomainsSpectraS3(request *models.GetStorageDomai
     return models.NewGetStorageDomainsSpectraS3Response(response)
 }
 
-func (client *Client) GetFeatureKeysSpectraS3(request *models.GetFeatureKeysSpectraS3Request) (*models.GetFeatureKeysSpectraS3Response, error) {
+func (client *Client) GetFeatureKeysSpectraS3(ctx context.Context, request *models.GetFeatureKeysSpectraS3Request) (*models.GetFeatureKeysSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3113,7 +3114,7 @@ func (client *Client) GetFeatureKeysSpectraS3(request *models.GetFeatureKeysSpec
         WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3132,7 +3133,7 @@ func (client *Client) GetFeatureKeysSpectraS3(request *models.GetFeatureKeysSpec
     return models.NewGetFeatureKeysSpectraS3Response(response)
 }
 
-func (client *Client) GetSystemFailuresSpectraS3(request *models.GetSystemFailuresSpectraS3Request) (*models.GetSystemFailuresSpectraS3Response, error) {
+func (client *Client) GetSystemFailuresSpectraS3(ctx context.Context, request *models.GetSystemFailuresSpectraS3Request) (*models.GetSystemFailuresSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3143,7 +3144,7 @@ func (client *Client) GetSystemFailuresSpectraS3(request *models.GetSystemFailur
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.SystemFailureType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3162,12 +3163,12 @@ func (client *Client) GetSystemFailuresSpectraS3(request *models.GetSystemFailur
     return models.NewGetSystemFailuresSpectraS3Response(response)
 }
 
-func (client *Client) GetSystemInformationSpectraS3(request *models.GetSystemInformationSpectraS3Request) (*models.GetSystemInformationSpectraS3Response, error) {
+func (client *Client) GetSystemInformationSpectraS3(ctx context.Context, request *models.GetSystemInformationSpectraS3Request) (*models.GetSystemInformationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/system_information").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3186,12 +3187,12 @@ func (client *Client) GetSystemInformationSpectraS3(request *models.GetSystemInf
     return models.NewGetSystemInformationSpectraS3Response(response)
 }
 
-func (client *Client) VerifySystemHealthSpectraS3(request *models.VerifySystemHealthSpectraS3Request) (*models.VerifySystemHealthSpectraS3Response, error) {
+func (client *Client) VerifySystemHealthSpectraS3(ctx context.Context, request *models.VerifySystemHealthSpectraS3Request) (*models.VerifySystemHealthSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/system_health").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3210,7 +3211,7 @@ func (client *Client) VerifySystemHealthSpectraS3(request *models.VerifySystemHe
     return models.NewVerifySystemHealthSpectraS3Response(response)
 }
 
-func (client *Client) GetBlobsOnTapeSpectraS3(request *models.GetBlobsOnTapeSpectraS3Request) (*models.GetBlobsOnTapeSpectraS3Response, error) {
+func (client *Client) GetBlobsOnTapeSpectraS3(ctx context.Context, request *models.GetBlobsOnTapeSpectraS3Request) (*models.GetBlobsOnTapeSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3220,7 +3221,7 @@ func (client *Client) GetBlobsOnTapeSpectraS3(request *models.GetBlobsOnTapeSpec
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithQueryParam("operation", "get_physical_placement").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3239,12 +3240,12 @@ func (client *Client) GetBlobsOnTapeSpectraS3(request *models.GetBlobsOnTapeSpec
     return models.NewGetBlobsOnTapeSpectraS3Response(response)
 }
 
-func (client *Client) GetTapeDensityDirectiveSpectraS3(request *models.GetTapeDensityDirectiveSpectraS3Request) (*models.GetTapeDensityDirectiveSpectraS3Response, error) {
+func (client *Client) GetTapeDensityDirectiveSpectraS3(ctx context.Context, request *models.GetTapeDensityDirectiveSpectraS3Request) (*models.GetTapeDensityDirectiveSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/tape_density_directive/" + request.TapeDensityDirective).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3263,7 +3264,7 @@ func (client *Client) GetTapeDensityDirectiveSpectraS3(request *models.GetTapeDe
     return models.NewGetTapeDensityDirectiveSpectraS3Response(response)
 }
 
-func (client *Client) GetTapeDensityDirectivesSpectraS3(request *models.GetTapeDensityDirectivesSpectraS3Request) (*models.GetTapeDensityDirectivesSpectraS3Response, error) {
+func (client *Client) GetTapeDensityDirectivesSpectraS3(ctx context.Context, request *models.GetTapeDensityDirectivesSpectraS3Request) (*models.GetTapeDensityDirectivesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3275,7 +3276,7 @@ func (client *Client) GetTapeDensityDirectivesSpectraS3(request *models.GetTapeD
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("partition_id", request.PartitionId).
         WithOptionalQueryParam("tape_type", request.TapeType).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3294,12 +3295,12 @@ func (client *Client) GetTapeDensityDirectivesSpectraS3(request *models.GetTapeD
     return models.NewGetTapeDensityDirectivesSpectraS3Response(response)
 }
 
-func (client *Client) GetTapeDriveSpectraS3(request *models.GetTapeDriveSpectraS3Request) (*models.GetTapeDriveSpectraS3Response, error) {
+func (client *Client) GetTapeDriveSpectraS3(ctx context.Context, request *models.GetTapeDriveSpectraS3Request) (*models.GetTapeDriveSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3318,7 +3319,7 @@ func (client *Client) GetTapeDriveSpectraS3(request *models.GetTapeDriveSpectraS
     return models.NewGetTapeDriveSpectraS3Response(response)
 }
 
-func (client *Client) GetTapeDrivesSpectraS3(request *models.GetTapeDrivesSpectraS3Request) (*models.GetTapeDrivesSpectraS3Response, error) {
+func (client *Client) GetTapeDrivesSpectraS3(ctx context.Context, request *models.GetTapeDrivesSpectraS3Request) (*models.GetTapeDrivesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3333,7 +3334,7 @@ func (client *Client) GetTapeDrivesSpectraS3(request *models.GetTapeDrivesSpectr
         WithOptionalQueryParam("serial_number", request.SerialNumber).
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TapeDriveType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3352,7 +3353,7 @@ func (client *Client) GetTapeDrivesSpectraS3(request *models.GetTapeDrivesSpectr
     return models.NewGetTapeDrivesSpectraS3Response(response)
 }
 
-func (client *Client) GetTapeFailuresSpectraS3(request *models.GetTapeFailuresSpectraS3Request) (*models.GetTapeFailuresSpectraS3Response, error) {
+func (client *Client) GetTapeFailuresSpectraS3(ctx context.Context, request *models.GetTapeFailuresSpectraS3Request) (*models.GetTapeFailuresSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3365,7 +3366,7 @@ func (client *Client) GetTapeFailuresSpectraS3(request *models.GetTapeFailuresSp
         WithOptionalQueryParam("tape_drive_id", request.TapeDriveId).
         WithOptionalQueryParam("tape_id", request.TapeId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TapeFailureType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3384,7 +3385,7 @@ func (client *Client) GetTapeFailuresSpectraS3(request *models.GetTapeFailuresSp
     return models.NewGetTapeFailuresSpectraS3Response(response)
 }
 
-func (client *Client) GetTapeLibrariesSpectraS3(request *models.GetTapeLibrariesSpectraS3Request) (*models.GetTapeLibrariesSpectraS3Response, error) {
+func (client *Client) GetTapeLibrariesSpectraS3(ctx context.Context, request *models.GetTapeLibrariesSpectraS3Request) (*models.GetTapeLibrariesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3396,7 +3397,7 @@ func (client *Client) GetTapeLibrariesSpectraS3(request *models.GetTapeLibraries
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("serial_number", request.SerialNumber).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3415,12 +3416,12 @@ func (client *Client) GetTapeLibrariesSpectraS3(request *models.GetTapeLibraries
     return models.NewGetTapeLibrariesSpectraS3Response(response)
 }
 
-func (client *Client) GetTapeLibrarySpectraS3(request *models.GetTapeLibrarySpectraS3Request) (*models.GetTapeLibrarySpectraS3Response, error) {
+func (client *Client) GetTapeLibrarySpectraS3(ctx context.Context, request *models.GetTapeLibrarySpectraS3Request) (*models.GetTapeLibrarySpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/tape_library/" + request.TapeLibraryId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3439,7 +3440,7 @@ func (client *Client) GetTapeLibrarySpectraS3(request *models.GetTapeLibrarySpec
     return models.NewGetTapeLibrarySpectraS3Response(response)
 }
 
-func (client *Client) GetTapePartitionFailuresSpectraS3(request *models.GetTapePartitionFailuresSpectraS3Request) (*models.GetTapePartitionFailuresSpectraS3Response, error) {
+func (client *Client) GetTapePartitionFailuresSpectraS3(ctx context.Context, request *models.GetTapePartitionFailuresSpectraS3Request) (*models.GetTapePartitionFailuresSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3451,7 +3452,7 @@ func (client *Client) GetTapePartitionFailuresSpectraS3(request *models.GetTapeP
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("partition_id", request.PartitionId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TapePartitionFailureType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3470,12 +3471,12 @@ func (client *Client) GetTapePartitionFailuresSpectraS3(request *models.GetTapeP
     return models.NewGetTapePartitionFailuresSpectraS3Response(response)
 }
 
-func (client *Client) GetTapePartitionSpectraS3(request *models.GetTapePartitionSpectraS3Request) (*models.GetTapePartitionSpectraS3Response, error) {
+func (client *Client) GetTapePartitionSpectraS3(ctx context.Context, request *models.GetTapePartitionSpectraS3Request) (*models.GetTapePartitionSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/tape_partition/" + request.TapePartition).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3494,13 +3495,13 @@ func (client *Client) GetTapePartitionSpectraS3(request *models.GetTapePartition
     return models.NewGetTapePartitionSpectraS3Response(response)
 }
 
-func (client *Client) GetTapePartitionWithFullDetailsSpectraS3(request *models.GetTapePartitionWithFullDetailsSpectraS3Request) (*models.GetTapePartitionWithFullDetailsSpectraS3Response, error) {
+func (client *Client) GetTapePartitionWithFullDetailsSpectraS3(ctx context.Context, request *models.GetTapePartitionWithFullDetailsSpectraS3Request) (*models.GetTapePartitionWithFullDetailsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/tape_partition/" + request.TapePartition).
         WithQueryParam("full_details", "").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3519,7 +3520,7 @@ func (client *Client) GetTapePartitionWithFullDetailsSpectraS3(request *models.G
     return models.NewGetTapePartitionWithFullDetailsSpectraS3Response(response)
 }
 
-func (client *Client) GetTapePartitionsSpectraS3(request *models.GetTapePartitionsSpectraS3Request) (*models.GetTapePartitionsSpectraS3Response, error) {
+func (client *Client) GetTapePartitionsSpectraS3(ctx context.Context, request *models.GetTapePartitionsSpectraS3Request) (*models.GetTapePartitionsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3534,7 +3535,7 @@ func (client *Client) GetTapePartitionsSpectraS3(request *models.GetTapePartitio
         WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
         WithOptionalQueryParam("serial_number", request.SerialNumber).
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3553,7 +3554,7 @@ func (client *Client) GetTapePartitionsSpectraS3(request *models.GetTapePartitio
     return models.NewGetTapePartitionsSpectraS3Response(response)
 }
 
-func (client *Client) GetTapePartitionsWithFullDetailsSpectraS3(request *models.GetTapePartitionsWithFullDetailsSpectraS3Request) (*models.GetTapePartitionsWithFullDetailsSpectraS3Response, error) {
+func (client *Client) GetTapePartitionsWithFullDetailsSpectraS3(ctx context.Context, request *models.GetTapePartitionsWithFullDetailsSpectraS3Request) (*models.GetTapePartitionsWithFullDetailsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3569,7 +3570,7 @@ func (client *Client) GetTapePartitionsWithFullDetailsSpectraS3(request *models.
         WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
         WithOptionalQueryParam("serial_number", request.SerialNumber).
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3588,12 +3589,12 @@ func (client *Client) GetTapePartitionsWithFullDetailsSpectraS3(request *models.
     return models.NewGetTapePartitionsWithFullDetailsSpectraS3Response(response)
 }
 
-func (client *Client) GetTapeSpectraS3(request *models.GetTapeSpectraS3Request) (*models.GetTapeSpectraS3Response, error) {
+func (client *Client) GetTapeSpectraS3(ctx context.Context, request *models.GetTapeSpectraS3Request) (*models.GetTapeSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/tape/" + request.TapeId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3612,7 +3613,7 @@ func (client *Client) GetTapeSpectraS3(request *models.GetTapeSpectraS3Request) 
     return models.NewGetTapeSpectraS3Response(response)
 }
 
-func (client *Client) GetTapesSpectraS3(request *models.GetTapesSpectraS3Request) (*models.GetTapesSpectraS3Response, error) {
+func (client *Client) GetTapesSpectraS3(ctx context.Context, request *models.GetTapesSpectraS3Request) (*models.GetTapesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3642,7 +3643,7 @@ func (client *Client) GetTapesSpectraS3(request *models.GetTapesSpectraS3Request
         WithOptionalQueryParam("type", request.String).
         WithOptionalQueryParam("verify_pending", networking.InterfaceToStrPtr(request.VerifyPending)).
         WithOptionalQueryParam("write_protected", networking.BoolPtrToStrPtr(request.WriteProtected)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3661,7 +3662,7 @@ func (client *Client) GetTapesSpectraS3(request *models.GetTapesSpectraS3Request
     return models.NewGetTapesSpectraS3Response(response)
 }
 
-func (client *Client) GetAzureTargetBucketNamesSpectraS3(request *models.GetAzureTargetBucketNamesSpectraS3Request) (*models.GetAzureTargetBucketNamesSpectraS3Response, error) {
+func (client *Client) GetAzureTargetBucketNamesSpectraS3(ctx context.Context, request *models.GetAzureTargetBucketNamesSpectraS3Request) (*models.GetAzureTargetBucketNamesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3673,7 +3674,7 @@ func (client *Client) GetAzureTargetBucketNamesSpectraS3(request *models.GetAzur
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3692,7 +3693,7 @@ func (client *Client) GetAzureTargetBucketNamesSpectraS3(request *models.GetAzur
     return models.NewGetAzureTargetBucketNamesSpectraS3Response(response)
 }
 
-func (client *Client) GetAzureTargetFailuresSpectraS3(request *models.GetAzureTargetFailuresSpectraS3Request) (*models.GetAzureTargetFailuresSpectraS3Response, error) {
+func (client *Client) GetAzureTargetFailuresSpectraS3(ctx context.Context, request *models.GetAzureTargetFailuresSpectraS3Request) (*models.GetAzureTargetFailuresSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3704,7 +3705,7 @@ func (client *Client) GetAzureTargetFailuresSpectraS3(request *models.GetAzureTa
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("target_id", request.TargetId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TargetFailureType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3723,12 +3724,12 @@ func (client *Client) GetAzureTargetFailuresSpectraS3(request *models.GetAzureTa
     return models.NewGetAzureTargetFailuresSpectraS3Response(response)
 }
 
-func (client *Client) GetAzureTargetReadPreferenceSpectraS3(request *models.GetAzureTargetReadPreferenceSpectraS3Request) (*models.GetAzureTargetReadPreferenceSpectraS3Response, error) {
+func (client *Client) GetAzureTargetReadPreferenceSpectraS3(ctx context.Context, request *models.GetAzureTargetReadPreferenceSpectraS3Request) (*models.GetAzureTargetReadPreferenceSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/azure_target_read_preference/" + request.AzureTargetReadPreference).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3747,7 +3748,7 @@ func (client *Client) GetAzureTargetReadPreferenceSpectraS3(request *models.GetA
     return models.NewGetAzureTargetReadPreferenceSpectraS3Response(response)
 }
 
-func (client *Client) GetAzureTargetReadPreferencesSpectraS3(request *models.GetAzureTargetReadPreferencesSpectraS3Request) (*models.GetAzureTargetReadPreferencesSpectraS3Response, error) {
+func (client *Client) GetAzureTargetReadPreferencesSpectraS3(ctx context.Context, request *models.GetAzureTargetReadPreferencesSpectraS3Request) (*models.GetAzureTargetReadPreferencesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3759,7 +3760,7 @@ func (client *Client) GetAzureTargetReadPreferencesSpectraS3(request *models.Get
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("read_preference", networking.InterfaceToStrPtr(request.ReadPreference)).
         WithOptionalQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3778,12 +3779,12 @@ func (client *Client) GetAzureTargetReadPreferencesSpectraS3(request *models.Get
     return models.NewGetAzureTargetReadPreferencesSpectraS3Response(response)
 }
 
-func (client *Client) GetAzureTargetSpectraS3(request *models.GetAzureTargetSpectraS3Request) (*models.GetAzureTargetSpectraS3Response, error) {
+func (client *Client) GetAzureTargetSpectraS3(ctx context.Context, request *models.GetAzureTargetSpectraS3Request) (*models.GetAzureTargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/azure_target/" + request.AzureTarget).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3802,7 +3803,7 @@ func (client *Client) GetAzureTargetSpectraS3(request *models.GetAzureTargetSpec
     return models.NewGetAzureTargetSpectraS3Response(response)
 }
 
-func (client *Client) GetAzureTargetsSpectraS3(request *models.GetAzureTargetsSpectraS3Request) (*models.GetAzureTargetsSpectraS3Response, error) {
+func (client *Client) GetAzureTargetsSpectraS3(ctx context.Context, request *models.GetAzureTargetsSpectraS3Request) (*models.GetAzureTargetsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3818,7 +3819,7 @@ func (client *Client) GetAzureTargetsSpectraS3(request *models.GetAzureTargetsSp
         WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
         WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3837,13 +3838,13 @@ func (client *Client) GetAzureTargetsSpectraS3(request *models.GetAzureTargetsSp
     return models.NewGetAzureTargetsSpectraS3Response(response)
 }
 
-func (client *Client) GetBlobsOnAzureTargetSpectraS3(request *models.GetBlobsOnAzureTargetSpectraS3Request) (*models.GetBlobsOnAzureTargetSpectraS3Response, error) {
+func (client *Client) GetBlobsOnAzureTargetSpectraS3(ctx context.Context, request *models.GetBlobsOnAzureTargetSpectraS3Request) (*models.GetBlobsOnAzureTargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/azure_target/" + request.AzureTarget).
         WithQueryParam("operation", "get_physical_placement").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3862,13 +3863,13 @@ func (client *Client) GetBlobsOnAzureTargetSpectraS3(request *models.GetBlobsOnA
     return models.NewGetBlobsOnAzureTargetSpectraS3Response(response)
 }
 
-func (client *Client) GetBlobsOnDs3TargetSpectraS3(request *models.GetBlobsOnDs3TargetSpectraS3Request) (*models.GetBlobsOnDs3TargetSpectraS3Response, error) {
+func (client *Client) GetBlobsOnDs3TargetSpectraS3(ctx context.Context, request *models.GetBlobsOnDs3TargetSpectraS3Request) (*models.GetBlobsOnDs3TargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/ds3_target/" + request.Ds3Target).
         WithQueryParam("operation", "get_physical_placement").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3887,12 +3888,12 @@ func (client *Client) GetBlobsOnDs3TargetSpectraS3(request *models.GetBlobsOnDs3
     return models.NewGetBlobsOnDs3TargetSpectraS3Response(response)
 }
 
-func (client *Client) GetDs3TargetDataPoliciesSpectraS3(request *models.GetDs3TargetDataPoliciesSpectraS3Request) (*models.GetDs3TargetDataPoliciesSpectraS3Response, error) {
+func (client *Client) GetDs3TargetDataPoliciesSpectraS3(ctx context.Context, request *models.GetDs3TargetDataPoliciesSpectraS3Request) (*models.GetDs3TargetDataPoliciesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/ds3_target_data_policies/" + request.Ds3TargetDataPolicies).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3911,7 +3912,7 @@ func (client *Client) GetDs3TargetDataPoliciesSpectraS3(request *models.GetDs3Ta
     return models.NewGetDs3TargetDataPoliciesSpectraS3Response(response)
 }
 
-func (client *Client) GetDs3TargetFailuresSpectraS3(request *models.GetDs3TargetFailuresSpectraS3Request) (*models.GetDs3TargetFailuresSpectraS3Response, error) {
+func (client *Client) GetDs3TargetFailuresSpectraS3(ctx context.Context, request *models.GetDs3TargetFailuresSpectraS3Request) (*models.GetDs3TargetFailuresSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3923,7 +3924,7 @@ func (client *Client) GetDs3TargetFailuresSpectraS3(request *models.GetDs3Target
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("target_id", request.TargetId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TargetFailureType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3942,12 +3943,12 @@ func (client *Client) GetDs3TargetFailuresSpectraS3(request *models.GetDs3Target
     return models.NewGetDs3TargetFailuresSpectraS3Response(response)
 }
 
-func (client *Client) GetDs3TargetReadPreferenceSpectraS3(request *models.GetDs3TargetReadPreferenceSpectraS3Request) (*models.GetDs3TargetReadPreferenceSpectraS3Response, error) {
+func (client *Client) GetDs3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.GetDs3TargetReadPreferenceSpectraS3Request) (*models.GetDs3TargetReadPreferenceSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/ds3_target_read_preference/" + request.Ds3TargetReadPreference).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3966,7 +3967,7 @@ func (client *Client) GetDs3TargetReadPreferenceSpectraS3(request *models.GetDs3
     return models.NewGetDs3TargetReadPreferenceSpectraS3Response(response)
 }
 
-func (client *Client) GetDs3TargetReadPreferencesSpectraS3(request *models.GetDs3TargetReadPreferencesSpectraS3Request) (*models.GetDs3TargetReadPreferencesSpectraS3Response, error) {
+func (client *Client) GetDs3TargetReadPreferencesSpectraS3(ctx context.Context, request *models.GetDs3TargetReadPreferencesSpectraS3Request) (*models.GetDs3TargetReadPreferencesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -3978,7 +3979,7 @@ func (client *Client) GetDs3TargetReadPreferencesSpectraS3(request *models.GetDs
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("read_preference", networking.InterfaceToStrPtr(request.ReadPreference)).
         WithOptionalQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -3997,12 +3998,12 @@ func (client *Client) GetDs3TargetReadPreferencesSpectraS3(request *models.GetDs
     return models.NewGetDs3TargetReadPreferencesSpectraS3Response(response)
 }
 
-func (client *Client) GetDs3TargetSpectraS3(request *models.GetDs3TargetSpectraS3Request) (*models.GetDs3TargetSpectraS3Response, error) {
+func (client *Client) GetDs3TargetSpectraS3(ctx context.Context, request *models.GetDs3TargetSpectraS3Request) (*models.GetDs3TargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/ds3_target/" + request.Ds3Target).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -4021,7 +4022,7 @@ func (client *Client) GetDs3TargetSpectraS3(request *models.GetDs3TargetSpectraS
     return models.NewGetDs3TargetSpectraS3Response(response)
 }
 
-func (client *Client) GetDs3TargetsSpectraS3(request *models.GetDs3TargetsSpectraS3Request) (*models.GetDs3TargetsSpectraS3Response, error) {
+func (client *Client) GetDs3TargetsSpectraS3(ctx context.Context, request *models.GetDs3TargetsSpectraS3Request) (*models.GetDs3TargetsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -4041,7 +4042,7 @@ func (client *Client) GetDs3TargetsSpectraS3(request *models.GetDs3TargetsSpectr
         WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
         WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -4060,13 +4061,13 @@ func (client *Client) GetDs3TargetsSpectraS3(request *models.GetDs3TargetsSpectr
     return models.NewGetDs3TargetsSpectraS3Response(response)
 }
 
-func (client *Client) GetBlobsOnS3TargetSpectraS3(request *models.GetBlobsOnS3TargetSpectraS3Request) (*models.GetBlobsOnS3TargetSpectraS3Response, error) {
+func (client *Client) GetBlobsOnS3TargetSpectraS3(ctx context.Context, request *models.GetBlobsOnS3TargetSpectraS3Request) (*models.GetBlobsOnS3TargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/s3_target/" + request.S3Target).
         WithQueryParam("operation", "get_physical_placement").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -4085,7 +4086,7 @@ func (client *Client) GetBlobsOnS3TargetSpectraS3(request *models.GetBlobsOnS3Ta
     return models.NewGetBlobsOnS3TargetSpectraS3Response(response)
 }
 
-func (client *Client) GetS3TargetBucketNamesSpectraS3(request *models.GetS3TargetBucketNamesSpectraS3Request) (*models.GetS3TargetBucketNamesSpectraS3Response, error) {
+func (client *Client) GetS3TargetBucketNamesSpectraS3(ctx context.Context, request *models.GetS3TargetBucketNamesSpectraS3Request) (*models.GetS3TargetBucketNamesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -4097,7 +4098,7 @@ func (client *Client) GetS3TargetBucketNamesSpectraS3(request *models.GetS3Targe
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -4116,7 +4117,7 @@ func (client *Client) GetS3TargetBucketNamesSpectraS3(request *models.GetS3Targe
     return models.NewGetS3TargetBucketNamesSpectraS3Response(response)
 }
 
-func (client *Client) GetS3TargetFailuresSpectraS3(request *models.GetS3TargetFailuresSpectraS3Request) (*models.GetS3TargetFailuresSpectraS3Response, error) {
+func (client *Client) GetS3TargetFailuresSpectraS3(ctx context.Context, request *models.GetS3TargetFailuresSpectraS3Request) (*models.GetS3TargetFailuresSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -4128,7 +4129,7 @@ func (client *Client) GetS3TargetFailuresSpectraS3(request *models.GetS3TargetFa
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("target_id", request.TargetId).
         WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TargetFailureType)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -4147,12 +4148,12 @@ func (client *Client) GetS3TargetFailuresSpectraS3(request *models.GetS3TargetFa
     return models.NewGetS3TargetFailuresSpectraS3Response(response)
 }
 
-func (client *Client) GetS3TargetReadPreferenceSpectraS3(request *models.GetS3TargetReadPreferenceSpectraS3Request) (*models.GetS3TargetReadPreferenceSpectraS3Response, error) {
+func (client *Client) GetS3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.GetS3TargetReadPreferenceSpectraS3Request) (*models.GetS3TargetReadPreferenceSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/s3_target_read_preference/" + request.S3TargetReadPreference).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -4171,7 +4172,7 @@ func (client *Client) GetS3TargetReadPreferenceSpectraS3(request *models.GetS3Ta
     return models.NewGetS3TargetReadPreferenceSpectraS3Response(response)
 }
 
-func (client *Client) GetS3TargetReadPreferencesSpectraS3(request *models.GetS3TargetReadPreferencesSpectraS3Request) (*models.GetS3TargetReadPreferencesSpectraS3Response, error) {
+func (client *Client) GetS3TargetReadPreferencesSpectraS3(ctx context.Context, request *models.GetS3TargetReadPreferencesSpectraS3Request) (*models.GetS3TargetReadPreferencesSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -4183,7 +4184,7 @@ func (client *Client) GetS3TargetReadPreferencesSpectraS3(request *models.GetS3T
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
         WithOptionalQueryParam("read_preference", networking.InterfaceToStrPtr(request.ReadPreference)).
         WithOptionalQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -4202,12 +4203,12 @@ func (client *Client) GetS3TargetReadPreferencesSpectraS3(request *models.GetS3T
     return models.NewGetS3TargetReadPreferencesSpectraS3Response(response)
 }
 
-func (client *Client) GetS3TargetSpectraS3(request *models.GetS3TargetSpectraS3Request) (*models.GetS3TargetSpectraS3Response, error) {
+func (client *Client) GetS3TargetSpectraS3(ctx context.Context, request *models.GetS3TargetSpectraS3Request) (*models.GetS3TargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/s3_target/" + request.S3Target).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -4226,7 +4227,7 @@ func (client *Client) GetS3TargetSpectraS3(request *models.GetS3TargetSpectraS3R
     return models.NewGetS3TargetSpectraS3Response(response)
 }
 
-func (client *Client) GetS3TargetsSpectraS3(request *models.GetS3TargetsSpectraS3Request) (*models.GetS3TargetsSpectraS3Response, error) {
+func (client *Client) GetS3TargetsSpectraS3(ctx context.Context, request *models.GetS3TargetsSpectraS3Request) (*models.GetS3TargetsSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -4245,7 +4246,7 @@ func (client *Client) GetS3TargetsSpectraS3(request *models.GetS3TargetsSpectraS
         WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
         WithOptionalQueryParam("region", networking.InterfaceToStrPtr(request.Region)).
         WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -4264,12 +4265,12 @@ func (client *Client) GetS3TargetsSpectraS3(request *models.GetS3TargetsSpectraS
     return models.NewGetS3TargetsSpectraS3Response(response)
 }
 
-func (client *Client) GetUserSpectraS3(request *models.GetUserSpectraS3Request) (*models.GetUserSpectraS3Response, error) {
+func (client *Client) GetUserSpectraS3(ctx context.Context, request *models.GetUserSpectraS3Request) (*models.GetUserSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
         WithPath("/_rest_/user/" + request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -4288,7 +4289,7 @@ func (client *Client) GetUserSpectraS3(request *models.GetUserSpectraS3Request) 
     return models.NewGetUserSpectraS3Response(response)
 }
 
-func (client *Client) GetUsersSpectraS3(request *models.GetUsersSpectraS3Request) (*models.GetUsersSpectraS3Response, error) {
+func (client *Client) GetUsersSpectraS3(ctx context.Context, request *models.GetUsersSpectraS3Request) (*models.GetUsersSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_GET).
@@ -4300,7 +4301,7 @@ func (client *Client) GetUsersSpectraS3(request *models.GetUsersSpectraS3Request
         WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
         WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
         WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err

--- a/ds3/ds3Heads.go
+++ b/ds3/ds3Heads.go
@@ -14,16 +14,17 @@
 package ds3
 
 import (
+    "context"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
 )
 
-func (client *Client) HeadBucket(request *models.HeadBucketRequest) (*models.HeadBucketResponse, error) {
+func (client *Client) HeadBucket(ctx context.Context, request *models.HeadBucketRequest) (*models.HeadBucketResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_HEAD).
         WithPath("/" + request.BucketName).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -41,13 +42,13 @@ func (client *Client) HeadBucket(request *models.HeadBucketRequest) (*models.Hea
     return models.NewHeadBucketResponse(response)
 }
 
-func (client *Client) HeadObject(request *models.HeadObjectRequest) (*models.HeadObjectResponse, error) {
+func (client *Client) HeadObject(ctx context.Context, request *models.HeadObjectRequest) (*models.HeadObjectResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_HEAD).
         WithPath("/" + request.BucketName + "/" + request.ObjectName).
         WithOptionalQueryParam("version_id", request.VersionId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err

--- a/ds3/ds3Posts.go
+++ b/ds3/ds3Posts.go
@@ -14,11 +14,12 @@
 package ds3
 
 import (
+    "context"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
 )
 
-func (client *Client) CompleteBlob(request *models.CompleteBlobRequest) (*models.CompleteBlobResponse, error) {
+func (client *Client) CompleteBlob(ctx context.Context, request *models.CompleteBlobRequest) (*models.CompleteBlobResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -28,7 +29,7 @@ func (client *Client) CompleteBlob(request *models.CompleteBlobRequest) (*models
         WithOptionalQueryParam("size", networking.Int64PtrToStrPtr(request.Size)).
         WithChecksum(request.Checksum).
         WithHeaders(request.Metadata).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -46,14 +47,14 @@ func (client *Client) CompleteBlob(request *models.CompleteBlobRequest) (*models
     return models.NewCompleteBlobResponse(response)
 }
 
-func (client *Client) CompleteMultiPartUpload(request *models.CompleteMultiPartUploadRequest) (*models.CompleteMultiPartUploadResponse, error) {
+func (client *Client) CompleteMultiPartUpload(ctx context.Context, request *models.CompleteMultiPartUploadRequest) (*models.CompleteMultiPartUploadResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/" + request.BucketName + "/" + request.ObjectName).
         WithQueryParam("upload_id", request.UploadId).
         WithReadCloser(buildPartsListStream(request.Parts)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -71,14 +72,14 @@ func (client *Client) CompleteMultiPartUpload(request *models.CompleteMultiPartU
     return models.NewCompleteMultiPartUploadResponse(response)
 }
 
-func (client *Client) DeleteObjects(request *models.DeleteObjectsRequest) (*models.DeleteObjectsResponse, error) {
+func (client *Client) DeleteObjects(ctx context.Context, request *models.DeleteObjectsRequest) (*models.DeleteObjectsResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/" + request.BucketName).
         WithQueryParam("delete", "").
         WithReadCloser(buildDeleteObjectsPayload(request.ObjectNames)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -96,13 +97,13 @@ func (client *Client) DeleteObjects(request *models.DeleteObjectsRequest) (*mode
     return models.NewDeleteObjectsResponse(response)
 }
 
-func (client *Client) InitiateMultiPartUpload(request *models.InitiateMultiPartUploadRequest) (*models.InitiateMultiPartUploadResponse, error) {
+func (client *Client) InitiateMultiPartUpload(ctx context.Context, request *models.InitiateMultiPartUploadRequest) (*models.InitiateMultiPartUploadResponse, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/" + request.BucketName + "/" + request.ObjectName).
         WithQueryParam("uploads", "").
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -120,7 +121,7 @@ func (client *Client) InitiateMultiPartUpload(request *models.InitiateMultiPartU
     return models.NewInitiateMultiPartUploadResponse(response)
 }
 
-func (client *Client) PutBucketAclForGroupSpectraS3(request *models.PutBucketAclForGroupSpectraS3Request) (*models.PutBucketAclForGroupSpectraS3Response, error) {
+func (client *Client) PutBucketAclForGroupSpectraS3(ctx context.Context, request *models.PutBucketAclForGroupSpectraS3Request) (*models.PutBucketAclForGroupSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -128,7 +129,7 @@ func (client *Client) PutBucketAclForGroupSpectraS3(request *models.PutBucketAcl
         WithQueryParam("bucket_id", request.BucketId).
         WithQueryParam("group_id", request.GroupId).
         WithQueryParam("permission", request.Permission.String()).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -146,7 +147,7 @@ func (client *Client) PutBucketAclForGroupSpectraS3(request *models.PutBucketAcl
     return models.NewPutBucketAclForGroupSpectraS3Response(response)
 }
 
-func (client *Client) PutBucketAclForUserSpectraS3(request *models.PutBucketAclForUserSpectraS3Request) (*models.PutBucketAclForUserSpectraS3Response, error) {
+func (client *Client) PutBucketAclForUserSpectraS3(ctx context.Context, request *models.PutBucketAclForUserSpectraS3Request) (*models.PutBucketAclForUserSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -154,7 +155,7 @@ func (client *Client) PutBucketAclForUserSpectraS3(request *models.PutBucketAclF
         WithQueryParam("bucket_id", request.BucketId).
         WithQueryParam("permission", request.Permission.String()).
         WithQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -172,14 +173,14 @@ func (client *Client) PutBucketAclForUserSpectraS3(request *models.PutBucketAclF
     return models.NewPutBucketAclForUserSpectraS3Response(response)
 }
 
-func (client *Client) PutDataPolicyAclForGroupSpectraS3(request *models.PutDataPolicyAclForGroupSpectraS3Request) (*models.PutDataPolicyAclForGroupSpectraS3Response, error) {
+func (client *Client) PutDataPolicyAclForGroupSpectraS3(ctx context.Context, request *models.PutDataPolicyAclForGroupSpectraS3Request) (*models.PutDataPolicyAclForGroupSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/_rest_/data_policy_acl").
         WithQueryParam("data_policy_id", request.DataPolicyId).
         WithQueryParam("group_id", request.GroupId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -197,14 +198,14 @@ func (client *Client) PutDataPolicyAclForGroupSpectraS3(request *models.PutDataP
     return models.NewPutDataPolicyAclForGroupSpectraS3Response(response)
 }
 
-func (client *Client) PutDataPolicyAclForUserSpectraS3(request *models.PutDataPolicyAclForUserSpectraS3Request) (*models.PutDataPolicyAclForUserSpectraS3Response, error) {
+func (client *Client) PutDataPolicyAclForUserSpectraS3(ctx context.Context, request *models.PutDataPolicyAclForUserSpectraS3Request) (*models.PutDataPolicyAclForUserSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/_rest_/data_policy_acl").
         WithQueryParam("data_policy_id", request.DataPolicyId).
         WithQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -222,14 +223,14 @@ func (client *Client) PutDataPolicyAclForUserSpectraS3(request *models.PutDataPo
     return models.NewPutDataPolicyAclForUserSpectraS3Response(response)
 }
 
-func (client *Client) PutGlobalBucketAclForGroupSpectraS3(request *models.PutGlobalBucketAclForGroupSpectraS3Request) (*models.PutGlobalBucketAclForGroupSpectraS3Response, error) {
+func (client *Client) PutGlobalBucketAclForGroupSpectraS3(ctx context.Context, request *models.PutGlobalBucketAclForGroupSpectraS3Request) (*models.PutGlobalBucketAclForGroupSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/_rest_/bucket_acl").
         WithQueryParam("group_id", request.GroupId).
         WithQueryParam("permission", request.Permission.String()).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -247,14 +248,14 @@ func (client *Client) PutGlobalBucketAclForGroupSpectraS3(request *models.PutGlo
     return models.NewPutGlobalBucketAclForGroupSpectraS3Response(response)
 }
 
-func (client *Client) PutGlobalBucketAclForUserSpectraS3(request *models.PutGlobalBucketAclForUserSpectraS3Request) (*models.PutGlobalBucketAclForUserSpectraS3Response, error) {
+func (client *Client) PutGlobalBucketAclForUserSpectraS3(ctx context.Context, request *models.PutGlobalBucketAclForUserSpectraS3Request) (*models.PutGlobalBucketAclForUserSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/_rest_/bucket_acl").
         WithQueryParam("permission", request.Permission.String()).
         WithQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -272,13 +273,13 @@ func (client *Client) PutGlobalBucketAclForUserSpectraS3(request *models.PutGlob
     return models.NewPutGlobalBucketAclForUserSpectraS3Response(response)
 }
 
-func (client *Client) PutGlobalDataPolicyAclForGroupSpectraS3(request *models.PutGlobalDataPolicyAclForGroupSpectraS3Request) (*models.PutGlobalDataPolicyAclForGroupSpectraS3Response, error) {
+func (client *Client) PutGlobalDataPolicyAclForGroupSpectraS3(ctx context.Context, request *models.PutGlobalDataPolicyAclForGroupSpectraS3Request) (*models.PutGlobalDataPolicyAclForGroupSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/_rest_/data_policy_acl").
         WithQueryParam("group_id", request.GroupId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -296,13 +297,13 @@ func (client *Client) PutGlobalDataPolicyAclForGroupSpectraS3(request *models.Pu
     return models.NewPutGlobalDataPolicyAclForGroupSpectraS3Response(response)
 }
 
-func (client *Client) PutGlobalDataPolicyAclForUserSpectraS3(request *models.PutGlobalDataPolicyAclForUserSpectraS3Request) (*models.PutGlobalDataPolicyAclForUserSpectraS3Response, error) {
+func (client *Client) PutGlobalDataPolicyAclForUserSpectraS3(ctx context.Context, request *models.PutGlobalDataPolicyAclForUserSpectraS3Request) (*models.PutGlobalDataPolicyAclForUserSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/_rest_/data_policy_acl").
         WithQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -320,7 +321,7 @@ func (client *Client) PutGlobalDataPolicyAclForUserSpectraS3(request *models.Put
     return models.NewPutGlobalDataPolicyAclForUserSpectraS3Response(response)
 }
 
-func (client *Client) PutBucketSpectraS3(request *models.PutBucketSpectraS3Request) (*models.PutBucketSpectraS3Response, error) {
+func (client *Client) PutBucketSpectraS3(ctx context.Context, request *models.PutBucketSpectraS3Request) (*models.PutBucketSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -330,7 +331,7 @@ func (client *Client) PutBucketSpectraS3(request *models.PutBucketSpectraS3Reque
         WithOptionalQueryParam("id", request.Id).
         WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
         WithOptionalQueryParam("user_id", request.UserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -348,7 +349,7 @@ func (client *Client) PutBucketSpectraS3(request *models.PutBucketSpectraS3Reque
     return models.NewPutBucketSpectraS3Response(response)
 }
 
-func (client *Client) PutAzureDataReplicationRuleSpectraS3(request *models.PutAzureDataReplicationRuleSpectraS3Request) (*models.PutAzureDataReplicationRuleSpectraS3Response, error) {
+func (client *Client) PutAzureDataReplicationRuleSpectraS3(ctx context.Context, request *models.PutAzureDataReplicationRuleSpectraS3Request) (*models.PutAzureDataReplicationRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -358,7 +359,7 @@ func (client *Client) PutAzureDataReplicationRuleSpectraS3(request *models.PutAz
         WithQueryParam("type", request.DataReplicationRuleType.String()).
         WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
         WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -376,7 +377,7 @@ func (client *Client) PutAzureDataReplicationRuleSpectraS3(request *models.PutAz
     return models.NewPutAzureDataReplicationRuleSpectraS3Response(response)
 }
 
-func (client *Client) PutDataPersistenceRuleSpectraS3(request *models.PutDataPersistenceRuleSpectraS3Request) (*models.PutDataPersistenceRuleSpectraS3Response, error) {
+func (client *Client) PutDataPersistenceRuleSpectraS3(ctx context.Context, request *models.PutDataPersistenceRuleSpectraS3Request) (*models.PutDataPersistenceRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -386,7 +387,7 @@ func (client *Client) PutDataPersistenceRuleSpectraS3(request *models.PutDataPer
         WithQueryParam("storage_domain_id", request.StorageDomainId).
         WithQueryParam("type", request.DataPersistenceRuleType.String()).
         WithOptionalQueryParam("minimum_days_to_retain", networking.IntPtrToStrPtr(request.MinimumDaysToRetain)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -404,7 +405,7 @@ func (client *Client) PutDataPersistenceRuleSpectraS3(request *models.PutDataPer
     return models.NewPutDataPersistenceRuleSpectraS3Response(response)
 }
 
-func (client *Client) PutDataPolicySpectraS3(request *models.PutDataPolicySpectraS3Request) (*models.PutDataPolicySpectraS3Response, error) {
+func (client *Client) PutDataPolicySpectraS3(ctx context.Context, request *models.PutDataPolicySpectraS3Request) (*models.PutDataPolicySpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -423,7 +424,7 @@ func (client *Client) PutDataPolicySpectraS3(request *models.PutDataPolicySpectr
         WithOptionalQueryParam("max_versions_to_keep", networking.IntPtrToStrPtr(request.MaxVersionsToKeep)).
         WithOptionalQueryParam("rebuild_priority", networking.InterfaceToStrPtr(request.RebuildPriority)).
         WithOptionalQueryParam("versioning", networking.InterfaceToStrPtr(request.Versioning)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -441,7 +442,7 @@ func (client *Client) PutDataPolicySpectraS3(request *models.PutDataPolicySpectr
     return models.NewPutDataPolicySpectraS3Response(response)
 }
 
-func (client *Client) PutDs3DataReplicationRuleSpectraS3(request *models.PutDs3DataReplicationRuleSpectraS3Request) (*models.PutDs3DataReplicationRuleSpectraS3Response, error) {
+func (client *Client) PutDs3DataReplicationRuleSpectraS3(ctx context.Context, request *models.PutDs3DataReplicationRuleSpectraS3Request) (*models.PutDs3DataReplicationRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -451,7 +452,7 @@ func (client *Client) PutDs3DataReplicationRuleSpectraS3(request *models.PutDs3D
         WithQueryParam("type", request.DataReplicationRuleType.String()).
         WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
         WithOptionalQueryParam("target_data_policy", request.TargetDataPolicy).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -469,7 +470,7 @@ func (client *Client) PutDs3DataReplicationRuleSpectraS3(request *models.PutDs3D
     return models.NewPutDs3DataReplicationRuleSpectraS3Response(response)
 }
 
-func (client *Client) PutS3DataReplicationRuleSpectraS3(request *models.PutS3DataReplicationRuleSpectraS3Request) (*models.PutS3DataReplicationRuleSpectraS3Response, error) {
+func (client *Client) PutS3DataReplicationRuleSpectraS3(ctx context.Context, request *models.PutS3DataReplicationRuleSpectraS3Request) (*models.PutS3DataReplicationRuleSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -480,7 +481,7 @@ func (client *Client) PutS3DataReplicationRuleSpectraS3(request *models.PutS3Dat
         WithOptionalQueryParam("initial_data_placement", networking.InterfaceToStrPtr(request.InitialDataPlacement)).
         WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
         WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -498,14 +499,14 @@ func (client *Client) PutS3DataReplicationRuleSpectraS3(request *models.PutS3Dat
     return models.NewPutS3DataReplicationRuleSpectraS3Response(response)
 }
 
-func (client *Client) PutGroupGroupMemberSpectraS3(request *models.PutGroupGroupMemberSpectraS3Request) (*models.PutGroupGroupMemberSpectraS3Response, error) {
+func (client *Client) PutGroupGroupMemberSpectraS3(ctx context.Context, request *models.PutGroupGroupMemberSpectraS3Request) (*models.PutGroupGroupMemberSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/_rest_/group_member").
         WithQueryParam("group_id", request.GroupId).
         WithQueryParam("member_group_id", request.MemberGroupId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -523,13 +524,13 @@ func (client *Client) PutGroupGroupMemberSpectraS3(request *models.PutGroupGroup
     return models.NewPutGroupGroupMemberSpectraS3Response(response)
 }
 
-func (client *Client) PutGroupSpectraS3(request *models.PutGroupSpectraS3Request) (*models.PutGroupSpectraS3Response, error) {
+func (client *Client) PutGroupSpectraS3(ctx context.Context, request *models.PutGroupSpectraS3Request) (*models.PutGroupSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/_rest_/group").
         WithQueryParam("name", request.Name).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -547,14 +548,14 @@ func (client *Client) PutGroupSpectraS3(request *models.PutGroupSpectraS3Request
     return models.NewPutGroupSpectraS3Response(response)
 }
 
-func (client *Client) PutUserGroupMemberSpectraS3(request *models.PutUserGroupMemberSpectraS3Request) (*models.PutUserGroupMemberSpectraS3Response, error) {
+func (client *Client) PutUserGroupMemberSpectraS3(ctx context.Context, request *models.PutUserGroupMemberSpectraS3Request) (*models.PutUserGroupMemberSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/_rest_/group_member").
         WithQueryParam("group_id", request.GroupId).
         WithQueryParam("member_user_id", request.MemberUserId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -572,7 +573,7 @@ func (client *Client) PutUserGroupMemberSpectraS3(request *models.PutUserGroupMe
     return models.NewPutUserGroupMemberSpectraS3Response(response)
 }
 
-func (client *Client) PutAzureTargetFailureNotificationRegistrationSpectraS3(request *models.PutAzureTargetFailureNotificationRegistrationSpectraS3Request) (*models.PutAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutAzureTargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutAzureTargetFailureNotificationRegistrationSpectraS3Request) (*models.PutAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -581,7 +582,7 @@ func (client *Client) PutAzureTargetFailureNotificationRegistrationSpectraS3(req
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -599,7 +600,7 @@ func (client *Client) PutAzureTargetFailureNotificationRegistrationSpectraS3(req
     return models.NewPutAzureTargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutBucketChangesNotificationRegistrationSpectraS3(request *models.PutBucketChangesNotificationRegistrationSpectraS3Request) (*models.PutBucketChangesNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutBucketChangesNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutBucketChangesNotificationRegistrationSpectraS3Request) (*models.PutBucketChangesNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -609,7 +610,7 @@ func (client *Client) PutBucketChangesNotificationRegistrationSpectraS3(request 
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -627,7 +628,7 @@ func (client *Client) PutBucketChangesNotificationRegistrationSpectraS3(request 
     return models.NewPutBucketChangesNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutDs3TargetFailureNotificationRegistrationSpectraS3(request *models.PutDs3TargetFailureNotificationRegistrationSpectraS3Request) (*models.PutDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutDs3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutDs3TargetFailureNotificationRegistrationSpectraS3Request) (*models.PutDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -636,7 +637,7 @@ func (client *Client) PutDs3TargetFailureNotificationRegistrationSpectraS3(reque
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -654,7 +655,7 @@ func (client *Client) PutDs3TargetFailureNotificationRegistrationSpectraS3(reque
     return models.NewPutDs3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutJobCompletedNotificationRegistrationSpectraS3(request *models.PutJobCompletedNotificationRegistrationSpectraS3Request) (*models.PutJobCompletedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutJobCompletedNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutJobCompletedNotificationRegistrationSpectraS3Request) (*models.PutJobCompletedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -664,7 +665,7 @@ func (client *Client) PutJobCompletedNotificationRegistrationSpectraS3(request *
         WithOptionalQueryParam("job_id", request.JobId).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -682,7 +683,7 @@ func (client *Client) PutJobCompletedNotificationRegistrationSpectraS3(request *
     return models.NewPutJobCompletedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutJobCreatedNotificationRegistrationSpectraS3(request *models.PutJobCreatedNotificationRegistrationSpectraS3Request) (*models.PutJobCreatedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutJobCreatedNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutJobCreatedNotificationRegistrationSpectraS3Request) (*models.PutJobCreatedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -691,7 +692,7 @@ func (client *Client) PutJobCreatedNotificationRegistrationSpectraS3(request *mo
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -709,7 +710,7 @@ func (client *Client) PutJobCreatedNotificationRegistrationSpectraS3(request *mo
     return models.NewPutJobCreatedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutJobCreationFailedNotificationRegistrationSpectraS3(request *models.PutJobCreationFailedNotificationRegistrationSpectraS3Request) (*models.PutJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutJobCreationFailedNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutJobCreationFailedNotificationRegistrationSpectraS3Request) (*models.PutJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -718,7 +719,7 @@ func (client *Client) PutJobCreationFailedNotificationRegistrationSpectraS3(requ
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -736,7 +737,7 @@ func (client *Client) PutJobCreationFailedNotificationRegistrationSpectraS3(requ
     return models.NewPutJobCreationFailedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutObjectCachedNotificationRegistrationSpectraS3(request *models.PutObjectCachedNotificationRegistrationSpectraS3Request) (*models.PutObjectCachedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutObjectCachedNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutObjectCachedNotificationRegistrationSpectraS3Request) (*models.PutObjectCachedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -746,7 +747,7 @@ func (client *Client) PutObjectCachedNotificationRegistrationSpectraS3(request *
         WithOptionalQueryParam("job_id", request.JobId).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -764,7 +765,7 @@ func (client *Client) PutObjectCachedNotificationRegistrationSpectraS3(request *
     return models.NewPutObjectCachedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutObjectLostNotificationRegistrationSpectraS3(request *models.PutObjectLostNotificationRegistrationSpectraS3Request) (*models.PutObjectLostNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutObjectLostNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutObjectLostNotificationRegistrationSpectraS3Request) (*models.PutObjectLostNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -773,7 +774,7 @@ func (client *Client) PutObjectLostNotificationRegistrationSpectraS3(request *mo
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -791,7 +792,7 @@ func (client *Client) PutObjectLostNotificationRegistrationSpectraS3(request *mo
     return models.NewPutObjectLostNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutObjectPersistedNotificationRegistrationSpectraS3(request *models.PutObjectPersistedNotificationRegistrationSpectraS3Request) (*models.PutObjectPersistedNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutObjectPersistedNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutObjectPersistedNotificationRegistrationSpectraS3Request) (*models.PutObjectPersistedNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -801,7 +802,7 @@ func (client *Client) PutObjectPersistedNotificationRegistrationSpectraS3(reques
         WithOptionalQueryParam("job_id", request.JobId).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -819,7 +820,7 @@ func (client *Client) PutObjectPersistedNotificationRegistrationSpectraS3(reques
     return models.NewPutObjectPersistedNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutPoolFailureNotificationRegistrationSpectraS3(request *models.PutPoolFailureNotificationRegistrationSpectraS3Request) (*models.PutPoolFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutPoolFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutPoolFailureNotificationRegistrationSpectraS3Request) (*models.PutPoolFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -828,7 +829,7 @@ func (client *Client) PutPoolFailureNotificationRegistrationSpectraS3(request *m
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -846,7 +847,7 @@ func (client *Client) PutPoolFailureNotificationRegistrationSpectraS3(request *m
     return models.NewPutPoolFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutS3TargetFailureNotificationRegistrationSpectraS3(request *models.PutS3TargetFailureNotificationRegistrationSpectraS3Request) (*models.PutS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutS3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutS3TargetFailureNotificationRegistrationSpectraS3Request) (*models.PutS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -855,7 +856,7 @@ func (client *Client) PutS3TargetFailureNotificationRegistrationSpectraS3(reques
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -873,7 +874,7 @@ func (client *Client) PutS3TargetFailureNotificationRegistrationSpectraS3(reques
     return models.NewPutS3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutStorageDomainFailureNotificationRegistrationSpectraS3(request *models.PutStorageDomainFailureNotificationRegistrationSpectraS3Request) (*models.PutStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutStorageDomainFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutStorageDomainFailureNotificationRegistrationSpectraS3Request) (*models.PutStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -882,7 +883,7 @@ func (client *Client) PutStorageDomainFailureNotificationRegistrationSpectraS3(r
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -900,7 +901,7 @@ func (client *Client) PutStorageDomainFailureNotificationRegistrationSpectraS3(r
     return models.NewPutStorageDomainFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutSystemFailureNotificationRegistrationSpectraS3(request *models.PutSystemFailureNotificationRegistrationSpectraS3Request) (*models.PutSystemFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutSystemFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutSystemFailureNotificationRegistrationSpectraS3Request) (*models.PutSystemFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -909,7 +910,7 @@ func (client *Client) PutSystemFailureNotificationRegistrationSpectraS3(request 
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -927,7 +928,7 @@ func (client *Client) PutSystemFailureNotificationRegistrationSpectraS3(request 
     return models.NewPutSystemFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutTapeFailureNotificationRegistrationSpectraS3(request *models.PutTapeFailureNotificationRegistrationSpectraS3Request) (*models.PutTapeFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutTapeFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutTapeFailureNotificationRegistrationSpectraS3Request) (*models.PutTapeFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -936,7 +937,7 @@ func (client *Client) PutTapeFailureNotificationRegistrationSpectraS3(request *m
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -954,7 +955,7 @@ func (client *Client) PutTapeFailureNotificationRegistrationSpectraS3(request *m
     return models.NewPutTapeFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutTapePartitionFailureNotificationRegistrationSpectraS3(request *models.PutTapePartitionFailureNotificationRegistrationSpectraS3Request) (*models.PutTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
+func (client *Client) PutTapePartitionFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutTapePartitionFailureNotificationRegistrationSpectraS3Request) (*models.PutTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -963,7 +964,7 @@ func (client *Client) PutTapePartitionFailureNotificationRegistrationSpectraS3(r
         WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
         WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
         WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -981,14 +982,14 @@ func (client *Client) PutTapePartitionFailureNotificationRegistrationSpectraS3(r
     return models.NewPutTapePartitionFailureNotificationRegistrationSpectraS3Response(response)
 }
 
-func (client *Client) PutPoolPartitionSpectraS3(request *models.PutPoolPartitionSpectraS3Request) (*models.PutPoolPartitionSpectraS3Response, error) {
+func (client *Client) PutPoolPartitionSpectraS3(ctx context.Context, request *models.PutPoolPartitionSpectraS3Request) (*models.PutPoolPartitionSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
         WithPath("/_rest_/pool_partition").
         WithQueryParam("name", request.Name).
         WithQueryParam("type", request.PoolType.String()).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1006,7 +1007,7 @@ func (client *Client) PutPoolPartitionSpectraS3(request *models.PutPoolPartition
     return models.NewPutPoolPartitionSpectraS3Response(response)
 }
 
-func (client *Client) PutPoolStorageDomainMemberSpectraS3(request *models.PutPoolStorageDomainMemberSpectraS3Request) (*models.PutPoolStorageDomainMemberSpectraS3Response, error) {
+func (client *Client) PutPoolStorageDomainMemberSpectraS3(ctx context.Context, request *models.PutPoolStorageDomainMemberSpectraS3Request) (*models.PutPoolStorageDomainMemberSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1014,7 +1015,7 @@ func (client *Client) PutPoolStorageDomainMemberSpectraS3(request *models.PutPoo
         WithQueryParam("pool_partition_id", request.PoolPartitionId).
         WithQueryParam("storage_domain_id", request.StorageDomainId).
         WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1032,7 +1033,7 @@ func (client *Client) PutPoolStorageDomainMemberSpectraS3(request *models.PutPoo
     return models.NewPutPoolStorageDomainMemberSpectraS3Response(response)
 }
 
-func (client *Client) PutStorageDomainSpectraS3(request *models.PutStorageDomainSpectraS3Request) (*models.PutStorageDomainSpectraS3Response, error) {
+func (client *Client) PutStorageDomainSpectraS3(ctx context.Context, request *models.PutStorageDomainSpectraS3Request) (*models.PutStorageDomainSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1050,7 +1051,7 @@ func (client *Client) PutStorageDomainSpectraS3(request *models.PutStorageDomain
         WithOptionalQueryParam("secure_media_allocation", networking.BoolPtrToStrPtr(request.SecureMediaAllocation)).
         WithOptionalQueryParam("verify_prior_to_auto_eject", networking.InterfaceToStrPtr(request.VerifyPriorToAutoEject)).
         WithOptionalQueryParam("write_optimization", networking.InterfaceToStrPtr(request.WriteOptimization)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1068,7 +1069,7 @@ func (client *Client) PutStorageDomainSpectraS3(request *models.PutStorageDomain
     return models.NewPutStorageDomainSpectraS3Response(response)
 }
 
-func (client *Client) PutTapeStorageDomainMemberSpectraS3(request *models.PutTapeStorageDomainMemberSpectraS3Request) (*models.PutTapeStorageDomainMemberSpectraS3Response, error) {
+func (client *Client) PutTapeStorageDomainMemberSpectraS3(ctx context.Context, request *models.PutTapeStorageDomainMemberSpectraS3Request) (*models.PutTapeStorageDomainMemberSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1078,7 +1079,7 @@ func (client *Client) PutTapeStorageDomainMemberSpectraS3(request *models.PutTap
         WithQueryParam("tape_type", request.TapeType).
         WithOptionalQueryParam("auto_compaction_threshold", networking.IntPtrToStrPtr(request.AutoCompactionThreshold)).
         WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1096,7 +1097,7 @@ func (client *Client) PutTapeStorageDomainMemberSpectraS3(request *models.PutTap
     return models.NewPutTapeStorageDomainMemberSpectraS3Response(response)
 }
 
-func (client *Client) PutTapeDensityDirectiveSpectraS3(request *models.PutTapeDensityDirectiveSpectraS3Request) (*models.PutTapeDensityDirectiveSpectraS3Response, error) {
+func (client *Client) PutTapeDensityDirectiveSpectraS3(ctx context.Context, request *models.PutTapeDensityDirectiveSpectraS3Request) (*models.PutTapeDensityDirectiveSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1104,7 +1105,7 @@ func (client *Client) PutTapeDensityDirectiveSpectraS3(request *models.PutTapeDe
         WithQueryParam("density", request.Density.String()).
         WithQueryParam("partition_id", request.PartitionId).
         WithQueryParam("tape_type", request.TapeType).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1122,7 +1123,7 @@ func (client *Client) PutTapeDensityDirectiveSpectraS3(request *models.PutTapeDe
     return models.NewPutTapeDensityDirectiveSpectraS3Response(response)
 }
 
-func (client *Client) PutAzureTargetBucketNameSpectraS3(request *models.PutAzureTargetBucketNameSpectraS3Request) (*models.PutAzureTargetBucketNameSpectraS3Response, error) {
+func (client *Client) PutAzureTargetBucketNameSpectraS3(ctx context.Context, request *models.PutAzureTargetBucketNameSpectraS3Request) (*models.PutAzureTargetBucketNameSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1130,7 +1131,7 @@ func (client *Client) PutAzureTargetBucketNameSpectraS3(request *models.PutAzure
         WithQueryParam("bucket_id", request.BucketId).
         WithQueryParam("name", request.Name).
         WithQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1148,7 +1149,7 @@ func (client *Client) PutAzureTargetBucketNameSpectraS3(request *models.PutAzure
     return models.NewPutAzureTargetBucketNameSpectraS3Response(response)
 }
 
-func (client *Client) PutAzureTargetReadPreferenceSpectraS3(request *models.PutAzureTargetReadPreferenceSpectraS3Request) (*models.PutAzureTargetReadPreferenceSpectraS3Response, error) {
+func (client *Client) PutAzureTargetReadPreferenceSpectraS3(ctx context.Context, request *models.PutAzureTargetReadPreferenceSpectraS3Request) (*models.PutAzureTargetReadPreferenceSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1156,7 +1157,7 @@ func (client *Client) PutAzureTargetReadPreferenceSpectraS3(request *models.PutA
         WithQueryParam("bucket_id", request.BucketId).
         WithQueryParam("read_preference", request.ReadPreference.String()).
         WithQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1174,7 +1175,7 @@ func (client *Client) PutAzureTargetReadPreferenceSpectraS3(request *models.PutA
     return models.NewPutAzureTargetReadPreferenceSpectraS3Response(response)
 }
 
-func (client *Client) RegisterAzureTargetSpectraS3(request *models.RegisterAzureTargetSpectraS3Request) (*models.RegisterAzureTargetSpectraS3Response, error) {
+func (client *Client) RegisterAzureTargetSpectraS3(ctx context.Context, request *models.RegisterAzureTargetSpectraS3Request) (*models.RegisterAzureTargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1188,7 +1189,7 @@ func (client *Client) RegisterAzureTargetSpectraS3(request *models.RegisterAzure
         WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
         WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
         WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1206,7 +1207,7 @@ func (client *Client) RegisterAzureTargetSpectraS3(request *models.RegisterAzure
     return models.NewRegisterAzureTargetSpectraS3Response(response)
 }
 
-func (client *Client) PutDs3TargetReadPreferenceSpectraS3(request *models.PutDs3TargetReadPreferenceSpectraS3Request) (*models.PutDs3TargetReadPreferenceSpectraS3Response, error) {
+func (client *Client) PutDs3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.PutDs3TargetReadPreferenceSpectraS3Request) (*models.PutDs3TargetReadPreferenceSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1214,7 +1215,7 @@ func (client *Client) PutDs3TargetReadPreferenceSpectraS3(request *models.PutDs3
         WithQueryParam("bucket_id", request.BucketId).
         WithQueryParam("read_preference", request.ReadPreference.String()).
         WithQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1232,7 +1233,7 @@ func (client *Client) PutDs3TargetReadPreferenceSpectraS3(request *models.PutDs3
     return models.NewPutDs3TargetReadPreferenceSpectraS3Response(response)
 }
 
-func (client *Client) RegisterDs3TargetSpectraS3(request *models.RegisterDs3TargetSpectraS3Request) (*models.RegisterDs3TargetSpectraS3Response, error) {
+func (client *Client) RegisterDs3TargetSpectraS3(ctx context.Context, request *models.RegisterDs3TargetSpectraS3Request) (*models.RegisterDs3TargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1249,7 +1250,7 @@ func (client *Client) RegisterDs3TargetSpectraS3(request *models.RegisterDs3Targ
         WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
         WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
         WithOptionalQueryParam("replicated_user_default_data_policy", request.ReplicatedUserDefaultDataPolicy).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1267,7 +1268,7 @@ func (client *Client) RegisterDs3TargetSpectraS3(request *models.RegisterDs3Targ
     return models.NewRegisterDs3TargetSpectraS3Response(response)
 }
 
-func (client *Client) PutS3TargetBucketNameSpectraS3(request *models.PutS3TargetBucketNameSpectraS3Request) (*models.PutS3TargetBucketNameSpectraS3Response, error) {
+func (client *Client) PutS3TargetBucketNameSpectraS3(ctx context.Context, request *models.PutS3TargetBucketNameSpectraS3Request) (*models.PutS3TargetBucketNameSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1275,7 +1276,7 @@ func (client *Client) PutS3TargetBucketNameSpectraS3(request *models.PutS3Target
         WithQueryParam("bucket_id", request.BucketId).
         WithQueryParam("name", request.Name).
         WithQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1293,7 +1294,7 @@ func (client *Client) PutS3TargetBucketNameSpectraS3(request *models.PutS3Target
     return models.NewPutS3TargetBucketNameSpectraS3Response(response)
 }
 
-func (client *Client) PutS3TargetReadPreferenceSpectraS3(request *models.PutS3TargetReadPreferenceSpectraS3Request) (*models.PutS3TargetReadPreferenceSpectraS3Response, error) {
+func (client *Client) PutS3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.PutS3TargetReadPreferenceSpectraS3Request) (*models.PutS3TargetReadPreferenceSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1301,7 +1302,7 @@ func (client *Client) PutS3TargetReadPreferenceSpectraS3(request *models.PutS3Ta
         WithQueryParam("bucket_id", request.BucketId).
         WithQueryParam("read_preference", request.ReadPreference.String()).
         WithQueryParam("target_id", request.TargetId).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1319,7 +1320,7 @@ func (client *Client) PutS3TargetReadPreferenceSpectraS3(request *models.PutS3Ta
     return models.NewPutS3TargetReadPreferenceSpectraS3Response(response)
 }
 
-func (client *Client) RegisterS3TargetSpectraS3(request *models.RegisterS3TargetSpectraS3Request) (*models.RegisterS3TargetSpectraS3Response, error) {
+func (client *Client) RegisterS3TargetSpectraS3(ctx context.Context, request *models.RegisterS3TargetSpectraS3Request) (*models.RegisterS3TargetSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1344,7 +1345,7 @@ func (client *Client) RegisterS3TargetSpectraS3(request *models.RegisterS3Target
         WithOptionalQueryParam("region", networking.InterfaceToStrPtr(request.Region)).
         WithOptionalQueryParam("restricted_access", networking.BoolPtrToStrPtr(request.RestrictedAccess)).
         WithOptionalQueryParam("staged_data_expiration_in_days", networking.IntPtrToStrPtr(request.StagedDataExpirationInDays)).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err
@@ -1362,7 +1363,7 @@ func (client *Client) RegisterS3TargetSpectraS3(request *models.RegisterS3Target
     return models.NewRegisterS3TargetSpectraS3Response(response)
 }
 
-func (client *Client) DelegateCreateUserSpectraS3(request *models.DelegateCreateUserSpectraS3Request) (*models.DelegateCreateUserSpectraS3Response, error) {
+func (client *Client) DelegateCreateUserSpectraS3(ctx context.Context, request *models.DelegateCreateUserSpectraS3Request) (*models.DelegateCreateUserSpectraS3Response, error) {
     // Build the http request
     httpRequest, err := networking.NewHttpRequestBuilder().
         WithHttpVerb(HTTP_VERB_POST).
@@ -1372,7 +1373,7 @@ func (client *Client) DelegateCreateUserSpectraS3(request *models.DelegateCreate
         WithOptionalQueryParam("id", request.Id).
         WithOptionalQueryParam("max_buckets", networking.IntPtrToStrPtr(request.MaxBuckets)).
         WithOptionalQueryParam("secret_key", request.SecretKey).
-        Build(client.connectionInfo)
+        Build(ctx, client.connectionInfo)
 
     if err != nil {
         return nil, err

--- a/ds3/ds3Puts.go
+++ b/ds3/ds3Puts.go
@@ -14,2799 +14,2801 @@
 package ds3
 
 import (
-	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-	"github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
-	"strconv"
+    "context"
+    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+    "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
 )
 
-func (client *Client) PutBucket(request *models.PutBucketRequest) (*models.PutBucketResponse, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/" + request.BucketName).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewPutBucketResponse(response)
-}
-
-func (client *Client) PutMultiPartUploadPart(request *models.PutMultiPartUploadPartRequest) (*models.PutMultiPartUploadPartResponse, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/"+request.BucketName+"/"+request.ObjectName).
-		WithQueryParam("part_number", strconv.Itoa(request.PartNumber)).
-		WithQueryParam("upload_id", request.UploadId).
-		WithReader(request.Content).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewPutMultiPartUploadPartResponse(response)
-}
-
-func (client *Client) PutObject(request *models.PutObjectRequest) (*models.PutObjectResponse, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/"+request.BucketName+"/"+request.ObjectName).
-		WithOptionalQueryParam("job", request.Job).
-		WithOptionalQueryParam("offset", networking.Int64PtrToStrPtr(request.Offset)).
-		WithReader(request.Content).
-		WithChecksum(request.Checksum).
-		WithHeaders(request.Metadata).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewPutObjectResponse(response)
-}
-
-func (client *Client) ModifyBucketSpectraS3(request *models.ModifyBucketSpectraS3Request) (*models.ModifyBucketSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/bucket/"+request.BucketName).
-		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-		WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
-		WithOptionalQueryParam("user_id", request.UserId).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyBucketSpectraS3Response(response)
-}
-
-func (client *Client) ForceFullCacheReclaimSpectraS3(request *models.ForceFullCacheReclaimSpectraS3Request) (*models.ForceFullCacheReclaimSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/cache_filesystem").
-		WithQueryParam("reclaim", "").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewForceFullCacheReclaimSpectraS3Response(response)
-}
-
-func (client *Client) ModifyCacheFilesystemSpectraS3(request *models.ModifyCacheFilesystemSpectraS3Request) (*models.ModifyCacheFilesystemSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/cache_filesystem/"+request.CacheFilesystem).
-		WithOptionalQueryParam("auto_reclaim_initiate_threshold", networking.Float64PtrToStrPtr(request.AutoReclaimInitiateThreshold)).
-		WithOptionalQueryParam("auto_reclaim_terminate_threshold", networking.Float64PtrToStrPtr(request.AutoReclaimTerminateThreshold)).
-		WithOptionalQueryParam("burst_threshold", networking.Float64PtrToStrPtr(request.BurstThreshold)).
-		WithOptionalQueryParam("cache_safety_enabled", networking.BoolPtrToStrPtr(request.CacheSafetyEnabled)).
-		WithOptionalQueryParam("max_capacity_in_bytes", networking.Int64PtrToStrPtr(request.MaxCapacityInBytes)).
-		WithOptionalQueryParam("needs_reconcile", networking.BoolPtrToStrPtr(request.NeedsReconcile)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyCacheFilesystemSpectraS3Response(response)
-}
-
-func (client *Client) ModifyDataPathBackendSpectraS3(request *models.ModifyDataPathBackendSpectraS3Request) (*models.ModifyDataPathBackendSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/data_path_backend").
-		WithOptionalQueryParam("activated", networking.BoolPtrToStrPtr(request.Activated)).
-		WithOptionalQueryParam("allow_new_job_requests", networking.BoolPtrToStrPtr(request.AllowNewJobRequests)).
-		WithOptionalQueryParam("auto_activate_timeout_in_mins", networking.IntPtrToStrPtr(request.AutoActivateTimeoutInMins)).
-		WithOptionalQueryParam("auto_inspect", networking.InterfaceToStrPtr(request.AutoInspect)).
-		WithOptionalQueryParam("cache_available_retry_after_in_seconds", networking.IntPtrToStrPtr(request.CacheAvailableRetryAfterInSeconds)).
-		WithOptionalQueryParam("default_verify_data_after_import", networking.InterfaceToStrPtr(request.DefaultVerifyDataAfterImport)).
-		WithOptionalQueryParam("default_verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.DefaultVerifyDataPriorToImport)).
-		WithOptionalQueryParam("iom_cache_limitation_percent", networking.Float64PtrToStrPtr(request.IomCacheLimitationPercent)).
-		WithOptionalQueryParam("iom_enabled", networking.BoolPtrToStrPtr(request.IomEnabled)).
-		WithOptionalQueryParam("max_aggregated_blobs_per_chunk", networking.IntPtrToStrPtr(request.MaxAggregatedBlobsPerChunk)).
-		WithOptionalQueryParam("max_number_of_concurrent_jobs", networking.IntPtrToStrPtr(request.MaxNumberOfConcurrentJobs)).
-		WithOptionalQueryParam("partially_verify_last_percent_of_tapes", networking.IntPtrToStrPtr(request.PartiallyVerifyLastPercentOfTapes)).
-		WithOptionalQueryParam("pool_safety_enabled", networking.BoolPtrToStrPtr(request.PoolSafetyEnabled)).
-		WithOptionalQueryParam("unavailable_media_policy", networking.InterfaceToStrPtr(request.UnavailableMediaPolicy)).
-		WithOptionalQueryParam("unavailable_pool_max_job_retry_in_mins", networking.IntPtrToStrPtr(request.UnavailablePoolMaxJobRetryInMins)).
-		WithOptionalQueryParam("unavailable_tape_partition_max_job_retry_in_mins", networking.IntPtrToStrPtr(request.UnavailableTapePartitionMaxJobRetryInMins)).
-		WithOptionalQueryParam("verify_checkpoint_before_read", networking.BoolPtrToStrPtr(request.VerifyCheckpointBeforeRead)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyDataPathBackendSpectraS3Response(response)
-}
-
-func (client *Client) ModifyAzureDataReplicationRuleSpectraS3(request *models.ModifyAzureDataReplicationRuleSpectraS3Request) (*models.ModifyAzureDataReplicationRuleSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/azure_data_replication_rule/"+request.AzureDataReplicationRule).
-		WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
-		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyAzureDataReplicationRuleSpectraS3Response(response)
-}
-
-func (client *Client) ModifyDataPersistenceRuleSpectraS3(request *models.ModifyDataPersistenceRuleSpectraS3Request) (*models.ModifyDataPersistenceRuleSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/data_persistence_rule/"+request.DataPersistenceRuleId).
-		WithOptionalQueryParam("isolation_level", networking.InterfaceToStrPtr(request.IsolationLevel)).
-		WithOptionalQueryParam("minimum_days_to_retain", networking.IntPtrToStrPtr(request.MinimumDaysToRetain)).
-		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataPersistenceRuleType)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyDataPersistenceRuleSpectraS3Response(response)
-}
-
-func (client *Client) ModifyDataPolicySpectraS3(request *models.ModifyDataPolicySpectraS3Request) (*models.ModifyDataPolicySpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/data_policy/"+request.DataPolicyId).
-		WithOptionalQueryParam("always_force_put_job_creation", networking.BoolPtrToStrPtr(request.AlwaysForcePutJobCreation)).
-		WithOptionalQueryParam("always_minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.AlwaysMinimizeSpanningAcrossMedia)).
-		WithOptionalQueryParam("blobbing_enabled", networking.BoolPtrToStrPtr(request.BlobbingEnabled)).
-		WithOptionalQueryParam("checksum_type", networking.InterfaceToStrPtr(request.ChecksumType)).
-		WithOptionalQueryParam("default_blob_size", networking.Int64PtrToStrPtr(request.DefaultBlobSize)).
-		WithOptionalQueryParam("default_get_job_priority", networking.InterfaceToStrPtr(request.DefaultGetJobPriority)).
-		WithOptionalQueryParam("default_put_job_priority", networking.InterfaceToStrPtr(request.DefaultPutJobPriority)).
-		WithOptionalQueryParam("default_verify_after_write", networking.BoolPtrToStrPtr(request.DefaultVerifyAfterWrite)).
-		WithOptionalQueryParam("default_verify_job_priority", networking.InterfaceToStrPtr(request.DefaultVerifyJobPriority)).
-		WithOptionalQueryParam("end_to_end_crc_required", networking.BoolPtrToStrPtr(request.EndToEndCrcRequired)).
-		WithOptionalQueryParam("max_versions_to_keep", networking.IntPtrToStrPtr(request.MaxVersionsToKeep)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("rebuild_priority", networking.InterfaceToStrPtr(request.RebuildPriority)).
-		WithOptionalQueryParam("versioning", networking.InterfaceToStrPtr(request.Versioning)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyDataPolicySpectraS3Response(response)
-}
-
-func (client *Client) ModifyDs3DataReplicationRuleSpectraS3(request *models.ModifyDs3DataReplicationRuleSpectraS3Request) (*models.ModifyDs3DataReplicationRuleSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/ds3_data_replication_rule/"+request.Ds3DataReplicationRule).
-		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-		WithOptionalQueryParam("target_data_policy", request.TargetDataPolicy).
-		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyDs3DataReplicationRuleSpectraS3Response(response)
-}
-
-func (client *Client) ModifyS3DataReplicationRuleSpectraS3(request *models.ModifyS3DataReplicationRuleSpectraS3Request) (*models.ModifyS3DataReplicationRuleSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/s3_data_replication_rule/"+request.S3DataReplicationRule).
-		WithOptionalQueryParam("initial_data_placement", networking.InterfaceToStrPtr(request.InitialDataPlacement)).
-		WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
-		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyS3DataReplicationRuleSpectraS3Response(response)
-}
-
-func (client *Client) MarkSuspectBlobAzureTargetsAsDegradedSpectraS3(request *models.MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/suspect_blob_azure_target").
-		WithOptionalVoidQueryParam("force", request.Force).
-		WithReadCloser(buildIdListPayload(request.Ids)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response(response)
-}
-
-func (client *Client) MarkSuspectBlobDs3TargetsAsDegradedSpectraS3(request *models.MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/suspect_blob_ds3_target").
-		WithOptionalVoidQueryParam("force", request.Force).
-		WithReadCloser(buildIdListPayload(request.Ids)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response(response)
-}
-
-func (client *Client) MarkSuspectBlobPoolsAsDegradedSpectraS3(request *models.MarkSuspectBlobPoolsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobPoolsAsDegradedSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/suspect_blob_pool").
-		WithOptionalVoidQueryParam("force", request.Force).
-		WithReadCloser(buildIdListPayload(request.Ids)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewMarkSuspectBlobPoolsAsDegradedSpectraS3Response(response)
-}
-
-func (client *Client) MarkSuspectBlobS3TargetsAsDegradedSpectraS3(request *models.MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobS3TargetsAsDegradedSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/suspect_blob_s3_target").
-		WithOptionalVoidQueryParam("force", request.Force).
-		WithReadCloser(buildIdListPayload(request.Ids)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Response(response)
-}
-
-func (client *Client) MarkSuspectBlobTapesAsDegradedSpectraS3(request *models.MarkSuspectBlobTapesAsDegradedSpectraS3Request) (*models.MarkSuspectBlobTapesAsDegradedSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/suspect_blob_tape").
-		WithOptionalVoidQueryParam("force", request.Force).
-		WithReadCloser(buildIdListPayload(request.Ids)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewMarkSuspectBlobTapesAsDegradedSpectraS3Response(response)
-}
-
-func (client *Client) ModifyGroupSpectraS3(request *models.ModifyGroupSpectraS3Request) (*models.ModifyGroupSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/group/"+request.Group).
-		WithOptionalQueryParam("name", request.Name).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyGroupSpectraS3Response(response)
-}
-
-func (client *Client) VerifyUserIsMemberOfGroupSpectraS3(request *models.VerifyUserIsMemberOfGroupSpectraS3Request) (*models.VerifyUserIsMemberOfGroupSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/group/"+request.Group).
-		WithOptionalQueryParam("user_id", request.UserId).
-		WithQueryParam("operation", "verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewVerifyUserIsMemberOfGroupSpectraS3Response(response)
-}
-
-func (client *Client) AllocateJobChunkSpectraS3(request *models.AllocateJobChunkSpectraS3Request) (*models.AllocateJobChunkSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/job_chunk/"+request.JobChunkId).
-		WithQueryParam("operation", "allocate").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewAllocateJobChunkSpectraS3Response(response)
-}
-
-func (client *Client) CloseAggregatingJobSpectraS3(request *models.CloseAggregatingJobSpectraS3Request) (*models.CloseAggregatingJobSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/job/"+request.JobId).
-		WithQueryParam("close_aggregating_job", "").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCloseAggregatingJobSpectraS3Response(response)
-}
-
-func (client *Client) GetBulkJobSpectraS3(request *models.GetBulkJobSpectraS3Request) (*models.GetBulkJobSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/bucket/"+request.BucketName).
-		WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
-		WithOptionalQueryParam("chunk_client_processing_order_guarantee", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)).
-		WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
-		WithOptionalQueryParam("implicit_job_id_resolution", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
-		WithQueryParam("operation", "start_bulk_get").
-		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewGetBulkJobSpectraS3Response(response)
-}
-
-func (client *Client) PutBulkJobSpectraS3(request *models.PutBulkJobSpectraS3Request) (*models.PutBulkJobSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/bucket/"+request.BucketName).
-		WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
-		WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
-		WithOptionalVoidQueryParam("force", request.Force).
-		WithOptionalVoidQueryParam("ignore_naming_conflicts", request.IgnoreNamingConflicts).
-		WithOptionalQueryParam("implicit_job_id_resolution", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution)).
-		WithOptionalQueryParam("max_upload_size", networking.Int64PtrToStrPtr(request.MaxUploadSize)).
-		WithOptionalQueryParam("minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.MinimizeSpanningAcrossMedia)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalVoidQueryParam("pre_allocate_job_space", request.PreAllocateJobSpace).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
-		WithOptionalQueryParam("verify_after_write", networking.BoolPtrToStrPtr(request.VerifyAfterWrite)).
-		WithQueryParam("operation", "start_bulk_put").
-		WithReadCloser(buildDs3PutObjectListStream(request.Objects)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewPutBulkJobSpectraS3Response(response)
-}
-
-func (client *Client) VerifyBulkJobSpectraS3(request *models.VerifyBulkJobSpectraS3Request) (*models.VerifyBulkJobSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/bucket/"+request.BucketName).
-		WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithQueryParam("operation", "start_bulk_verify").
-		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewVerifyBulkJobSpectraS3Response(response)
-}
-
-func (client *Client) ModifyActiveJobSpectraS3(request *models.ModifyActiveJobSpectraS3Request) (*models.ModifyActiveJobSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/active_job/"+request.ActiveJobId).
-		WithOptionalQueryParam("created_at", request.CreatedAt).
-		WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyActiveJobSpectraS3Response(response)
-}
-
-func (client *Client) ModifyJobSpectraS3(request *models.ModifyJobSpectraS3Request) (*models.ModifyJobSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/job/"+request.JobId).
-		WithOptionalQueryParam("created_at", request.CreatedAt).
-		WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyJobSpectraS3Response(response)
-}
-
-func (client *Client) ReplicatePutJobSpectraS3(request *models.ReplicatePutJobSpectraS3Request) (*models.ReplicatePutJobSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/bucket/"+request.BucketName).
-		WithQueryParam("replicate", "").
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithQueryParam("operation", "start_bulk_put").
-		WithReadCloser(buildStreamFromString(request.RequestPayload)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewReplicatePutJobSpectraS3Response(response)
-}
-
-func (client *Client) StageObjectsJobSpectraS3(request *models.StageObjectsJobSpectraS3Request) (*models.StageObjectsJobSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/bucket/"+request.BucketName).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithQueryParam("operation", "start_bulk_stage").
-		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewStageObjectsJobSpectraS3Response(response)
-}
-
-func (client *Client) VerifySafeToCreatePutJobSpectraS3(request *models.VerifySafeToCreatePutJobSpectraS3Request) (*models.VerifySafeToCreatePutJobSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/bucket/"+request.BucketName).
-		WithQueryParam("operation", "verify_safe_to_start_bulk_put").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewVerifySafeToCreatePutJobSpectraS3Response(response)
-}
-
-func (client *Client) ModifyNodeSpectraS3(request *models.ModifyNodeSpectraS3Request) (*models.ModifyNodeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/node/"+request.Node).
-		WithOptionalQueryParam("dns_name", request.DnsName).
-		WithOptionalQueryParam("name", request.Name).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyNodeSpectraS3Response(response)
-}
-
-func (client *Client) GetPhysicalPlacementForObjectsSpectraS3(request *models.GetPhysicalPlacementForObjectsSpectraS3Request) (*models.GetPhysicalPlacementForObjectsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/bucket/"+request.BucketName).
-		WithOptionalQueryParam("storage_domain", request.StorageDomain).
-		WithQueryParam("operation", "get_physical_placement").
-		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewGetPhysicalPlacementForObjectsSpectraS3Response(response)
-}
-
-func (client *Client) GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3(request *models.GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request) (*models.GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/bucket/"+request.BucketName).
-		WithQueryParam("full_details", "").
-		WithOptionalQueryParam("storage_domain", request.StorageDomain).
-		WithQueryParam("operation", "get_physical_placement").
-		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response(response)
-}
-
-func (client *Client) UndeleteObjectSpectraS3(request *models.UndeleteObjectSpectraS3Request) (*models.UndeleteObjectSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/object").
-		WithQueryParam("bucket_id", request.BucketId).
-		WithQueryParam("name", request.Name).
-		WithOptionalQueryParam("version_id", request.VersionId).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewUndeleteObjectSpectraS3Response(response)
-}
-
-func (client *Client) CancelImportOnAllPoolsSpectraS3(request *models.CancelImportOnAllPoolsSpectraS3Request) (*models.CancelImportOnAllPoolsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool").
-		WithQueryParam("operation", "cancel_import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelImportOnAllPoolsSpectraS3Response(response)
-}
-
-func (client *Client) CancelImportPoolSpectraS3(request *models.CancelImportPoolSpectraS3Request) (*models.CancelImportPoolSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool/"+request.Pool).
-		WithQueryParam("operation", "cancel_import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelImportPoolSpectraS3Response(response)
-}
-
-func (client *Client) CancelVerifyOnAllPoolsSpectraS3(request *models.CancelVerifyOnAllPoolsSpectraS3Request) (*models.CancelVerifyOnAllPoolsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool").
-		WithQueryParam("operation", "cancel_verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelVerifyOnAllPoolsSpectraS3Response(response)
-}
-
-func (client *Client) CancelVerifyPoolSpectraS3(request *models.CancelVerifyPoolSpectraS3Request) (*models.CancelVerifyPoolSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool/"+request.Pool).
-		WithQueryParam("operation", "cancel_verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelVerifyPoolSpectraS3Response(response)
-}
-
-func (client *Client) CompactAllPoolsSpectraS3(request *models.CompactAllPoolsSpectraS3Request) (*models.CompactAllPoolsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool").
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithQueryParam("operation", "compact").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCompactAllPoolsSpectraS3Response(response)
-}
-
-func (client *Client) CompactPoolSpectraS3(request *models.CompactPoolSpectraS3Request) (*models.CompactPoolSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool/"+request.Pool).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithQueryParam("operation", "compact").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCompactPoolSpectraS3Response(response)
-}
-
-func (client *Client) DeallocatePoolSpectraS3(request *models.DeallocatePoolSpectraS3Request) (*models.DeallocatePoolSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool/"+request.Pool).
-		WithQueryParam("operation", "deallocate").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewDeallocatePoolSpectraS3Response(response)
-}
-
-func (client *Client) ForcePoolEnvironmentRefreshSpectraS3(request *models.ForcePoolEnvironmentRefreshSpectraS3Request) (*models.ForcePoolEnvironmentRefreshSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool_environment").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewForcePoolEnvironmentRefreshSpectraS3Response(response)
-}
-
-func (client *Client) FormatAllForeignPoolsSpectraS3(request *models.FormatAllForeignPoolsSpectraS3Request) (*models.FormatAllForeignPoolsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool").
-		WithQueryParam("operation", "format").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewFormatAllForeignPoolsSpectraS3Response(response)
-}
-
-func (client *Client) FormatForeignPoolSpectraS3(request *models.FormatForeignPoolSpectraS3Request) (*models.FormatForeignPoolSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool/"+request.Pool).
-		WithQueryParam("operation", "format").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewFormatForeignPoolSpectraS3Response(response)
-}
-
-func (client *Client) ImportAllPoolsSpectraS3(request *models.ImportAllPoolsSpectraS3Request) (*models.ImportAllPoolsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool").
-		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-		WithOptionalQueryParam("user_id", request.UserId).
-		WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
-		WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
-		WithQueryParam("operation", "import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewImportAllPoolsSpectraS3Response(response)
-}
-
-func (client *Client) ImportPoolSpectraS3(request *models.ImportPoolSpectraS3Request) (*models.ImportPoolSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool/"+request.Pool).
-		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-		WithOptionalQueryParam("user_id", request.UserId).
-		WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
-		WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
-		WithQueryParam("operation", "import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewImportPoolSpectraS3Response(response)
-}
-
-func (client *Client) ModifyAllPoolsSpectraS3(request *models.ModifyAllPoolsSpectraS3Request) (*models.ModifyAllPoolsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool").
-		WithQueryParam("quiesced", request.Quiesced.String()).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyAllPoolsSpectraS3Response(response)
-}
-
-func (client *Client) ModifyPoolPartitionSpectraS3(request *models.ModifyPoolPartitionSpectraS3Request) (*models.ModifyPoolPartitionSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool_partition/"+request.PoolPartition).
-		WithOptionalQueryParam("name", request.Name).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyPoolPartitionSpectraS3Response(response)
-}
-
-func (client *Client) ModifyPoolSpectraS3(request *models.ModifyPoolSpectraS3Request) (*models.ModifyPoolSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool/"+request.Pool).
-		WithOptionalQueryParam("partition_id", request.PartitionId).
-		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyPoolSpectraS3Response(response)
-}
-
-func (client *Client) VerifyAllPoolsSpectraS3(request *models.VerifyAllPoolsSpectraS3Request) (*models.VerifyAllPoolsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool").
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithQueryParam("operation", "verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewVerifyAllPoolsSpectraS3Response(response)
-}
-
-func (client *Client) VerifyPoolSpectraS3(request *models.VerifyPoolSpectraS3Request) (*models.VerifyPoolSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/pool/"+request.Pool).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithQueryParam("operation", "verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewVerifyPoolSpectraS3Response(response)
-}
-
-func (client *Client) ConvertStorageDomainToDs3TargetSpectraS3(request *models.ConvertStorageDomainToDs3TargetSpectraS3Request) (*models.ConvertStorageDomainToDs3TargetSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/storage_domain/"+request.StorageDomain).
-		WithQueryParam("convert_to_ds3_target", request.ConvertToDs3Target).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewConvertStorageDomainToDs3TargetSpectraS3Response(response)
-}
-
-func (client *Client) ModifyStorageDomainMemberSpectraS3(request *models.ModifyStorageDomainMemberSpectraS3Request) (*models.ModifyStorageDomainMemberSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/storage_domain_member/"+request.StorageDomainMember).
-		WithOptionalQueryParam("auto_compaction_threshold", networking.IntPtrToStrPtr(request.AutoCompactionThreshold)).
-		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-		WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyStorageDomainMemberSpectraS3Response(response)
-}
-
-func (client *Client) ModifyStorageDomainSpectraS3(request *models.ModifyStorageDomainSpectraS3Request) (*models.ModifyStorageDomainSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/storage_domain/"+request.StorageDomain).
-		WithOptionalQueryParam("auto_eject_media_full_threshold", networking.Int64PtrToStrPtr(request.AutoEjectMediaFullThreshold)).
-		WithOptionalQueryParam("auto_eject_upon_cron", request.AutoEjectUponCron).
-		WithOptionalQueryParam("auto_eject_upon_job_cancellation", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCancellation)).
-		WithOptionalQueryParam("auto_eject_upon_job_completion", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCompletion)).
-		WithOptionalQueryParam("auto_eject_upon_media_full", networking.BoolPtrToStrPtr(request.AutoEjectUponMediaFull)).
-		WithOptionalQueryParam("ltfs_file_naming", networking.InterfaceToStrPtr(request.LtfsFileNaming)).
-		WithOptionalQueryParam("max_tape_fragmentation_percent", networking.IntPtrToStrPtr(request.MaxTapeFragmentationPercent)).
-		WithOptionalQueryParam("maximum_auto_verification_frequency_in_days", networking.IntPtrToStrPtr(request.MaximumAutoVerificationFrequencyInDays)).
-		WithOptionalQueryParam("media_ejection_allowed", networking.BoolPtrToStrPtr(request.MediaEjectionAllowed)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("secure_media_allocation", networking.BoolPtrToStrPtr(request.SecureMediaAllocation)).
-		WithOptionalQueryParam("verify_prior_to_auto_eject", networking.InterfaceToStrPtr(request.VerifyPriorToAutoEject)).
-		WithOptionalQueryParam("write_optimization", networking.InterfaceToStrPtr(request.WriteOptimization)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyStorageDomainSpectraS3Response(response)
-}
-
-func (client *Client) ForceFeatureKeyValidationSpectraS3(request *models.ForceFeatureKeyValidationSpectraS3Request) (*models.ForceFeatureKeyValidationSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/feature_key").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewForceFeatureKeyValidationSpectraS3Response(response)
-}
-
-func (client *Client) ResetInstanceIdentifierSpectraS3(request *models.ResetInstanceIdentifierSpectraS3Request) (*models.ResetInstanceIdentifierSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/instance_identifier").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewResetInstanceIdentifierSpectraS3Response(response)
-}
-
-func (client *Client) CancelEjectOnAllTapesSpectraS3(request *models.CancelEjectOnAllTapesSpectraS3Request) (*models.CancelEjectOnAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithQueryParam("operation", "cancel_eject").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelEjectOnAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) CancelEjectTapeSpectraS3(request *models.CancelEjectTapeSpectraS3Request) (*models.CancelEjectTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithQueryParam("operation", "cancel_eject").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelEjectTapeSpectraS3Response(response)
-}
-
-func (client *Client) CancelFormatOnAllTapesSpectraS3(request *models.CancelFormatOnAllTapesSpectraS3Request) (*models.CancelFormatOnAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithQueryParam("operation", "cancel_format").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelFormatOnAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) CancelFormatTapeSpectraS3(request *models.CancelFormatTapeSpectraS3Request) (*models.CancelFormatTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithQueryParam("operation", "cancel_format").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelFormatTapeSpectraS3Response(response)
-}
-
-func (client *Client) CancelImportOnAllTapesSpectraS3(request *models.CancelImportOnAllTapesSpectraS3Request) (*models.CancelImportOnAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithQueryParam("operation", "cancel_import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelImportOnAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) CancelImportTapeSpectraS3(request *models.CancelImportTapeSpectraS3Request) (*models.CancelImportTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithQueryParam("operation", "cancel_import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelImportTapeSpectraS3Response(response)
-}
-
-func (client *Client) CancelOnlineOnAllTapesSpectraS3(request *models.CancelOnlineOnAllTapesSpectraS3Request) (*models.CancelOnlineOnAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithQueryParam("operation", "cancel_online").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelOnlineOnAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) CancelOnlineTapeSpectraS3(request *models.CancelOnlineTapeSpectraS3Request) (*models.CancelOnlineTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithQueryParam("operation", "cancel_online").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelOnlineTapeSpectraS3Response(response)
-}
-
-func (client *Client) CancelTestTapeDriveSpectraS3(request *models.CancelTestTapeDriveSpectraS3Request) (*models.CancelTestTapeDriveSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
-		WithQueryParam("operation", "cancel_test").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelTestTapeDriveSpectraS3Response(response)
-}
-
-func (client *Client) CancelVerifyOnAllTapesSpectraS3(request *models.CancelVerifyOnAllTapesSpectraS3Request) (*models.CancelVerifyOnAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithQueryParam("operation", "cancel_verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelVerifyOnAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) CancelVerifyTapeSpectraS3(request *models.CancelVerifyTapeSpectraS3Request) (*models.CancelVerifyTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithQueryParam("operation", "cancel_verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCancelVerifyTapeSpectraS3Response(response)
-}
-
-func (client *Client) CleanTapeDriveSpectraS3(request *models.CleanTapeDriveSpectraS3Request) (*models.CleanTapeDriveSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
-		WithQueryParam("operation", "clean").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewCleanTapeDriveSpectraS3Response(response)
-}
-
-func (client *Client) PutDriveDumpSpectraS3(request *models.PutDriveDumpSpectraS3Request) (*models.PutDriveDumpSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
-		WithQueryParam("operation", "dump").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewPutDriveDumpSpectraS3Response(response)
-}
-
-func (client *Client) EjectAllTapesSpectraS3(request *models.EjectAllTapesSpectraS3Request) (*models.EjectAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithOptionalQueryParam("eject_label", request.EjectLabel).
-		WithOptionalQueryParam("eject_location", request.EjectLocation).
-		WithQueryParam("operation", "eject").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewEjectAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) EjectStorageDomainBlobsSpectraS3(request *models.EjectStorageDomainBlobsSpectraS3Request) (*models.EjectStorageDomainBlobsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithQueryParam("blobs", "").
-		WithQueryParam("bucket_id", request.BucketId).
-		WithQueryParam("storage_domain", request.StorageDomain).
-		WithOptionalQueryParam("eject_label", request.EjectLabel).
-		WithOptionalQueryParam("eject_location", request.EjectLocation).
-		WithQueryParam("operation", "eject").
-		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewEjectStorageDomainBlobsSpectraS3Response(response)
-}
-
-func (client *Client) EjectStorageDomainSpectraS3(request *models.EjectStorageDomainSpectraS3Request) (*models.EjectStorageDomainSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithQueryParam("storage_domain", request.StorageDomain).
-		WithOptionalQueryParam("bucket_id", request.BucketId).
-		WithOptionalQueryParam("eject_label", request.EjectLabel).
-		WithOptionalQueryParam("eject_location", request.EjectLocation).
-		WithQueryParam("operation", "eject").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewEjectStorageDomainSpectraS3Response(response)
-}
-
-func (client *Client) EjectTapeSpectraS3(request *models.EjectTapeSpectraS3Request) (*models.EjectTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithOptionalQueryParam("eject_label", request.EjectLabel).
-		WithOptionalQueryParam("eject_location", request.EjectLocation).
-		WithQueryParam("operation", "eject").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewEjectTapeSpectraS3Response(response)
-}
-
-func (client *Client) ForceTapeEnvironmentRefreshSpectraS3(request *models.ForceTapeEnvironmentRefreshSpectraS3Request) (*models.ForceTapeEnvironmentRefreshSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape_environment").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewForceTapeEnvironmentRefreshSpectraS3Response(response)
-}
-
-func (client *Client) FormatAllTapesSpectraS3(request *models.FormatAllTapesSpectraS3Request) (*models.FormatAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithOptionalVoidQueryParam("force", request.Force).
-		WithQueryParam("operation", "format").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewFormatAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) FormatTapeSpectraS3(request *models.FormatTapeSpectraS3Request) (*models.FormatTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithOptionalVoidQueryParam("force", request.Force).
-		WithQueryParam("operation", "format").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewFormatTapeSpectraS3Response(response)
-}
-
-func (client *Client) ImportAllTapesSpectraS3(request *models.ImportAllTapesSpectraS3Request) (*models.ImportAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-		WithOptionalQueryParam("user_id", request.UserId).
-		WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
-		WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
-		WithQueryParam("operation", "import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewImportAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) ImportTapeSpectraS3(request *models.ImportTapeSpectraS3Request) (*models.ImportTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-		WithOptionalQueryParam("user_id", request.UserId).
-		WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
-		WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
-		WithQueryParam("operation", "import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewImportTapeSpectraS3Response(response)
-}
-
-func (client *Client) InspectAllTapesSpectraS3(request *models.InspectAllTapesSpectraS3Request) (*models.InspectAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-		WithQueryParam("operation", "inspect").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewInspectAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) InspectTapeSpectraS3(request *models.InspectTapeSpectraS3Request) (*models.InspectTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-		WithQueryParam("operation", "inspect").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewInspectTapeSpectraS3Response(response)
-}
-
-func (client *Client) MarkTapeForCompactionSpectraS3(request *models.MarkTapeForCompactionSpectraS3Request) (*models.MarkTapeForCompactionSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithQueryParam("operation", "mark_for_compaction").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewMarkTapeForCompactionSpectraS3Response(response)
-}
-
-func (client *Client) ModifyAllTapePartitionsSpectraS3(request *models.ModifyAllTapePartitionsSpectraS3Request) (*models.ModifyAllTapePartitionsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape_partition").
-		WithQueryParam("quiesced", request.Quiesced.String()).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyAllTapePartitionsSpectraS3Response(response)
-}
-
-func (client *Client) ModifyTapeDriveSpectraS3(request *models.ModifyTapeDriveSpectraS3Request) (*models.ModifyTapeDriveSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
-		WithOptionalQueryParam("max_failed_tapes", networking.IntPtrToStrPtr(request.MaxFailedTapes)).
-		WithOptionalQueryParam("minimum_task_priority", networking.InterfaceToStrPtr(request.MinimumTaskPriority)).
-		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-		WithOptionalQueryParam("reserved_task_type", networking.InterfaceToStrPtr(request.ReservedTaskType)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyTapeDriveSpectraS3Response(response)
-}
-
-func (client *Client) ModifyTapePartitionSpectraS3(request *models.ModifyTapePartitionSpectraS3Request) (*models.ModifyTapePartitionSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape_partition/"+request.TapePartition).
-		WithOptionalQueryParam("auto_compaction_enabled", networking.BoolPtrToStrPtr(request.AutoCompactionEnabled)).
-		WithOptionalQueryParam("auto_quiesce_enabled", networking.BoolPtrToStrPtr(request.AutoQuiesceEnabled)).
-		WithOptionalQueryParam("drive_idle_timeout_in_minutes", networking.IntPtrToStrPtr(request.DriveIdleTimeoutInMinutes)).
-		WithOptionalQueryParam("minimum_read_reserved_drives", networking.IntPtrToStrPtr(request.MinimumReadReservedDrives)).
-		WithOptionalQueryParam("minimum_write_reserved_drives", networking.IntPtrToStrPtr(request.MinimumWriteReservedDrives)).
-		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-		WithOptionalQueryParam("serial_number", request.SerialNumber).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyTapePartitionSpectraS3Response(response)
-}
-
-func (client *Client) ModifyTapeSpectraS3(request *models.ModifyTapeSpectraS3Request) (*models.ModifyTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithOptionalQueryParam("eject_label", request.EjectLabel).
-		WithOptionalQueryParam("eject_location", request.EjectLocation).
-		WithOptionalQueryParam("role", networking.InterfaceToStrPtr(request.Role)).
-		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyTapeSpectraS3Response(response)
-}
-
-func (client *Client) OnlineAllTapesSpectraS3(request *models.OnlineAllTapesSpectraS3Request) (*models.OnlineAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithQueryParam("operation", "online").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewOnlineAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) OnlineTapeSpectraS3(request *models.OnlineTapeSpectraS3Request) (*models.OnlineTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithQueryParam("operation", "online").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewOnlineTapeSpectraS3Response(response)
-}
-
-func (client *Client) RawImportAllTapesSpectraS3(request *models.RawImportAllTapesSpectraS3Request) (*models.RawImportAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithQueryParam("bucket_id", request.BucketId).
-		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-		WithQueryParam("operation", "import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewRawImportAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) RawImportTapeSpectraS3(request *models.RawImportTapeSpectraS3Request) (*models.RawImportTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithQueryParam("bucket_id", request.BucketId).
-		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-		WithQueryParam("operation", "import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewRawImportTapeSpectraS3Response(response)
-}
-
-func (client *Client) TestTapeDriveSpectraS3(request *models.TestTapeDriveSpectraS3Request) (*models.TestTapeDriveSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
-		WithOptionalVoidQueryParam("skip_clean", request.SkipClean).
-		WithOptionalQueryParam("tape_id", request.TapeId).
-		WithQueryParam("operation", "test").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewTestTapeDriveSpectraS3Response(response)
-}
-
-func (client *Client) VerifyAllTapesSpectraS3(request *models.VerifyAllTapesSpectraS3Request) (*models.VerifyAllTapesSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape").
-		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-		WithQueryParam("operation", "verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewVerifyAllTapesSpectraS3Response(response)
-}
-
-func (client *Client) VerifyTapeSpectraS3(request *models.VerifyTapeSpectraS3Request) (*models.VerifyTapeSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/tape/"+request.TapeId).
-		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-		WithQueryParam("operation", "verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewVerifyTapeSpectraS3Response(response)
-}
-
-func (client *Client) ForceTargetEnvironmentRefreshSpectraS3(request *models.ForceTargetEnvironmentRefreshSpectraS3Request) (*models.ForceTargetEnvironmentRefreshSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/target_environment").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewForceTargetEnvironmentRefreshSpectraS3Response(response)
-}
-
-func (client *Client) ImportAzureTargetSpectraS3(request *models.ImportAzureTargetSpectraS3Request) (*models.ImportAzureTargetSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/azure_target/"+request.AzureTarget).
-		WithQueryParam("cloud_bucket_name", request.CloudBucketName).
-		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithOptionalQueryParam("user_id", request.UserId).
-		WithQueryParam("operation", "import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewImportAzureTargetSpectraS3Response(response)
-}
-
-func (client *Client) ModifyAllAzureTargetsSpectraS3(request *models.ModifyAllAzureTargetsSpectraS3Request) (*models.ModifyAllAzureTargetsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/azure_target").
-		WithQueryParam("quiesced", request.Quiesced.String()).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyAllAzureTargetsSpectraS3Response(response)
-}
-
-func (client *Client) ModifyAzureTargetSpectraS3(request *models.ModifyAzureTargetSpectraS3Request) (*models.ModifyAzureTargetSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/azure_target/"+request.AzureTarget).
-		WithOptionalQueryParam("account_key", request.AccountKey).
-		WithOptionalQueryParam("account_name", request.AccountName).
-		WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
-		WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
-		WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
-		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-		WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyAzureTargetSpectraS3Response(response)
-}
-
-func (client *Client) VerifyAzureTargetSpectraS3(request *models.VerifyAzureTargetSpectraS3Request) (*models.VerifyAzureTargetSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/azure_target/"+request.AzureTarget).
-		WithOptionalVoidQueryParam("full_details", request.FullDetails).
-		WithQueryParam("operation", "verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewVerifyAzureTargetSpectraS3Response(response)
-}
-
-func (client *Client) ModifyAllDs3TargetsSpectraS3(request *models.ModifyAllDs3TargetsSpectraS3Request) (*models.ModifyAllDs3TargetsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/ds3_target").
-		WithQueryParam("quiesced", request.Quiesced.String()).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyAllDs3TargetsSpectraS3Response(response)
-}
-
-func (client *Client) ModifyDs3TargetSpectraS3(request *models.ModifyDs3TargetSpectraS3Request) (*models.ModifyDs3TargetSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/ds3_target/"+request.Ds3Target).
-		WithOptionalQueryParam("access_control_replication", networking.InterfaceToStrPtr(request.AccessControlReplication)).
-		WithOptionalQueryParam("admin_auth_id", request.AdminAuthId).
-		WithOptionalQueryParam("admin_secret_key", request.AdminSecretKey).
-		WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
-		WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
-		WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
-		WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
-		WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
-		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-		WithOptionalQueryParam("replicated_user_default_data_policy", request.ReplicatedUserDefaultDataPolicy).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyDs3TargetSpectraS3Response(response)
-}
-
-func (client *Client) PairBackRegisteredDs3TargetSpectraS3(request *models.PairBackRegisteredDs3TargetSpectraS3Request) (*models.PairBackRegisteredDs3TargetSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/ds3_target/"+request.Ds3Target).
-		WithOptionalQueryParam("access_control_replication", networking.InterfaceToStrPtr(request.AccessControlReplication)).
-		WithOptionalQueryParam("admin_auth_id", request.AdminAuthId).
-		WithOptionalQueryParam("admin_secret_key", request.AdminSecretKey).
-		WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
-		WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
-		WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
-		WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
-		WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
-		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-		WithOptionalQueryParam("replicated_user_default_data_policy", request.ReplicatedUserDefaultDataPolicy).
-		WithQueryParam("operation", "pair_back").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewPairBackRegisteredDs3TargetSpectraS3Response(response)
-}
-
-func (client *Client) VerifyDs3TargetSpectraS3(request *models.VerifyDs3TargetSpectraS3Request) (*models.VerifyDs3TargetSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/ds3_target/"+request.Ds3Target).
-		WithOptionalVoidQueryParam("full_details", request.FullDetails).
-		WithQueryParam("operation", "verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewVerifyDs3TargetSpectraS3Response(response)
-}
-
-func (client *Client) ImportS3TargetSpectraS3(request *models.ImportS3TargetSpectraS3Request) (*models.ImportS3TargetSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/s3_target/"+request.S3Target).
-		WithQueryParam("cloud_bucket_name", request.CloudBucketName).
-		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-		WithOptionalQueryParam("user_id", request.UserId).
-		WithQueryParam("operation", "import").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewImportS3TargetSpectraS3Response(response)
-}
-
-func (client *Client) ModifyAllS3TargetsSpectraS3(request *models.ModifyAllS3TargetsSpectraS3Request) (*models.ModifyAllS3TargetsSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/s3_target").
-		WithQueryParam("quiesced", request.Quiesced.String()).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyAllS3TargetsSpectraS3Response(response)
-}
-
-func (client *Client) ModifyS3TargetSpectraS3(request *models.ModifyS3TargetSpectraS3Request) (*models.ModifyS3TargetSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/s3_target/"+request.S3Target).
-		WithOptionalQueryParam("access_key", request.AccessKey).
-		WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
-		WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
-		WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
-		WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
-		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-		WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("naming_mode", networking.InterfaceToStrPtr(request.NamingMode)).
-		WithOptionalQueryParam("offline_data_staging_window_in_tb", networking.IntPtrToStrPtr(request.OfflineDataStagingWindowInTb)).
-		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-		WithOptionalQueryParam("proxy_domain", request.ProxyDomain).
-		WithOptionalQueryParam("proxy_host", request.ProxyHost).
-		WithOptionalQueryParam("proxy_password", request.ProxyPassword).
-		WithOptionalQueryParam("proxy_port", networking.IntPtrToStrPtr(request.ProxyPort)).
-		WithOptionalQueryParam("proxy_username", request.ProxyUsername).
-		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-		WithOptionalQueryParam("region", networking.InterfaceToStrPtr(request.Region)).
-		WithOptionalQueryParam("restricted_access", networking.BoolPtrToStrPtr(request.RestrictedAccess)).
-		WithOptionalQueryParam("secret_key", request.SecretKey).
-		WithOptionalQueryParam("staged_data_expiration_in_days", networking.IntPtrToStrPtr(request.StagedDataExpirationInDays)).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyS3TargetSpectraS3Response(response)
-}
-
-func (client *Client) VerifyS3TargetSpectraS3(request *models.VerifyS3TargetSpectraS3Request) (*models.VerifyS3TargetSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/s3_target/"+request.S3Target).
-		WithOptionalVoidQueryParam("full_details", request.FullDetails).
-		WithQueryParam("operation", "verify").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewVerifyS3TargetSpectraS3Response(response)
-}
-
-func (client *Client) ModifyUserSpectraS3(request *models.ModifyUserSpectraS3Request) (*models.ModifyUserSpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/user/"+request.UserId).
-		WithOptionalQueryParam("default_data_policy_id", request.DefaultDataPolicyId).
-		WithOptionalQueryParam("max_buckets", networking.IntPtrToStrPtr(request.MaxBuckets)).
-		WithOptionalQueryParam("name", request.Name).
-		WithOptionalQueryParam("secret_key", request.SecretKey).
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewModifyUserSpectraS3Response(response)
-}
-
-func (client *Client) RegenerateUserSecretKeySpectraS3(request *models.RegenerateUserSecretKeySpectraS3Request) (*models.RegenerateUserSecretKeySpectraS3Response, error) {
-	// Build the http request
-	httpRequest, err := networking.NewHttpRequestBuilder().
-		WithHttpVerb(HTTP_VERB_PUT).
-		WithPath("/_rest_/user/"+request.UserId).
-		WithQueryParam("operation", "regenerate_secret_key").
-		Build(client.connectionInfo)
-
-	if err != nil {
-		return nil, err
-	}
-
-	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-
-	// Invoke the HTTP request.
-	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-	if requestErr != nil {
-		return nil, requestErr
-	}
-
-	// Create a response object based on the result.
-	return models.NewRegenerateUserSecretKeySpectraS3Response(response)
+func (client *Client) PutBucket(ctx context.Context, request *models.PutBucketRequest) (*models.PutBucketResponse, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/" + request.BucketName).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewPutBucketResponse(response)
+}
+
+func (client *Client) PutMultiPartUploadPart(ctx context.Context, request *models.PutMultiPartUploadPartRequest) (*models.PutMultiPartUploadPartResponse, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/" + request.BucketName + "/" + request.ObjectName).
+        WithQueryParam("part_number", strconv.Itoa(request.PartNumber)).
+        WithQueryParam("upload_id", request.UploadId).
+        WithReader(request.Content).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewPutMultiPartUploadPartResponse(response)
+}
+
+func (client *Client) PutObject(ctx context.Context, request *models.PutObjectRequest) (*models.PutObjectResponse, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/" + request.BucketName + "/" + request.ObjectName).
+        WithOptionalQueryParam("job", request.Job).
+        WithOptionalQueryParam("offset", networking.Int64PtrToStrPtr(request.Offset)).
+        WithReader(request.Content).
+        WithChecksum(request.Checksum).
+        WithHeaders(request.Metadata).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewPutObjectResponse(response)
+}
+
+func (client *Client) ModifyBucketSpectraS3(ctx context.Context, request *models.ModifyBucketSpectraS3Request) (*models.ModifyBucketSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/bucket/" + request.BucketName).
+        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+        WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
+        WithOptionalQueryParam("user_id", request.UserId).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyBucketSpectraS3Response(response)
+}
+
+func (client *Client) ForceFullCacheReclaimSpectraS3(ctx context.Context, request *models.ForceFullCacheReclaimSpectraS3Request) (*models.ForceFullCacheReclaimSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/cache_filesystem").
+        WithQueryParam("reclaim", "").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewForceFullCacheReclaimSpectraS3Response(response)
+}
+
+func (client *Client) ModifyCacheFilesystemSpectraS3(ctx context.Context, request *models.ModifyCacheFilesystemSpectraS3Request) (*models.ModifyCacheFilesystemSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/cache_filesystem/" + request.CacheFilesystem).
+        WithOptionalQueryParam("auto_reclaim_initiate_threshold", networking.Float64PtrToStrPtr(request.AutoReclaimInitiateThreshold)).
+        WithOptionalQueryParam("auto_reclaim_terminate_threshold", networking.Float64PtrToStrPtr(request.AutoReclaimTerminateThreshold)).
+        WithOptionalQueryParam("burst_threshold", networking.Float64PtrToStrPtr(request.BurstThreshold)).
+        WithOptionalQueryParam("cache_safety_enabled", networking.BoolPtrToStrPtr(request.CacheSafetyEnabled)).
+        WithOptionalQueryParam("max_capacity_in_bytes", networking.Int64PtrToStrPtr(request.MaxCapacityInBytes)).
+        WithOptionalQueryParam("needs_reconcile", networking.BoolPtrToStrPtr(request.NeedsReconcile)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyCacheFilesystemSpectraS3Response(response)
+}
+
+func (client *Client) ModifyDataPathBackendSpectraS3(ctx context.Context, request *models.ModifyDataPathBackendSpectraS3Request) (*models.ModifyDataPathBackendSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/data_path_backend").
+        WithOptionalQueryParam("activated", networking.BoolPtrToStrPtr(request.Activated)).
+        WithOptionalQueryParam("allow_new_job_requests", networking.BoolPtrToStrPtr(request.AllowNewJobRequests)).
+        WithOptionalQueryParam("auto_activate_timeout_in_mins", networking.IntPtrToStrPtr(request.AutoActivateTimeoutInMins)).
+        WithOptionalQueryParam("auto_inspect", networking.InterfaceToStrPtr(request.AutoInspect)).
+        WithOptionalQueryParam("cache_available_retry_after_in_seconds", networking.IntPtrToStrPtr(request.CacheAvailableRetryAfterInSeconds)).
+        WithOptionalQueryParam("default_verify_data_after_import", networking.InterfaceToStrPtr(request.DefaultVerifyDataAfterImport)).
+        WithOptionalQueryParam("default_verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.DefaultVerifyDataPriorToImport)).
+        WithOptionalQueryParam("iom_cache_limitation_percent", networking.Float64PtrToStrPtr(request.IomCacheLimitationPercent)).
+        WithOptionalQueryParam("iom_enabled", networking.BoolPtrToStrPtr(request.IomEnabled)).
+        WithOptionalQueryParam("max_aggregated_blobs_per_chunk", networking.IntPtrToStrPtr(request.MaxAggregatedBlobsPerChunk)).
+        WithOptionalQueryParam("max_number_of_concurrent_jobs", networking.IntPtrToStrPtr(request.MaxNumberOfConcurrentJobs)).
+        WithOptionalQueryParam("partially_verify_last_percent_of_tapes", networking.IntPtrToStrPtr(request.PartiallyVerifyLastPercentOfTapes)).
+        WithOptionalQueryParam("pool_safety_enabled", networking.BoolPtrToStrPtr(request.PoolSafetyEnabled)).
+        WithOptionalQueryParam("unavailable_media_policy", networking.InterfaceToStrPtr(request.UnavailableMediaPolicy)).
+        WithOptionalQueryParam("unavailable_pool_max_job_retry_in_mins", networking.IntPtrToStrPtr(request.UnavailablePoolMaxJobRetryInMins)).
+        WithOptionalQueryParam("unavailable_tape_partition_max_job_retry_in_mins", networking.IntPtrToStrPtr(request.UnavailableTapePartitionMaxJobRetryInMins)).
+        WithOptionalQueryParam("verify_checkpoint_before_read", networking.BoolPtrToStrPtr(request.VerifyCheckpointBeforeRead)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyDataPathBackendSpectraS3Response(response)
+}
+
+func (client *Client) ModifyAzureDataReplicationRuleSpectraS3(ctx context.Context, request *models.ModifyAzureDataReplicationRuleSpectraS3Request) (*models.ModifyAzureDataReplicationRuleSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/azure_data_replication_rule/" + request.AzureDataReplicationRule).
+        WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
+        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyAzureDataReplicationRuleSpectraS3Response(response)
+}
+
+func (client *Client) ModifyDataPersistenceRuleSpectraS3(ctx context.Context, request *models.ModifyDataPersistenceRuleSpectraS3Request) (*models.ModifyDataPersistenceRuleSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/data_persistence_rule/" + request.DataPersistenceRuleId).
+        WithOptionalQueryParam("isolation_level", networking.InterfaceToStrPtr(request.IsolationLevel)).
+        WithOptionalQueryParam("minimum_days_to_retain", networking.IntPtrToStrPtr(request.MinimumDaysToRetain)).
+        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataPersistenceRuleType)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyDataPersistenceRuleSpectraS3Response(response)
+}
+
+func (client *Client) ModifyDataPolicySpectraS3(ctx context.Context, request *models.ModifyDataPolicySpectraS3Request) (*models.ModifyDataPolicySpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/data_policy/" + request.DataPolicyId).
+        WithOptionalQueryParam("always_force_put_job_creation", networking.BoolPtrToStrPtr(request.AlwaysForcePutJobCreation)).
+        WithOptionalQueryParam("always_minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.AlwaysMinimizeSpanningAcrossMedia)).
+        WithOptionalQueryParam("blobbing_enabled", networking.BoolPtrToStrPtr(request.BlobbingEnabled)).
+        WithOptionalQueryParam("checksum_type", networking.InterfaceToStrPtr(request.ChecksumType)).
+        WithOptionalQueryParam("default_blob_size", networking.Int64PtrToStrPtr(request.DefaultBlobSize)).
+        WithOptionalQueryParam("default_get_job_priority", networking.InterfaceToStrPtr(request.DefaultGetJobPriority)).
+        WithOptionalQueryParam("default_put_job_priority", networking.InterfaceToStrPtr(request.DefaultPutJobPriority)).
+        WithOptionalQueryParam("default_verify_after_write", networking.BoolPtrToStrPtr(request.DefaultVerifyAfterWrite)).
+        WithOptionalQueryParam("default_verify_job_priority", networking.InterfaceToStrPtr(request.DefaultVerifyJobPriority)).
+        WithOptionalQueryParam("end_to_end_crc_required", networking.BoolPtrToStrPtr(request.EndToEndCrcRequired)).
+        WithOptionalQueryParam("max_versions_to_keep", networking.IntPtrToStrPtr(request.MaxVersionsToKeep)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("rebuild_priority", networking.InterfaceToStrPtr(request.RebuildPriority)).
+        WithOptionalQueryParam("versioning", networking.InterfaceToStrPtr(request.Versioning)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyDataPolicySpectraS3Response(response)
+}
+
+func (client *Client) ModifyDs3DataReplicationRuleSpectraS3(ctx context.Context, request *models.ModifyDs3DataReplicationRuleSpectraS3Request) (*models.ModifyDs3DataReplicationRuleSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/ds3_data_replication_rule/" + request.Ds3DataReplicationRule).
+        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+        WithOptionalQueryParam("target_data_policy", request.TargetDataPolicy).
+        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyDs3DataReplicationRuleSpectraS3Response(response)
+}
+
+func (client *Client) ModifyS3DataReplicationRuleSpectraS3(ctx context.Context, request *models.ModifyS3DataReplicationRuleSpectraS3Request) (*models.ModifyS3DataReplicationRuleSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/s3_data_replication_rule/" + request.S3DataReplicationRule).
+        WithOptionalQueryParam("initial_data_placement", networking.InterfaceToStrPtr(request.InitialDataPlacement)).
+        WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
+        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyS3DataReplicationRuleSpectraS3Response(response)
+}
+
+func (client *Client) MarkSuspectBlobAzureTargetsAsDegradedSpectraS3(ctx context.Context, request *models.MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/suspect_blob_azure_target").
+        WithOptionalVoidQueryParam("force", request.Force).
+        WithReadCloser(buildIdListPayload(request.Ids)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response(response)
+}
+
+func (client *Client) MarkSuspectBlobDs3TargetsAsDegradedSpectraS3(ctx context.Context, request *models.MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/suspect_blob_ds3_target").
+        WithOptionalVoidQueryParam("force", request.Force).
+        WithReadCloser(buildIdListPayload(request.Ids)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response(response)
+}
+
+func (client *Client) MarkSuspectBlobPoolsAsDegradedSpectraS3(ctx context.Context, request *models.MarkSuspectBlobPoolsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobPoolsAsDegradedSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/suspect_blob_pool").
+        WithOptionalVoidQueryParam("force", request.Force).
+        WithReadCloser(buildIdListPayload(request.Ids)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewMarkSuspectBlobPoolsAsDegradedSpectraS3Response(response)
+}
+
+func (client *Client) MarkSuspectBlobS3TargetsAsDegradedSpectraS3(ctx context.Context, request *models.MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobS3TargetsAsDegradedSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/suspect_blob_s3_target").
+        WithOptionalVoidQueryParam("force", request.Force).
+        WithReadCloser(buildIdListPayload(request.Ids)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Response(response)
+}
+
+func (client *Client) MarkSuspectBlobTapesAsDegradedSpectraS3(ctx context.Context, request *models.MarkSuspectBlobTapesAsDegradedSpectraS3Request) (*models.MarkSuspectBlobTapesAsDegradedSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/suspect_blob_tape").
+        WithOptionalVoidQueryParam("force", request.Force).
+        WithReadCloser(buildIdListPayload(request.Ids)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewMarkSuspectBlobTapesAsDegradedSpectraS3Response(response)
+}
+
+func (client *Client) ModifyGroupSpectraS3(ctx context.Context, request *models.ModifyGroupSpectraS3Request) (*models.ModifyGroupSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/group/" + request.Group).
+        WithOptionalQueryParam("name", request.Name).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyGroupSpectraS3Response(response)
+}
+
+func (client *Client) VerifyUserIsMemberOfGroupSpectraS3(ctx context.Context, request *models.VerifyUserIsMemberOfGroupSpectraS3Request) (*models.VerifyUserIsMemberOfGroupSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/group/" + request.Group).
+        WithOptionalQueryParam("user_id", request.UserId).
+        WithQueryParam("operation", "verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewVerifyUserIsMemberOfGroupSpectraS3Response(response)
+}
+
+func (client *Client) AllocateJobChunkSpectraS3(ctx context.Context, request *models.AllocateJobChunkSpectraS3Request) (*models.AllocateJobChunkSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/job_chunk/" + request.JobChunkId).
+        WithQueryParam("operation", "allocate").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewAllocateJobChunkSpectraS3Response(response)
+}
+
+func (client *Client) CloseAggregatingJobSpectraS3(ctx context.Context, request *models.CloseAggregatingJobSpectraS3Request) (*models.CloseAggregatingJobSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/job/" + request.JobId).
+        WithQueryParam("close_aggregating_job", "").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCloseAggregatingJobSpectraS3Response(response)
+}
+
+func (client *Client) GetBulkJobSpectraS3(ctx context.Context, request *models.GetBulkJobSpectraS3Request) (*models.GetBulkJobSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/bucket/" + request.BucketName).
+        WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
+        WithOptionalQueryParam("chunk_client_processing_order_guarantee", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)).
+        WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
+        WithOptionalQueryParam("implicit_job_id_resolution", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
+        WithQueryParam("operation", "start_bulk_get").
+        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewGetBulkJobSpectraS3Response(response)
+}
+
+func (client *Client) PutBulkJobSpectraS3(ctx context.Context, request *models.PutBulkJobSpectraS3Request) (*models.PutBulkJobSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/bucket/" + request.BucketName).
+        WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
+        WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
+        WithOptionalVoidQueryParam("force", request.Force).
+        WithOptionalVoidQueryParam("ignore_naming_conflicts", request.IgnoreNamingConflicts).
+        WithOptionalQueryParam("implicit_job_id_resolution", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution)).
+        WithOptionalQueryParam("max_upload_size", networking.Int64PtrToStrPtr(request.MaxUploadSize)).
+        WithOptionalQueryParam("minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.MinimizeSpanningAcrossMedia)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalVoidQueryParam("pre_allocate_job_space", request.PreAllocateJobSpace).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
+        WithOptionalQueryParam("verify_after_write", networking.BoolPtrToStrPtr(request.VerifyAfterWrite)).
+        WithQueryParam("operation", "start_bulk_put").
+        WithReadCloser(buildDs3PutObjectListStream(request.Objects)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewPutBulkJobSpectraS3Response(response)
+}
+
+func (client *Client) VerifyBulkJobSpectraS3(ctx context.Context, request *models.VerifyBulkJobSpectraS3Request) (*models.VerifyBulkJobSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/bucket/" + request.BucketName).
+        WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithQueryParam("operation", "start_bulk_verify").
+        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewVerifyBulkJobSpectraS3Response(response)
+}
+
+func (client *Client) ModifyActiveJobSpectraS3(ctx context.Context, request *models.ModifyActiveJobSpectraS3Request) (*models.ModifyActiveJobSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/active_job/" + request.ActiveJobId).
+        WithOptionalQueryParam("created_at", request.CreatedAt).
+        WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyActiveJobSpectraS3Response(response)
+}
+
+func (client *Client) ModifyJobSpectraS3(ctx context.Context, request *models.ModifyJobSpectraS3Request) (*models.ModifyJobSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/job/" + request.JobId).
+        WithOptionalQueryParam("created_at", request.CreatedAt).
+        WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyJobSpectraS3Response(response)
+}
+
+func (client *Client) ReplicatePutJobSpectraS3(ctx context.Context, request *models.ReplicatePutJobSpectraS3Request) (*models.ReplicatePutJobSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/bucket/" + request.BucketName).
+        WithQueryParam("replicate", "").
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithQueryParam("operation", "start_bulk_put").
+        WithReadCloser(buildStreamFromString(request.RequestPayload)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewReplicatePutJobSpectraS3Response(response)
+}
+
+func (client *Client) StageObjectsJobSpectraS3(ctx context.Context, request *models.StageObjectsJobSpectraS3Request) (*models.StageObjectsJobSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/bucket/" + request.BucketName).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithQueryParam("operation", "start_bulk_stage").
+        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewStageObjectsJobSpectraS3Response(response)
+}
+
+func (client *Client) VerifySafeToCreatePutJobSpectraS3(ctx context.Context, request *models.VerifySafeToCreatePutJobSpectraS3Request) (*models.VerifySafeToCreatePutJobSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/bucket/" + request.BucketName).
+        WithQueryParam("operation", "verify_safe_to_start_bulk_put").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewVerifySafeToCreatePutJobSpectraS3Response(response)
+}
+
+func (client *Client) ModifyNodeSpectraS3(ctx context.Context, request *models.ModifyNodeSpectraS3Request) (*models.ModifyNodeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/node/" + request.Node).
+        WithOptionalQueryParam("dns_name", request.DnsName).
+        WithOptionalQueryParam("name", request.Name).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyNodeSpectraS3Response(response)
+}
+
+func (client *Client) GetPhysicalPlacementForObjectsSpectraS3(ctx context.Context, request *models.GetPhysicalPlacementForObjectsSpectraS3Request) (*models.GetPhysicalPlacementForObjectsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/bucket/" + request.BucketName).
+        WithOptionalQueryParam("storage_domain", request.StorageDomain).
+        WithQueryParam("operation", "get_physical_placement").
+        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewGetPhysicalPlacementForObjectsSpectraS3Response(response)
+}
+
+func (client *Client) GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3(ctx context.Context, request *models.GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request) (*models.GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/bucket/" + request.BucketName).
+        WithQueryParam("full_details", "").
+        WithOptionalQueryParam("storage_domain", request.StorageDomain).
+        WithQueryParam("operation", "get_physical_placement").
+        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response(response)
+}
+
+func (client *Client) UndeleteObjectSpectraS3(ctx context.Context, request *models.UndeleteObjectSpectraS3Request) (*models.UndeleteObjectSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/object").
+        WithQueryParam("bucket_id", request.BucketId).
+        WithQueryParam("name", request.Name).
+        WithOptionalQueryParam("version_id", request.VersionId).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewUndeleteObjectSpectraS3Response(response)
+}
+
+func (client *Client) CancelImportOnAllPoolsSpectraS3(ctx context.Context, request *models.CancelImportOnAllPoolsSpectraS3Request) (*models.CancelImportOnAllPoolsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool").
+        WithQueryParam("operation", "cancel_import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelImportOnAllPoolsSpectraS3Response(response)
+}
+
+func (client *Client) CancelImportPoolSpectraS3(ctx context.Context, request *models.CancelImportPoolSpectraS3Request) (*models.CancelImportPoolSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool/" + request.Pool).
+        WithQueryParam("operation", "cancel_import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelImportPoolSpectraS3Response(response)
+}
+
+func (client *Client) CancelVerifyOnAllPoolsSpectraS3(ctx context.Context, request *models.CancelVerifyOnAllPoolsSpectraS3Request) (*models.CancelVerifyOnAllPoolsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool").
+        WithQueryParam("operation", "cancel_verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelVerifyOnAllPoolsSpectraS3Response(response)
+}
+
+func (client *Client) CancelVerifyPoolSpectraS3(ctx context.Context, request *models.CancelVerifyPoolSpectraS3Request) (*models.CancelVerifyPoolSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool/" + request.Pool).
+        WithQueryParam("operation", "cancel_verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelVerifyPoolSpectraS3Response(response)
+}
+
+func (client *Client) CompactAllPoolsSpectraS3(ctx context.Context, request *models.CompactAllPoolsSpectraS3Request) (*models.CompactAllPoolsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool").
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithQueryParam("operation", "compact").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCompactAllPoolsSpectraS3Response(response)
+}
+
+func (client *Client) CompactPoolSpectraS3(ctx context.Context, request *models.CompactPoolSpectraS3Request) (*models.CompactPoolSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool/" + request.Pool).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithQueryParam("operation", "compact").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCompactPoolSpectraS3Response(response)
+}
+
+func (client *Client) DeallocatePoolSpectraS3(ctx context.Context, request *models.DeallocatePoolSpectraS3Request) (*models.DeallocatePoolSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool/" + request.Pool).
+        WithQueryParam("operation", "deallocate").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewDeallocatePoolSpectraS3Response(response)
+}
+
+func (client *Client) ForcePoolEnvironmentRefreshSpectraS3(ctx context.Context, request *models.ForcePoolEnvironmentRefreshSpectraS3Request) (*models.ForcePoolEnvironmentRefreshSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool_environment").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewForcePoolEnvironmentRefreshSpectraS3Response(response)
+}
+
+func (client *Client) FormatAllForeignPoolsSpectraS3(ctx context.Context, request *models.FormatAllForeignPoolsSpectraS3Request) (*models.FormatAllForeignPoolsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool").
+        WithQueryParam("operation", "format").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewFormatAllForeignPoolsSpectraS3Response(response)
+}
+
+func (client *Client) FormatForeignPoolSpectraS3(ctx context.Context, request *models.FormatForeignPoolSpectraS3Request) (*models.FormatForeignPoolSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool/" + request.Pool).
+        WithQueryParam("operation", "format").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewFormatForeignPoolSpectraS3Response(response)
+}
+
+func (client *Client) ImportAllPoolsSpectraS3(ctx context.Context, request *models.ImportAllPoolsSpectraS3Request) (*models.ImportAllPoolsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool").
+        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+        WithOptionalQueryParam("user_id", request.UserId).
+        WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
+        WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
+        WithQueryParam("operation", "import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewImportAllPoolsSpectraS3Response(response)
+}
+
+func (client *Client) ImportPoolSpectraS3(ctx context.Context, request *models.ImportPoolSpectraS3Request) (*models.ImportPoolSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool/" + request.Pool).
+        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+        WithOptionalQueryParam("user_id", request.UserId).
+        WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
+        WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
+        WithQueryParam("operation", "import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewImportPoolSpectraS3Response(response)
+}
+
+func (client *Client) ModifyAllPoolsSpectraS3(ctx context.Context, request *models.ModifyAllPoolsSpectraS3Request) (*models.ModifyAllPoolsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool").
+        WithQueryParam("quiesced", request.Quiesced.String()).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyAllPoolsSpectraS3Response(response)
+}
+
+func (client *Client) ModifyPoolPartitionSpectraS3(ctx context.Context, request *models.ModifyPoolPartitionSpectraS3Request) (*models.ModifyPoolPartitionSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool_partition/" + request.PoolPartition).
+        WithOptionalQueryParam("name", request.Name).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyPoolPartitionSpectraS3Response(response)
+}
+
+func (client *Client) ModifyPoolSpectraS3(ctx context.Context, request *models.ModifyPoolSpectraS3Request) (*models.ModifyPoolSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool/" + request.Pool).
+        WithOptionalQueryParam("partition_id", request.PartitionId).
+        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyPoolSpectraS3Response(response)
+}
+
+func (client *Client) VerifyAllPoolsSpectraS3(ctx context.Context, request *models.VerifyAllPoolsSpectraS3Request) (*models.VerifyAllPoolsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool").
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithQueryParam("operation", "verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewVerifyAllPoolsSpectraS3Response(response)
+}
+
+func (client *Client) VerifyPoolSpectraS3(ctx context.Context, request *models.VerifyPoolSpectraS3Request) (*models.VerifyPoolSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/pool/" + request.Pool).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithQueryParam("operation", "verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewVerifyPoolSpectraS3Response(response)
+}
+
+func (client *Client) ConvertStorageDomainToDs3TargetSpectraS3(ctx context.Context, request *models.ConvertStorageDomainToDs3TargetSpectraS3Request) (*models.ConvertStorageDomainToDs3TargetSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/storage_domain/" + request.StorageDomain).
+        WithQueryParam("convert_to_ds3_target", request.ConvertToDs3Target).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewConvertStorageDomainToDs3TargetSpectraS3Response(response)
+}
+
+func (client *Client) ModifyStorageDomainMemberSpectraS3(ctx context.Context, request *models.ModifyStorageDomainMemberSpectraS3Request) (*models.ModifyStorageDomainMemberSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/storage_domain_member/" + request.StorageDomainMember).
+        WithOptionalQueryParam("auto_compaction_threshold", networking.IntPtrToStrPtr(request.AutoCompactionThreshold)).
+        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+        WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyStorageDomainMemberSpectraS3Response(response)
+}
+
+func (client *Client) ModifyStorageDomainSpectraS3(ctx context.Context, request *models.ModifyStorageDomainSpectraS3Request) (*models.ModifyStorageDomainSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/storage_domain/" + request.StorageDomain).
+        WithOptionalQueryParam("auto_eject_media_full_threshold", networking.Int64PtrToStrPtr(request.AutoEjectMediaFullThreshold)).
+        WithOptionalQueryParam("auto_eject_upon_cron", request.AutoEjectUponCron).
+        WithOptionalQueryParam("auto_eject_upon_job_cancellation", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCancellation)).
+        WithOptionalQueryParam("auto_eject_upon_job_completion", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCompletion)).
+        WithOptionalQueryParam("auto_eject_upon_media_full", networking.BoolPtrToStrPtr(request.AutoEjectUponMediaFull)).
+        WithOptionalQueryParam("ltfs_file_naming", networking.InterfaceToStrPtr(request.LtfsFileNaming)).
+        WithOptionalQueryParam("max_tape_fragmentation_percent", networking.IntPtrToStrPtr(request.MaxTapeFragmentationPercent)).
+        WithOptionalQueryParam("maximum_auto_verification_frequency_in_days", networking.IntPtrToStrPtr(request.MaximumAutoVerificationFrequencyInDays)).
+        WithOptionalQueryParam("media_ejection_allowed", networking.BoolPtrToStrPtr(request.MediaEjectionAllowed)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("secure_media_allocation", networking.BoolPtrToStrPtr(request.SecureMediaAllocation)).
+        WithOptionalQueryParam("verify_prior_to_auto_eject", networking.InterfaceToStrPtr(request.VerifyPriorToAutoEject)).
+        WithOptionalQueryParam("write_optimization", networking.InterfaceToStrPtr(request.WriteOptimization)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyStorageDomainSpectraS3Response(response)
+}
+
+func (client *Client) ForceFeatureKeyValidationSpectraS3(ctx context.Context, request *models.ForceFeatureKeyValidationSpectraS3Request) (*models.ForceFeatureKeyValidationSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/feature_key").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewForceFeatureKeyValidationSpectraS3Response(response)
+}
+
+func (client *Client) ResetInstanceIdentifierSpectraS3(ctx context.Context, request *models.ResetInstanceIdentifierSpectraS3Request) (*models.ResetInstanceIdentifierSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/instance_identifier").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewResetInstanceIdentifierSpectraS3Response(response)
+}
+
+func (client *Client) CancelEjectOnAllTapesSpectraS3(ctx context.Context, request *models.CancelEjectOnAllTapesSpectraS3Request) (*models.CancelEjectOnAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithQueryParam("operation", "cancel_eject").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelEjectOnAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) CancelEjectTapeSpectraS3(ctx context.Context, request *models.CancelEjectTapeSpectraS3Request) (*models.CancelEjectTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithQueryParam("operation", "cancel_eject").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelEjectTapeSpectraS3Response(response)
+}
+
+func (client *Client) CancelFormatOnAllTapesSpectraS3(ctx context.Context, request *models.CancelFormatOnAllTapesSpectraS3Request) (*models.CancelFormatOnAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithQueryParam("operation", "cancel_format").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelFormatOnAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) CancelFormatTapeSpectraS3(ctx context.Context, request *models.CancelFormatTapeSpectraS3Request) (*models.CancelFormatTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithQueryParam("operation", "cancel_format").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelFormatTapeSpectraS3Response(response)
+}
+
+func (client *Client) CancelImportOnAllTapesSpectraS3(ctx context.Context, request *models.CancelImportOnAllTapesSpectraS3Request) (*models.CancelImportOnAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithQueryParam("operation", "cancel_import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelImportOnAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) CancelImportTapeSpectraS3(ctx context.Context, request *models.CancelImportTapeSpectraS3Request) (*models.CancelImportTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithQueryParam("operation", "cancel_import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelImportTapeSpectraS3Response(response)
+}
+
+func (client *Client) CancelOnlineOnAllTapesSpectraS3(ctx context.Context, request *models.CancelOnlineOnAllTapesSpectraS3Request) (*models.CancelOnlineOnAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithQueryParam("operation", "cancel_online").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelOnlineOnAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) CancelOnlineTapeSpectraS3(ctx context.Context, request *models.CancelOnlineTapeSpectraS3Request) (*models.CancelOnlineTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithQueryParam("operation", "cancel_online").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelOnlineTapeSpectraS3Response(response)
+}
+
+func (client *Client) CancelTestTapeDriveSpectraS3(ctx context.Context, request *models.CancelTestTapeDriveSpectraS3Request) (*models.CancelTestTapeDriveSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
+        WithQueryParam("operation", "cancel_test").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelTestTapeDriveSpectraS3Response(response)
+}
+
+func (client *Client) CancelVerifyOnAllTapesSpectraS3(ctx context.Context, request *models.CancelVerifyOnAllTapesSpectraS3Request) (*models.CancelVerifyOnAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithQueryParam("operation", "cancel_verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelVerifyOnAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) CancelVerifyTapeSpectraS3(ctx context.Context, request *models.CancelVerifyTapeSpectraS3Request) (*models.CancelVerifyTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithQueryParam("operation", "cancel_verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCancelVerifyTapeSpectraS3Response(response)
+}
+
+func (client *Client) CleanTapeDriveSpectraS3(ctx context.Context, request *models.CleanTapeDriveSpectraS3Request) (*models.CleanTapeDriveSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
+        WithQueryParam("operation", "clean").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewCleanTapeDriveSpectraS3Response(response)
+}
+
+func (client *Client) PutDriveDumpSpectraS3(ctx context.Context, request *models.PutDriveDumpSpectraS3Request) (*models.PutDriveDumpSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
+        WithQueryParam("operation", "dump").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewPutDriveDumpSpectraS3Response(response)
+}
+
+func (client *Client) EjectAllTapesSpectraS3(ctx context.Context, request *models.EjectAllTapesSpectraS3Request) (*models.EjectAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithOptionalQueryParam("eject_label", request.EjectLabel).
+        WithOptionalQueryParam("eject_location", request.EjectLocation).
+        WithQueryParam("operation", "eject").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewEjectAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) EjectStorageDomainBlobsSpectraS3(ctx context.Context, request *models.EjectStorageDomainBlobsSpectraS3Request) (*models.EjectStorageDomainBlobsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithQueryParam("blobs", "").
+        WithQueryParam("bucket_id", request.BucketId).
+        WithQueryParam("storage_domain", request.StorageDomain).
+        WithOptionalQueryParam("eject_label", request.EjectLabel).
+        WithOptionalQueryParam("eject_location", request.EjectLocation).
+        WithQueryParam("operation", "eject").
+        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewEjectStorageDomainBlobsSpectraS3Response(response)
+}
+
+func (client *Client) EjectStorageDomainSpectraS3(ctx context.Context, request *models.EjectStorageDomainSpectraS3Request) (*models.EjectStorageDomainSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithQueryParam("storage_domain", request.StorageDomain).
+        WithOptionalQueryParam("bucket_id", request.BucketId).
+        WithOptionalQueryParam("eject_label", request.EjectLabel).
+        WithOptionalQueryParam("eject_location", request.EjectLocation).
+        WithQueryParam("operation", "eject").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewEjectStorageDomainSpectraS3Response(response)
+}
+
+func (client *Client) EjectTapeSpectraS3(ctx context.Context, request *models.EjectTapeSpectraS3Request) (*models.EjectTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithOptionalQueryParam("eject_label", request.EjectLabel).
+        WithOptionalQueryParam("eject_location", request.EjectLocation).
+        WithQueryParam("operation", "eject").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewEjectTapeSpectraS3Response(response)
+}
+
+func (client *Client) ForceTapeEnvironmentRefreshSpectraS3(ctx context.Context, request *models.ForceTapeEnvironmentRefreshSpectraS3Request) (*models.ForceTapeEnvironmentRefreshSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape_environment").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewForceTapeEnvironmentRefreshSpectraS3Response(response)
+}
+
+func (client *Client) FormatAllTapesSpectraS3(ctx context.Context, request *models.FormatAllTapesSpectraS3Request) (*models.FormatAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithOptionalVoidQueryParam("force", request.Force).
+        WithQueryParam("operation", "format").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewFormatAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) FormatTapeSpectraS3(ctx context.Context, request *models.FormatTapeSpectraS3Request) (*models.FormatTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithOptionalVoidQueryParam("force", request.Force).
+        WithQueryParam("operation", "format").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewFormatTapeSpectraS3Response(response)
+}
+
+func (client *Client) ImportAllTapesSpectraS3(ctx context.Context, request *models.ImportAllTapesSpectraS3Request) (*models.ImportAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+        WithOptionalQueryParam("user_id", request.UserId).
+        WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
+        WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
+        WithQueryParam("operation", "import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewImportAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) ImportTapeSpectraS3(ctx context.Context, request *models.ImportTapeSpectraS3Request) (*models.ImportTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+        WithOptionalQueryParam("user_id", request.UserId).
+        WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
+        WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
+        WithQueryParam("operation", "import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewImportTapeSpectraS3Response(response)
+}
+
+func (client *Client) InspectAllTapesSpectraS3(ctx context.Context, request *models.InspectAllTapesSpectraS3Request) (*models.InspectAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+        WithQueryParam("operation", "inspect").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewInspectAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) InspectTapeSpectraS3(ctx context.Context, request *models.InspectTapeSpectraS3Request) (*models.InspectTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+        WithQueryParam("operation", "inspect").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewInspectTapeSpectraS3Response(response)
+}
+
+func (client *Client) MarkTapeForCompactionSpectraS3(ctx context.Context, request *models.MarkTapeForCompactionSpectraS3Request) (*models.MarkTapeForCompactionSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithQueryParam("operation", "mark_for_compaction").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewMarkTapeForCompactionSpectraS3Response(response)
+}
+
+func (client *Client) ModifyAllTapePartitionsSpectraS3(ctx context.Context, request *models.ModifyAllTapePartitionsSpectraS3Request) (*models.ModifyAllTapePartitionsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape_partition").
+        WithQueryParam("quiesced", request.Quiesced.String()).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyAllTapePartitionsSpectraS3Response(response)
+}
+
+func (client *Client) ModifyTapeDriveSpectraS3(ctx context.Context, request *models.ModifyTapeDriveSpectraS3Request) (*models.ModifyTapeDriveSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
+        WithOptionalQueryParam("max_failed_tapes", networking.IntPtrToStrPtr(request.MaxFailedTapes)).
+        WithOptionalQueryParam("minimum_task_priority", networking.InterfaceToStrPtr(request.MinimumTaskPriority)).
+        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+        WithOptionalQueryParam("reserved_task_type", networking.InterfaceToStrPtr(request.ReservedTaskType)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyTapeDriveSpectraS3Response(response)
+}
+
+func (client *Client) ModifyTapePartitionSpectraS3(ctx context.Context, request *models.ModifyTapePartitionSpectraS3Request) (*models.ModifyTapePartitionSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape_partition/" + request.TapePartition).
+        WithOptionalQueryParam("auto_compaction_enabled", networking.BoolPtrToStrPtr(request.AutoCompactionEnabled)).
+        WithOptionalQueryParam("auto_quiesce_enabled", networking.BoolPtrToStrPtr(request.AutoQuiesceEnabled)).
+        WithOptionalQueryParam("drive_idle_timeout_in_minutes", networking.IntPtrToStrPtr(request.DriveIdleTimeoutInMinutes)).
+        WithOptionalQueryParam("minimum_read_reserved_drives", networking.IntPtrToStrPtr(request.MinimumReadReservedDrives)).
+        WithOptionalQueryParam("minimum_write_reserved_drives", networking.IntPtrToStrPtr(request.MinimumWriteReservedDrives)).
+        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+        WithOptionalQueryParam("serial_number", request.SerialNumber).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyTapePartitionSpectraS3Response(response)
+}
+
+func (client *Client) ModifyTapeSpectraS3(ctx context.Context, request *models.ModifyTapeSpectraS3Request) (*models.ModifyTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithOptionalQueryParam("eject_label", request.EjectLabel).
+        WithOptionalQueryParam("eject_location", request.EjectLocation).
+        WithOptionalQueryParam("role", networking.InterfaceToStrPtr(request.Role)).
+        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyTapeSpectraS3Response(response)
+}
+
+func (client *Client) OnlineAllTapesSpectraS3(ctx context.Context, request *models.OnlineAllTapesSpectraS3Request) (*models.OnlineAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithQueryParam("operation", "online").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewOnlineAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) OnlineTapeSpectraS3(ctx context.Context, request *models.OnlineTapeSpectraS3Request) (*models.OnlineTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithQueryParam("operation", "online").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewOnlineTapeSpectraS3Response(response)
+}
+
+func (client *Client) RawImportAllTapesSpectraS3(ctx context.Context, request *models.RawImportAllTapesSpectraS3Request) (*models.RawImportAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithQueryParam("bucket_id", request.BucketId).
+        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+        WithQueryParam("operation", "import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewRawImportAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) RawImportTapeSpectraS3(ctx context.Context, request *models.RawImportTapeSpectraS3Request) (*models.RawImportTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithQueryParam("bucket_id", request.BucketId).
+        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+        WithQueryParam("operation", "import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewRawImportTapeSpectraS3Response(response)
+}
+
+func (client *Client) TestTapeDriveSpectraS3(ctx context.Context, request *models.TestTapeDriveSpectraS3Request) (*models.TestTapeDriveSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
+        WithOptionalVoidQueryParam("skip_clean", request.SkipClean).
+        WithOptionalQueryParam("tape_id", request.TapeId).
+        WithQueryParam("operation", "test").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewTestTapeDriveSpectraS3Response(response)
+}
+
+func (client *Client) VerifyAllTapesSpectraS3(ctx context.Context, request *models.VerifyAllTapesSpectraS3Request) (*models.VerifyAllTapesSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape").
+        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+        WithQueryParam("operation", "verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewVerifyAllTapesSpectraS3Response(response)
+}
+
+func (client *Client) VerifyTapeSpectraS3(ctx context.Context, request *models.VerifyTapeSpectraS3Request) (*models.VerifyTapeSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/tape/" + request.TapeId).
+        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+        WithQueryParam("operation", "verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewVerifyTapeSpectraS3Response(response)
+}
+
+func (client *Client) ForceTargetEnvironmentRefreshSpectraS3(ctx context.Context, request *models.ForceTargetEnvironmentRefreshSpectraS3Request) (*models.ForceTargetEnvironmentRefreshSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/target_environment").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewForceTargetEnvironmentRefreshSpectraS3Response(response)
+}
+
+func (client *Client) ImportAzureTargetSpectraS3(ctx context.Context, request *models.ImportAzureTargetSpectraS3Request) (*models.ImportAzureTargetSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/azure_target/" + request.AzureTarget).
+        WithQueryParam("cloud_bucket_name", request.CloudBucketName).
+        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithOptionalQueryParam("user_id", request.UserId).
+        WithQueryParam("operation", "import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewImportAzureTargetSpectraS3Response(response)
+}
+
+func (client *Client) ModifyAllAzureTargetsSpectraS3(ctx context.Context, request *models.ModifyAllAzureTargetsSpectraS3Request) (*models.ModifyAllAzureTargetsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/azure_target").
+        WithQueryParam("quiesced", request.Quiesced.String()).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyAllAzureTargetsSpectraS3Response(response)
+}
+
+func (client *Client) ModifyAzureTargetSpectraS3(ctx context.Context, request *models.ModifyAzureTargetSpectraS3Request) (*models.ModifyAzureTargetSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/azure_target/" + request.AzureTarget).
+        WithOptionalQueryParam("account_key", request.AccountKey).
+        WithOptionalQueryParam("account_name", request.AccountName).
+        WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
+        WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
+        WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
+        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+        WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyAzureTargetSpectraS3Response(response)
+}
+
+func (client *Client) VerifyAzureTargetSpectraS3(ctx context.Context, request *models.VerifyAzureTargetSpectraS3Request) (*models.VerifyAzureTargetSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/azure_target/" + request.AzureTarget).
+        WithOptionalVoidQueryParam("full_details", request.FullDetails).
+        WithQueryParam("operation", "verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewVerifyAzureTargetSpectraS3Response(response)
+}
+
+func (client *Client) ModifyAllDs3TargetsSpectraS3(ctx context.Context, request *models.ModifyAllDs3TargetsSpectraS3Request) (*models.ModifyAllDs3TargetsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/ds3_target").
+        WithQueryParam("quiesced", request.Quiesced.String()).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyAllDs3TargetsSpectraS3Response(response)
+}
+
+func (client *Client) ModifyDs3TargetSpectraS3(ctx context.Context, request *models.ModifyDs3TargetSpectraS3Request) (*models.ModifyDs3TargetSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/ds3_target/" + request.Ds3Target).
+        WithOptionalQueryParam("access_control_replication", networking.InterfaceToStrPtr(request.AccessControlReplication)).
+        WithOptionalQueryParam("admin_auth_id", request.AdminAuthId).
+        WithOptionalQueryParam("admin_secret_key", request.AdminSecretKey).
+        WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
+        WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
+        WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
+        WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
+        WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
+        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+        WithOptionalQueryParam("replicated_user_default_data_policy", request.ReplicatedUserDefaultDataPolicy).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyDs3TargetSpectraS3Response(response)
+}
+
+func (client *Client) PairBackRegisteredDs3TargetSpectraS3(ctx context.Context, request *models.PairBackRegisteredDs3TargetSpectraS3Request) (*models.PairBackRegisteredDs3TargetSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/ds3_target/" + request.Ds3Target).
+        WithOptionalQueryParam("access_control_replication", networking.InterfaceToStrPtr(request.AccessControlReplication)).
+        WithOptionalQueryParam("admin_auth_id", request.AdminAuthId).
+        WithOptionalQueryParam("admin_secret_key", request.AdminSecretKey).
+        WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
+        WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
+        WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
+        WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
+        WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
+        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+        WithOptionalQueryParam("replicated_user_default_data_policy", request.ReplicatedUserDefaultDataPolicy).
+        WithQueryParam("operation", "pair_back").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewPairBackRegisteredDs3TargetSpectraS3Response(response)
+}
+
+func (client *Client) VerifyDs3TargetSpectraS3(ctx context.Context, request *models.VerifyDs3TargetSpectraS3Request) (*models.VerifyDs3TargetSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/ds3_target/" + request.Ds3Target).
+        WithOptionalVoidQueryParam("full_details", request.FullDetails).
+        WithQueryParam("operation", "verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewVerifyDs3TargetSpectraS3Response(response)
+}
+
+func (client *Client) ImportS3TargetSpectraS3(ctx context.Context, request *models.ImportS3TargetSpectraS3Request) (*models.ImportS3TargetSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/s3_target/" + request.S3Target).
+        WithQueryParam("cloud_bucket_name", request.CloudBucketName).
+        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+        WithOptionalQueryParam("user_id", request.UserId).
+        WithQueryParam("operation", "import").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewImportS3TargetSpectraS3Response(response)
+}
+
+func (client *Client) ModifyAllS3TargetsSpectraS3(ctx context.Context, request *models.ModifyAllS3TargetsSpectraS3Request) (*models.ModifyAllS3TargetsSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/s3_target").
+        WithQueryParam("quiesced", request.Quiesced.String()).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyAllS3TargetsSpectraS3Response(response)
+}
+
+func (client *Client) ModifyS3TargetSpectraS3(ctx context.Context, request *models.ModifyS3TargetSpectraS3Request) (*models.ModifyS3TargetSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/s3_target/" + request.S3Target).
+        WithOptionalQueryParam("access_key", request.AccessKey).
+        WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
+        WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
+        WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
+        WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
+        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+        WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("naming_mode", networking.InterfaceToStrPtr(request.NamingMode)).
+        WithOptionalQueryParam("offline_data_staging_window_in_tb", networking.IntPtrToStrPtr(request.OfflineDataStagingWindowInTb)).
+        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+        WithOptionalQueryParam("proxy_domain", request.ProxyDomain).
+        WithOptionalQueryParam("proxy_host", request.ProxyHost).
+        WithOptionalQueryParam("proxy_password", request.ProxyPassword).
+        WithOptionalQueryParam("proxy_port", networking.IntPtrToStrPtr(request.ProxyPort)).
+        WithOptionalQueryParam("proxy_username", request.ProxyUsername).
+        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+        WithOptionalQueryParam("region", networking.InterfaceToStrPtr(request.Region)).
+        WithOptionalQueryParam("restricted_access", networking.BoolPtrToStrPtr(request.RestrictedAccess)).
+        WithOptionalQueryParam("secret_key", request.SecretKey).
+        WithOptionalQueryParam("staged_data_expiration_in_days", networking.IntPtrToStrPtr(request.StagedDataExpirationInDays)).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyS3TargetSpectraS3Response(response)
+}
+
+func (client *Client) VerifyS3TargetSpectraS3(ctx context.Context, request *models.VerifyS3TargetSpectraS3Request) (*models.VerifyS3TargetSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/s3_target/" + request.S3Target).
+        WithOptionalVoidQueryParam("full_details", request.FullDetails).
+        WithQueryParam("operation", "verify").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewVerifyS3TargetSpectraS3Response(response)
+}
+
+func (client *Client) ModifyUserSpectraS3(ctx context.Context, request *models.ModifyUserSpectraS3Request) (*models.ModifyUserSpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/user/" + request.UserId).
+        WithOptionalQueryParam("default_data_policy_id", request.DefaultDataPolicyId).
+        WithOptionalQueryParam("max_buckets", networking.IntPtrToStrPtr(request.MaxBuckets)).
+        WithOptionalQueryParam("name", request.Name).
+        WithOptionalQueryParam("secret_key", request.SecretKey).
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewModifyUserSpectraS3Response(response)
+}
+
+func (client *Client) RegenerateUserSecretKeySpectraS3(ctx context.Context, request *models.RegenerateUserSecretKeySpectraS3Request) (*models.RegenerateUserSecretKeySpectraS3Response, error) {
+    // Build the http request
+    httpRequest, err := networking.NewHttpRequestBuilder().
+        WithHttpVerb(HTTP_VERB_PUT).
+        WithPath("/_rest_/user/" + request.UserId).
+        WithQueryParam("operation", "regenerate_secret_key").
+        Build(ctx, client.connectionInfo)
+
+    if err != nil {
+        return nil, err
+    }
+
+    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+
+    // Invoke the HTTP request.
+    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+    if requestErr != nil {
+        return nil, requestErr
+    }
+
+    // Create a response object based on the result.
+    return models.NewRegenerateUserSecretKeySpectraS3Response(response)
 }
+
+

--- a/ds3/ds3Puts.go
+++ b/ds3/ds3Puts.go
@@ -17,6 +17,7 @@ import (
     "context"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+    "strconv"
 )
 
 func (client *Client) PutBucket(ctx context.Context, request *models.PutBucketRequest) (*models.PutBucketResponse, error) {

--- a/ds3/networking/httpRequestBuilder.go
+++ b/ds3/networking/httpRequestBuilder.go
@@ -12,6 +12,7 @@
 package networking
 
 import (
+    "context"
     "io"
     "net/http"
     "net/url"
@@ -108,8 +109,8 @@ func (builder *HttpRequestBuilder) WithContentType(contentType string) *HttpRequ
     return builder
 }
 
-func (builder *HttpRequestBuilder) Build(conn *ConnectionInfo) (*http.Request, error) {
-    httpRequest, err := http.NewRequest(builder.signatureFields.Verb, builder.buildUrl(conn), builder.reader)
+func (builder *HttpRequestBuilder) Build(ctx context.Context, conn *ConnectionInfo) (*http.Request, error) {
+    httpRequest, err := http.NewRequestWithContext(ctx, builder.signatureFields.Verb, builder.buildUrl(conn), builder.reader)
     if err != nil {
         return nil, err
     }

--- a/ds3/networking/networkRetry.go
+++ b/ds3/networking/networkRetry.go
@@ -29,6 +29,12 @@ func (networkRetryDecorator *NetworkRetryDecorator) Invoke(httpRequest *http.Req
     // Handle as many Network related retries as we're allowed.
     var lastErr error
     for i := 0; i <= networkRetryDecorator.policy.maxRetries; i++ {
+        // Bail early if the request's context has been cancelled or its deadline exceeded
+        // — otherwise we'd keep slamming attempts at an already-dead context.
+        if err := httpRequest.Context().Err(); err != nil {
+            return nil, err
+        }
+
         ds3Response, err := networkRetryDecorator.network.Invoke(httpRequest)
 
         // If request was performed successfully then return response.

--- a/ds3/networking/networking_test.go
+++ b/ds3/networking/networking_test.go
@@ -12,6 +12,7 @@
 package networking
 
 import (
+    "context"
     "testing"
     "net/url"
     "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
@@ -51,7 +52,7 @@ func TestBuildingAuthorizationDigestWithMetadata(t *testing.T) {
 	httpRequestBuilder.
 		WithHeader(models.AMZ_META_HEADER + shasta, samoyed).
 		WithHeader(models.AMZ_META_HEADER + gracie, eskimo).
-		Build(&connectionInfo)
+		Build(context.Background(), &connectionInfo)
 
 	amazonHeaders := httpRequestBuilder.signatureFields.CanonicalizedAmzHeaders
 
@@ -78,7 +79,7 @@ func TestBuildingAuthorizationDigestWithSignatureQueryParams(t *testing.T) {
 		WithQueryParam("uploads", "two").
 		WithQueryParam("doesnotexist", "four").
 		WithQueryParam("versionId", "version").
-		Build(&connectionInfo)
+		Build(context.Background(), &connectionInfo)
 
 	subResources := httpRequestBuilder.signatureFields.CanonicalizedSubResources
 

--- a/ds3_cli/commands/bulkGet.go
+++ b/ds3_cli/commands/bulkGet.go
@@ -10,14 +10,14 @@ import (
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
-func bulkGet(client *ds3.Client, args *Arguments) error {
+func bulkGet(ctx context.Context, client *ds3.Client, args *Arguments) error {
     // Validate arguments.
     if args.Bucket == "" {
         return errors.New("Must specify a bucket name when doing a bulk_get.")
     }
 
     // Determine the objects that we need to queue a bulk get for.
-    objects, err := getBucketObjects(client, args)
+    objects, err := getBucketObjects(ctx, client, args)
     if err != nil {
         return err
     }
@@ -28,20 +28,20 @@ func bulkGet(client *ds3.Client, args *Arguments) error {
     }
 
     // Run request.
-    response, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3RequestWithPartialObjects(args.Bucket, ds3GetObjects))
+    response, err := client.GetBulkJobSpectraS3(ctx, models.NewGetBulkJobSpectraS3RequestWithPartialObjects(args.Bucket, ds3GetObjects))
     if err != nil {
         return err
     }
 
     // Handle the responses in parallel
-    return handleBulkResponse(response.MasterObjectList.Objects, buildBulkHandler(client, args.Bucket))
+    return handleBulkResponse(response.MasterObjectList.Objects, buildBulkHandler(ctx, client, args.Bucket))
 }
 
 // Returns a function that gets an object from a bulk get.
-func buildBulkHandler(client *ds3.Client, bucketName string) bulkHandler {
+func buildBulkHandler(ctx context.Context, client *ds3.Client, bucketName string) bulkHandler {
     return func(obj models.BulkObject) error {
         // Perform the request.
-        response, requestErr := client.GetObject(context.Background(), models.NewGetObjectRequest(bucketName, *obj.Name))
+        response, requestErr := client.GetObject(ctx, models.NewGetObjectRequest(bucketName, *obj.Name))
         if requestErr != nil {
             return requestErr
         }

--- a/ds3_cli/commands/bulkGet.go
+++ b/ds3_cli/commands/bulkGet.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+    "context"
     "io"
     "os"
     "path"
@@ -27,7 +28,7 @@ func bulkGet(client *ds3.Client, args *Arguments) error {
     }
 
     // Run request.
-    response, err := client.GetBulkJobSpectraS3(models.NewGetBulkJobSpectraS3RequestWithPartialObjects(args.Bucket, ds3GetObjects))
+    response, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3RequestWithPartialObjects(args.Bucket, ds3GetObjects))
     if err != nil {
         return err
     }
@@ -40,7 +41,7 @@ func bulkGet(client *ds3.Client, args *Arguments) error {
 func buildBulkHandler(client *ds3.Client, bucketName string) bulkHandler {
     return func(obj models.BulkObject) error {
         // Perform the request.
-        response, requestErr := client.GetObject(models.NewGetObjectRequest(bucketName, *obj.Name))
+        response, requestErr := client.GetObject(context.Background(), models.NewGetObjectRequest(bucketName, *obj.Name))
         if requestErr != nil {
             return requestErr
         }

--- a/ds3_cli/commands/bulkPut.go
+++ b/ds3_cli/commands/bulkPut.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+    "context"
     "errors"
     "io/ioutil"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
@@ -29,7 +30,7 @@ func bulkPut(client *ds3.Client, args *Arguments) error {
     }
 
     // Run request.
-    response, err := client.PutBulkJobSpectraS3(models.NewPutBulkJobSpectraS3Request(args.Bucket, objects))
+    response, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(args.Bucket, objects))
     if err != nil {
         return err
     }
@@ -48,7 +49,7 @@ func buildFilePutter(client *ds3.Client, bucketName string) bulkHandler {
         }
 
         // Submit the put object request.
-        _, putErr := client.PutObject(models.NewPutObjectRequest(
+        _, putErr := client.PutObject(context.Background(), models.NewPutObjectRequest(
             bucketName,
             *obj.Name,
             sizeReadCloser,

--- a/ds3_cli/commands/bulkPut.go
+++ b/ds3_cli/commands/bulkPut.go
@@ -8,7 +8,7 @@ import (
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
-func bulkPut(client *ds3.Client, args *Arguments) error {
+func bulkPut(ctx context.Context, client *ds3.Client, args *Arguments) error {
     // Validate arguments.
     if args.Bucket == "" {
         return errors.New("Must specify a bucket name when doing a bulk_put.")
@@ -30,17 +30,17 @@ func bulkPut(client *ds3.Client, args *Arguments) error {
     }
 
     // Run request.
-    response, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(args.Bucket, objects))
+    response, err := client.PutBulkJobSpectraS3(ctx, models.NewPutBulkJobSpectraS3Request(args.Bucket, objects))
     if err != nil {
         return err
     }
 
     // Handle the responses in parallel
-    return handleBulkResponse(response.MasterObjectList.Objects, buildFilePutter(client, args.Bucket))
+    return handleBulkResponse(response.MasterObjectList.Objects, buildFilePutter(ctx, client, args.Bucket))
 }
 
 // Returns a function that puts an object for a bulk put.
-func buildFilePutter(client *ds3.Client, bucketName string) bulkHandler {
+func buildFilePutter(ctx context.Context, client *ds3.Client, bucketName string) bulkHandler {
     return func(obj models.BulkObject) error {
         // Read the file.
         sizeReadCloser, fileErr := readFile(*obj.Name)
@@ -49,7 +49,7 @@ func buildFilePutter(client *ds3.Client, bucketName string) bulkHandler {
         }
 
         // Submit the put object request.
-        _, putErr := client.PutObject(context.Background(), models.NewPutObjectRequest(
+        _, putErr := client.PutObject(ctx, models.NewPutObjectRequest(
             bucketName,
             *obj.Name,
             sizeReadCloser,

--- a/ds3_cli/commands/deleteBucket.go
+++ b/ds3_cli/commands/deleteBucket.go
@@ -7,14 +7,14 @@ import (
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
-func deleteBucket(client *ds3.Client, args *Arguments) error {
+func deleteBucket(ctx context.Context, client *ds3.Client, args *Arguments) error {
     // Validate arguments.
     if args.Bucket == "" {
         return errors.New("Must specify a bucket name when doing delete_bucket.")
     }
 
     // Run request.
-    _, err := client.DeleteBucket(context.Background(), models.NewDeleteBucketRequest(args.Bucket))
+    _, err := client.DeleteBucket(ctx, models.NewDeleteBucketRequest(args.Bucket))
     return err
 }
 

--- a/ds3_cli/commands/deleteBucket.go
+++ b/ds3_cli/commands/deleteBucket.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+    "context"
     "errors"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -13,7 +14,7 @@ func deleteBucket(client *ds3.Client, args *Arguments) error {
     }
 
     // Run request.
-    _, err := client.DeleteBucket(models.NewDeleteBucketRequest(args.Bucket))
+    _, err := client.DeleteBucket(context.Background(), models.NewDeleteBucketRequest(args.Bucket))
     return err
 }
 

--- a/ds3_cli/commands/deleteObject.go
+++ b/ds3_cli/commands/deleteObject.go
@@ -7,7 +7,7 @@ import (
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
-func deleteObject(client *ds3.Client, args *Arguments) error {
+func deleteObject(ctx context.Context, client *ds3.Client, args *Arguments) error {
     // Validate arguments.
     if args.Bucket == "" {
         return errors.New("Must specify a bucket name when doing delete_object.")
@@ -17,7 +17,7 @@ func deleteObject(client *ds3.Client, args *Arguments) error {
     }
 
     // Run request.
-    _, err := client.DeleteObject(context.Background(), models.NewDeleteObjectRequest(args.Bucket, args.Key))
+    _, err := client.DeleteObject(ctx, models.NewDeleteObjectRequest(args.Bucket, args.Key))
     return err
 }
 

--- a/ds3_cli/commands/deleteObject.go
+++ b/ds3_cli/commands/deleteObject.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+    "context"
     "errors"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -16,7 +17,7 @@ func deleteObject(client *ds3.Client, args *Arguments) error {
     }
 
     // Run request.
-    _, err := client.DeleteObject(models.NewDeleteObjectRequest(args.Bucket, args.Key))
+    _, err := client.DeleteObject(context.Background(), models.NewDeleteObjectRequest(args.Bucket, args.Key))
     return err
 }
 

--- a/ds3_cli/commands/ds3Command.go
+++ b/ds3_cli/commands/ds3Command.go
@@ -1,11 +1,12 @@
 package commands
 
 import (
+    "context"
     "fmt"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
 )
 
-type command func(*ds3.Client, *Arguments) error
+type command func(context.Context, *ds3.Client, *Arguments) error
 
 var availableCommands = map[string]command {
     "get_service": getService,
@@ -22,12 +23,11 @@ var availableCommands = map[string]command {
     "bulk_put": bulkPut,
 }
 
-func RunCommand(client *ds3.Client, args *Arguments) error {
+func RunCommand(ctx context.Context, client *ds3.Client, args *Arguments) error {
     cmd, ok := availableCommands[args.Command]
     if ok {
-        return cmd(client, args)
+        return cmd(ctx, client, args)
     } else {
         return fmt.Errorf("Unsupported command: '%s'", args.Command)
     }
 }
-

--- a/ds3_cli/commands/getBucket.go
+++ b/ds3_cli/commands/getBucket.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+    "context"
     "fmt"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
 )
@@ -16,8 +17,8 @@ func getMinInt(a, b int) int {
     }
 }
 
-func getBucket(client *ds3.Client, args *Arguments) error {
-    objects, err := getBucketObjects(client, args)
+func getBucket(ctx context.Context, client *ds3.Client, args *Arguments) error {
+    objects, err := getBucketObjects(ctx, client, args)
     if err != nil {
         return err
     }

--- a/ds3_cli/commands/getBucketObjects.go
+++ b/ds3_cli/commands/getBucketObjects.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+    "context"
     "errors"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -29,7 +30,7 @@ func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Ds3PutObjec
         request := buildRequest(args, remainingKeys, marker)
 
         // Send the request.
-        response, err := client.GetBucket(request)
+        response, err := client.GetBucket(context.Background(), request)
         if err != nil {
             return nil, err
         }

--- a/ds3_cli/commands/getBucketObjects.go
+++ b/ds3_cli/commands/getBucketObjects.go
@@ -10,7 +10,7 @@ import (
 // Gets all objects in a bucket, performing multiple requests if the results
 // are paged. Also supports limiting to an arbitrary number of keys independent
 // of page size.
-func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Ds3PutObject, error) {
+func getBucketObjects(ctx context.Context, client *ds3.Client, args *Arguments) ([]models.Ds3PutObject, error) {
     // Validate arguments.
     if args.Bucket == "" {
         return nil, errors.New("Must specify a bucket name when doing get_bucket.")
@@ -30,7 +30,7 @@ func getBucketObjects(client *ds3.Client, args *Arguments) ([]models.Ds3PutObjec
         request := buildRequest(args, remainingKeys, marker)
 
         // Send the request.
-        response, err := client.GetBucket(context.Background(), request)
+        response, err := client.GetBucket(ctx, request)
         if err != nil {
             return nil, err
         }

--- a/ds3_cli/commands/getObject.go
+++ b/ds3_cli/commands/getObject.go
@@ -9,7 +9,7 @@ import (
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
-func getObject(client *ds3.Client, args *Arguments) error {
+func getObject(ctx context.Context, client *ds3.Client, args *Arguments) error {
     // Validate the arguments.
     if args.Bucket == "" {
         return errors.New("Must specify a bucket.")
@@ -30,7 +30,7 @@ func getObject(client *ds3.Client, args *Arguments) error {
     }
 
     // Perform the request.
-    response, requestErr := client.GetObject(context.Background(), request)
+    response, requestErr := client.GetObject(ctx, request)
     if requestErr != nil {
         return requestErr
     }

--- a/ds3_cli/commands/getObject.go
+++ b/ds3_cli/commands/getObject.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+    "context"
     "os"
     "io"
     "errors"
@@ -29,7 +30,7 @@ func getObject(client *ds3.Client, args *Arguments) error {
     }
 
     // Perform the request.
-    response, requestErr := client.GetObject(request)
+    response, requestErr := client.GetObject(context.Background(), request)
     if requestErr != nil {
         return requestErr
     }

--- a/ds3_cli/commands/getService.go
+++ b/ds3_cli/commands/getService.go
@@ -7,8 +7,8 @@ import (
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
-func getService(client *ds3.Client, args *Arguments) error {
-    response, err := client.GetService(context.Background(), models.NewGetServiceRequest())
+func getService(ctx context.Context, client *ds3.Client, args *Arguments) error {
+    response, err := client.GetService(ctx, models.NewGetServiceRequest())
     if err == nil {
         for _, bucket := range response.ListAllMyBucketsResult.Buckets {
             fmt.Println(bucket.Name)

--- a/ds3_cli/commands/getService.go
+++ b/ds3_cli/commands/getService.go
@@ -1,13 +1,14 @@
 package commands
 
 import (
+    "context"
     "fmt"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
 func getService(client *ds3.Client, args *Arguments) error {
-    response, err := client.GetService(models.NewGetServiceRequest())
+    response, err := client.GetService(context.Background(), models.NewGetServiceRequest())
     if err == nil {
         for _, bucket := range response.ListAllMyBucketsResult.Buckets {
             fmt.Println(bucket.Name)

--- a/ds3_cli/commands/putBucket.go
+++ b/ds3_cli/commands/putBucket.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+    "context"
     "errors"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -13,7 +14,7 @@ func putBucket(client *ds3.Client, args *Arguments) error {
     }
 
     // Run request.
-    _, err := client.PutBucket(models.NewPutBucketRequest(args.Bucket))
+    _, err := client.PutBucket(context.Background(), models.NewPutBucketRequest(args.Bucket))
     return err
 }
 

--- a/ds3_cli/commands/putBucket.go
+++ b/ds3_cli/commands/putBucket.go
@@ -7,14 +7,14 @@ import (
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
-func putBucket(client *ds3.Client, args *Arguments) error {
+func putBucket(ctx context.Context, client *ds3.Client, args *Arguments) error {
     // Validate arguments.
     if args.Bucket == "" {
         return errors.New("Must specify a bucket name when doing put_bucket.")
     }
 
     // Run request.
-    _, err := client.PutBucket(context.Background(), models.NewPutBucketRequest(args.Bucket))
+    _, err := client.PutBucket(ctx, models.NewPutBucketRequest(args.Bucket))
     return err
 }
 

--- a/ds3_cli/commands/putObject.go
+++ b/ds3_cli/commands/putObject.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+    "context"
     "errors"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -22,7 +23,7 @@ func putObject(client *ds3.Client, args *Arguments) error {
     }
 
     // Run request.
-    _, err := client.PutObject(models.NewPutObjectRequest(args.Bucket, args.Key, sizedContent))
+    _, err := client.PutObject(context.Background(), models.NewPutObjectRequest(args.Bucket, args.Key, sizedContent))
     return err
 }
 

--- a/ds3_cli/commands/putObject.go
+++ b/ds3_cli/commands/putObject.go
@@ -7,7 +7,7 @@ import (
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
-func putObject(client *ds3.Client, args *Arguments) error {
+func putObject(ctx context.Context, client *ds3.Client, args *Arguments) error {
     // Validate arguments.
     if args.Bucket == "" {
         return errors.New("Must specify a bucket name when doing put_object.")
@@ -23,7 +23,7 @@ func putObject(client *ds3.Client, args *Arguments) error {
     }
 
     // Run request.
-    _, err := client.PutObject(context.Background(), models.NewPutObjectRequest(args.Bucket, args.Key, sizedContent))
+    _, err := client.PutObject(ctx, models.NewPutObjectRequest(args.Bucket, args.Key, sizedContent))
     return err
 }
 

--- a/ds3_cli/main.go
+++ b/ds3_cli/main.go
@@ -1,12 +1,21 @@
 package main
 
 import (
+    "context"
     "log"
+    "os"
+    "os/signal"
+    "syscall"
+
     "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
     "github.com/SpectraLogic/ds3_go_sdk/ds3_cli/commands"
 )
 
 func main() {
+    // Cancel the operation if the user interrupts (Ctrl+C) or the process is asked to terminate.
+    ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+    defer stop()
+
     // Parse the arguments.
     args, argsErr := commands.ParseArgs()
     if argsErr != nil {
@@ -20,10 +29,7 @@ func main() {
     }
 
     // Run the command
-    if cmdErr := commands.RunCommand(client, args); cmdErr != nil {
+    if cmdErr := commands.RunCommand(ctx, client, args); cmdErr != nil {
         log.Fatal(cmdErr)
     }
 }
-
-
-

--- a/ds3_integration/concurrency_test.go
+++ b/ds3_integration/concurrency_test.go
@@ -1,6 +1,7 @@
 package ds3_integration
 
 import (
+    "context"
     "testing"
     "sync"
     "log"
@@ -20,7 +21,7 @@ func putFileWithClient(name string, offset int64, jobId string, content *[]byte,
     defer group.Done()
     log.Printf("Putting file %s", name)
 
-    _, err := client.PutObject(models.NewPutObjectRequest(testBucket, name, ds3.BuildByteReaderWithSizeDecorator(*content)).
+    _, err := client.PutObject(context.Background(), models.NewPutObjectRequest(testBucket, name, ds3.BuildByteReaderWithSizeDecorator(*content)).
         WithOffset(offset).
         WithJob(jobId))
 
@@ -47,7 +48,7 @@ func TestConcurrentClientUsage(t *testing.T) {
         ds3Objects = append(ds3Objects, models.Ds3PutObject{ Name:fmt.Sprintf("file%d", i), Size:size })
     }
 
-    bulkPut, err := client.PutBulkJobSpectraS3(models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
+    bulkPut, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
     ds3Testing.AssertNilError(t, err)
 
     // launch go routines to put files concurrently
@@ -55,7 +56,7 @@ func TestConcurrentClientUsage(t *testing.T) {
     group.Add(n)
 
     for _, chunk := range bulkPut.MasterObjectList.Objects {
-        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
+        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
         ds3Testing.AssertNilError(t, allocateErr)
         for _, obj := range allocateChunk.Objects.Objects {
             go putFileWithClient(*obj.Name, obj.Offset, bulkPut.MasterObjectList.JobId, &content, &group, t)
@@ -77,7 +78,7 @@ func putFileWithSendNetwork(name string, offset int64, jobId string, content *[]
         WithReader(ds3.BuildByteReaderWithSizeDecorator(*content)).
         WithChecksum(models.NewNoneChecksum()).
         WithHeaders(make(map[string]string)).
-        Build(info)
+        Build(context.Background(), info)
 
     //networkRetryDecorator := networking.NewNetworkRetryDecorator(network, 5)
     t.Logf("Created request to for file '%s' to url '%s'", name, httpRequest.URL.String())
@@ -112,7 +113,7 @@ func TestConcurrentSendNetworkUsage(t *testing.T) {
         ds3Objects = append(ds3Objects, models.Ds3PutObject{ Name:fmt.Sprintf("file%d", i), Size:size })
     }
 
-    bulkPut, err := client.PutBulkJobSpectraS3(models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
+    bulkPut, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
     ds3Testing.AssertNilError(t, err)
 
     // launch go routines to put files concurrently
@@ -135,7 +136,7 @@ func TestConcurrentSendNetworkUsage(t *testing.T) {
 
     for _, chunk := range bulkPut.MasterObjectList.Objects {
         //TODO Try get available job chunks ready for client processing instead
-        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
+        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
         ds3Testing.AssertNilError(t, allocateErr)
         for _, obj := range allocateChunk.Objects.Objects {
             go putFileWithSendNetwork(*obj.Name, obj.Offset, bulkPut.MasterObjectList.JobId, &content, testBucket, &group, t, network, &info)

--- a/ds3_integration/smoke_test.go
+++ b/ds3_integration/smoke_test.go
@@ -13,6 +13,7 @@ package ds3_integration
 
 import (
     "bytes"
+    "context"
     "fmt"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -46,7 +47,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetService(t *testing.T) {
-    response, err := client.GetService(models.NewGetServiceRequest())
+    response, err := client.GetService(context.Background(), models.NewGetServiceRequest())
     ds3Testing.AssertNilError(t, err)
     if response == nil {
         t.Fatal("Received an unexpected nil response.")
@@ -177,7 +178,7 @@ func TestDeleteBucketNonEmpty(t *testing.T) {
     ds3Testing.AssertNilError(t, putObjErr)
 
     //Attempt to delete non-empty bucket without force
-    _, deleteErr := client.DeleteBucketSpectraS3(models.NewDeleteBucketSpectraS3Request(bucketName))
+    _, deleteErr := client.DeleteBucketSpectraS3(context.Background(), models.NewDeleteBucketSpectraS3Request(bucketName))
     ds3Testing.AssertBadStatusCodeError(t, 409, deleteErr)
 }
 
@@ -194,13 +195,13 @@ func TestGetBucketNonexistent(t *testing.T) {
 }
 
 func TestHeadBucket(t *testing.T) {
-    _, err := client.HeadBucket(models.NewHeadBucketRequest(testBucket))
+    _, err := client.HeadBucket(context.Background(), models.NewHeadBucketRequest(testBucket))
     ds3Testing.AssertNilError(t, err)
 }
 
 func TestHeadBucketNonExistent(t *testing.T) {
     bucketName := "not-here"
-    _, err := client.HeadBucket(models.NewHeadBucketRequest(bucketName))
+    _, err := client.HeadBucket(context.Background(), models.NewHeadBucketRequest(bucketName))
     ds3Testing.AssertBadStatusCodeError(t, 404, err)
 }
 
@@ -218,7 +219,7 @@ func TestGetBucketPagination(t *testing.T) {
     ds3Testing.AssertNilError(t, err)
 
     //Test files indexed 0-4
-    result1, err := client.GetBucket(models.NewGetBucketRequest(testBucket).WithMaxKeys(5))
+    result1, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket).WithMaxKeys(5))
     ds3Testing.AssertNilError(t, err)
     ds3Testing.AssertInt(t, "Number of Objects", 5, len(result1.ListBucketResult.Objects))
     if result1.ListBucketResult.NextMarker == nil {
@@ -230,6 +231,7 @@ func TestGetBucketPagination(t *testing.T) {
 
     // Test files indexed 5-9
     result2, err := client.GetBucket(
+        context.Background(),
         models.NewGetBucketRequest(testBucket).
             WithMaxKeys(5).
             WithMarker(*result1.ListBucketResult.NextMarker))
@@ -245,6 +247,7 @@ func TestGetBucketPagination(t *testing.T) {
 
     // Test files indexed 10-14
     result3, err := client.GetBucket(
+        context.Background(),
         models.NewGetBucketRequest(testBucket).
             WithMaxKeys(5).
             WithMarker(*result2.ListBucketResult.NextMarker))
@@ -278,7 +281,7 @@ func TestGetBucketDelimiter(t *testing.T) {
     ds3Testing.AssertNilError(t, err)
 
     //Test files indexed 0-4
-    result, err := client.GetBucket(models.NewGetBucketRequest(testBucket).WithDelimiter("/"))
+    result, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket).WithDelimiter("/"))
     ds3Testing.AssertNilError(t, err)
     ds3Testing.AssertInt(t, "Number of Objects", 10, len(result.ListBucketResult.Objects))
     ds3Testing.AssertInt(t, "Number of Common Prefixes", 1, len(result.ListBucketResult.CommonPrefixes))
@@ -295,15 +298,15 @@ func TestBulkPut(t *testing.T) {
     ds3Testing.AssertNilError(t, objErr)
 
     // Create bulk put job
-    bulkPut, bulkPutErr := client.PutBulkJobSpectraS3(models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
+    bulkPut, bulkPutErr := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
     ds3Testing.AssertNilError(t, bulkPutErr)
 
     for _, chunk := range bulkPut.MasterObjectList.Objects {
-        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
+        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
         ds3Testing.AssertNilError(t, allocateErr)
         for _, obj := range allocateChunk.Objects.Objects {
             content := books[*obj.Name]
-            _, putObjErr := client.PutObject(models.NewPutObjectRequest(testBucket, *obj.Name, content).
+            _, putObjErr := client.PutObject(context.Background(), models.NewPutObjectRequest(testBucket, *obj.Name, content).
                 WithOffset(obj.Offset).
                 WithJob(bulkPut.MasterObjectList.JobId))
 
@@ -312,7 +315,7 @@ func TestBulkPut(t *testing.T) {
     }
 
     // Verify books are in the bucket
-    getBucket, getBucketErr := client.GetBucket(models.NewGetBucketRequest(testBucket))
+    getBucket, getBucketErr := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket))
     ds3Testing.AssertNilError(t, getBucketErr)
     if len(getBucket.ListBucketResult.Objects) != len(books) {
         t.Fatalf("Expected '%d' objects in bucket '%s', but found '%d'.", len(books), testBucket, len(getBucket.ListBucketResult.Objects))
@@ -329,21 +332,21 @@ func TestBulkGet(t *testing.T) {
     ds3Testing.AssertNilError(t, bookErr)
 
     // Create bulk get job
-    bucketContents, bucketErr := client.GetBucket(models.NewGetBucketRequest(testBucket))
+    bucketContents, bucketErr := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket))
     ds3Testing.AssertNilError(t, bucketErr)
     ds3Testing.AssertInt(t, "Number of Objects on BP", 4, len(bucketContents.ListBucketResult.Objects))
 
     objectNames := testutils.ConvertObjectsIntoObjectNameList(bucketContents.ListBucketResult.Objects)
-    bulkGet, bulkGetErr := client.GetBulkJobSpectraS3(models.NewGetBulkJobSpectraS3Request(testBucket, objectNames))
+    bulkGet, bulkGetErr := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3Request(testBucket, objectNames))
     ds3Testing.AssertNilError(t, bulkGetErr)
 
-    availableChunks, chunksErr := client.GetJobChunkSpectraS3(models.NewGetJobChunkSpectraS3Request(bulkGet.MasterObjectList.JobId))
+    availableChunks, chunksErr := client.GetJobChunkSpectraS3(context.Background(), models.NewGetJobChunkSpectraS3Request(bulkGet.MasterObjectList.JobId))
     ds3Testing.AssertNilError(t, chunksErr)
 
     // Get all objects and verify content
     for _, obj := range availableChunks.Objects.Objects {
         func() {
-            getObj, objErr := client.GetObject(models.NewGetObjectRequest(testBucket, *obj.Name))
+            getObj, objErr := client.GetObject(context.Background(), models.NewGetObjectRequest(testBucket, *obj.Name))
             ds3Testing.AssertNilError(t, objErr)
 
             defer getObj.Content.Close()
@@ -390,11 +393,11 @@ func TestSettingDefaultDataPolicy(t *testing.T) {
     getDataPolicyResponse, getErr := testutils.GetDataPolicyLogError(t, client, dataPolicyName)
     ds3Testing.AssertNilError(t, getErr)
 
-    modifyResponse, modifyErr := client.ModifyUserSpectraS3(models.NewModifyUserSpectraS3Request(user.Id).
+    modifyResponse, modifyErr := client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(user.Id).
         WithDefaultDataPolicyId(getDataPolicyResponse.DataPolicy.Id))
     ds3Testing.AssertNilError(t, modifyErr)
 
-    defer client.ModifyUserSpectraS3(models.NewModifyUserSpectraS3Request(user.Id).
+    defer client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(user.Id).
         WithDefaultDataPolicyId(*curDataPolicy))
 
     ds3Testing.AssertNonNilStringPtr(t, "Name", defaultUser, modifyResponse.SpectraUser.Name)
@@ -405,10 +408,10 @@ func TestStorageDomain(t *testing.T) {
     storageDomainName := "GoTestStorageDomain"
 
     // Create storage domain
-    putResponse, putErr := client.PutStorageDomainSpectraS3(models.NewPutStorageDomainSpectraS3Request(storageDomainName))
+    putResponse, putErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(storageDomainName))
     ds3Testing.AssertNilError(t, putErr)
 
-    defer client.DeleteStorageDomainSpectraS3(models.NewDeleteStorageDomainSpectraS3Request(storageDomainName))
+    defer client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(storageDomainName))
 
     ds3Testing.AssertNonNilStringPtr(t, "Name", storageDomainName, putResponse.StorageDomain.Name)
 }
@@ -417,10 +420,10 @@ func TestPoolPartition(t *testing.T) {
     poolPartitionName := "GoTestPoolPartition"
 
     // Create pool partition
-    putResponse, putErr := client.PutPoolPartitionSpectraS3(models.NewPutPoolPartitionSpectraS3Request(poolPartitionName, models.POOL_TYPE_ONLINE))
+    putResponse, putErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(poolPartitionName, models.POOL_TYPE_ONLINE))
     ds3Testing.AssertNilError(t, putErr)
 
-    defer client.DeletePoolPartitionSpectraS3(models.NewDeletePoolPartitionSpectraS3Request(poolPartitionName))
+    defer client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(poolPartitionName))
 
     ds3Testing.AssertNonNilStringPtr(t, "Name", poolPartitionName, putResponse.PoolPartition.Name)
     if putResponse.PoolPartition.Type != models.POOL_TYPE_ONLINE {
@@ -432,24 +435,24 @@ func TestStorageDomainMember(t *testing.T) {
     varTestName := "GoTestStorageDomainMember"
 
     // Create storage domain
-    storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(models.NewPutStorageDomainSpectraS3Request(varTestName))
+    storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(varTestName))
     ds3Testing.AssertNilError(t, storageDomainErr)
 
-    defer client.DeleteStorageDomainSpectraS3(models.NewDeleteStorageDomainSpectraS3Request(varTestName))
+    defer client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(varTestName))
 
     // Create pool partition
-    poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(models.NewPutPoolPartitionSpectraS3Request(varTestName, models.POOL_TYPE_ONLINE))
+    poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(varTestName, models.POOL_TYPE_ONLINE))
     ds3Testing.AssertNilError(t, poolPartitionErr)
 
-    defer client.DeletePoolPartitionSpectraS3(models.NewDeletePoolPartitionSpectraS3Request(varTestName))
+    defer client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(varTestName))
 
     // Create storage domain member linking pool partition to storage domain
-    response, err := client.PutPoolStorageDomainMemberSpectraS3(models.NewPutPoolStorageDomainMemberSpectraS3Request(
+    response, err := client.PutPoolStorageDomainMemberSpectraS3(context.Background(), models.NewPutPoolStorageDomainMemberSpectraS3Request(
         poolPartitionResponse.PoolPartition.Id,
         storageDomainResponse.StorageDomain.Id))
     ds3Testing.AssertNilError(t, err)
 
-    defer client.DeleteStorageDomainMemberSpectraS3(models.NewDeleteStorageDomainMemberSpectraS3Request(response.StorageDomainMember.Id))
+    defer client.DeleteStorageDomainMemberSpectraS3(context.Background(), models.NewDeleteStorageDomainMemberSpectraS3Request(response.StorageDomainMember.Id))
 
     ds3Testing.AssertNonNilStringPtr(t, "PoolPartitionId", poolPartitionResponse.PoolPartition.Id, response.StorageDomainMember.PoolPartitionId)
     ds3Testing.AssertString(t, "StorageDomainId", storageDomainResponse.StorageDomain.Id, response.StorageDomainMember.StorageDomainId)
@@ -467,34 +470,34 @@ func TestDataPersistenceRule(t *testing.T) {
     defer testutils.DeleteDataPolicyLogError(t, client, varTestName)
 
     // Create storage domain
-    storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(models.NewPutStorageDomainSpectraS3Request(varTestName))
+    storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(varTestName))
     ds3Testing.AssertNilError(t, storageDomainErr)
 
-    defer client.DeleteStorageDomainSpectraS3(models.NewDeleteStorageDomainSpectraS3Request(varTestName))
+    defer client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(varTestName))
 
     // Create pool partition
-    poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(models.NewPutPoolPartitionSpectraS3Request(varTestName, models.POOL_TYPE_ONLINE))
+    poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(varTestName, models.POOL_TYPE_ONLINE))
     ds3Testing.AssertNilError(t, poolPartitionErr)
 
-    defer client.DeletePoolPartitionSpectraS3(models.NewDeletePoolPartitionSpectraS3Request(varTestName))
+    defer client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(varTestName))
 
     // Create storage domain member linking pool partition to storage domain
-    memberResponse, memberErr := client.PutPoolStorageDomainMemberSpectraS3(models.NewPutPoolStorageDomainMemberSpectraS3Request(
+    memberResponse, memberErr := client.PutPoolStorageDomainMemberSpectraS3(context.Background(), models.NewPutPoolStorageDomainMemberSpectraS3Request(
         poolPartitionResponse.PoolPartition.Id,
         storageDomainResponse.StorageDomain.Id))
     ds3Testing.AssertNilError(t, memberErr)
 
-    defer client.DeleteStorageDomainMemberSpectraS3(models.NewDeleteStorageDomainMemberSpectraS3Request(memberResponse.StorageDomainMember.Id))
+    defer client.DeleteStorageDomainMemberSpectraS3(context.Background(), models.NewDeleteStorageDomainMemberSpectraS3Request(memberResponse.StorageDomainMember.Id))
 
     // Create data persistence rule linking data policy and storage domain
-    response, err := client.PutDataPersistenceRuleSpectraS3(models.NewPutDataPersistenceRuleSpectraS3Request(
+    response, err := client.PutDataPersistenceRuleSpectraS3(context.Background(), models.NewPutDataPersistenceRuleSpectraS3Request(
         dataPersistenceRuleType,
         putDataPolicyResponse.DataPolicy.Id,
         dataIsolationLevel,
         storageDomainResponse.StorageDomain.Id))
     ds3Testing.AssertNilError(t, err)
 
-    defer client.DeleteDataPersistenceRuleSpectraS3(models.NewDeleteDataPersistenceRuleSpectraS3Request(response.DataPersistenceRule.Id))
+    defer client.DeleteDataPersistenceRuleSpectraS3(context.Background(), models.NewDeleteDataPersistenceRuleSpectraS3Request(response.DataPersistenceRule.Id))
 
     ds3Testing.AssertString(t, "DataPolicyId", putDataPolicyResponse.DataPolicy.Id, response.DataPersistenceRule.DataPolicyId)
     ds3Testing.AssertString(t, "StorageDomainId", storageDomainResponse.StorageDomain.Id, response.DataPersistenceRule.StorageDomainId)
@@ -517,11 +520,11 @@ func TestPuttingFolder(t *testing.T) {
 
     readSizer := newNilReadSizer(nil, 0)
     putObjectRequest := models.NewPutObjectRequest(bucketName, folderPath, &readSizer)
-    _, err = client.PutObject(putObjectRequest)
+    _, err = client.PutObject(context.Background(), putObjectRequest)
     ds3Testing.AssertNilError(t, err)
 
     getBucketRequest := models.NewGetBucketRequest(bucketName)
-    getBucketResponse, err := client.GetBucket(getBucketRequest)
+    getBucketResponse, err := client.GetBucket(context.Background(), getBucketRequest)
     ds3Testing.AssertNilError(t, err)
 
     ds3Testing.AssertInt(t, "Number of objects in bucket", 1, len(getBucketResponse.ListBucketResult.Objects))
@@ -550,12 +553,12 @@ func TestPuttingZeroLengthObject(t *testing.T) {
         WithMetaData("_a", "A").
         WithMetaData("b", "B")
 
-    _, err = client.PutObject(putObjectRequest)
+    _, err = client.PutObject(context.Background(), putObjectRequest)
 
     ds3Testing.AssertNilError(t, err)
 
     getBucketRequest := models.NewGetBucketRequest(bucketName)
-    getBucketResponse, err := client.GetBucket(getBucketRequest)
+    getBucketResponse, err := client.GetBucket(context.Background(), getBucketRequest)
     ds3Testing.AssertNilError(t, err)
 
     ds3Testing.AssertInt(t, "Number of objects in bucket", 1, len(getBucketResponse.ListBucketResult.Objects))
@@ -575,7 +578,7 @@ func TestDeleteObjects(t *testing.T) {
     testutils.PutTestBooks(client, bucketName)
 
     // list all objects in the bucket
-    getBucket, err := client.GetBucket(models.NewGetBucketRequest(bucketName))
+    getBucket, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(bucketName))
 
     ds3Testing.AssertInt(t, "number of objects to delete", 4, len(getBucket.ListBucketResult.Objects))
 
@@ -585,6 +588,6 @@ func TestDeleteObjects(t *testing.T) {
     }
 
     deleteObjs := models.NewDeleteObjectsRequest(bucketName, names)
-    _, err = client.DeleteObjects(deleteObjs)
+    _, err = client.DeleteObjects(context.Background(), deleteObjs)
     ds3Testing.AssertNilError(t, err)
 }

--- a/ds3_integration/utils/testUtils.go
+++ b/ds3_integration/utils/testUtils.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+    "context"
     "testing"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
@@ -23,12 +24,13 @@ var BookTitles = []string{ "beowulf.txt", "sherlock_holmes.txt", "tale_of_two_ci
 // Retrieves the specified objects from the BP bucket and compares the content to
 // to local files. Assumes that local file names and BP object names are the same.
 func VerifyFilesOnBP(t *testing.T, bucketName string, objectNames []string, filePath string, client *ds3.Client) {
-    bulkGet, err := client.GetBulkJobSpectraS3(models.NewGetBulkJobSpectraS3Request(bucketName, objectNames))
+    bulkGet, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3Request(bucketName, objectNames))
     ds3Testing.AssertNilError(t, err)
     totalChunkCount := len(bulkGet.MasterObjectList.Objects)
     curChunkCount := 0
     for curChunkCount < totalChunkCount {
         chunksReady, err := client.GetJobChunksReadyForClientProcessingSpectraS3(
+            context.Background(),
             models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(bulkGet.MasterObjectList.JobId))
 
         ds3Testing.AssertNilError(t, err)
@@ -38,7 +40,7 @@ func VerifyFilesOnBP(t *testing.T, bucketName string, objectNames []string, file
             for _, curChunk := range chunksReady.MasterObjectList.Objects {
                 for _, curObj := range curChunk.Objects {
 
-                    getObj, _ := client.GetObject(models.NewGetObjectRequest(bucketName, *curObj.Name).
+                    getObj, _ := client.GetObject(context.Background(), models.NewGetObjectRequest(bucketName, *curObj.Name).
                         WithJob(bulkGet.MasterObjectList.JobId).
                         WithOffset(curObj.Offset))
                     ds3Testing.AssertNilError(t, err)
@@ -137,19 +139,19 @@ func PutTestBooks(client *ds3.Client, bucketName string) error {
     }
 
     // Create bulk put job
-    bulkPut, bulkPutErr := client.PutBulkJobSpectraS3(models.NewPutBulkJobSpectraS3Request(bucketName, ds3Objects))
+    bulkPut, bulkPutErr := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(bucketName, ds3Objects))
     if bulkPutErr != nil {
         return bulkPutErr
     }
 
     for _, chunk := range bulkPut.MasterObjectList.Objects {
-        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
+        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
         if allocateErr != nil {
             return allocateErr
         }
         for _, obj := range allocateChunk.Objects.Objects {
             content := books[*obj.Name]
-            _, putObjErr := client.PutObject(models.NewPutObjectRequest(bucketName, *obj.Name, content).
+            _, putObjErr := client.PutObject(context.Background(), models.NewPutObjectRequest(bucketName, *obj.Name, content).
                 WithOffset(obj.Offset).
                 WithJob(bulkPut.MasterObjectList.JobId))
 
@@ -163,13 +165,13 @@ func PutTestBooks(client *ds3.Client, bucketName string) error {
 
 func CancelAllJobsForBucket(client *ds3.Client, bucketName string) {
     //Cancel all jobs on bucket
-    getJobs, err := client.GetJobsSpectraS3(models.NewGetJobsSpectraS3Request())
+    getJobs, err := client.GetJobsSpectraS3(context.Background(), models.NewGetJobsSpectraS3Request())
     if err != nil {
         log.Printf("WARNING: Cleanup error when attempting to get all jobs for bucket '%s': '%s.", bucketName, err.Error())
         return
     }
     for _, job := range getJobs.JobList.Jobs {
-        if _, err = client.CancelJobSpectraS3(models.NewCancelJobSpectraS3Request(job.JobId)); err != nil {
+        if _, err = client.CancelJobSpectraS3(context.Background(), models.NewCancelJobSpectraS3Request(job.JobId)); err != nil {
             log.Printf("WARNING: Unable to cancel job: %s", job.JobId)
         }
     }
@@ -179,7 +181,7 @@ func DeleteBucketContents(client *ds3.Client, bucketName string) {
     CancelAllJobsForBucket(client, bucketName)
 
     //Get the contents of bucket
-    getBucket, err := client.GetBucket(models.NewGetBucketRequest(bucketName))
+    getBucket, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(bucketName))
     if err != nil {
         log.Printf("WARNING: Cleanup error when attempting to get contents of bucket '%s': '%s'.", bucketName, err.Error())
         return
@@ -266,7 +268,7 @@ func PutObjectWithJobId(client *ds3.Client, bucketName string, objectName string
     if jobId != "" {
         putObjRequest = putObjRequest.WithJob(jobId)
     }
-    putObjectResponse, putErr := client.PutObject(putObjRequest)
+    putObjectResponse, putErr := client.PutObject(context.Background(), putObjRequest)
     if putErr != nil {
         return putErr
     }
@@ -277,19 +279,19 @@ func PutObjectWithJobId(client *ds3.Client, bucketName string, objectName string
 }
 
 func PutEmptyObjects(client *ds3.Client, bucketName string, objects []models.Ds3PutObject) (error) {
-    putBulk, err := client.PutBulkJobSpectraS3(models.NewPutBulkJobSpectraS3Request(bucketName, objects))
+    putBulk, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(bucketName, objects))
     if err != nil {
         return err
     }
     for _, chunk := range putBulk.MasterObjectList.Objects {
-        allocateChunk, err := client.AllocateJobChunkSpectraS3(models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
+        allocateChunk, err := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
         if err != nil {
-            client.CancelJobSpectraS3(models.NewCancelJobSpectraS3Request(putBulk.MasterObjectList.JobId))
+            client.CancelJobSpectraS3(context.Background(), models.NewCancelJobSpectraS3Request(putBulk.MasterObjectList.JobId))
             return err
         }
         for _, obj := range allocateChunk.Objects.Objects {
             if err = PutObjectWithJobId(client, bucketName, *obj.Name, putBulk.MasterObjectList.JobId, []byte{}); err != nil {
-                client.CancelJobSpectraS3(models.NewCancelJobSpectraS3Request(putBulk.MasterObjectList.JobId))
+                client.CancelJobSpectraS3(context.Background(), models.NewCancelJobSpectraS3Request(putBulk.MasterObjectList.JobId))
                 return err
             }
         }
@@ -309,7 +311,7 @@ func DeleteObjectLogError(t *testing.T, client *ds3.Client, bucketName string, o
 
 // Deletes the specified object. Returns an error if not successful.
 func DeleteObject(client *ds3.Client, bucketName string, objectName string) (error) {
-    deleteObjectResponse, deleteErr := client.DeleteObject(models.NewDeleteObjectRequest(bucketName, objectName))
+    deleteObjectResponse, deleteErr := client.DeleteObject(context.Background(), models.NewDeleteObjectRequest(bucketName, objectName))
     if deleteErr != nil {
         return deleteErr
     }
@@ -332,7 +334,7 @@ func GetObjectLogError(t *testing.T, client *ds3.Client, bucketName string, obje
 
 // Retrieves the specified object. Returns an error if not successful.
 func GetObject(client *ds3.Client, bucketName string, objectName string) (*models.GetObjectResponse, error) {
-    response, err := client.GetObject(models.NewGetObjectRequest(bucketName, objectName))
+    response, err := client.GetObject(context.Background(), models.NewGetObjectRequest(bucketName, objectName))
     if err != nil {
         return nil, err
     } else if response == nil {
@@ -353,7 +355,7 @@ func PutBucketLogError(t *testing.T, client *ds3.Client, bucketName string) (err
 
 // Puts the specified bucket. Returns an error if not successful.
 func PutBucket(client *ds3.Client, bucketName string) (error) {
-    putBucketResponse, putErr := client.PutBucket(models.NewPutBucketRequest(bucketName))
+    putBucketResponse, putErr := client.PutBucket(context.Background(), models.NewPutBucketRequest(bucketName))
     if putErr != nil {
         return putErr
     }
@@ -375,7 +377,7 @@ func DeleteBucketLogError(t *testing.T, client *ds3.Client, bucketName string) (
 
 // Deletes the specified bucket and returns an error if one occurs
 func DeleteBucket(client *ds3.Client, bucketName string) (error) {
-    deleteBucket, deleteErr := client.DeleteBucketSpectraS3(models.NewDeleteBucketSpectraS3Request(bucketName).WithForce())
+    deleteBucket, deleteErr := client.DeleteBucketSpectraS3(context.Background(), models.NewDeleteBucketSpectraS3Request(bucketName).WithForce())
     if deleteErr != nil {
         return deleteErr
     }
@@ -398,7 +400,7 @@ func GetBucketLogError(t *testing.T, client *ds3.Client, bucketName string) (*mo
 
 // Retrieves the specified bucket. Returns an error if unsuccessful.
 func GetBucket(client *ds3.Client, bucketName string) (*models.GetBucketResponse, error) {
-    response, err := client.GetBucket(models.NewGetBucketRequest(bucketName))
+    response, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(bucketName))
     if err != nil {
         return nil, err
     } else if response == nil {
@@ -410,7 +412,7 @@ func GetBucket(client *ds3.Client, bucketName string) (*models.GetBucketResponse
 // Deletes the specified data policy. If an error occurs, it is logged, and the calling
 // test is marked as failed, but continues running.
 func DeleteDataPolicyLogError(t *testing.T, client *ds3.Client, dataPolicyId string) (error) {
-    _, deleteErr := client.DeleteDataPolicySpectraS3(models.NewDeleteDataPolicySpectraS3Request(dataPolicyId))
+    _, deleteErr := client.DeleteDataPolicySpectraS3(context.Background(), models.NewDeleteDataPolicySpectraS3Request(dataPolicyId))
     if deleteErr != nil {
         t.Errorf("Unable to delete Data Policy '%s': '%s'.", dataPolicyId, deleteErr.Error())
     }
@@ -420,7 +422,7 @@ func DeleteDataPolicyLogError(t *testing.T, client *ds3.Client, dataPolicyId str
 // Creates the specified data policy. If an error occurs, it is logged, and the calling
 // test is marked as failed, but continues running.
 func PutDataPolicyLogError(t *testing.T, client *ds3.Client, dataPolicyName string) (*models.PutDataPolicySpectraS3Response, error) {
-    response, err := client.PutDataPolicySpectraS3(models.NewPutDataPolicySpectraS3Request(dataPolicyName))
+    response, err := client.PutDataPolicySpectraS3(context.Background(), models.NewPutDataPolicySpectraS3Request(dataPolicyName))
     if err != nil {
         t.Errorf("Unable to create Data Policy '%s': '%s'.", dataPolicyName, err.Error())
     }
@@ -430,7 +432,7 @@ func PutDataPolicyLogError(t *testing.T, client *ds3.Client, dataPolicyName stri
 // Retrieves the specified data policy. If an error occurs, it is logged, and the calling
 // test is marked as failed, but continues running
 func GetDataPolicyLogError(t *testing.T, client *ds3.Client, dataPolicyId string) (*models.GetDataPolicySpectraS3Response, error) {
-    response, err := client.GetDataPolicySpectraS3(models.NewGetDataPolicySpectraS3Request(dataPolicyId))
+    response, err := client.GetDataPolicySpectraS3(context.Background(), models.NewGetDataPolicySpectraS3Request(dataPolicyId))
     if err != nil {
         t.Errorf("Unable to get Data Policy '%s': '%s'.", dataPolicyId, err.Error())
     }
@@ -441,7 +443,7 @@ func GetDataPolicyLogError(t *testing.T, client *ds3.Client, dataPolicyId string
 // If there is not exactly 1 user with the specified name, it is treated as an error. If an
 // error occurs, it is logged, and the calling  test is marked as failed, but continues running.
 func GetUserByNameLogError(t *testing.T, client *ds3.Client, userName string) (*models.SpectraUser, error) {
-    response, err := client.GetUsersSpectraS3(models.NewGetUsersSpectraS3Request().WithName(userName))
+    response, err := client.GetUsersSpectraS3(context.Background(), models.NewGetUsersSpectraS3Request().WithName(userName))
     if err != nil {
         t.Errorf("Unable to get user '%s': '%s'.", userName, err.Error())
         return nil, err
@@ -486,14 +488,14 @@ func SetupTestEnv(testBucket string, userName string, envTestNameSpace string) (
     }
 
     // Create data policy
-    dataPolicyResponse, dataPolicyErr := client.PutDataPolicySpectraS3(models.NewPutDataPolicySpectraS3Request(envTestNameSpace))
+    dataPolicyResponse, dataPolicyErr := client.PutDataPolicySpectraS3(context.Background(), models.NewPutDataPolicySpectraS3Request(envTestNameSpace))
     if dataPolicyErr != nil {
         return nil, &ids, dataPolicyErr
     }
     ids.DataPolicyId = &dataPolicyResponse.DataPolicy.Id
 
     // Modify default user to use new data policy
-    modifyResponse, modifyErr := client.ModifyUserSpectraS3(models.NewModifyUserSpectraS3Request(userName).
+    modifyResponse, modifyErr := client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(userName).
         WithDefaultDataPolicyId(dataPolicyResponse.DataPolicy.Id))
     if modifyErr != nil {
         return nil, &ids, modifyErr
@@ -502,7 +504,7 @@ func SetupTestEnv(testBucket string, userName string, envTestNameSpace string) (
     ids.UserId = &modifyResponse.SpectraUser.Id
 
     // Create pool partition
-    poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(models.NewPutPoolPartitionSpectraS3Request(
+    poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(
         envTestNameSpace,
         models.POOL_TYPE_ONLINE))
     if poolPartitionErr != nil {
@@ -511,14 +513,14 @@ func SetupTestEnv(testBucket string, userName string, envTestNameSpace string) (
     ids.PoolPartitionId = &poolPartitionResponse.PoolPartition.Id
 
     // Create storage domain
-    storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(models.NewPutStorageDomainSpectraS3Request(envTestNameSpace))
+    storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(envTestNameSpace))
     if storageDomainErr != nil {
         return nil, &ids, storageDomainErr
     }
     ids.StorageDomainId = &storageDomainResponse.StorageDomain.Id
 
     // Create storage domain member linking pool partition to storage domain
-    memberResponse, memberErr := client.PutPoolStorageDomainMemberSpectraS3(models.NewPutPoolStorageDomainMemberSpectraS3Request(
+    memberResponse, memberErr := client.PutPoolStorageDomainMemberSpectraS3(context.Background(), models.NewPutPoolStorageDomainMemberSpectraS3Request(
         poolPartitionResponse.PoolPartition.Id,
         storageDomainResponse.StorageDomain.Id))
     if memberErr != nil {
@@ -527,7 +529,7 @@ func SetupTestEnv(testBucket string, userName string, envTestNameSpace string) (
     ids.StorageDomainMemberId = &memberResponse.StorageDomainMember.Id
 
     // Create data persistence rule
-    ruleResponse, ruleErr := client.PutDataPersistenceRuleSpectraS3(models.NewPutDataPersistenceRuleSpectraS3Request(
+    ruleResponse, ruleErr := client.PutDataPersistenceRuleSpectraS3(context.Background(), models.NewPutDataPersistenceRuleSpectraS3Request(
         models.DATA_PERSISTENCE_RULE_TYPE_PERMANENT,
         dataPolicyResponse.DataPolicy.Id,
         models.DATA_ISOLATION_LEVEL_STANDARD,
@@ -565,38 +567,38 @@ func TeardownTestEnv(client *ds3.Client, ids *TestIds, testBucket string) {
 
     // Delete data persistence rule
     if ids.DataPersistenceRuleId != nil {
-        _, err := client.DeleteDataPersistenceRuleSpectraS3(models.NewDeleteDataPersistenceRuleSpectraS3Request(*ids.DataPersistenceRuleId))
+        _, err := client.DeleteDataPersistenceRuleSpectraS3(context.Background(), models.NewDeleteDataPersistenceRuleSpectraS3Request(*ids.DataPersistenceRuleId))
         logErrViaPrint(err)
     }
 
     // Delete storage domain member
     if ids.StorageDomainMemberId != nil {
-        _, err := client.DeleteStorageDomainMemberSpectraS3(models.NewDeleteStorageDomainMemberSpectraS3Request(*ids.StorageDomainMemberId))
+        _, err := client.DeleteStorageDomainMemberSpectraS3(context.Background(), models.NewDeleteStorageDomainMemberSpectraS3Request(*ids.StorageDomainMemberId))
         logErrViaPrint(err)
     }
 
     // Delete storage domain
     if ids.StorageDomainId != nil {
-        _, err := client.DeleteStorageDomainSpectraS3(models.NewDeleteStorageDomainSpectraS3Request(*ids.StorageDomainId))
+        _, err := client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(*ids.StorageDomainId))
         logErrViaPrint(err)
     }
 
     // Delete pool partition
     if ids.PoolPartitionId != nil {
-        _, err := client.DeletePoolPartitionSpectraS3(models.NewDeletePoolPartitionSpectraS3Request(*ids.PoolPartitionId))
+        _, err := client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(*ids.PoolPartitionId))
         logErrViaPrint(err)
     }
 
     // Modify user to use its original data policy
     if ids.OriginalDataPolicyId != nil {
-        _, err := client.ModifyUserSpectraS3(models.NewModifyUserSpectraS3Request(*ids.UserId).
+        _, err := client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(*ids.UserId).
             WithDefaultDataPolicyId(*ids.OriginalDataPolicyId))
         logErrViaPrint(err)
     }
 
     // Delete data policy
     if ids.DataPolicyId != nil {
-        _, err := client.DeleteDataPolicySpectraS3(models.NewDeleteDataPolicySpectraS3Request(*ids.DataPolicyId))
+        _, err := client.DeleteDataPolicySpectraS3(context.Background(), models.NewDeleteDataPolicySpectraS3Request(*ids.DataPolicyId))
         logErrViaPrint(err)
     }
 }

--- a/ds3_utils/ds3Testing/assertUtil.go
+++ b/ds3_utils/ds3Testing/assertUtil.go
@@ -70,7 +70,7 @@ func AssertNonNilInt64Ptr(t *testing.T, label string, expected int64, actual *in
 }
 
 // Asserts if a specified int64 is nil. If not, Fatal.
-func AssertInt64PtrIsNil(t *testing.T, label int64, actual *int64) {
+func AssertInt64PtrIsNil(t *testing.T, label string, actual *int64) {
     if actual != nil {
         t.Fatalf("Expected %s to be 'nil' but was '%d'.", label, *actual)
     }

--- a/helpers/getProducer.go
+++ b/helpers/getProducer.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+    "context"
     "fmt"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -120,7 +121,7 @@ func (producer *getProducer) transferOperationBuilder(info getObjectInfo) Transf
             getObjRequest = getObjRequest.WithRanges(blobRanges...)
         }
 
-        getObjResponse, err := producer.client.GetObject(getObjRequest)
+        getObjResponse, err := producer.client.GetObject(context.Background(), getObjRequest)
         if err != nil {
             producer.strategy.Listeners.Errored(info.blob.Name(), err)
             info.channelBuilder.SetFatalError(err)
@@ -205,7 +206,7 @@ func RetryGettingBlobRange(client *ds3.Client, bucketName string, objectName str
         WithOffset(blobOffset).
         WithRanges(partOfBlobToFetch)
 
-    getObjResponse, err := client.GetObject(getObjRequest)
+    getObjResponse, err := client.GetObject(context.Background(), getObjRequest)
     if err != nil {
         return 0, err
     }
@@ -369,7 +370,7 @@ func (producer *getProducer) queueBlobsReadyForTransfer(totalBlobCount int64) (i
     // not be able to receive everything, so not all chunks will necessarily be
     // returned
     chunksReady := ds3Models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(producer.JobMasterObjectList.JobId)
-    chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(chunksReady)
+    chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), chunksReady)
     if err != nil {
         producer.Errorf("unrecoverable error: %v", err)
         return processedCount, err

--- a/helpers/getProducer.go
+++ b/helpers/getProducer.go
@@ -16,6 +16,7 @@ import (
 const timesToRetryGettingPartialBlob = 5
 
 type getProducer struct {
+    ctx                  context.Context
     JobMasterObjectList  *ds3Models.MasterObjectList //MOL from put bulk job creation
     queue                *chan TransferOperation
     strategy             *ReadTransferStrategy
@@ -32,6 +33,7 @@ type getProducer struct {
 }
 
 func newGetProducer(
+    ctx context.Context,
     jobMasterObjectList *ds3Models.MasterObjectList,
     getObjects *[]helperModels.GetObject,
     queue *chan TransferOperation,
@@ -41,6 +43,7 @@ func newGetProducer(
     doneNotifier NotifyBlobDone) *getProducer {
 
     return &getProducer{
+        ctx:                  ctx,
         JobMasterObjectList:  jobMasterObjectList,
         queue:                queue,
         strategy:             strategy,
@@ -121,7 +124,7 @@ func (producer *getProducer) transferOperationBuilder(info getObjectInfo) Transf
             getObjRequest = getObjRequest.WithRanges(blobRanges...)
         }
 
-        getObjResponse, err := producer.client.GetObject(context.Background(), getObjRequest)
+        getObjResponse, err := producer.client.GetObject(producer.ctx, getObjRequest)
         if err != nil {
             producer.strategy.Listeners.Errored(info.blob.Name(), err)
             info.channelBuilder.SetFatalError(err)
@@ -153,7 +156,7 @@ func (producer *getProducer) transferOperationBuilder(info getObjectInfo) Transf
             }
             if bytesWritten != info.blob.Length() {
                 producer.Errorf("failed to copy all content of object '%s' at offset '%d': only wrote %d of %d bytes", info.blob.Name(), info.blob.Offset(), bytesWritten, info.blob.Length())
-                err := GetRemainingBlob(producer.client, info.bucketName, info.blob, bytesWritten, writer, producer.Logger)
+                err := GetRemainingBlob(producer.ctx, producer.client, info.bucketName, info.blob, bytesWritten, writer, producer.Logger)
                 if err != nil {
                     producer.strategy.Listeners.Errored(info.blob.Name(), err)
                     info.channelBuilder.SetFatalError(err)
@@ -175,14 +178,14 @@ func (producer *getProducer) transferOperationBuilder(info getObjectInfo) Transf
     }
 }
 
-func GetRemainingBlob(client *ds3.Client, bucketName string, blob *helperModels.BlobDescription, amountAlreadyRetrieved int64, writer io.Writer, logger sdk_log.Logger) error {
+func GetRemainingBlob(ctx context.Context, client *ds3.Client, bucketName string, blob *helperModels.BlobDescription, amountAlreadyRetrieved int64, writer io.Writer, logger sdk_log.Logger) error {
     logger.Debugf("starting retry for fetching partial blob '%s' at offset '%d': amount to retrieve %d", blob.Name(), blob.Offset(), blob.Length() - amountAlreadyRetrieved)
     bytesRetrievedSoFar := amountAlreadyRetrieved
     timesRetried := 0
     rangeEnd := blob.Offset() + blob.Length() -1
     for bytesRetrievedSoFar < blob.Length() && timesRetried < timesToRetryGettingPartialBlob {
         rangeStart := blob.Offset() + bytesRetrievedSoFar
-        bytesRetrievedThisRound, err := RetryGettingBlobRange(client, bucketName, blob.Name(), blob.Offset(), rangeStart, rangeEnd, writer, logger)
+        bytesRetrievedThisRound, err := RetryGettingBlobRange(ctx, client, bucketName, blob.Name(), blob.Offset(), rangeStart, rangeEnd, writer, logger)
         if err != nil {
             logger.Errorf("failed to get object '%s' at offset '%d', range %d=%d attempt %d: %s", blob.Name(), blob.Offset(), rangeStart, rangeEnd, timesRetried, err.Error())
         }
@@ -196,7 +199,7 @@ func GetRemainingBlob(client *ds3.Client, bucketName string, blob *helperModels.
     return nil
 }
 
-func RetryGettingBlobRange(client *ds3.Client, bucketName string, objectName string, blobOffset int64, rangeStart int64, rangeEnd int64, writer io.Writer, logger sdk_log.Logger) (int64, error) {
+func RetryGettingBlobRange(ctx context.Context, client *ds3.Client, bucketName string, objectName string, blobOffset int64, rangeStart int64, rangeEnd int64, writer io.Writer, logger sdk_log.Logger) (int64, error) {
     // perform a naked get call for the rest of the blob that we originally failed to get
     partOfBlobToFetch := ds3Models.Range{
         Start: rangeStart,
@@ -206,7 +209,7 @@ func RetryGettingBlobRange(client *ds3.Client, bucketName string, objectName str
         WithOffset(blobOffset).
         WithRanges(partOfBlobToFetch)
 
-    getObjResponse, err := client.GetObject(context.Background(), getObjRequest)
+    getObjResponse, err := client.GetObject(ctx, getObjRequest)
     if err != nil {
         return 0, err
     }
@@ -342,7 +345,11 @@ func (producer *getProducer) run() error {
             producer.doneNotifier.Wait()
         } else if producer.hasMoreToProcess(totalBlobCount) {
             // nothing could be processed, cache is probably full, wait a bit before trying again
-            time.Sleep(producer.strategy.BlobStrategy.delay())
+            select {
+            case <-producer.ctx.Done():
+                return producer.ctx.Err()
+            case <-time.After(producer.strategy.BlobStrategy.delay()):
+            }
         }
     }
     return nil
@@ -370,7 +377,7 @@ func (producer *getProducer) queueBlobsReadyForTransfer(totalBlobCount int64) (i
     // not be able to receive everything, so not all chunks will necessarily be
     // returned
     chunksReady := ds3Models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(producer.JobMasterObjectList.JobId)
-    chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), chunksReady)
+    chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(producer.ctx, chunksReady)
     if err != nil {
         producer.Errorf("unrecoverable error: %v", err)
         return processedCount, err

--- a/helpers/getTransfernator.go
+++ b/helpers/getTransfernator.go
@@ -11,18 +11,18 @@ import (
 )
 
 type getTransceiver struct {
-    BucketName string
+    BucketName  string
     ReadObjects *[]helperModels.GetObject
-    Strategy *ReadTransferStrategy
-    Client *ds3.Client
+    Strategy    *ReadTransferStrategy
+    Client      *ds3.Client
 }
 
 func newGetTransceiver(bucketName string, readObjects *[]helperModels.GetObject, strategy *ReadTransferStrategy, client *ds3.Client) *getTransceiver {
     return &getTransceiver{
-        BucketName:bucketName,
-        ReadObjects:readObjects,
-        Strategy:strategy,
-        Client:client,
+        BucketName:  bucketName,
+        ReadObjects: readObjects,
+        Strategy:    strategy,
+        Client:      client,
     }
 }
 
@@ -69,10 +69,10 @@ func createPartialGetObjects(getObject helperModels.GetObject) []ds3Models.Ds3Ge
     return partialObjects
 }
 
-func (transceiver *getTransceiver) createBulkGetJob() (*ds3Models.GetBulkJobSpectraS3Response, *[]helperModels.GetObject, error) {
+func (transceiver *getTransceiver) createBulkGetJob(ctx context.Context) (*ds3Models.GetBulkJobSpectraS3Response, *[]helperModels.GetObject, error) {
     // attempt to create a bulk get of all objects
     bulkGet := newBulkGetRequest(transceiver.BucketName, transceiver.ReadObjects, transceiver.Strategy.Options)
-    bulkGetResponse, err := transceiver.Client.GetBulkJobSpectraS3(context.Background(), bulkGet)
+    bulkGetResponse, err := transceiver.Client.GetBulkJobSpectraS3(ctx, bulkGet)
     if err == nil {
         return bulkGetResponse, transceiver.ReadObjects, nil
     }
@@ -86,7 +86,7 @@ func (transceiver *getTransceiver) createBulkGetJob() (*ds3Models.GetBulkJobSpec
     // head each item and try again for all objects that exist in the bucket
     var objectsThatExist []helperModels.GetObject
     for _, obj := range *transceiver.ReadObjects {
-        _, err := transceiver.Client.HeadObject(context.Background(), ds3Models.NewHeadObjectRequest(transceiver.BucketName, obj.Name))
+        _, err := transceiver.Client.HeadObject(ctx, ds3Models.NewHeadObjectRequest(transceiver.BucketName, obj.Name))
         if err != nil {
             // mark file as having a fatal error
             readableErr := fmt.Errorf("failed HeadObject call on %s: %v", obj.Name, err)
@@ -102,7 +102,7 @@ func (transceiver *getTransceiver) createBulkGetJob() (*ds3Models.GetBulkJobSpec
 
     // create bulk get job for all objects that exist in the bucket
     bulkGet = newBulkGetRequest(transceiver.BucketName, &objectsThatExist, transceiver.Strategy.Options)
-    bulkGetResponse, err = transceiver.Client.GetBulkJobSpectraS3(context.Background(), bulkGet)
+    bulkGetResponse, err = transceiver.Client.GetBulkJobSpectraS3(ctx, bulkGet)
     if err != nil {
         return nil, nil, err
     } else {
@@ -110,9 +110,9 @@ func (transceiver *getTransceiver) createBulkGetJob() (*ds3Models.GetBulkJobSpec
     }
 }
 
-func (transceiver *getTransceiver) transfer() (string, error) {
+func (transceiver *getTransceiver) transfer(ctx context.Context) (string, error) {
     // create bulk get job
-    bulkGetResponse, objectsToRetrieve, err := transceiver.createBulkGetJob()
+    bulkGetResponse, objectsToRetrieve, err := transceiver.createBulkGetJob(ctx)
     if err != nil {
         return "", err
     }
@@ -123,7 +123,7 @@ func (transceiver *getTransceiver) transfer() (string, error) {
     doneNotifier := NewConditionalBool()
 
     queue := newOperationQueue(transceiver.Strategy.BlobStrategy.maxWaitingTransfers(), transceiver.Client.Logger)
-    producer := newGetProducer(&bulkGetResponse.MasterObjectList, objectsToRetrieve, &queue, transceiver.Strategy, transceiver.Client, &waitGroup, doneNotifier)
+    producer := newGetProducer(ctx, &bulkGetResponse.MasterObjectList, objectsToRetrieve, &queue, transceiver.Strategy, transceiver.Client, &waitGroup, doneNotifier)
     consumer := newConsumer(&queue, &waitGroup, transceiver.Strategy.BlobStrategy.maxConcurrentTransfers(), doneNotifier)
 
     // Wait for completion of producer-consumer goroutines

--- a/helpers/getTransfernator.go
+++ b/helpers/getTransfernator.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+    "context"
     "fmt"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -71,7 +72,7 @@ func createPartialGetObjects(getObject helperModels.GetObject) []ds3Models.Ds3Ge
 func (transceiver *getTransceiver) createBulkGetJob() (*ds3Models.GetBulkJobSpectraS3Response, *[]helperModels.GetObject, error) {
     // attempt to create a bulk get of all objects
     bulkGet := newBulkGetRequest(transceiver.BucketName, transceiver.ReadObjects, transceiver.Strategy.Options)
-    bulkGetResponse, err := transceiver.Client.GetBulkJobSpectraS3(bulkGet)
+    bulkGetResponse, err := transceiver.Client.GetBulkJobSpectraS3(context.Background(), bulkGet)
     if err == nil {
         return bulkGetResponse, transceiver.ReadObjects, nil
     }
@@ -85,7 +86,7 @@ func (transceiver *getTransceiver) createBulkGetJob() (*ds3Models.GetBulkJobSpec
     // head each item and try again for all objects that exist in the bucket
     var objectsThatExist []helperModels.GetObject
     for _, obj := range *transceiver.ReadObjects {
-        _, err := transceiver.Client.HeadObject(ds3Models.NewHeadObjectRequest(transceiver.BucketName, obj.Name))
+        _, err := transceiver.Client.HeadObject(context.Background(), ds3Models.NewHeadObjectRequest(transceiver.BucketName, obj.Name))
         if err != nil {
             // mark file as having a fatal error
             readableErr := fmt.Errorf("failed HeadObject call on %s: %v", obj.Name, err)
@@ -101,7 +102,7 @@ func (transceiver *getTransceiver) createBulkGetJob() (*ds3Models.GetBulkJobSpec
 
     // create bulk get job for all objects that exist in the bucket
     bulkGet = newBulkGetRequest(transceiver.BucketName, &objectsThatExist, transceiver.Strategy.Options)
-    bulkGetResponse, err = transceiver.Client.GetBulkJobSpectraS3(bulkGet)
+    bulkGetResponse, err = transceiver.Client.GetBulkJobSpectraS3(context.Background(), bulkGet)
     if err != nil {
         return nil, nil, err
     } else {

--- a/helpers/helpersImpl.go
+++ b/helpers/helpersImpl.go
@@ -19,20 +19,22 @@ type HelperInterface interface {
     // Puts the specified list of objects on the Black Pearl in the specified bucket.
     // Returns the Black Pearl bulk put Job ID and any errors that may have occurred.
     // A job ID will be returned if a BP job was successfully created, regardless of
-    // whether additional errors occur.
-    PutObjects(bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (string, error)
+    // whether additional errors occur. Cancelling ctx aborts in-flight requests and
+    // stops the producer between attempts.
+    PutObjects(ctx context.Context, bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (string, error)
 
     // Retrieves the list of objects from the specified bucket on the Black Pearl.
     // Returns the Black Pearl bulk get Job ID and any errors that may have occurred.
     // A job ID will be returned if a BP job was successfully created, regardless of
-    // whether additional errors occur.
-    GetObjects(bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (string, error)
+    // whether additional errors occur. Cancelling ctx aborts in-flight requests and
+    // stops the producer between attempts.
+    GetObjects(ctx context.Context, bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (string, error)
 
     // Retrieves the list of objects from the specified bucket on the Black Pearl.
     // If a get job cannot be created due to insufficient cache space to fulfill an
     // IN_ORDER processing guarantee, then the job is split across multiple BP jobs.
     // This allows for the IN_ORDER retrieval of objects that exceed available cache space.
-    GetObjectsSpanningJobs(bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) ([]string, error)
+    GetObjectsSpanningJobs(ctx context.Context, bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) ([]string, error)
 }
 
 type HelperImpl struct {
@@ -53,19 +55,19 @@ func (helper *HelperImpl) ListObjectsFromDirectory(directoryName string) []helpe
 }
 */
 
-func (helper *HelperImpl) PutObjects(bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (string, error) {
+func (helper *HelperImpl) PutObjects(ctx context.Context, bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (string, error) {
     transceiver := newPutTransceiver(bucketName, &objects, &strategy, helper.client)
-    return transceiver.transfer()
+    return transceiver.transfer(ctx)
 }
 
-func (helper *HelperImpl) GetObjects(bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (string, error) {
+func (helper *HelperImpl) GetObjects(ctx context.Context, bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (string, error) {
     transceiver := newGetTransceiver(bucketName, &objects, &strategy, helper.client)
-    return transceiver.transfer()
+    return transceiver.transfer(ctx)
 }
 
-func (helper *HelperImpl) GetObjectsSpanningJobs(bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) ([]string, error) {
+func (helper *HelperImpl) GetObjectsSpanningJobs(ctx context.Context, bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) ([]string, error) {
     // Attempt to send the entire job at once
-    jobId, err := helper.GetObjects(bucketName, objects, strategy)
+    jobId, err := helper.GetObjects(ctx, bucketName, objects, strategy)
     if err == nil {
         // success
         return []string{jobId}, nil
@@ -77,7 +79,7 @@ func (helper *HelperImpl) GetObjectsSpanningJobs(bucketName string, objects []he
     // Retrieve each file individually
     var jobIds []string
     for _, getObject := range objects {
-        fileJobIds := helper.retrieveIndividualFile(bucketName, getObject, strategy)
+        fileJobIds := helper.retrieveIndividualFile(ctx, bucketName, getObject, strategy)
         jobIds = append(jobIds, fileJobIds...)
     }
     return jobIds, nil
@@ -96,9 +98,9 @@ func (helper *HelperImpl) isCannotPreAllocateError(err error) bool {
     return false
 }
 
-func (helper *HelperImpl) retrieveIndividualFile(bucketName string, getObject helperModels.GetObject, strategy ReadTransferStrategy) []string {
+func (helper *HelperImpl) retrieveIndividualFile(ctx context.Context, bucketName string, getObject helperModels.GetObject, strategy ReadTransferStrategy) []string {
     // Get the blob offsets
-    headObject, err := helper.client.HeadObject(context.Background(), models.NewHeadObjectRequest(bucketName, getObject.Name))
+    headObject, err := helper.client.HeadObject(ctx, models.NewHeadObjectRequest(bucketName, getObject.Name))
     if err != nil {
         getObject.ChannelBuilder.SetFatalError(err)
         return nil
@@ -114,7 +116,7 @@ func (helper *HelperImpl) retrieveIndividualFile(bucketName string, getObject he
 
     // Get the object size
     objectsDetails, err := helper.client.GetObjectsWithFullDetailsSpectraS3(
-        context.Background(),
+        ctx,
         models.NewGetObjectsWithFullDetailsSpectraS3Request().
             WithBucketId(bucketName).WithName(getObject.Name).
             WithLatest(true))
@@ -152,7 +154,7 @@ func (helper *HelperImpl) retrieveIndividualFile(bucketName string, getObject he
             continue
         }
 
-        jobId, err := helper.retrieveBlob(bucketName, getObject, blobRanges, strategy)
+        jobId, err := helper.retrieveBlob(ctx, bucketName, getObject, blobRanges, strategy)
         if err != nil {
             getObject.ChannelBuilder.SetFatalError(err)
             return nil
@@ -167,7 +169,7 @@ func (helper *HelperImpl) retrieveIndividualFile(bucketName string, getObject he
     return jobIds
 }
 
-func (helper *HelperImpl) retrieveBlob(bucketName string, getObject helperModels.GetObject, blobRanges []models.Range, strategy ReadTransferStrategy) (string, error) {
+func (helper *HelperImpl) retrieveBlob(ctx context.Context, bucketName string, getObject helperModels.GetObject, blobRanges []models.Range, strategy ReadTransferStrategy) (string, error) {
     // Since there is only one blob being retrieved, create the job with Order-Guarantee=None so that the
     // job will wait if cache needs to be reclaimed on the BP before the chunk can be allocated.
     getObjectBlob := getObject
@@ -176,5 +178,5 @@ func (helper *HelperImpl) retrieveBlob(bucketName string, getObject helperModels
     strategyCopy := strategy
     strategyCopy.Options.ChunkClientProcessingOrderGuarantee = models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_NONE
 
-    return helper.GetObjects(bucketName, []helperModels.GetObject{getObjectBlob}, strategyCopy)
+    return helper.GetObjects(ctx, bucketName, []helperModels.GetObject{getObjectBlob}, strategyCopy)
 }

--- a/helpers/helpersImpl.go
+++ b/helpers/helpersImpl.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+    "context"
     "fmt"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -97,7 +98,7 @@ func (helper *HelperImpl) isCannotPreAllocateError(err error) bool {
 
 func (helper *HelperImpl) retrieveIndividualFile(bucketName string, getObject helperModels.GetObject, strategy ReadTransferStrategy) []string {
     // Get the blob offsets
-    headObject, err := helper.client.HeadObject(models.NewHeadObjectRequest(bucketName, getObject.Name))
+    headObject, err := helper.client.HeadObject(context.Background(), models.NewHeadObjectRequest(bucketName, getObject.Name))
     if err != nil {
         getObject.ChannelBuilder.SetFatalError(err)
         return nil
@@ -113,6 +114,7 @@ func (helper *HelperImpl) retrieveIndividualFile(bucketName string, getObject he
 
     // Get the object size
     objectsDetails, err := helper.client.GetObjectsWithFullDetailsSpectraS3(
+        context.Background(),
         models.NewGetObjectsWithFullDetailsSpectraS3Request().
             WithBucketId(bucketName).WithName(getObject.Name).
             WithLatest(true))

--- a/helpers/helpersImpl_test.go
+++ b/helpers/helpersImpl_test.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
@@ -142,7 +143,7 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 	ds3Testing.AssertNilError(t, err)
 
 	// Ensure the cache is set to minimum of 1 GB
-	getCacheResp, err := simClient.GetCacheFilesystemsSpectraS3(ds3Models.NewGetCacheFilesystemsSpectraS3Request())
+	getCacheResp, err := simClient.GetCacheFilesystemsSpectraS3(context.Background(), ds3Models.NewGetCacheFilesystemsSpectraS3Request())
 	ds3Testing.AssertNilError(t, err)
 
 	t.Logf("CACHE:")
@@ -150,20 +151,20 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 		t.Logf("%d) %s, (%v)", i, curCache.Id, curCache.MaxCapacityInBytes)
 
 		req := ds3Models.NewModifyCacheFilesystemSpectraS3Request(curCache.Id).WithMaxCapacityInBytes(minCache)
-		modifyResp, err := simClient.ModifyCacheFilesystemSpectraS3(req)
+		modifyResp, err := simClient.ModifyCacheFilesystemSpectraS3(context.Background(), req)
 		ds3Testing.AssertNilError(t, err)
 		t.Logf("modified: %s, (%v)", modifyResp.CacheFilesystem.Id, modifyResp.CacheFilesystem.MaxCapacityInBytes)
 	}
 
 	// Make sure that our test bucket exists with a file in it
-	_, err = simClient.GetBucketSpectraS3(ds3Models.NewGetBucketSpectraS3Request(bucketName))
+	_, err = simClient.GetBucketSpectraS3(context.Background(), ds3Models.NewGetBucketSpectraS3Request(bucketName))
 	if err != nil {
 		t.Logf("Creating bucket: %s", bucketName)
-		_, err := simClient.PutBucket(ds3Models.NewPutBucketRequest(bucketName))
+		_, err := simClient.PutBucket(context.Background(), ds3Models.NewPutBucketRequest(bucketName))
 		ds3Testing.AssertNilError(t, err)
 
 		defer func() {
-			_, err := simClient.DeleteBucketSpectraS3(ds3Models.NewDeleteBucketSpectraS3Request(bucketName).WithForce())
+			_, err := simClient.DeleteBucketSpectraS3(context.Background(), ds3Models.NewDeleteBucketSpectraS3Request(bucketName).WithForce())
 			if err != nil {
 				t.Errorf("failed to delete bucket with force '%s': %v", bucketName, err)
 			}
@@ -209,7 +210,7 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 	ds3Testing.AssertNilError(t, err)
 
 	defer func() {
-		_, err := simClient.DeleteObject(ds3Models.NewDeleteObjectRequest(bucketName, objectName))
+		_, err := simClient.DeleteObject(context.Background(), ds3Models.NewDeleteObjectRequest(bucketName, objectName))
 		if err != nil {
 			t.Errorf("failed to delete object %s: %v", objectName, err)
 		}
@@ -226,7 +227,7 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			// reclaim cache since simulator doesn't seem to do it on its own
-			_, err := simClient.ForceFullCacheReclaimSpectraS3(ds3Models.NewForceFullCacheReclaimSpectraS3Request())
+			_, err := simClient.ForceFullCacheReclaimSpectraS3(context.Background(), ds3Models.NewForceFullCacheReclaimSpectraS3Request())
 			ds3Testing.AssertNilError(t, err)
 
 			readStrategy := ReadTransferStrategy{

--- a/helpers/helpersImpl_test.go
+++ b/helpers/helpersImpl_test.go
@@ -206,7 +206,7 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 		},
 	}
 
-	_, err = helperWrapper.PutObjects(bucketName, []models.PutObject{putObject}, writeStrategy)
+	_, err = helperWrapper.PutObjects(context.Background(), bucketName, []models.PutObject{putObject}, writeStrategy)
 	ds3Testing.AssertNilError(t, err)
 
 	defer func() {
@@ -253,7 +253,7 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 					FatalErrorHandler: channels.FatalErrorHandler{},
 				},
 			}
-			getJobIds, err := helperWrapper.GetObjectsSpanningJobs(bucketName, []models.GetObject{getObject}, readStrategy)
+			getJobIds, err := helperWrapper.GetObjectsSpanningJobs(context.Background(), bucketName, []models.GetObject{getObject}, readStrategy)
 			ds3Testing.AssertNilError(t, err)
 
 			// verify amount of data retrieved

--- a/helpers/putProducer.go
+++ b/helpers/putProducer.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+    "context"
     "fmt"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -99,7 +100,7 @@ func (producer *putProducer) transferOperationBuilder(info putObjectInfo) Transf
 
 		producer.maybeAddMetadata(info, putObjRequest)
 
-        _, err = producer.client.PutObject(putObjRequest)
+        _, err = producer.client.PutObject(context.Background(), putObjRequest)
         if err != nil {
             producer.strategy.Listeners.Errored(info.blob.Name(), err)
 
@@ -296,7 +297,7 @@ func (producer *putProducer) queueBlobsReadyForTransfer(totalBlobCount int64) (i
     // not be able to receive everything, so not all chunks will necessarily be
     // returned
     chunksReady := ds3Models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(producer.JobMasterObjectList.JobId)
-    chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(chunksReady)
+    chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), chunksReady)
     if err != nil {
         producer.Errorf("unrecoverable error: %v", err)
         return processedCount, err

--- a/helpers/putProducer.go
+++ b/helpers/putProducer.go
@@ -12,6 +12,7 @@ import (
 )
 
 type putProducer struct {
+    ctx                  context.Context
     JobMasterObjectList  *ds3Models.MasterObjectList //MOL from put bulk job creation
     WriteObjects         *[]helperModels.PutObject
     queue                *chan TransferOperation
@@ -28,6 +29,7 @@ type putProducer struct {
 }
 
 func newPutProducer(
+    ctx context.Context,
     jobMasterObjectList *ds3Models.MasterObjectList,
     putObjects *[]helperModels.PutObject,
     queue *chan TransferOperation,
@@ -37,6 +39,7 @@ func newPutProducer(
     doneNotifier NotifyBlobDone) *putProducer {
 
     return &putProducer{
+        ctx:                  ctx,
         JobMasterObjectList:  jobMasterObjectList,
         WriteObjects:         putObjects,
         queue:                queue,
@@ -100,7 +103,7 @@ func (producer *putProducer) transferOperationBuilder(info putObjectInfo) Transf
 
 		producer.maybeAddMetadata(info, putObjRequest)
 
-        _, err = producer.client.PutObject(context.Background(), putObjRequest)
+        _, err = producer.client.PutObject(producer.ctx, putObjRequest)
         if err != nil {
             producer.strategy.Listeners.Errored(info.blob.Name(), err)
 
@@ -269,7 +272,11 @@ func (producer *putProducer) run() error {
             producer.doneNotifier.Wait()
         } else if producer.hasMoreToProcess(totalBlobCount) {
             // nothing could be processed, cache is probably full, wait a bit before trying again
-            time.Sleep(producer.strategy.BlobStrategy.delay())
+            select {
+            case <-producer.ctx.Done():
+                return producer.ctx.Err()
+            case <-time.After(producer.strategy.BlobStrategy.delay()):
+            }
         }
     }
     return nil
@@ -297,7 +304,7 @@ func (producer *putProducer) queueBlobsReadyForTransfer(totalBlobCount int64) (i
     // not be able to receive everything, so not all chunks will necessarily be
     // returned
     chunksReady := ds3Models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(producer.JobMasterObjectList.JobId)
-    chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), chunksReady)
+    chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(producer.ctx, chunksReady)
     if err != nil {
         producer.Errorf("unrecoverable error: %v", err)
         return processedCount, err

--- a/helpers/putTransceiver.go
+++ b/helpers/putTransceiver.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+    "context"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
@@ -68,7 +69,7 @@ func (transceiver *putTransceiver) transfer() (string, error) {
     // create bulk put job
     bulkPut := newBulkPutRequest(transceiver.BucketName, transceiver.WriteObjects, transceiver.Strategy.Options)
 
-    bulkPutResponse, err := transceiver.Client.PutBulkJobSpectraS3(bulkPut)
+    bulkPutResponse, err := transceiver.Client.PutBulkJobSpectraS3(context.Background(), bulkPut)
     if err != nil {
         return "", err
     }

--- a/helpers/putTransceiver.go
+++ b/helpers/putTransceiver.go
@@ -9,18 +9,18 @@ import (
 )
 
 type putTransceiver struct {
-    BucketName string
+    BucketName   string
     WriteObjects *[]helperModels.PutObject
-    Strategy *WriteTransferStrategy
-    Client *ds3.Client
+    Strategy     *WriteTransferStrategy
+    Client       *ds3.Client
 }
 
 func newPutTransceiver(bucketName string, writeObjects *[]helperModels.PutObject, strategy *WriteTransferStrategy, client *ds3.Client) *putTransceiver {
     return &putTransceiver{
-        BucketName:bucketName,
-        WriteObjects:writeObjects,
-        Strategy:strategy,
-        Client:client,
+        BucketName:   bucketName,
+        WriteObjects: writeObjects,
+        Strategy:     strategy,
+        Client:       client,
     }
 }
 
@@ -65,11 +65,11 @@ func newBulkPutRequest(bucketName string, writeObjects *[]helperModels.PutObject
     return bulkPut
 }
 
-func (transceiver *putTransceiver) transfer() (string, error) {
+func (transceiver *putTransceiver) transfer(ctx context.Context) (string, error) {
     // create bulk put job
     bulkPut := newBulkPutRequest(transceiver.BucketName, transceiver.WriteObjects, transceiver.Strategy.Options)
 
-    bulkPutResponse, err := transceiver.Client.PutBulkJobSpectraS3(context.Background(), bulkPut)
+    bulkPutResponse, err := transceiver.Client.PutBulkJobSpectraS3(ctx, bulkPut)
     if err != nil {
         return "", err
     }
@@ -80,7 +80,7 @@ func (transceiver *putTransceiver) transfer() (string, error) {
     doneNotifier := NewConditionalBool()
 
     queue := newOperationQueue(transceiver.Strategy.BlobStrategy.maxWaitingTransfers(), transceiver.Client.Logger)
-    producer := newPutProducer(&bulkPutResponse.MasterObjectList, transceiver.WriteObjects, &queue, transceiver.Strategy, transceiver.Client, &waitGroup, doneNotifier)
+    producer := newPutProducer(ctx, &bulkPutResponse.MasterObjectList, transceiver.WriteObjects, &queue, transceiver.Strategy, transceiver.Client, &waitGroup, doneNotifier)
     consumer := newConsumer(&queue, &waitGroup, transceiver.Strategy.BlobStrategy.maxConcurrentTransfers(), doneNotifier)
 
     // Wait for completion of producer-consumer goroutines

--- a/helpers_integration/helpersImpl_test.go
+++ b/helpers_integration/helpersImpl_test.go
@@ -2,6 +2,7 @@ package helpers_integration
 
 import (
     "bytes"
+    "context"
     "fmt"
     "github.com/SpectraLogic/ds3_go_sdk/ds3"
     ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -58,7 +59,7 @@ func TestPutBulk(t *testing.T) {
     }
 
     // verify all books are on BP
-    getBucket, getBucketErr := client.GetBucket(ds3Models.NewGetBucketRequest(testBucket))
+    getBucket, getBucketErr := client.GetBucket(context.Background(), ds3Models.NewGetBucketRequest(testBucket))
     ds3Testing.AssertNilError(t, getBucketErr)
     if len(getBucket.ListBucketResult.Objects) != len(*writeObjects) {
         t.Fatalf("Expected '%d' objects in bucket '%s', but found '%d'.", len(*writeObjects), testBucket, len(getBucket.ListBucketResult.Objects))
@@ -527,7 +528,7 @@ func TestRetryGettingBlobRange(t *testing.T) {
     }
 
     // Try to get some data from each blob
-    getJob, err := client.GetJobSpectraS3(ds3Models.NewGetJobSpectraS3Request(putJobId))
+    getJob, err := client.GetJobSpectraS3(context.Background(), ds3Models.NewGetJobSpectraS3Request(putJobId))
     ds3Testing.AssertNilError(t, err)
 
     blobsChecked := 0
@@ -586,7 +587,7 @@ func TestGetRemainingBlob(t *testing.T) {
     }
 
     // Try to get some data from each blob
-    getJob, err := client.GetJobSpectraS3(ds3Models.NewGetJobSpectraS3Request(putJobId))
+    getJob, err := client.GetJobSpectraS3(context.Background(), ds3Models.NewGetJobSpectraS3Request(putJobId))
     ds3Testing.AssertNilError(t, err)
 
     blobsChecked := 0

--- a/helpers_integration/helpersImpl_test.go
+++ b/helpers_integration/helpersImpl_test.go
@@ -52,7 +52,7 @@ func TestPutBulk(t *testing.T) {
     writeObjects, err := getTestBooksAsWriteObjects()
     ds3Testing.AssertNilError(t, err)
 
-    jobId, err := helper.PutObjects(testBucket, *writeObjects, strategy)
+    jobId, err := helper.PutObjects(context.Background(), testBucket, *writeObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     if jobId == "" {
         t.Error("expected to get a BP job ID, but instead got nothing")
@@ -85,7 +85,7 @@ func TestPutBulkBlobSpanningChunksRandomAccess(t *testing.T) {
 
     ds3Testing.AssertNilError(t, err)
 
-    jobId, err := helper.PutObjects(testBucket, writeObjects, strategy)
+    jobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     if jobId == "" {
         t.Error("expected to get a BP job ID, but instead got nothing")
@@ -108,7 +108,7 @@ func TestPutBulkBlobSpanningChunksStreamAccess(t *testing.T) {
 
     ds3Testing.AssertNilError(t, err)
 
-    jobId, err := helper.PutObjects(testBucket, writeObjects, strategy)
+    jobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     if jobId == "" {
         t.Error("expected to get a BP job ID, but instead got nothing")
@@ -152,7 +152,7 @@ func TestPutBulkBlobSpanningChunksStreamAccessDoesNotExist(t *testing.T) {
 
     ds3Testing.AssertNilError(t, err)
 
-    _, err = helper.PutObjects(testBucket, writeObjects, strategy)
+    _, err = helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     ds3Testing.AssertBool(t, "error callback called", true, errorCallbackCalled)
 }
@@ -197,7 +197,7 @@ func TestGetBulk(t *testing.T) {
         {Name: testutils.BookTitles[3], ChannelBuilder: channels.NewWriteChannelBuilder(file3.Name())},
     }
 
-    jobId, err := helper.GetObjects(testBucket, readObjects, strategy)
+    jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     if jobId == "" {
         t.Error("expected to get a BP job ID, but instead got nothing")
@@ -231,7 +231,7 @@ func TestGetBulkBlobSpanningChunksRandomAccess(t *testing.T) {
         {Name: LargeBookTitle, ChannelBuilder: channels.NewWriteChannelBuilder(file.Name())},
     }
 
-    jobId, err := helper.GetObjects(testBucket, readObjects, strategy)
+    jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     if jobId == "" {
         t.Error("expected to get a BP job ID, but instead got nothing")
@@ -266,7 +266,7 @@ func TestGetBulkBlobSpanningChunksStreaming(t *testing.T) {
         {Name: LargeBookTitle, ChannelBuilder: &testStreamAccessWriteChannelBuilder{f: fileWriter}},
     }
 
-    jobId, err := helper.GetObjects(testBucket, readObjects, strategy)
+    jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     if jobId == "" {
         t.Error("expected to get a BP job ID, but instead got nothing")
@@ -310,7 +310,7 @@ func TestGetBulkBlobSpanningChunksStreamingFailBlob(t *testing.T) {
         {Name: LargeBookTitle, ChannelBuilder: &testStreamAccessWriteFailOnFirstBlob{}},
     }
 
-    _, err = helper.GetObjects(testBucket, readObjects, strategy)
+    _, err = helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     ds3Testing.AssertBool(t, "error callback called", true, errorCallbackCalled)
 }
@@ -344,7 +344,7 @@ func TestGetBulkPartialObjectRandomAccess(t *testing.T) {
         {Name: LargeBookTitle, ChannelBuilder: channels.NewPartialObjectChannelBuilder(file.Name(), ranges), Ranges: ranges},
     }
 
-    jobId, err := helper.GetObjects(testBucket, readObjects, strategy)
+    jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     if jobId == "" {
         t.Error("expected to get a BP job ID, but instead got nothing")
@@ -386,7 +386,7 @@ func TestPutObjectDoesNotExist(t *testing.T) {
 
     writeObjects := []helperModels.PutObject{nonExistentPutObj}
 
-    _, err := helper.PutObjects(testBucket, writeObjects, strategy)
+    _, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
     ds3Testing.AssertNilError(t, err)
 
     ds3Testing.AssertBool(t, "error callback was called", true, errorCallbackCalled)
@@ -474,7 +474,7 @@ func TestBulkPutAndGetLotsOfFiles(t *testing.T) {
         Listeners: newErrorOnErrorListenerStrategy(t),
     }
 
-    jobId, err := helper.PutObjects(testBucket, writeObjects, writeStrategy)
+    jobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, writeStrategy)
     ds3Testing.AssertNilError(t, err)
     if jobId == "" {
         t.Error("expected to get a BP job ID, but instead got nothing")
@@ -499,7 +499,7 @@ func TestBulkPutAndGetLotsOfFiles(t *testing.T) {
         Listeners: newErrorOnErrorListenerStrategy(t),
     }
 
-    jobId, err = helper.GetObjects(testBucket, readObjects, readStrategy)
+    jobId, err = helper.GetObjects(context.Background(), testBucket, readObjects, readStrategy)
     ds3Testing.AssertNilError(t, err)
 
     if jobId == "" {
@@ -521,7 +521,7 @@ func TestRetryGettingBlobRange(t *testing.T) {
     var writeObjects []helperModels.PutObject
     writeObjects = append(writeObjects, *writeObj)
 
-    putJobId, err := helper.PutObjects(testBucket, writeObjects, strategy)
+    putJobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     if putJobId == "" {
         t.Error("expected to get a BP job ID, but instead got nothing")
@@ -546,7 +546,7 @@ func TestRetryGettingBlobRange(t *testing.T) {
                 // get a range of the blob
                 startRange := blob.Offset + 10 // retrieve subset of blob
                 endRange := blob.Length + blob.Offset - 1
-                bytesWritten, err := helpers.RetryGettingBlobRange(client, testBucket, writeObj.PutObject.Name, blob.Offset, startRange, endRange, tempFile, client.Logger)
+                bytesWritten, err := helpers.RetryGettingBlobRange(context.Background(), client, testBucket, writeObj.PutObject.Name, blob.Offset, startRange, endRange, tempFile, client.Logger)
                 ds3Testing.AssertNilError(t, err)
                 ds3Testing.AssertInt64(t, "bytes written", endRange-startRange+1, bytesWritten)
 
@@ -580,7 +580,7 @@ func TestGetRemainingBlob(t *testing.T) {
     var writeObjects []helperModels.PutObject
     writeObjects = append(writeObjects, *writeObj)
 
-    putJobId, err := helper.PutObjects(testBucket, writeObjects, strategy)
+    putJobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     if putJobId == "" {
         t.Error("expected to get a BP job ID, but instead got nothing")
@@ -605,7 +605,7 @@ func TestGetRemainingBlob(t *testing.T) {
                 // get the remainder of the blob after skipping some bytes
                 blob := helperModels.NewBlobDescription(*blob.Name, blob.Offset, blob.Length)
                 var amountToSkip int64 = 10
-                err = helpers.GetRemainingBlob(client, testBucket, &blob, amountToSkip, tempFile, client.Logger)
+                err = helpers.GetRemainingBlob(context.Background(), client, testBucket, &blob, amountToSkip, tempFile, client.Logger)
                 ds3Testing.AssertNilError(t, err)
 
                 // verify that retrieved partial blob is correct
@@ -685,7 +685,7 @@ func TestRetryGetObjectsWhenSomeObjectsDoNotExist(t *testing.T) {
         {Name: "doesNotExist2", ChannelBuilder: doesNotExistChannelBuilder2},
     }
 
-    jobId, err := helper.GetObjects(testBucket, readObjects, strategy)
+    jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
     ds3Testing.AssertNilError(t, err)
     if jobId == "" {
         t.Error("expected to get a BP job ID, but instead got nothing")
@@ -740,7 +740,7 @@ func TestRetryGetObjectsWhenNoObjectExist(t *testing.T) {
         {Name: "doesNotExist1", ChannelBuilder: doesNotExistChannelBuilder1},
     }
 
-    _, err = helper.GetObjects(testBucket, readObjects, strategy)
+    _, err = helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
     if err == nil {
         t.Fatalf("expected error when creating GET job")
     } else if !strings.Contains(err.Error(), "Could not find requested blobs for") {

--- a/helpers_integration/largeFileTestUtil.go
+++ b/helpers_integration/largeFileTestUtil.go
@@ -1,6 +1,7 @@
 package helpers_integration
 
 import (
+    "context"
     "io"
     "bytes"
     "fmt"
@@ -49,6 +50,6 @@ func LoadLargeFile(t *testing.T, bucket string, client *ds3.Client) error {
     var writeObjects []helperModels.PutObject
     writeObjects = append(writeObjects, *writeObj)
 
-    _, err = helper.PutObjects(bucket, writeObjects, newTestTransferStrategy(t))
+    _, err = helper.PutObjects(context.Background(), bucket, writeObjects, newTestTransferStrategy(t))
     return err
 }

--- a/samples/functions/getBucketSample.go
+++ b/samples/functions/getBucketSample.go
@@ -12,6 +12,7 @@
 package functions
 
 import (
+    "context"
     "log"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
@@ -34,7 +35,7 @@ func GetBucketSample() {
     bucketRequest := models.NewGetBucketRequest(utils.BucketName)
 
     // Perform the Get Bucket call by using the client and invoking the desired command.
-    bucketResponse, err := client.GetBucket(bucketRequest)
+    bucketResponse, err := client.GetBucket(context.Background(), bucketRequest)
     if err != nil {
         log.Fatal(err)
     }

--- a/samples/functions/getBulkSample.go
+++ b/samples/functions/getBulkSample.go
@@ -12,6 +12,7 @@
 package functions
 
 import (
+    "context"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
     "log"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
@@ -32,7 +33,7 @@ func GetBulkSample() {
     }
 
     // Get a list of all objects in the target bucket.
-    bucketResponse, err := client.GetBucket(models.NewGetBucketRequest(utils.BucketName))
+    bucketResponse, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(utils.BucketName))
     if err != nil {
         log.Fatal(err)
     }
@@ -50,7 +51,7 @@ func GetBulkSample() {
 
     // Send the bulk get request to the server. Note that this creates the bulk get job,
     // but does not retrieve the objects.
-    bulkGetResponse, err := client.GetBulkJobSpectraS3(bulkGetRequest)
+    bulkGetResponse, err := client.GetBulkJobSpectraS3(context.Background(), bulkGetRequest)
     if err != nil {
         log.Fatal(err)
     }
@@ -63,7 +64,7 @@ func GetBulkSample() {
         // Get the chunks that the server can send. The server may need to retrieve
         // objects into cache from the tape.
         chunksReady := models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(bulkGetResponse.MasterObjectList.JobId)
-        chunksReadyResponse, err := client.GetJobChunksReadyForClientProcessingSpectraS3(chunksReady)
+        chunksReadyResponse, err := client.GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), chunksReady)
         if err != nil {
             log.Fatal(err)
         }
@@ -81,7 +82,7 @@ func GetBulkSample() {
                         WithJob(bulkGetResponse.MasterObjectList.JobId).
                         WithOffset(curObj.Offset)
 
-                    getObjResponse, err := client.GetObject(getObjRequest)
+                    getObjResponse, err := client.GetObject(context.Background(), getObjRequest)
                     if err != nil {
                         log.Fatal(err)
                     }

--- a/samples/functions/getObjectSample.go
+++ b/samples/functions/getObjectSample.go
@@ -12,6 +12,7 @@
 package functions
 
 import (
+    "context"
     "log"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
@@ -33,7 +34,7 @@ func GetObjectSample() {
 
     // Grab the first book defined in utils.BookNames
     getObjRequest := models.NewGetObjectRequest(utils.BucketName, utils.BookNames[0])
-    getObjResponse, err := client.GetObject(getObjRequest)
+    getObjResponse, err := client.GetObject(context.Background(), getObjRequest)
     if err != nil {
         log.Fatal(err)
     }

--- a/samples/functions/getServiceSample.go
+++ b/samples/functions/getServiceSample.go
@@ -12,6 +12,7 @@
 package functions
 
 import (
+    "context"
     "log"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
@@ -32,7 +33,7 @@ func GetServiceSample() {
     request := models.NewGetServiceRequest()
 
     // Perform the Get Service call by using the client and invoking the desired command.
-    response, err := client.GetService(request)
+    response, err := client.GetService(context.Background(), request)
     if err != nil {
         log.Fatal(err)
     }

--- a/samples/functions/putBucketSample.go
+++ b/samples/functions/putBucketSample.go
@@ -12,6 +12,7 @@
 package functions
 
 import (
+    "context"
     "fmt"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
     "log"
@@ -39,7 +40,7 @@ func PutBucketSample() {
     bucket1Request := models.NewPutBucketRequest(bucket1Name)
 
     // Perform the put bucket call by using the client and invoking the command
-    _, err = client.PutBucket(bucket1Request)
+    _, err = client.PutBucket(context.Background(), bucket1Request)
     if err != nil {
         log.Fatal(err)
     }
@@ -55,7 +56,7 @@ func PutBucketSample() {
     bucket2Request := models.NewPutBucketSpectraS3Request(bucket2Name).WithDataPolicyId(dataPolicyName)
 
     // Perform the spectra S3 put bucket call by using the client and invoking the command
-    _, err = client.PutBucketSpectraS3(bucket2Request)
+    _, err = client.PutBucketSpectraS3(context.Background(), bucket2Request)
     if err != nil {
         log.Fatal(err)
     }

--- a/samples/functions/putBulkSample.go
+++ b/samples/functions/putBulkSample.go
@@ -12,6 +12,7 @@
 package functions
 
 import (
+    "context"
     "log"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
@@ -31,7 +32,7 @@ func PutBulkSample() {
     }
 
     // Create a bucket where our files will be stored.
-    _, err = client.PutBucket(models.NewPutBucketRequest(utils.BucketName))
+    _, err = client.PutBucket(context.Background(), models.NewPutBucketRequest(utils.BucketName))
     if err != nil {
         log.Fatal(err)
     }
@@ -53,7 +54,7 @@ func PutBulkSample() {
 
     // Send the bulk put request to the server. This creates the job, but does not
     // directly send the data.
-    putBulkResponse, err := client.PutBulkJobSpectraS3(putBulkRequest)
+    putBulkResponse, err := client.PutBulkJobSpectraS3(context.Background(), putBulkRequest)
     if err != nil {
         log.Fatal(err)
     }
@@ -71,7 +72,7 @@ func PutBulkSample() {
         // not be able to receive everything, so not all chunks will necessarily be
         // returned
         chunksReady := models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(putBulkResponse.MasterObjectList.JobId)
-        chunksReadyResponse, err := client.GetJobChunksReadyForClientProcessingSpectraS3(chunksReady)
+        chunksReadyResponse, err := client.GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), chunksReady)
         if err != nil {
             log.Fatal(err)
         }
@@ -94,7 +95,7 @@ func PutBulkSample() {
                         WithJob(chunksReadyResponse.MasterObjectList.JobId).
                         WithOffset(curObj.Offset)
 
-                    _, err = client.PutObject(putObjRequest)
+                    _, err = client.PutObject(context.Background(), putObjRequest)
                     if err != nil {
                         log.Fatal(err)
                     }


### PR DESCRIPTION
This adds end-to-end Go context support to the DS3 Go SDK so callers can cancel in-flight operations and propagate deadlines. This is a breaking API change. Every public method on the generated client now takes a context as its first parameter. The hand-written helpers were also changed accordingly. A minimum mechanical change to applications would involve passing in `context.TODO()` or `context.Background()` however it's better to use a proper context that matches the application's goals.

The "ds3" package was regenerated using the updated ds3_autogen and the same 5.8 contract that was used the last time this SDK was generated. Thus, no DS3 API changes are being introduced.

The network retry loop was updated to check the context on every iteration, and exit early if the context has an error attached to it.

The DS3 CLI application was updated to use a context that is canceled on SIGTERM (e.g., control-c).

Fix a pre-existing bug in AssertInt64PtrIsNil, so label is a string instead of an int64, as it was causing `go vet` to fail.

This also includes some minor whitespace changes to better match Go conventions.