### PR TITLE
Fix integration test issues

### DIFF
--- a/ds3_integration/digest_test.go
+++ b/ds3_integration/digest_test.go
@@ -33,7 +33,8 @@ func testPutBeowulfWithSpecifiedObjectName(objectName string, t *testing.T) {
 
     //Verify that object exists
     getObjectResponse, err := testutils.GetObjectLogError(t, client, testBucket, objectName)
-    if err != nil {
+    ds3Testing.AssertNilError(t, err)
+    if err == nil {
         defer getObjectResponse.Content.Close()
         bs, err := ioutil.ReadAll(getObjectResponse.Content)
         ds3Testing.AssertNilError(t, err)

--- a/ds3_integration/utils/testUtils.go
+++ b/ds3_integration/utils/testUtils.go
@@ -38,10 +38,10 @@ func VerifyFilesOnBP(t *testing.T, bucketName string, objectNames []string, file
             for _, curChunk := range chunksReady.MasterObjectList.Objects {
                 for _, curObj := range curChunk.Objects {
 
-                    getObj, _ := client.GetObject(models.NewGetObjectRequest(bucketName, *curObj.Name).
+                    getObj, getErr := client.GetObject(models.NewGetObjectRequest(bucketName, *curObj.Name).
                         WithJob(bulkGet.MasterObjectList.JobId).
                         WithOffset(curObj.Offset))
-                    ds3Testing.AssertNilError(t, err)
+                    ds3Testing.AssertNilError(t, getErr)
 
                     VerifyPartialFile(t, filePath + *curObj.Name, curObj.Length, curObj.Offset, getObj.Content)
                     getObj.Content.Close()
@@ -169,8 +169,11 @@ func CancelAllJobsForBucket(client *ds3.Client, bucketName string) {
         return
     }
     for _, job := range getJobs.JobList.Jobs {
+        if job.BucketName == nil || *job.BucketName != bucketName {
+            continue
+        }
         if _, err = client.CancelJobSpectraS3(models.NewCancelJobSpectraS3Request(job.JobId)); err != nil {
-            log.Printf("WARNING: Unable to cancel job: %s", job.JobId)
+            log.Printf("WARNING: Unable to cancel job %s for bucket %s: %s", job.JobId, bucketName, err)
         }
     }
 }

--- a/ds3_utils/ds3Testing/assertUtil.go
+++ b/ds3_utils/ds3Testing/assertUtil.go
@@ -70,7 +70,7 @@ func AssertNonNilInt64Ptr(t *testing.T, label string, expected int64, actual *in
 }
 
 // Asserts if a specified int64 is nil. If not, Fatal.
-func AssertInt64PtrIsNil(t *testing.T, label int64, actual *int64) {
+func AssertInt64PtrIsNil(t *testing.T, label string, actual *int64) {
     if actual != nil {
         t.Fatalf("Expected %s to be 'nil' but was '%d'.", label, *actual)
     }


### PR DESCRIPTION
* ds3_utils/ds3Testing/assertUtil.go: AssertInt64PtrIsNil declared `label` as int64, but its Fatalf format string expects %s. `go vet` rejected this and blocked the entire ds3Testing package from compiling. Changed the parameter to `string` to match the other AssertX helpers; no in-tree callers needed updating.

* ds3_integration/digest_test.go: testPutBeowulfWithSpecifiedObjectName inverted its error check — the verification block ran only when GET failed, dereferencing a nil response and panicking. The happy path never compared bytes, so the spaces/utf8 variants were silent false positives. Flipped the condition and added an explicit AssertNilError so a failed GET is now reported instead of crashing the test binary.

* ds3_integration/utils/testUtils.go (VerifyFilesOnBP): the GetObject error was discarded with `_`, then a stale outer `err` was asserted, then the nil response was dereferenced. When GetObject failed, the test panicked instead of failing cleanly — and on helpers_integration this aborted the rest of the package.

* ds3_integration/utils/testUtils.go (CancelAllJobsForBucket): Fixed to only cancel all jobs for the given bucket, instead of all jobs across all buckets.