### PR TITLE
"go fmt" the code base

### DIFF
--- a/ds3/buildclient/buildClient.go
+++ b/ds3/buildclient/buildClient.go
@@ -1,12 +1,12 @@
 package buildclient
 
 import (
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_cli/commands"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "net/url"
-    "errors"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
-    "os"
+	"errors"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_cli/commands"
+	"net/url"
+	"os"
 )
 
 const EndpointEnv = "DS3_ENDPOINT"
@@ -16,48 +16,52 @@ const ProxyEnv = "DS3_PROXY"
 
 // Creates a client from cli arguments
 func FromArgs(args *commands.Arguments) (*ds3.Client, error) {
-    return createClient(args.Endpoint, args.AccessKey, args.SecretKey, args.Proxy)
+	return createClient(args.Endpoint, args.AccessKey, args.SecretKey, args.Proxy)
 }
 
 // Creates a client from environment variables
 func FromEnv() (*ds3.Client, error) {
-    //Retrieve the environment variables
-    endpoint := os.Getenv(EndpointEnv)
-    accessKey := os.Getenv(AccessKeyEnv)
-    secretKey := os.Getenv(SecretKeyEnv)
-    proxy := os.Getenv(ProxyEnv)
+	//Retrieve the environment variables
+	endpoint := os.Getenv(EndpointEnv)
+	accessKey := os.Getenv(AccessKeyEnv)
+	secretKey := os.Getenv(SecretKeyEnv)
+	proxy := os.Getenv(ProxyEnv)
 
-    // Validate required arguments and create client if all required values are present
-    switch {
-    case endpoint == "": return nil, errors.New("Must specify an endpoint.")
-    case accessKey == "": return nil, errors.New("Must specify an access key.")
-    case secretKey == "": return nil, errors.New("Must specify an secret key.")
-    default: return createClient(endpoint, accessKey, secretKey, proxy)
-    }
+	// Validate required arguments and create client if all required values are present
+	switch {
+	case endpoint == "":
+		return nil, errors.New("Must specify an endpoint.")
+	case accessKey == "":
+		return nil, errors.New("Must specify an access key.")
+	case secretKey == "":
+		return nil, errors.New("Must specify an secret key.")
+	default:
+		return createClient(endpoint, accessKey, secretKey, proxy)
+	}
 }
 
 // Creates a client
 func createClient(endpoint, accessKey, secretKey, proxy string) (*ds3.Client, error) {
-    // Parse endpoint.
-    endpointUrl, endpointErr := url.Parse(endpoint)
-    if endpointErr != nil {
-        return nil, errors.New("The endpoint format was invalid.")
-    }
+	// Parse endpoint.
+	endpointUrl, endpointErr := url.Parse(endpoint)
+	if endpointErr != nil {
+		return nil, errors.New("The endpoint format was invalid.")
+	}
 
-    // Parse proxy.
-    var proxyUrlPtr *url.URL
-    if len(proxy) != 0 {
-        var proxyErr error
-        proxyUrlPtr, proxyErr = url.Parse(proxy)
-        if proxyErr != nil {
-            return nil, errors.New("The proxy format was invalid.")
-        }
-    }
+	// Parse proxy.
+	var proxyUrlPtr *url.URL
+	if len(proxy) != 0 {
+		var proxyErr error
+		proxyUrlPtr, proxyErr = url.Parse(proxy)
+		if proxyErr != nil {
+			return nil, errors.New("The proxy format was invalid.")
+		}
+	}
 
-    // Create the client.
-    client := ds3.
-    NewClientBuilder(endpointUrl, &networking.Credentials{AccessId: accessKey, Key: secretKey}).
-        WithProxy(proxyUrlPtr).
-        BuildClient()
-    return client, nil
+	// Create the client.
+	client := ds3.
+		NewClientBuilder(endpointUrl, &networking.Credentials{AccessId: accessKey, Key: secretKey}).
+		WithProxy(proxyUrlPtr).
+		BuildClient()
+	return client, nil
 }

--- a/ds3/ds3Client.go
+++ b/ds3/ds3Client.go
@@ -1,100 +1,100 @@
 package ds3
 
 import (
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
-    "net/url"
-    "time"
-    "github.com/SpectraLogic/ds3_go_sdk/sdk_log"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+	"github.com/SpectraLogic/ds3_go_sdk/sdk_log"
+	"net/url"
+	"time"
 )
 
 const (
-    HTTP_VERB_GET    = "GET"
-    HTTP_VERB_PUT    = "PUT"
-    HTTP_VERB_POST   = "POST"
-    HTTP_VERB_DELETE = "DELETE"
-    HTTP_VERB_HEAD   = "HEAD"
-    HTTP_VERB_PATCH  = "PATCH"
+	HTTP_VERB_GET    = "GET"
+	HTTP_VERB_PUT    = "PUT"
+	HTTP_VERB_POST   = "POST"
+	HTTP_VERB_DELETE = "DELETE"
+	HTTP_VERB_HEAD   = "HEAD"
+	HTTP_VERB_PATCH  = "PATCH"
 )
 
 type Client struct {
-    sendNetwork    networking.Network
-    clientPolicy   *ClientPolicy
-    connectionInfo *networking.ConnectionInfo
+	sendNetwork    networking.Network
+	clientPolicy   *ClientPolicy
+	connectionInfo *networking.ConnectionInfo
 
-    // Logger where all messages will be logged to
-    sdk_log.Logger
+	// Logger where all messages will be logged to
+	sdk_log.Logger
 }
 
 type ClientBuilder struct {
-    connectionInfo *networking.ConnectionInfo
-    clientPolicy   *ClientPolicy
-    logger         sdk_log.Logger
+	connectionInfo *networking.ConnectionInfo
+	clientPolicy   *ClientPolicy
+	logger         sdk_log.Logger
 }
 
 type ClientPolicy struct {
-    maxRetries int // Maximum number of times to attempt sending a request amidst network issues
-    maxRedirect int // Maximum number of times to attempt redirect retries
+	maxRetries  int // Maximum number of times to attempt sending a request amidst network issues
+	maxRedirect int // Maximum number of times to attempt redirect retries
 }
 
 const DEFAULT_MAX_RETRIES = 5
 const DEFAULT_MAX_REDIRECTS = 5
 
 func NewClientBuilder(endpoint *url.URL, creds *networking.Credentials) *ClientBuilder {
-    return &ClientBuilder{
-        connectionInfo: &networking.ConnectionInfo{
-            Endpoint:    endpoint,
-            Credentials: creds,
-            Proxy:       nil},
-        clientPolicy: &ClientPolicy{
-            maxRetries: DEFAULT_MAX_RETRIES,
-            maxRedirect: DEFAULT_MAX_REDIRECTS},
-    }
+	return &ClientBuilder{
+		connectionInfo: &networking.ConnectionInfo{
+			Endpoint:    endpoint,
+			Credentials: creds,
+			Proxy:       nil},
+		clientPolicy: &ClientPolicy{
+			maxRetries:  DEFAULT_MAX_RETRIES,
+			maxRedirect: DEFAULT_MAX_REDIRECTS},
+	}
 }
 
 func (clientBuilder *ClientBuilder) WithProxy(proxy *url.URL) *ClientBuilder {
-    clientBuilder.connectionInfo.Proxy = proxy
-    return clientBuilder
+	clientBuilder.connectionInfo.Proxy = proxy
+	return clientBuilder
 }
 
 func (clientBuilder *ClientBuilder) WithRedirectRetryCount(count int) *ClientBuilder {
-    clientBuilder.clientPolicy.maxRedirect = count
-    return clientBuilder
+	clientBuilder.clientPolicy.maxRedirect = count
+	return clientBuilder
 }
 
 func (clientBuilder *ClientBuilder) WithNetworkRetryCount(count int) *ClientBuilder {
-    clientBuilder.clientPolicy.maxRetries = count
-    return clientBuilder
+	clientBuilder.clientPolicy.maxRetries = count
+	return clientBuilder
 }
 
 func (clientBuilder *ClientBuilder) WithIgnoreServerCertificate(ignoreServerCert bool) *ClientBuilder {
-    clientBuilder.connectionInfo.IgnoreServerCertificate = ignoreServerCert
-    return clientBuilder
+	clientBuilder.connectionInfo.IgnoreServerCertificate = ignoreServerCert
+	return clientBuilder
 }
 
 func (clientBuilder *ClientBuilder) WithLogger(logger sdk_log.Logger) *ClientBuilder {
-    clientBuilder.logger = logger
-    return clientBuilder
+	clientBuilder.logger = logger
+	return clientBuilder
 }
 
 func (clientBuilder *ClientBuilder) WithMaxIdleConnsPerHost(count int) *ClientBuilder {
-    clientBuilder.connectionInfo.MaxIdleConnsPerHost = count
-    return clientBuilder
+	clientBuilder.connectionInfo.MaxIdleConnsPerHost = count
+	return clientBuilder
 }
 
 func (clientBuilder *ClientBuilder) WithIdleConnTimeout(timeout time.Duration) *ClientBuilder {
-    clientBuilder.connectionInfo.IdleConnTimeout = timeout
-    return clientBuilder
+	clientBuilder.connectionInfo.IdleConnTimeout = timeout
+	return clientBuilder
 }
 
 func (clientBuilder *ClientBuilder) BuildClient() *Client {
-    if clientBuilder.logger == nil {
-        clientBuilder.logger = sdk_log.NewSimpleLogger()
-    }
+	if clientBuilder.logger == nil {
+		clientBuilder.logger = sdk_log.NewSimpleLogger()
+	}
 
-    return &Client{
-        sendNetwork:    networking.NewSendNetwork(clientBuilder.connectionInfo),
-        clientPolicy:   clientBuilder.clientPolicy,
-        connectionInfo: clientBuilder.connectionInfo,
-        Logger:         clientBuilder.logger,
-    }
+	return &Client{
+		sendNetwork:    networking.NewSendNetwork(clientBuilder.connectionInfo),
+		clientPolicy:   clientBuilder.clientPolicy,
+		connectionInfo: clientBuilder.connectionInfo,
+		Logger:         clientBuilder.logger,
+	}
 }

--- a/ds3/ds3Client_test.go
+++ b/ds3/ds3Client_test.go
@@ -12,1981 +12,1980 @@
 package ds3
 
 import (
-    "context"
-    "testing"
-    "strconv"
-    "net/url"
-    "net/http"
-    "io/ioutil"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "reflect"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"context"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strconv"
+	"testing"
 )
 
 func TestGetService(t *testing.T) {
-    stringResponse := "<ListAllMyBucketsResult xmlns=\"http://doc.s3.amazonaws.com/2006-03-01\"><Owner><ID>ryan</ID><DisplayName>ryan</DisplayName></Owner><Buckets><Bucket><Name>testBucket2</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest1</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest2</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest3</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest4</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest5</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest6</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>testBucket3</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>testBucket1</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>testbucket</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket></Buckets></ListAllMyBucketsResult>"
-    expectedBucketNames := []string {
-        "testBucket2",
-        "bulkTest",
-        "bulkTest1",
-        "bulkTest2",
-        "bulkTest3",
-        "bulkTest4",
-        "bulkTest5",
-        "bulkTest6",
-        "testBucket3",
-        "testBucket1",
-        "testbucket",
-    }
-    expectedCreationDates := []string {
-        "2013-12-11T23:20:09",
-        "2013-12-11T23:20:09",
-        "2013-12-11T23:20:09",
-        "2013-12-11T23:20:09",
-        "2013-12-11T23:20:09",
-        "2013-12-11T23:20:09",
-        "2013-12-11T23:20:09",
-        "2013-12-11T23:20:09",
-        "2013-12-11T23:20:09",
-        "2013-12-11T23:20:09",
-        "2013-12-11T23:20:09",
-    }
+	stringResponse := "<ListAllMyBucketsResult xmlns=\"http://doc.s3.amazonaws.com/2006-03-01\"><Owner><ID>ryan</ID><DisplayName>ryan</DisplayName></Owner><Buckets><Bucket><Name>testBucket2</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest1</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest2</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest3</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest4</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest5</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>bulkTest6</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>testBucket3</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>testBucket1</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket><Bucket><Name>testbucket</Name><CreationDate>2013-12-11T23:20:09</CreationDate></Bucket></Buckets></ListAllMyBucketsResult>"
+	expectedBucketNames := []string{
+		"testBucket2",
+		"bulkTest",
+		"bulkTest1",
+		"bulkTest2",
+		"bulkTest3",
+		"bulkTest4",
+		"bulkTest5",
+		"bulkTest6",
+		"testBucket3",
+		"testBucket1",
+		"testbucket",
+	}
+	expectedCreationDates := []string{
+		"2013-12-11T23:20:09",
+		"2013-12-11T23:20:09",
+		"2013-12-11T23:20:09",
+		"2013-12-11T23:20:09",
+		"2013-12-11T23:20:09",
+		"2013-12-11T23:20:09",
+		"2013-12-11T23:20:09",
+		"2013-12-11T23:20:09",
+		"2013-12-11T23:20:09",
+		"2013-12-11T23:20:09",
+		"2013-12-11T23:20:09",
+	}
 
-    // Create and run the mocked client.
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/", &url.Values{}, &http.Header{}, nil).
-        Returning(200, stringResponse, nil).
-        GetService(context.Background(), models.NewGetServiceRequest())
+	// Create and run the mocked client.
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/", &url.Values{}, &http.Header{}, nil).
+		Returning(200, stringResponse, nil).
+		GetService(context.Background(), models.NewGetServiceRequest())
 
-    // Validate the error contents.
-    ds3Testing.AssertNilError(t, err)
+	// Validate the error contents.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response.
-    if response == nil {
-        t.Fatalf("Received an unexpected nil response.")
-    }
+	// Check the response.
+	if response == nil {
+		t.Fatalf("Received an unexpected nil response.")
+	}
 
-    ds3Testing.AssertString(t, "Id", "ryan", response.ListAllMyBucketsResult.Owner.Id)
-    ds3Testing.AssertNonNilStringPtr(t, "DisplayName", "ryan", response.ListAllMyBucketsResult.Owner.DisplayName)
-    if len(response.ListAllMyBucketsResult.Buckets) != len(expectedBucketNames) {
-        t.Fatalf("Parsed an unexpected number (%d) of buckets.", len(response.ListAllMyBucketsResult.Buckets))
-    }
-    for i, bucket := range response.ListAllMyBucketsResult.Buckets {
-        ds3Testing.AssertNonNilStringPtr(t, "Name", expectedBucketNames[i], bucket.Name)
-        ds3Testing.AssertNonNilStringPtr(t, "CreationDate", expectedCreationDates[i], bucket.CreationDate)
-    }
+	ds3Testing.AssertString(t, "Id", "ryan", response.ListAllMyBucketsResult.Owner.Id)
+	ds3Testing.AssertNonNilStringPtr(t, "DisplayName", "ryan", response.ListAllMyBucketsResult.Owner.DisplayName)
+	if len(response.ListAllMyBucketsResult.Buckets) != len(expectedBucketNames) {
+		t.Fatalf("Parsed an unexpected number (%d) of buckets.", len(response.ListAllMyBucketsResult.Buckets))
+	}
+	for i, bucket := range response.ListAllMyBucketsResult.Buckets {
+		ds3Testing.AssertNonNilStringPtr(t, "Name", expectedBucketNames[i], bucket.Name)
+		ds3Testing.AssertNonNilStringPtr(t, "CreationDate", expectedCreationDates[i], bucket.CreationDate)
+	}
 }
 
 func TestGetBadService(t *testing.T) {
-    // Create and run the mocked client.
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/", &url.Values{}, &http.Header{}, nil).
-        Returning(400, "", nil).
-        GetService(context.Background(), models.NewGetServiceRequest())
+	// Create and run the mocked client.
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/", &url.Values{}, &http.Header{}, nil).
+		Returning(400, "", nil).
+		GetService(context.Background(), models.NewGetServiceRequest())
 
-    // Check the response.
-    if response != nil {
-        t.Fatal("Expected a nil response but received a value.")
-    }
+	// Check the response.
+	if response != nil {
+		t.Fatal("Expected a nil response but received a value.")
+	}
 
-    // Validate the error contents.
-    if err == nil {
-        t.Fatal("Expected an error but didn't get one.")
-    }
+	// Validate the error contents.
+	if err == nil {
+		t.Fatal("Expected an error but didn't get one.")
+	}
 
-    expectedError := "Received a status code of 400 when [200] was expected. Could not parse the response for additional information."
-    ds3Testing.AssertString(t, "Error", expectedError, err.Error())
+	expectedError := "Received a status code of 400 when [200] was expected. Could not parse the response for additional information."
+	ds3Testing.AssertString(t, "Error", expectedError, err.Error())
 }
 
 func TestGetBucket(t *testing.T) {
-    stringResponse := "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>remoteTest16</Name><Prefix/><Marker/><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>user/hduser/gutenberg/20417.txt.utf-8</Key><LastModified>2014-01-03T13:26:47.000Z</LastModified><ETag>NOTRETURNED</ETag><Size>674570</Size><StorageClass>STANDARD</StorageClass><Owner><ID>ryan</ID><DisplayName>ryan</DisplayName></Owner></Contents><Contents><Key>user/hduser/gutenberg/5000.txt.utf-8</Key><LastModified>2014-01-03T13:26:47.000Z</LastModified><ETag>NOTRETURNED</ETag><Size>1423803</Size><StorageClass>STANDARD</StorageClass><Owner><ID>ryan</ID><DisplayName>ryan</DisplayName></Owner></Contents><Contents><Key>user/hduser/gutenberg/4300.txt.utf-8</Key><LastModified>2014-01-03T13:26:47.000Z</LastModified><ETag>NOTRETURNED</ETag><Size>1573150</Size><StorageClass>STANDARD</StorageClass><Owner><ID>ryan</ID><DisplayName>ryan</DisplayName></Owner></Contents></ListBucketResult>"
-    keys := []string {
-        "user/hduser/gutenberg/20417.txt.utf-8",
-        "user/hduser/gutenberg/5000.txt.utf-8",
-        "user/hduser/gutenberg/4300.txt.utf-8",
-    }
-    lastModifieds := []string {
-        "2014-01-03T13:26:47.000Z",
-        "2014-01-03T13:26:47.000Z",
-        "2014-01-03T13:26:47.000Z",
-    }
-    etags := []string { "NOTRETURNED", "NOTRETURNED", "NOTRETURNED" }
-    sizes := []int64 { 674570, 1423803, 1573150 }
-    storageClasses := []string { "STANDARD", "STANDARD", "STANDARD" }
-    ids := []string { "ryan", "ryan", "ryan" }
-    displayNames := ids
+	stringResponse := "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>remoteTest16</Name><Prefix/><Marker/><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>user/hduser/gutenberg/20417.txt.utf-8</Key><LastModified>2014-01-03T13:26:47.000Z</LastModified><ETag>NOTRETURNED</ETag><Size>674570</Size><StorageClass>STANDARD</StorageClass><Owner><ID>ryan</ID><DisplayName>ryan</DisplayName></Owner></Contents><Contents><Key>user/hduser/gutenberg/5000.txt.utf-8</Key><LastModified>2014-01-03T13:26:47.000Z</LastModified><ETag>NOTRETURNED</ETag><Size>1423803</Size><StorageClass>STANDARD</StorageClass><Owner><ID>ryan</ID><DisplayName>ryan</DisplayName></Owner></Contents><Contents><Key>user/hduser/gutenberg/4300.txt.utf-8</Key><LastModified>2014-01-03T13:26:47.000Z</LastModified><ETag>NOTRETURNED</ETag><Size>1573150</Size><StorageClass>STANDARD</StorageClass><Owner><ID>ryan</ID><DisplayName>ryan</DisplayName></Owner></Contents></ListBucketResult>"
+	keys := []string{
+		"user/hduser/gutenberg/20417.txt.utf-8",
+		"user/hduser/gutenberg/5000.txt.utf-8",
+		"user/hduser/gutenberg/4300.txt.utf-8",
+	}
+	lastModifieds := []string{
+		"2014-01-03T13:26:47.000Z",
+		"2014-01-03T13:26:47.000Z",
+		"2014-01-03T13:26:47.000Z",
+	}
+	etags := []string{"NOTRETURNED", "NOTRETURNED", "NOTRETURNED"}
+	sizes := []int64{674570, 1423803, 1573150}
+	storageClasses := []string{"STANDARD", "STANDARD", "STANDARD"}
+	ids := []string{"ryan", "ryan", "ryan"}
+	displayNames := ids
 
-    // Create and run the mocked client.
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/remoteTest16", &url.Values{}, &http.Header{}, nil).
-        Returning(200, stringResponse, nil).
-        GetBucket(context.Background(), models.NewGetBucketRequest("remoteTest16"))
+	// Create and run the mocked client.
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/remoteTest16", &url.Values{}, &http.Header{}, nil).
+		Returning(200, stringResponse, nil).
+		GetBucket(context.Background(), models.NewGetBucketRequest("remoteTest16"))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 
-    if len(response.ListBucketResult.Objects) != len(keys) {
-        t.Fatalf("Expected %d objects but got %d.", len(keys), len(response.ListBucketResult.Objects))
-    }
-    ds3Testing.AssertNonNilStringPtr(t, "Name", "remoteTest16", response.ListBucketResult.Name)
-    ds3Testing.AssertStringPtrIsNil(t, "Prefix", response.ListBucketResult.Prefix)
-    ds3Testing.AssertStringPtrIsNil(t, "Marker", response.ListBucketResult.Marker)
-    ds3Testing.AssertInt(t, "MaxKeys", 1000, response.ListBucketResult.MaxKeys)
-    ds3Testing.AssertBool(t, "Truncated", false, response.ListBucketResult.Truncated)
-    for i, object := range response.ListBucketResult.Objects {
-        ds3Testing.AssertNonNilStringPtr(t, "Key", keys[i], object.Key)
-        ds3Testing.AssertNonNilStringPtr(t, "LastModified", lastModifieds[i], object.LastModified)
-        ds3Testing.AssertNonNilStringPtr(t, "ETag", etags[i], object.ETag)
-        ds3Testing.AssertInt64(t, "Size", sizes[i], object.Size)
-        ds3Testing.AssertNonNilStringPtr(t, "StorageClass", storageClasses[i], object.StorageClass)
-        ds3Testing.AssertString(t, "Id", ids[i], object.Owner.Id)
-        ds3Testing.AssertNonNilStringPtr(t, "DisplayName", displayNames[i], object.Owner.DisplayName)
-    }
+	if len(response.ListBucketResult.Objects) != len(keys) {
+		t.Fatalf("Expected %d objects but got %d.", len(keys), len(response.ListBucketResult.Objects))
+	}
+	ds3Testing.AssertNonNilStringPtr(t, "Name", "remoteTest16", response.ListBucketResult.Name)
+	ds3Testing.AssertStringPtrIsNil(t, "Prefix", response.ListBucketResult.Prefix)
+	ds3Testing.AssertStringPtrIsNil(t, "Marker", response.ListBucketResult.Marker)
+	ds3Testing.AssertInt(t, "MaxKeys", 1000, response.ListBucketResult.MaxKeys)
+	ds3Testing.AssertBool(t, "Truncated", false, response.ListBucketResult.Truncated)
+	for i, object := range response.ListBucketResult.Objects {
+		ds3Testing.AssertNonNilStringPtr(t, "Key", keys[i], object.Key)
+		ds3Testing.AssertNonNilStringPtr(t, "LastModified", lastModifieds[i], object.LastModified)
+		ds3Testing.AssertNonNilStringPtr(t, "ETag", etags[i], object.ETag)
+		ds3Testing.AssertInt64(t, "Size", sizes[i], object.Size)
+		ds3Testing.AssertNonNilStringPtr(t, "StorageClass", storageClasses[i], object.StorageClass)
+		ds3Testing.AssertString(t, "Id", ids[i], object.Owner.Id)
+		ds3Testing.AssertNonNilStringPtr(t, "DisplayName", displayNames[i], object.Owner.DisplayName)
+	}
 }
 
 func TestGetBucketWithCommonPrefixes(t *testing.T) {
-    stringResponse := "<ListBucketResult><CommonPrefixes><Prefix>movies/</Prefix></CommonPrefixes><CommonPrefixes><Prefix>scores/</Prefix></CommonPrefixes><Contents><ETag/><Key>music.mp3</Key><LastModified/><Owner><DisplayName>jason</DisplayName><ID>a0b789ef-dcbd-4004-82af-6679a26329bf</ID></Owner><Size>0</Size><StorageClass/></Contents><Contents><ETag/><Key>song.mp3</Key><LastModified/><Owner><DisplayName>jason</DisplayName><ID>a0b789ef-dcbd-4004-82af-6679a26329bf</ID></Owner><Size>0</Size><StorageClass/></Contents><CreationDate>2017-03-23T23:26:34.000Z</CreationDate><Delimiter>/</Delimiter><IsTruncated>false</IsTruncated><Marker/><MaxKeys>1000</MaxKeys><Name>bucket1</Name><NextMarker/><Prefix/></ListBucketResult>"
-    keys := []string {
-        "music.mp3",
-        "song.mp3",
-    }
+	stringResponse := "<ListBucketResult><CommonPrefixes><Prefix>movies/</Prefix></CommonPrefixes><CommonPrefixes><Prefix>scores/</Prefix></CommonPrefixes><Contents><ETag/><Key>music.mp3</Key><LastModified/><Owner><DisplayName>jason</DisplayName><ID>a0b789ef-dcbd-4004-82af-6679a26329bf</ID></Owner><Size>0</Size><StorageClass/></Contents><Contents><ETag/><Key>song.mp3</Key><LastModified/><Owner><DisplayName>jason</DisplayName><ID>a0b789ef-dcbd-4004-82af-6679a26329bf</ID></Owner><Size>0</Size><StorageClass/></Contents><CreationDate>2017-03-23T23:26:34.000Z</CreationDate><Delimiter>/</Delimiter><IsTruncated>false</IsTruncated><Marker/><MaxKeys>1000</MaxKeys><Name>bucket1</Name><NextMarker/><Prefix/></ListBucketResult>"
+	keys := []string{
+		"music.mp3",
+		"song.mp3",
+	}
 
-    ids := []string {
-        "a0b789ef-dcbd-4004-82af-6679a26329bf",
-        "a0b789ef-dcbd-4004-82af-6679a26329bf",
-    }
-    expectedPrefixes := []string {
-        "movies/",
-        "scores/",
-    }
+	ids := []string{
+		"a0b789ef-dcbd-4004-82af-6679a26329bf",
+		"a0b789ef-dcbd-4004-82af-6679a26329bf",
+	}
+	expectedPrefixes := []string{
+		"movies/",
+		"scores/",
+	}
 
-    displayName := "jason"
+	displayName := "jason"
 
-    // Create and run the mocked client.
-    bucketName := "bucket1"
-    delimiter := "/"
-    queryParams := &url.Values{"delimiter": []string{delimiter}}
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/" + bucketName, queryParams, &http.Header{}, nil).
-        Returning(200, stringResponse, nil).
-        GetBucket(context.Background(), models.NewGetBucketRequest(bucketName).WithDelimiter(delimiter))
+	// Create and run the mocked client.
+	bucketName := "bucket1"
+	delimiter := "/"
+	queryParams := &url.Values{"delimiter": []string{delimiter}}
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/"+bucketName, queryParams, &http.Header{}, nil).
+		Returning(200, stringResponse, nil).
+		GetBucket(context.Background(), models.NewGetBucketRequest(bucketName).WithDelimiter(delimiter))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 
-    if len(response.ListBucketResult.CommonPrefixes) != len(expectedPrefixes) {
-        t.Fatalf("Expected %d common prefixes but got %d.", len(expectedPrefixes), len(response.ListBucketResult.CommonPrefixes))
-    }
-    for i, prefix := range response.ListBucketResult.CommonPrefixes {
-        ds3Testing.AssertString(t, "CommonPrefix", expectedPrefixes[i], prefix)
-    }
+	if len(response.ListBucketResult.CommonPrefixes) != len(expectedPrefixes) {
+		t.Fatalf("Expected %d common prefixes but got %d.", len(expectedPrefixes), len(response.ListBucketResult.CommonPrefixes))
+	}
+	for i, prefix := range response.ListBucketResult.CommonPrefixes {
+		ds3Testing.AssertString(t, "CommonPrefix", expectedPrefixes[i], prefix)
+	}
 
-    if len(response.ListBucketResult.Objects) != len(keys) {
-        t.Fatalf("Expected %d objects but got %d.", len(keys), len(response.ListBucketResult.Objects))
-    }
-    ds3Testing.AssertNonNilStringPtr(t, "Name", bucketName, response.ListBucketResult.Name)
-    ds3Testing.AssertStringPtrIsNil(t, "Prefix", response.ListBucketResult.Prefix)
-    ds3Testing.AssertStringPtrIsNil(t, "Marker", response.ListBucketResult.Marker)
-    ds3Testing.AssertInt(t, "MaxKeys", 1000, response.ListBucketResult.MaxKeys)
-    ds3Testing.AssertBool(t, "Truncated", false, response.ListBucketResult.Truncated)
-    for i, object := range response.ListBucketResult.Objects {
-        ds3Testing.AssertNonNilStringPtr(t, "Key", keys[i], object.Key)
-        ds3Testing.AssertStringPtrIsNil(t, "LastModified", object.LastModified)
-        ds3Testing.AssertStringPtrIsNil(t, "ETag", object.ETag)
-        ds3Testing.AssertInt64(t, "Size", 0, object.Size)
-        ds3Testing.AssertStringPtrIsNil(t, "StorageClass", object.StorageClass)
-        ds3Testing.AssertString(t, "Id", ids[i], object.Owner.Id)
-        ds3Testing.AssertNonNilStringPtr(t, "DisplayName", displayName, object.Owner.DisplayName)
-    }
+	if len(response.ListBucketResult.Objects) != len(keys) {
+		t.Fatalf("Expected %d objects but got %d.", len(keys), len(response.ListBucketResult.Objects))
+	}
+	ds3Testing.AssertNonNilStringPtr(t, "Name", bucketName, response.ListBucketResult.Name)
+	ds3Testing.AssertStringPtrIsNil(t, "Prefix", response.ListBucketResult.Prefix)
+	ds3Testing.AssertStringPtrIsNil(t, "Marker", response.ListBucketResult.Marker)
+	ds3Testing.AssertInt(t, "MaxKeys", 1000, response.ListBucketResult.MaxKeys)
+	ds3Testing.AssertBool(t, "Truncated", false, response.ListBucketResult.Truncated)
+	for i, object := range response.ListBucketResult.Objects {
+		ds3Testing.AssertNonNilStringPtr(t, "Key", keys[i], object.Key)
+		ds3Testing.AssertStringPtrIsNil(t, "LastModified", object.LastModified)
+		ds3Testing.AssertStringPtrIsNil(t, "ETag", object.ETag)
+		ds3Testing.AssertInt64(t, "Size", 0, object.Size)
+		ds3Testing.AssertStringPtrIsNil(t, "StorageClass", object.StorageClass)
+		ds3Testing.AssertString(t, "Id", ids[i], object.Owner.Id)
+		ds3Testing.AssertNonNilStringPtr(t, "DisplayName", displayName, object.Owner.DisplayName)
+	}
 }
 
 func TestPutBucket(t *testing.T) {
-    // Create and run the mocked client.
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_PUT, "/bucketName", &url.Values{}, &http.Header{}, nil).
-        Returning(200, "", nil).
-        PutBucket(context.Background(), models.NewPutBucketRequest("bucketName"))
+	// Create and run the mocked client.
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_PUT, "/bucketName", &url.Values{}, &http.Header{}, nil).
+		Returning(200, "", nil).
+		PutBucket(context.Background(), models.NewPutBucketRequest("bucketName"))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 }
 
 func TestDeleteBucket(t *testing.T) {
-    // Create and run the mocked client.
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_DELETE, "/bucketName", &url.Values{}, &http.Header{}, nil).
-        Returning(204, "", nil).
-        DeleteBucket(context.Background(), models.NewDeleteBucketRequest("bucketName"))
+	// Create and run the mocked client.
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/bucketName", &url.Values{}, &http.Header{}, nil).
+		Returning(204, "", nil).
+		DeleteBucket(context.Background(), models.NewDeleteBucketRequest("bucketName"))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 }
 
 func TestDeleteFolderRecursivelySpectraS3(t *testing.T) {
-    bucketId := "a24d14f3-e2f0-4bfb-ab71-f99d5ef43745"
-    folderName := "FolderName"
-    queryParams := &url.Values{"bucket_id": []string{bucketId}, "recursive": []string{""}}
+	bucketId := "a24d14f3-e2f0-4bfb-ab71-f99d5ef43745"
+	folderName := "FolderName"
+	queryParams := &url.Values{"bucket_id": []string{bucketId}, "recursive": []string{""}}
 
-    // Create and run the mocked client.
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_DELETE, "/_rest_/folder/FolderName", queryParams, &http.Header{}, nil).
-            Returning(204, "", nil).
-            DeleteFolderRecursivelySpectraS3(context.Background(), models.NewDeleteFolderRecursivelySpectraS3Request(bucketId, folderName))
+	// Create and run the mocked client.
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/_rest_/folder/FolderName", queryParams, &http.Header{}, nil).
+		Returning(204, "", nil).
+		DeleteFolderRecursivelySpectraS3(context.Background(), models.NewDeleteFolderRecursivelySpectraS3Request(bucketId, folderName))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 }
 
 func TestDeleteObject(t *testing.T) {
-    // Create and run the mocked client.
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_DELETE, "/bucketName/my/file.txt", &url.Values{}, &http.Header{}, nil).
-        Returning(204, "", nil).
-        DeleteObject(context.Background(), models.NewDeleteObjectRequest("bucketName", "my/file.txt"))
+	// Create and run the mocked client.
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/bucketName/my/file.txt", &url.Values{}, &http.Header{}, nil).
+		Returning(204, "", nil).
+		DeleteObject(context.Background(), models.NewDeleteObjectRequest("bucketName", "my/file.txt"))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 }
 
 func TestGetBadBucket(t *testing.T) {
-    // Create and run the mocked client.
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/remoteTest16", &url.Values{}, &http.Header{}, nil).
-        Returning(400, "", nil).
-        GetBucket(context.Background(), models.NewGetBucketRequest("remoteTest16"))
+	// Create and run the mocked client.
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/remoteTest16", &url.Values{}, &http.Header{}, nil).
+		Returning(400, "", nil).
+		GetBucket(context.Background(), models.NewGetBucketRequest("remoteTest16"))
 
-    // Check the error result.
-    if err == nil {
-        t.Fatal("Expected an error but got nil.")
-    }
+	// Check the error result.
+	if err == nil {
+		t.Fatal("Expected an error but got nil.")
+	}
 
-    expectedError := "Received a status code of 400 when [200] was expected. Could not parse the response for additional information."
-    ds3Testing.AssertString(t, "Error", expectedError, err.Error())
+	expectedError := "Received a status code of 400 when [200] was expected. Could not parse the response for additional information."
+	ds3Testing.AssertString(t, "Error", expectedError, err.Error())
 
-    // Check the response value.
-    if response != nil {
-        t.Fatal("Response was supposed to be nil.")
-    }
+	// Check the response value.
+	if response != nil {
+		t.Fatal("Response was supposed to be nil.")
+	}
 }
 
 func TestGetObject(t *testing.T) {
-    stringResponse := "object contents"
+	stringResponse := "object contents"
 
-    // Create and run the mocked client.
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/bucketName/object", &url.Values{}, &http.Header{}, nil).
-        Returning(200, stringResponse, nil).
-        GetObject(context.Background(), models.NewGetObjectRequest("bucketName", "object"))
+	// Create and run the mocked client.
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/bucketName/object", &url.Values{}, &http.Header{}, nil).
+		Returning(200, stringResponse, nil).
+		GetObject(context.Background(), models.NewGetObjectRequest("bucketName", "object"))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
-    if response.Content == nil {
-        t.Fatal("Response content was unexpectedly nil.")
-    }
-    defer response.Content.Close()
-    bs, readErr := ioutil.ReadAll(response.Content)
-    ds3Testing.AssertNilError(t, readErr)
-    ds3Testing.AssertString(t, "Response", stringResponse, string(bs))
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
+	if response.Content == nil {
+		t.Fatal("Response content was unexpectedly nil.")
+	}
+	defer response.Content.Close()
+	bs, readErr := ioutil.ReadAll(response.Content)
+	ds3Testing.AssertNilError(t, readErr)
+	ds3Testing.AssertString(t, "Response", stringResponse, string(bs))
 }
 
 func TestGetPartialObject(t *testing.T) {
-    stringResponse := "object contents"
+	stringResponse := "object contents"
 
-    // Create and run the mocked client.
-    requestHeaders := &http.Header{}
-    requestHeaders.Add("Range", "bytes=1-5,7-8,20-500")
+	// Create and run the mocked client.
+	requestHeaders := &http.Header{}
+	requestHeaders.Add("Range", "bytes=1-5,7-8,20-500")
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/bucketName/object", &url.Values{}, requestHeaders, nil).
-        Returning(206, stringResponse, nil).
-        GetObject(context.Background(), models.NewGetObjectRequest("bucketName", "object").
-            WithRanges(
-                models.Range{Start: 1, End: 5},
-                models.Range{Start: 7, End: 8},
-                models.Range{Start: 20, End: 500}))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/bucketName/object", &url.Values{}, requestHeaders, nil).
+		Returning(206, stringResponse, nil).
+		GetObject(context.Background(), models.NewGetObjectRequest("bucketName", "object").
+			WithRanges(
+				models.Range{Start: 1, End: 5},
+				models.Range{Start: 7, End: 8},
+				models.Range{Start: 20, End: 500}))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
-    if response.Content == nil {
-        t.Fatal("Response content was unexpectedly nil.")
-    }
-    defer response.Content.Close()
-    bs, readErr := ioutil.ReadAll(response.Content)
-    ds3Testing.AssertNilError(t, readErr)
-    ds3Testing.AssertString(t, "Response", stringResponse, string(bs))
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
+	if response.Content == nil {
+		t.Fatal("Response content was unexpectedly nil.")
+	}
+	defer response.Content.Close()
+	bs, readErr := ioutil.ReadAll(response.Content)
+	ds3Testing.AssertNilError(t, readErr)
+	ds3Testing.AssertString(t, "Response", stringResponse, string(bs))
 }
 
 func TestGetObjectRange(t *testing.T) {
-    stringResponse := "object contents"
-    requestHeaders := &http.Header{"Range": []string{"bytes=20-179"}}
+	stringResponse := "object contents"
+	requestHeaders := &http.Header{"Range": []string{"bytes=20-179"}}
 
-    // Create and run the mocked client.
-    request := models.NewGetObjectRequest("bucketName", "object").
-            WithRanges(models.Range{Start: 20, End: 179})
+	// Create and run the mocked client.
+	request := models.NewGetObjectRequest("bucketName", "object").
+		WithRanges(models.Range{Start: 20, End: 179})
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/bucketName/object", &url.Values{}, requestHeaders, nil).
-        Returning(200, stringResponse, &http.Header{"Range": []string{"bytes=20-179"}}).
-        GetObject(context.Background(), request)
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/bucketName/object", &url.Values{}, requestHeaders, nil).
+		Returning(200, stringResponse, &http.Header{"Range": []string{"bytes=20-179"}}).
+		GetObject(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
-    if response.Content == nil {
-        t.Fatal("Response content was unexpectedly nil.")
-    }
-    defer response.Content.Close()
-    bs, readErr := ioutil.ReadAll(response.Content)
-    ds3Testing.AssertNilError(t, readErr)
-    ds3Testing.AssertString(t, "Response", stringResponse, string(bs))
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
+	if response.Content == nil {
+		t.Fatal("Response content was unexpectedly nil.")
+	}
+	defer response.Content.Close()
+	bs, readErr := ioutil.ReadAll(response.Content)
+	ds3Testing.AssertNilError(t, readErr)
+	ds3Testing.AssertString(t, "Response", stringResponse, string(bs))
 }
 
 func TestGetObjectsDetailsSpectraS3(t *testing.T) {
-    bucketId := "a24d14f3-e2f0-4bfb-ab71-f99d5ef43745"
-    stringResponse := "<Data><S3Object><BucketId>a24d14f3-e2f0-4bfb-ab71-f99d5ef43745</BucketId><CreationDate>2015-09-21T20:06:47.694Z</CreationDate><Id>e37c3ce0-12aa-4f54-87e3-42532aca0e5e</Id><Name>beowulf.txt</Name><Type>DATA</Type></S3Object>" +
-            "<S3Object><BucketId>a24d14f3-e2f0-4bfb-ab71-f99d5ef43745</BucketId><CreationDate>2015-09-21T20:06:47.779Z</CreationDate><Id>dc628815-c723-4c4e-b68b-5f5d10f38af5</Id><Name>sherlock_holmes.txt</Name><Type>DATA</Type></S3Object>" +
-            "<S3Object><BucketId>a24d14f3-e2f0-4bfb-ab71-f99d5ef43745</BucketId><CreationDate>2015-09-21T20:06:47.772Z</CreationDate><Id>4f6985fd-fbae-4421-ba27-66fdb96187c5</Id><Name>tale_of_two_cities.txt</Name><Type>DATA</Type></S3Object>" +
-            "<S3Object><BucketId>a24d14f3-e2f0-4bfb-ab71-f99d5ef43745</BucketId><CreationDate>2015-09-21T20:06:47.696Z</CreationDate><Id>82c18910-fadb-4461-a152-bf714ae91b55</Id><Name>ulysses.txt</Name><Type>DATA</Type></S3Object></Data>"
+	bucketId := "a24d14f3-e2f0-4bfb-ab71-f99d5ef43745"
+	stringResponse := "<Data><S3Object><BucketId>a24d14f3-e2f0-4bfb-ab71-f99d5ef43745</BucketId><CreationDate>2015-09-21T20:06:47.694Z</CreationDate><Id>e37c3ce0-12aa-4f54-87e3-42532aca0e5e</Id><Name>beowulf.txt</Name><Type>DATA</Type></S3Object>" +
+		"<S3Object><BucketId>a24d14f3-e2f0-4bfb-ab71-f99d5ef43745</BucketId><CreationDate>2015-09-21T20:06:47.779Z</CreationDate><Id>dc628815-c723-4c4e-b68b-5f5d10f38af5</Id><Name>sherlock_holmes.txt</Name><Type>DATA</Type></S3Object>" +
+		"<S3Object><BucketId>a24d14f3-e2f0-4bfb-ab71-f99d5ef43745</BucketId><CreationDate>2015-09-21T20:06:47.772Z</CreationDate><Id>4f6985fd-fbae-4421-ba27-66fdb96187c5</Id><Name>tale_of_two_cities.txt</Name><Type>DATA</Type></S3Object>" +
+		"<S3Object><BucketId>a24d14f3-e2f0-4bfb-ab71-f99d5ef43745</BucketId><CreationDate>2015-09-21T20:06:47.696Z</CreationDate><Id>82c18910-fadb-4461-a152-bf714ae91b55</Id><Name>ulysses.txt</Name><Type>DATA</Type></S3Object></Data>"
 
-    request := models.NewGetObjectsDetailsSpectraS3Request().WithBucketId(bucketId)
+	request := models.NewGetObjectsDetailsSpectraS3Request().WithBucketId(bucketId)
 
-    responseHeaders := &http.Header{"page-truncated": []string{"0"}, "total-result-count": []string{"4"}}
-    queryParams := &url.Values{"bucket_id": []string{bucketId}}
+	responseHeaders := &http.Header{"page-truncated": []string{"0"}, "total-result-count": []string{"4"}}
+	queryParams := &url.Values{"bucket_id": []string{bucketId}}
 
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_GET, "/_rest_/object", queryParams, &http.Header{}, nil).
-            Returning(200, stringResponse, responseHeaders).
-            GetObjectsDetailsSpectraS3(context.Background(), request)
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/object", queryParams, &http.Header{}, nil).
+		Returning(200, stringResponse, responseHeaders).
+		GetObjectsDetailsSpectraS3(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
-    if response.S3ObjectList.S3Objects == nil {
-        t.Fatal("S3Object list was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
+	if response.S3ObjectList.S3Objects == nil {
+		t.Fatal("S3Object list was unexpectedly nil.")
+	}
 
-    expectedNames := []string{"beowulf.txt", "sherlock_holmes.txt", "tale_of_two_cities.txt", "ulysses.txt"}
-    expectedCreationDates := []string{"2015-09-21T20:06:47.694Z", "2015-09-21T20:06:47.779Z", "2015-09-21T20:06:47.772Z", "2015-09-21T20:06:47.696Z"}
-    expectedIds := []string{"e37c3ce0-12aa-4f54-87e3-42532aca0e5e", "dc628815-c723-4c4e-b68b-5f5d10f38af5", "4f6985fd-fbae-4421-ba27-66fdb96187c5", "82c18910-fadb-4461-a152-bf714ae91b55"}
+	expectedNames := []string{"beowulf.txt", "sherlock_holmes.txt", "tale_of_two_cities.txt", "ulysses.txt"}
+	expectedCreationDates := []string{"2015-09-21T20:06:47.694Z", "2015-09-21T20:06:47.779Z", "2015-09-21T20:06:47.772Z", "2015-09-21T20:06:47.696Z"}
+	expectedIds := []string{"e37c3ce0-12aa-4f54-87e3-42532aca0e5e", "dc628815-c723-4c4e-b68b-5f5d10f38af5", "4f6985fd-fbae-4421-ba27-66fdb96187c5", "82c18910-fadb-4461-a152-bf714ae91b55"}
 
-    if len(response.S3ObjectList.S3Objects) != len(expectedNames) {
-        t.Fatalf("Expected '%d' S3Objects, but got '%d'", len(expectedNames), len(response.S3ObjectList.S3Objects))
-    }
+	if len(response.S3ObjectList.S3Objects) != len(expectedNames) {
+		t.Fatalf("Expected '%d' S3Objects, but got '%d'", len(expectedNames), len(response.S3ObjectList.S3Objects))
+	}
 
-    for i, object := range response.S3ObjectList.S3Objects {
-        ds3Testing.AssertString(t, "BucketId", bucketId, object.BucketId)
-        ds3Testing.AssertNonNilStringPtr(t, "CreationDate", expectedCreationDates[i], object.CreationDate)
-        ds3Testing.AssertString(t, "Id", expectedIds[i], object.Id)
-        ds3Testing.AssertNonNilStringPtr(t, "Name", expectedNames[i], object.Name)
-        if object.Type != models.S3_OBJECT_TYPE_DATA {
-            t.Fatalf("Expected type of '%d' but was '%d'.", models.S3_OBJECT_TYPE_DATA, object.Type)
-        }
-    }
+	for i, object := range response.S3ObjectList.S3Objects {
+		ds3Testing.AssertString(t, "BucketId", bucketId, object.BucketId)
+		ds3Testing.AssertNonNilStringPtr(t, "CreationDate", expectedCreationDates[i], object.CreationDate)
+		ds3Testing.AssertString(t, "Id", expectedIds[i], object.Id)
+		ds3Testing.AssertNonNilStringPtr(t, "Name", expectedNames[i], object.Name)
+		if object.Type != models.S3_OBJECT_TYPE_DATA {
+			t.Fatalf("Expected type of '%d' but was '%d'.", models.S3_OBJECT_TYPE_DATA, object.Type)
+		}
+	}
 }
 
 func TestGetJobToReplicateSpectraS3(t *testing.T) {
-    stringResponse := "object contents"
+	stringResponse := "object contents"
 
-    // Create and run the mocked client.
-    request := models.NewGetJobToReplicateSpectraS3Request("23a876ec-2fac-4dc8-b8e6-98d6026e7f4a")
+	// Create and run the mocked client.
+	request := models.NewGetJobToReplicateSpectraS3Request("23a876ec-2fac-4dc8-b8e6-98d6026e7f4a")
 
-    expectedParams := &url.Values{"replicate": []string{""}}
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/_rest_/job/23a876ec-2fac-4dc8-b8e6-98d6026e7f4a", expectedParams, &http.Header{}, nil).
-        Returning(200, stringResponse, nil).
-        GetJobToReplicateSpectraS3(context.Background(), request)
+	expectedParams := &url.Values{"replicate": []string{""}}
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/job/23a876ec-2fac-4dc8-b8e6-98d6026e7f4a", expectedParams, &http.Header{}, nil).
+		Returning(200, stringResponse, nil).
+		GetJobToReplicateSpectraS3(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
-    ds3Testing.AssertString(t, "Content", stringResponse, response.Content)
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
+	ds3Testing.AssertString(t, "Content", stringResponse, response.Content)
 }
 
 func TestPutObject(t *testing.T) {
-    stringResponse := "object contents"
+	stringResponse := "object contents"
 
-    // Create and run the mocked client.
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_PUT, "/bucketName/object", &url.Values{}, &http.Header{}, nil).
-        Returning(200, "", nil).
-        PutObject(context.Background(), models.NewPutObjectRequest(
-            "bucketName",
-            "object",
-            BuildByteReaderWithSizeDecorator([]byte(stringResponse)),
-        ))
+	// Create and run the mocked client.
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_PUT, "/bucketName/object", &url.Values{}, &http.Header{}, nil).
+		Returning(200, "", nil).
+		PutObject(context.Background(), models.NewPutObjectRequest(
+			"bucketName",
+			"object",
+			BuildByteReaderWithSizeDecorator([]byte(stringResponse)),
+		))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 }
 
 func TestPutObjectWithMetaData(t *testing.T) {
-    stringResponse := "object contents"
+	stringResponse := "object contents"
 
-    expectedMetaData := &http.Header{}
-    expectedMetaData.Add("x-amz-meta-test1", "test1value")
-    expectedMetaData.Add("x-amz-meta-test2", "test2value,test2value2")
+	expectedMetaData := &http.Header{}
+	expectedMetaData.Add("x-amz-meta-test1", "test1value")
+	expectedMetaData.Add("x-amz-meta-test2", "test2value,test2value2")
 
-    request := models.NewPutObjectRequest(
-        "bucketName",
-        "object",
-        BuildByteReaderWithSizeDecorator([]byte(stringResponse))).
-            WithMetaData("x-amz-meta-test1", "test1value").
-            WithMetaData("test2", "test2value", "test2value2")
+	request := models.NewPutObjectRequest(
+		"bucketName",
+		"object",
+		BuildByteReaderWithSizeDecorator([]byte(stringResponse))).
+		WithMetaData("x-amz-meta-test1", "test1value").
+		WithMetaData("test2", "test2value", "test2value2")
 
-    if len(request.Metadata) < 1 {
-        t.Fatal("Expected there to be metadata")
-    }
+	if len(request.Metadata) < 1 {
+		t.Fatal("Expected there to be metadata")
+	}
 
-    // Create and run the mocked client.
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_PUT, "/bucketName/object", &url.Values{}, expectedMetaData, nil).
-            Returning(200, "", nil).
-            PutObject(context.Background(), request)
+	// Create and run the mocked client.
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_PUT, "/bucketName/object", &url.Values{}, expectedMetaData, nil).
+		Returning(200, "", nil).
+		PutObject(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 }
 
 func TestBulkPut(t *testing.T) {
-    runBulkPutTest(
-        t,
-        "start_bulk_put",
-        func(client *Client, objects []models.Ds3PutObject) ([]models.Objects, error) {
-            request, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request("bucketName", objects))
-            return request.MasterObjectList.Objects, err
-        },
-    )
+	runBulkPutTest(
+		t,
+		"start_bulk_put",
+		func(client *Client, objects []models.Ds3PutObject) ([]models.Objects, error) {
+			request, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request("bucketName", objects))
+			return request.MasterObjectList.Objects, err
+		},
+	)
 }
 
 type bulkPutTest func(*Client, []models.Ds3PutObject) ([]models.Objects, error)
 
 func runBulkPutTest(t *testing.T, operation string, callToTest bulkPutTest) {
-    keys := []string { "file2", "file1", "file3" }
-    sizes := []int64 { 1202, 256, 2523 }
+	keys := []string{"file2", "file1", "file3"}
+	sizes := []int64{1202, 256, 2523}
 
-    stringRequest := "<Objects><Object Name=\"file1\" Size=\"256\"></Object><Object Name=\"file2\" Size=\"1202\"></Object><Object Name=\"file3\" Size=\"2523\"></Object></Objects>"
-    stringResponse := "<MasterObjectList><Objects><Object Name='file2' Length='1202'/><Object Name='file1' Length='256'/><Object Name='file3' Length='2523'/></Objects></MasterObjectList>"
+	stringRequest := "<Objects><Object Name=\"file1\" Size=\"256\"></Object><Object Name=\"file2\" Size=\"1202\"></Object><Object Name=\"file3\" Size=\"2523\"></Object></Objects>"
+	stringResponse := "<MasterObjectList><Objects><Object Name='file2' Length='1202'/><Object Name='file1' Length='256'/><Object Name='file3' Length='2523'/></Objects></MasterObjectList>"
 
-    inputObjects := []models.Ds3PutObject {
-        {Name: "file1", Size: 256 },
-        {Name: "file2", Size: 1202 },
-        {Name: "file3", Size: 2523 },
-    }
+	inputObjects := []models.Ds3PutObject{
+		{Name: "file1", Size: 256},
+		{Name: "file2", Size: 1202},
+		{Name: "file3", Size: 2523},
+	}
 
-    // Create and run the mocked client.
-    client := mockedClient(t).
-        Expecting(
-            HTTP_VERB_PUT,
-            "/_rest_/bucket/bucketName",
-            &url.Values{"operation": []string{operation}},
-            &http.Header{},
-            &stringRequest,
-        ).
-        Returning(200, stringResponse, nil)
-    response, err := callToTest(client, inputObjects)
+	// Create and run the mocked client.
+	client := mockedClient(t).
+		Expecting(
+			HTTP_VERB_PUT,
+			"/_rest_/bucket/bucketName",
+			&url.Values{"operation": []string{operation}},
+			&http.Header{},
+			&stringRequest,
+		).
+		Returning(200, stringResponse, nil)
+	response, err := callToTest(client, inputObjects)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
-    if len(response) != 1 {
-        t.Fatalf("Expected 1 object list but got %d.", len(response))
-    }
-    if len(response[0].Objects) != len(keys) {
-        t.Fatalf("Expected %d objects but got %d.", len(keys), len(response[0].Objects))
-    }
-    for i, obj := range response[0].Objects {
-        ds3Testing.AssertNonNilStringPtr(t, "Name", keys[i], obj.Name)
-        ds3Testing.AssertInt64(t, "Length", sizes[i], obj.Length)
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
+	if len(response) != 1 {
+		t.Fatalf("Expected 1 object list but got %d.", len(response))
+	}
+	if len(response[0].Objects) != len(keys) {
+		t.Fatalf("Expected %d objects but got %d.", len(keys), len(response[0].Objects))
+	}
+	for i, obj := range response[0].Objects {
+		ds3Testing.AssertNonNilStringPtr(t, "Name", keys[i], obj.Name)
+		ds3Testing.AssertInt64(t, "Length", sizes[i], obj.Length)
+	}
 }
 
 func TestBulkGetWithSimpleDs3GetObjets(t *testing.T) {
-    objects := []models.Ds3GetObject {
-        models.NewDs3GetObject("file1"),
-        models.NewDs3GetObject("file2"),
-        models.NewDs3GetObject("file3"),
-    }
+	objects := []models.Ds3GetObject{
+		models.NewDs3GetObject("file1"),
+		models.NewDs3GetObject("file2"),
+		models.NewDs3GetObject("file3"),
+	}
 
-    stringRequest := "<Objects><Object Name=\"file1\"></Object><Object Name=\"file2\"></Object><Object Name=\"file3\"></Object></Objects>"
+	stringRequest := "<Objects><Object Name=\"file1\"></Object><Object Name=\"file2\"></Object><Object Name=\"file3\"></Object></Objects>"
 
-    runBulkGetTest(
-        t,
-        "start_bulk_get",
-        &stringRequest,
-        func(client *Client) ([]models.Objects, error) {
-            request, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
-            return request.MasterObjectList.Objects, err
-        },
-    )
+	runBulkGetTest(
+		t,
+		"start_bulk_get",
+		&stringRequest,
+		func(client *Client) ([]models.Objects, error) {
+			request, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
+			return request.MasterObjectList.Objects, err
+		},
+	)
 }
 
 func TestBulkGetWithPartialDs3GetObjects(t *testing.T) {
-    objects := []models.Ds3GetObject {
-        models.NewPartialDs3GetObject("file1", 10, 100),
-        models.NewPartialDs3GetObject("file2", 20, 200),
-        models.NewPartialDs3GetObject("file3", 30, 300),
-    }
+	objects := []models.Ds3GetObject{
+		models.NewPartialDs3GetObject("file1", 10, 100),
+		models.NewPartialDs3GetObject("file2", 20, 200),
+		models.NewPartialDs3GetObject("file3", 30, 300),
+	}
 
-    stringRequest := "<Objects><Object Name=\"file1\" Length=\"10\" Offset=\"100\"></Object><Object Name=\"file2\" Length=\"20\" Offset=\"200\"></Object><Object Name=\"file3\" Length=\"30\" Offset=\"300\"></Object></Objects>"
+	stringRequest := "<Objects><Object Name=\"file1\" Length=\"10\" Offset=\"100\"></Object><Object Name=\"file2\" Length=\"20\" Offset=\"200\"></Object><Object Name=\"file3\" Length=\"30\" Offset=\"300\"></Object></Objects>"
 
-    runBulkGetTest(
-        t,
-        "start_bulk_get",
-        &stringRequest,
-        func(client *Client) ([]models.Objects, error) {
-            request, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
-            return request.MasterObjectList.Objects, err
-        },
-    )
+	runBulkGetTest(
+		t,
+		"start_bulk_get",
+		&stringRequest,
+		func(client *Client) ([]models.Objects, error) {
+			request, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
+			return request.MasterObjectList.Objects, err
+		},
+	)
 }
 
 func TestBulkGetWithObjectNames(t *testing.T) {
-    objects := []string {"file1", "file2", "file3"}
+	objects := []string{"file1", "file2", "file3"}
 
-    stringRequest := "<Objects><Object Name=\"file1\"></Object><Object Name=\"file2\"></Object><Object Name=\"file3\"></Object></Objects>"
+	stringRequest := "<Objects><Object Name=\"file1\"></Object><Object Name=\"file2\"></Object><Object Name=\"file3\"></Object></Objects>"
 
-    runBulkGetTest(
-        t,
-        "start_bulk_get",
-        &stringRequest,
-        func(client *Client) ([]models.Objects, error) {
-            request, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3Request("bucketName", objects))
-            return request.MasterObjectList.Objects, err
-        },
-    )
+	runBulkGetTest(
+		t,
+		"start_bulk_get",
+		&stringRequest,
+		func(client *Client) ([]models.Objects, error) {
+			request, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3Request("bucketName", objects))
+			return request.MasterObjectList.Objects, err
+		},
+	)
 }
 
 func TestBulkVerifyWithPartialDs3GetObjects(t *testing.T) {
-    objects := []models.Ds3GetObject {
-        models.NewPartialDs3GetObject("file1", 10, 100),
-        models.NewPartialDs3GetObject("file2", 20, 200),
-        models.NewPartialDs3GetObject("file3", 30, 300),
-    }
+	objects := []models.Ds3GetObject{
+		models.NewPartialDs3GetObject("file1", 10, 100),
+		models.NewPartialDs3GetObject("file2", 20, 200),
+		models.NewPartialDs3GetObject("file3", 30, 300),
+	}
 
-    stringRequest := "<Objects><Object Name=\"file1\" Length=\"10\" Offset=\"100\"></Object><Object Name=\"file2\" Length=\"20\" Offset=\"200\"></Object><Object Name=\"file3\" Length=\"30\" Offset=\"300\"></Object></Objects>"
+	stringRequest := "<Objects><Object Name=\"file1\" Length=\"10\" Offset=\"100\"></Object><Object Name=\"file2\" Length=\"20\" Offset=\"200\"></Object><Object Name=\"file3\" Length=\"30\" Offset=\"300\"></Object></Objects>"
 
-    runBulkGetTest(
-        t,
-        "start_bulk_verify",
-        &stringRequest,
-        func(client *Client) ([]models.Objects, error) {
-            request, err := client.VerifyBulkJobSpectraS3(context.Background(), models.NewVerifyBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
-            return request.MasterObjectList.Objects, err
-        },
-    )
+	runBulkGetTest(
+		t,
+		"start_bulk_verify",
+		&stringRequest,
+		func(client *Client) ([]models.Objects, error) {
+			request, err := client.VerifyBulkJobSpectraS3(context.Background(), models.NewVerifyBulkJobSpectraS3RequestWithPartialObjects("bucketName", objects))
+			return request.MasterObjectList.Objects, err
+		},
+	)
 }
 
 func TestBulkVerifyWithObjectNames(t *testing.T) {
-    objects := []string {"file1", "file2", "file3"}
+	objects := []string{"file1", "file2", "file3"}
 
-    stringRequest := "<Objects><Object Name=\"file1\"></Object><Object Name=\"file2\"></Object><Object Name=\"file3\"></Object></Objects>"
+	stringRequest := "<Objects><Object Name=\"file1\"></Object><Object Name=\"file2\"></Object><Object Name=\"file3\"></Object></Objects>"
 
-    runBulkGetTest(
-        t,
-        "start_bulk_verify",
-        &stringRequest,
-        func(client *Client) ([]models.Objects, error) {
-            request, err := client.VerifyBulkJobSpectraS3(context.Background(), models.NewVerifyBulkJobSpectraS3Request("bucketName", objects))
-            return request.MasterObjectList.Objects, err
-        },
-    )
+	runBulkGetTest(
+		t,
+		"start_bulk_verify",
+		&stringRequest,
+		func(client *Client) ([]models.Objects, error) {
+			request, err := client.VerifyBulkJobSpectraS3(context.Background(), models.NewVerifyBulkJobSpectraS3Request("bucketName", objects))
+			return request.MasterObjectList.Objects, err
+		},
+	)
 }
 
 type bulkGetTest func(*Client) ([]models.Objects, error)
 
 func runBulkGetTest(t *testing.T, operation string, stringRequest *string, callToTest bulkGetTest) {
-    keys := []string { "file2", "file1", "file3" }
-    sizes := []int64 { 1202, 256, 2523 }
+	keys := []string{"file2", "file1", "file3"}
+	sizes := []int64{1202, 256, 2523}
 
-    stringResponse := "<MasterObjectList><Objects><Object Name='file2' Length='1202'/><Object Name='file1' Length='256'/><Object Name='file3' Length='2523'/></Objects></MasterObjectList>"
+	stringResponse := "<MasterObjectList><Objects><Object Name='file2' Length='1202'/><Object Name='file1' Length='256'/><Object Name='file3' Length='2523'/></Objects></MasterObjectList>"
 
-    // Create and run the mocked client.
-    client := mockedClient(t).
-        Expecting(
-        HTTP_VERB_PUT,
-        "/_rest_/bucket/bucketName",
-        &url.Values{"operation": []string{operation}},
-        &http.Header{},
-        stringRequest,
-    ).
-        Returning(200, stringResponse, nil)
-    response, err := callToTest(client)
+	// Create and run the mocked client.
+	client := mockedClient(t).
+		Expecting(
+			HTTP_VERB_PUT,
+			"/_rest_/bucket/bucketName",
+			&url.Values{"operation": []string{operation}},
+			&http.Header{},
+			stringRequest,
+		).
+		Returning(200, stringResponse, nil)
+	response, err := callToTest(client)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
-    if len(response) != 1 {
-        t.Fatalf("Expected 1 object list but got %d.", len(response))
-    }
-    if len(response[0].Objects) != len(keys) {
-        t.Fatalf("Expected %d objects but got %d.", len(keys), len(response[0].Objects))
-    }
-    for i, obj := range response[0].Objects {
-        ds3Testing.AssertNonNilStringPtr(t, "Name", keys[i], obj.Name)
-        ds3Testing.AssertInt64(t, "Length", sizes[i], obj.Length)
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
+	if len(response) != 1 {
+		t.Fatalf("Expected 1 object list but got %d.", len(response))
+	}
+	if len(response[0].Objects) != len(keys) {
+		t.Fatalf("Expected %d objects but got %d.", len(keys), len(response[0].Objects))
+	}
+	for i, obj := range response[0].Objects {
+		ds3Testing.AssertNonNilStringPtr(t, "Name", keys[i], obj.Name)
+		ds3Testing.AssertInt64(t, "Length", sizes[i], obj.Length)
+	}
 }
 
 func TestInitiateMultipart(t *testing.T) {
-    stringResponse := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><InitiateMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Bucket>example-bucket</Bucket><Key>example-object</Key><UploadId>VXBsb2FkIElEIGZvciA2aWWpbmcncyBteS1tb3ZpZS5tMnRzIHVwbG9hZA</UploadId></InitiateMultipartUploadResult>"
+	stringResponse := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><InitiateMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Bucket>example-bucket</Bucket><Key>example-object</Key><UploadId>VXBsb2FkIElEIGZvciA2aWWpbmcncyBteS1tb3ZpZS5tMnRzIHVwbG9hZA</UploadId></InitiateMultipartUploadResult>"
 
-    // Create and run the mocked client.
-    qs := &url.Values{"uploads": []string{""}}
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_POST, "/bucketName/object", qs, &http.Header{}, nil).
-        Returning(200, stringResponse, nil).
-        InitiateMultiPartUpload(context.Background(), models.NewInitiateMultiPartUploadRequest(
-            "bucketName",
-            "object",
-        ))
+	// Create and run the mocked client.
+	qs := &url.Values{"uploads": []string{""}}
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_POST, "/bucketName/object", qs, &http.Header{}, nil).
+		Returning(200, stringResponse, nil).
+		InitiateMultiPartUpload(context.Background(), models.NewInitiateMultiPartUploadRequest(
+			"bucketName",
+			"object",
+		))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
-    ds3Testing.AssertNonNilStringPtr(t, "Bucket", "example-bucket", response.InitiateMultipartUploadResult.Bucket)
-    ds3Testing.AssertNonNilStringPtr(t, "Key", "example-object", response.InitiateMultipartUploadResult.Key)
-    ds3Testing.AssertNonNilStringPtr(t, "UploadId", "VXBsb2FkIElEIGZvciA2aWWpbmcncyBteS1tb3ZpZS5tMnRzIHVwbG9hZA", response.InitiateMultipartUploadResult.UploadId)
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
+	ds3Testing.AssertNonNilStringPtr(t, "Bucket", "example-bucket", response.InitiateMultipartUploadResult.Bucket)
+	ds3Testing.AssertNonNilStringPtr(t, "Key", "example-object", response.InitiateMultipartUploadResult.Key)
+	ds3Testing.AssertNonNilStringPtr(t, "UploadId", "VXBsb2FkIElEIGZvciA2aWWpbmcncyBteS1tb3ZpZS5tMnRzIHVwbG9hZA", response.InitiateMultipartUploadResult.UploadId)
 }
 
 func TestPutPart(t *testing.T) {
-    content := "this is the part content"
-    partNumber := 2
-    uploadId := "VXBsb2FkIElEIGZvciA2aWWpbmcncyBteS1tb3ZpZS5tMnRzIHVwbG9hZA"
-    eTag := "b54357faf0632cce46e942fa68356b38"
+	content := "this is the part content"
+	partNumber := 2
+	uploadId := "VXBsb2FkIElEIGZvciA2aWWpbmcncyBteS1tb3ZpZS5tMnRzIHVwbG9hZA"
+	eTag := "b54357faf0632cce46e942fa68356b38"
 
-    // Create and run the mocked client.
-    qs := &url.Values{
-        "part_number": []string{strconv.Itoa(partNumber)},
-        "upload_id": []string{uploadId},
-    }
-    responseHeaders := &http.Header{}
-    responseHeaders.Add("ETag", eTag)
+	// Create and run the mocked client.
+	qs := &url.Values{
+		"part_number": []string{strconv.Itoa(partNumber)},
+		"upload_id":   []string{uploadId},
+	}
+	responseHeaders := &http.Header{}
+	responseHeaders.Add("ETag", eTag)
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_PUT, "/bucketName/object", qs, &http.Header{}, &content).
-        Returning(200, "", responseHeaders).
-        PutMultiPartUploadPart(context.Background(), models.NewPutMultiPartUploadPartRequest(
-            "bucketName",
-            "object",
-            BuildByteReaderWithSizeDecorator([]byte(content)),
-            partNumber,
-            uploadId,
-        ))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_PUT, "/bucketName/object", qs, &http.Header{}, &content).
+		Returning(200, "", responseHeaders).
+		PutMultiPartUploadPart(context.Background(), models.NewPutMultiPartUploadPartRequest(
+			"bucketName",
+			"object",
+			BuildByteReaderWithSizeDecorator([]byte(content)),
+			partNumber,
+			uploadId,
+		))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
 
-    ds3Testing.AssertString(t, "etag header", eTag, response.Headers.Get("etag"))
+	ds3Testing.AssertString(t, "etag header", eTag, response.Headers.Get("etag"))
 }
 
 func TestCompleteMultipart(t *testing.T) {
-    bucket := "bucketName"
-    key := "object"
-    location := "http://my-server/bucketName/object"
-    etag := "b54357faf0632cce46e942fa68356b38"
-    uploadId := "VXBsb2FkIElEIGZvciA2aWWpbmcncyBteS1tb3ZpZS5tMnRzIHVwbG9hZA"
-    expectedRequest := "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>7a112844c1a2327e617f530cb06dccf8</ETag></Part><Part><PartNumber>2</PartNumber><ETag>7162e29f4e40da7f521d0794b57770ba</ETag></Part></CompleteMultipartUpload>"
-    expectedResponse := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Location>http://my-server/bucketName/object</Location><Bucket>bucketName</Bucket><Key>object</Key><ETag>b54357faf0632cce46e942fa68356b38</ETag></CompleteMultipartUploadResult>"
+	bucket := "bucketName"
+	key := "object"
+	location := "http://my-server/bucketName/object"
+	etag := "b54357faf0632cce46e942fa68356b38"
+	uploadId := "VXBsb2FkIElEIGZvciA2aWWpbmcncyBteS1tb3ZpZS5tMnRzIHVwbG9hZA"
+	expectedRequest := "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>7a112844c1a2327e617f530cb06dccf8</ETag></Part><Part><PartNumber>2</PartNumber><ETag>7162e29f4e40da7f521d0794b57770ba</ETag></Part></CompleteMultipartUpload>"
+	expectedResponse := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Location>http://my-server/bucketName/object</Location><Bucket>bucketName</Bucket><Key>object</Key><ETag>b54357faf0632cce46e942fa68356b38</ETag></CompleteMultipartUploadResult>"
 
-    // Create and run the mocked client.
-    qs := &url.Values{
-        "upload_id": []string{uploadId},
-    }
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_POST, "/bucketName/object", qs, &http.Header{}, &expectedRequest).
-        Returning(200, expectedResponse, &http.Header{"etag": []string{etag}}).
-        CompleteMultiPartUpload(context.Background(), models.NewCompleteMultiPartUploadRequest(
-            bucket,
-            key,
-            []models.Part{
-                {PartNumber: 1, ETag: "7a112844c1a2327e617f530cb06dccf8"},
-                {PartNumber: 2, ETag: "7162e29f4e40da7f521d0794b57770ba"},
-            },
-            uploadId,
-        ))
+	// Create and run the mocked client.
+	qs := &url.Values{
+		"upload_id": []string{uploadId},
+	}
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_POST, "/bucketName/object", qs, &http.Header{}, &expectedRequest).
+		Returning(200, expectedResponse, &http.Header{"etag": []string{etag}}).
+		CompleteMultiPartUpload(context.Background(), models.NewCompleteMultiPartUploadRequest(
+			bucket,
+			key,
+			[]models.Part{
+				{PartNumber: 1, ETag: "7a112844c1a2327e617f530cb06dccf8"},
+				{PartNumber: 2, ETag: "7162e29f4e40da7f521d0794b57770ba"},
+			},
+			uploadId,
+		))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
 
-    ds3Testing.AssertNonNilStringPtr(t, "Location", location, response.CompleteMultipartUploadResult.Location)
-    ds3Testing.AssertNonNilStringPtr(t, "Bucket", bucket, response.CompleteMultipartUploadResult.Bucket)
-    ds3Testing.AssertNonNilStringPtr(t, "Key", key, response.CompleteMultipartUploadResult.Key)
-    ds3Testing.AssertNonNilStringPtr(t, "ETag", etag, response.CompleteMultipartUploadResult.ETag)
+	ds3Testing.AssertNonNilStringPtr(t, "Location", location, response.CompleteMultipartUploadResult.Location)
+	ds3Testing.AssertNonNilStringPtr(t, "Bucket", bucket, response.CompleteMultipartUploadResult.Bucket)
+	ds3Testing.AssertNonNilStringPtr(t, "Key", key, response.CompleteMultipartUploadResult.Key)
+	ds3Testing.AssertNonNilStringPtr(t, "ETag", etag, response.CompleteMultipartUploadResult.ETag)
 }
 
 func TestDeleteObjects(t *testing.T) {
-    bucket := "bucketName"
-    objectNames := []string {"obj1", "obj2", "obj3"}
-    expectedRequest := "<Delete><Object><Key>obj1</Key></Object><Object><Key>obj2</Key></Object><Object><Key>obj3</Key></Object></Delete>"
-    expectedResponse := "<DeleteResult><Deleted><Key>obj1</Key></Deleted><Deleted><Key>obj2</Key></Deleted><Error><Code>ObjectNotFound</Code><Key>obj3</Key><Message>Object not found</Message></Error></DeleteResult>"
+	bucket := "bucketName"
+	objectNames := []string{"obj1", "obj2", "obj3"}
+	expectedRequest := "<Delete><Object><Key>obj1</Key></Object><Object><Key>obj2</Key></Object><Object><Key>obj3</Key></Object></Delete>"
+	expectedResponse := "<DeleteResult><Deleted><Key>obj1</Key></Deleted><Deleted><Key>obj2</Key></Deleted><Error><Code>ObjectNotFound</Code><Key>obj3</Key><Message>Object not found</Message></Error></DeleteResult>"
 
-    expectedDeleted := []models.S3ObjectToDelete{
-        { Key:&objectNames[0], },
-        { Key:&objectNames[1], },
-    }
+	expectedDeleted := []models.S3ObjectToDelete{
+		{Key: &objectNames[0]},
+		{Key: &objectNames[1]},
+	}
 
-    code := "ObjectNotFound"
-    message := "Object not found"
-    expectedErrors := []models.DeleteObjectError {
-        {
-            Code:    &code,
-            Key:     &objectNames[2],
-            Message: &message,
-        },
-    }
+	code := "ObjectNotFound"
+	message := "Object not found"
+	expectedErrors := []models.DeleteObjectError{
+		{
+			Code:    &code,
+			Key:     &objectNames[2],
+			Message: &message,
+		},
+	}
 
-    // Create and run the mocked client.
-    qs := &url.Values{
-        "delete": []string{""},
-    }
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_POST, "/bucketName", qs, &http.Header{}, &expectedRequest).
-        Returning(200, expectedResponse, &http.Header{}).
-        DeleteObjects(context.Background(), models.NewDeleteObjectsRequest(bucket, objectNames))
+	// Create and run the mocked client.
+	qs := &url.Values{
+		"delete": []string{""},
+	}
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_POST, "/bucketName", qs, &http.Header{}, &expectedRequest).
+		Returning(200, expectedResponse, &http.Header{}).
+		DeleteObjects(context.Background(), models.NewDeleteObjectsRequest(bucket, objectNames))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 
-    if response.DeleteResult.DeletedObjects == nil {
-        t.Fatalf("Expected '%v' but got 'nil'", expectedDeleted)
-    }
+	if response.DeleteResult.DeletedObjects == nil {
+		t.Fatalf("Expected '%v' but got 'nil'", expectedDeleted)
+	}
 
-    if !reflect.DeepEqual(response.DeleteResult.DeletedObjects, expectedDeleted) {
-        t.Fatalf("Expected '%v' but got '%v'", expectedDeleted, response.DeleteResult.DeletedObjects)
-    }
+	if !reflect.DeepEqual(response.DeleteResult.DeletedObjects, expectedDeleted) {
+		t.Fatalf("Expected '%v' but got '%v'", expectedDeleted, response.DeleteResult.DeletedObjects)
+	}
 
-    if response.DeleteResult.Errors == nil {
-        t.Fatalf("Expected '%v' but got 'nil'", expectedErrors)
-    }
+	if response.DeleteResult.Errors == nil {
+		t.Fatalf("Expected '%v' but got 'nil'", expectedErrors)
+	}
 
-    if !reflect.DeepEqual(response.DeleteResult.Errors, expectedErrors) {
-        t.Fatalf("Expected '%v' but got '%v'", expectedErrors, response.DeleteResult.Errors)
-    }
+	if !reflect.DeepEqual(response.DeleteResult.Errors, expectedErrors) {
+		t.Fatalf("Expected '%v' but got '%v'", expectedErrors, response.DeleteResult.Errors)
+	}
 }
 
 func TestAllocateJobChunkSpectraS3(t *testing.T) {
-    responseString := "<Objects ChunkId=\"203f6886-b058-4f7c-a012-8779176453b1\" ChunkNumber=\"3\" NodeId=\"a02053b9-0147-11e4-8d6a-002590c1177c\">" +
-            "<Object Name=\"client00obj000004-8000000\" InCache=\"true\" Length=\"5368709120\" Offset=\"0\"/>" +
-            "<Object Name=\"client00obj000004-8000000\" InCache=\"true\" Length=\"2823290880\" Offset=\"5368709120\"/>" +
-            "<Object Name=\"client00obj000003-8000000\" InCache=\"true\" Length=\"2823290880\" Offset=\"5368709120\"/>" +
-            "<Object Name=\"client00obj000003-8000000\" InCache=\"true\" Length=\"5368709120\" Offset=\"0\"/>" +
-            "</Objects>"
+	responseString := "<Objects ChunkId=\"203f6886-b058-4f7c-a012-8779176453b1\" ChunkNumber=\"3\" NodeId=\"a02053b9-0147-11e4-8d6a-002590c1177c\">" +
+		"<Object Name=\"client00obj000004-8000000\" InCache=\"true\" Length=\"5368709120\" Offset=\"0\"/>" +
+		"<Object Name=\"client00obj000004-8000000\" InCache=\"true\" Length=\"2823290880\" Offset=\"5368709120\"/>" +
+		"<Object Name=\"client00obj000003-8000000\" InCache=\"true\" Length=\"2823290880\" Offset=\"5368709120\"/>" +
+		"<Object Name=\"client00obj000003-8000000\" InCache=\"true\" Length=\"5368709120\" Offset=\"0\"/>" +
+		"</Objects>"
 
-    chunkId := "203f6886-b058-4f7c-a012-8779176453b1"
-    nodeId := "a02053b9-0147-11e4-8d6a-002590c1177c"
+	chunkId := "203f6886-b058-4f7c-a012-8779176453b1"
+	nodeId := "a02053b9-0147-11e4-8d6a-002590c1177c"
 
-    qp := &url.Values{"operation": []string{"allocate"}}
+	qp := &url.Values{"operation": []string{"allocate"}}
 
-    request := models.NewAllocateJobChunkSpectraS3Request(chunkId)
+	request := models.NewAllocateJobChunkSpectraS3Request(chunkId)
 
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_PUT, "/_rest_/job_chunk/203f6886-b058-4f7c-a012-8779176453b1", qp, &http.Header{}, nil).
-            Returning(200, responseString, nil).
-            AllocateJobChunkSpectraS3(context.Background(), request)
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_PUT, "/_rest_/job_chunk/203f6886-b058-4f7c-a012-8779176453b1", qp, &http.Header{}, nil).
+		Returning(200, responseString, nil).
+		AllocateJobChunkSpectraS3(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
-    ds3Testing.AssertString(t, "ChunkId", chunkId, response.Objects.ChunkId)
-    ds3Testing.AssertInt(t, "ChunkNumber", 3, response.Objects.ChunkNumber)
-    ds3Testing.AssertNonNilStringPtr(t, "NodeId", nodeId, response.Objects.NodeId)
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
+	ds3Testing.AssertString(t, "ChunkId", chunkId, response.Objects.ChunkId)
+	ds3Testing.AssertInt(t, "ChunkNumber", 3, response.Objects.ChunkNumber)
+	ds3Testing.AssertNonNilStringPtr(t, "NodeId", nodeId, response.Objects.NodeId)
 
-    expectedNames := []string{"client00obj000004-8000000", "client00obj000004-8000000", "client00obj000003-8000000", "client00obj000003-8000000"}
-    expectedOffsets := []int64{0, 5368709120, 5368709120, 0}
-    expectedLengths := []int64{5368709120, 2823290880, 2823290880, 5368709120}
+	expectedNames := []string{"client00obj000004-8000000", "client00obj000004-8000000", "client00obj000003-8000000", "client00obj000003-8000000"}
+	expectedOffsets := []int64{0, 5368709120, 5368709120, 0}
+	expectedLengths := []int64{5368709120, 2823290880, 2823290880, 5368709120}
 
-    if len(response.Objects.Objects) != len(expectedNames) {
-        t.Fatalf("Expected number of objects '%d' but got '%d'.", len(response.Objects.Objects), len(expectedNames))
-    }
-    for i, obj := range response.Objects.Objects {
-        ds3Testing.AssertNonNilStringPtr(t, "Name", expectedNames[i], obj.Name)
-        ds3Testing.AssertNonNilBoolPtr(t, "InCache", true, obj.InCache)
-        ds3Testing.AssertInt64(t, "Offset", expectedOffsets[i], obj.Offset)
-        ds3Testing.AssertInt64(t, "Length", expectedLengths[i], obj.Length)
-    }
+	if len(response.Objects.Objects) != len(expectedNames) {
+		t.Fatalf("Expected number of objects '%d' but got '%d'.", len(response.Objects.Objects), len(expectedNames))
+	}
+	for i, obj := range response.Objects.Objects {
+		ds3Testing.AssertNonNilStringPtr(t, "Name", expectedNames[i], obj.Name)
+		ds3Testing.AssertNonNilBoolPtr(t, "InCache", true, obj.InCache)
+		ds3Testing.AssertInt64(t, "Offset", expectedOffsets[i], obj.Offset)
+		ds3Testing.AssertInt64(t, "Length", expectedLengths[i], obj.Length)
+	}
 }
 
 const (
-    test_master_object_list_id  = "1a85e743-ec8f-4789-afec-97e587a26936"
-    test_master_object_list_xml = "<MasterObjectList BucketName=\"bucket8192000000\" JobId=\"1a85e743-ec8f-4789-afec-97e587a26936\" Priority=\"NORMAL\" RequestType=\"GET\" StartDate=\"2014-07-01T20:12:52.000Z\">" +
-            "  <Nodes>" +
-            "    <Node EndPoint=\"10.1.18.12\" HttpPort=\"80\" HttpsPort=\"443\" Id=\"a02053b9-0147-11e4-8d6a-002590c1177c\"/>" +
-            "    <Node EndPoint=\"10.1.18.13\" HttpsPort=\"443\" Id=\"95e97010-8e70-4733-926c-aeeb21796848\"/>" +
-            "  </Nodes>" +
-            "  <Objects ChunkId=\"f58370c2-2538-4e78-a9f8-e4d2676bdf44\" ChunkNumber=\"0\" NodeId=\"a02053b9-0147-11e4-8d6a-002590c1177c\">" +
-            "    <Object Name=\"client00obj000004-8000000\" InCache=\"true\" Length=\"5368709120\" Offset=\"0\"/>" +
-            "    <Object Name=\"client00obj000004-8000000\" InCache=\"true\" Length=\"2823290880\" Offset=\"5368709120\"/>" +
-            "  </Objects>" +
-            "  <Objects ChunkId=\"4137d768-25bb-4942-9d36-b92dfbe75e01\" ChunkNumber=\"1\" NodeId=\"95e97010-8e70-4733-926c-aeeb21796848\">" +
-            "    <Object Name=\"client00obj000008-8000000\" InCache=\"true\" Length=\"2823290880\" Offset=\"5368709120\"/>" +
-            "    <Object Name=\"client00obj000008-8000000\" InCache=\"true\" Length=\"5368709120\" Offset=\"0\"/>" +
-            "  </Objects>" +
-            "</MasterObjectList>"
+	test_master_object_list_id  = "1a85e743-ec8f-4789-afec-97e587a26936"
+	test_master_object_list_xml = "<MasterObjectList BucketName=\"bucket8192000000\" JobId=\"1a85e743-ec8f-4789-afec-97e587a26936\" Priority=\"NORMAL\" RequestType=\"GET\" StartDate=\"2014-07-01T20:12:52.000Z\">" +
+		"  <Nodes>" +
+		"    <Node EndPoint=\"10.1.18.12\" HttpPort=\"80\" HttpsPort=\"443\" Id=\"a02053b9-0147-11e4-8d6a-002590c1177c\"/>" +
+		"    <Node EndPoint=\"10.1.18.13\" HttpsPort=\"443\" Id=\"95e97010-8e70-4733-926c-aeeb21796848\"/>" +
+		"  </Nodes>" +
+		"  <Objects ChunkId=\"f58370c2-2538-4e78-a9f8-e4d2676bdf44\" ChunkNumber=\"0\" NodeId=\"a02053b9-0147-11e4-8d6a-002590c1177c\">" +
+		"    <Object Name=\"client00obj000004-8000000\" InCache=\"true\" Length=\"5368709120\" Offset=\"0\"/>" +
+		"    <Object Name=\"client00obj000004-8000000\" InCache=\"true\" Length=\"2823290880\" Offset=\"5368709120\"/>" +
+		"  </Objects>" +
+		"  <Objects ChunkId=\"4137d768-25bb-4942-9d36-b92dfbe75e01\" ChunkNumber=\"1\" NodeId=\"95e97010-8e70-4733-926c-aeeb21796848\">" +
+		"    <Object Name=\"client00obj000008-8000000\" InCache=\"true\" Length=\"2823290880\" Offset=\"5368709120\"/>" +
+		"    <Object Name=\"client00obj000008-8000000\" InCache=\"true\" Length=\"5368709120\" Offset=\"0\"/>" +
+		"  </Objects>" +
+		"</MasterObjectList>"
 )
 
 func verifyMasterObjectList(t *testing.T, masterObjectList models.MasterObjectList) {
-    bucketName := "bucket8192000000"
-    startDate := "2014-07-01T20:12:52.000Z"
-    ds3Testing.AssertNonNilStringPtr(t, "BucketName", bucketName, masterObjectList.BucketName)
-    ds3Testing.AssertString(t, "JobId", test_master_object_list_id, masterObjectList.JobId)
-    if masterObjectList.Priority != models.PRIORITY_NORMAL {
-        t.Fatalf("Expected priority '%d' but got '%d'.", models.PRIORITY_NORMAL, masterObjectList.Priority)
-    }
-    if masterObjectList.RequestType != models.JOB_REQUEST_TYPE_GET {
-        t.Fatalf("Expected request type '%d' but got '%d'.", models.JOB_REQUEST_TYPE_GET, masterObjectList.RequestType)
-    }
-    ds3Testing.AssertString(t, "StartDate", startDate, masterObjectList.StartDate)
+	bucketName := "bucket8192000000"
+	startDate := "2014-07-01T20:12:52.000Z"
+	ds3Testing.AssertNonNilStringPtr(t, "BucketName", bucketName, masterObjectList.BucketName)
+	ds3Testing.AssertString(t, "JobId", test_master_object_list_id, masterObjectList.JobId)
+	if masterObjectList.Priority != models.PRIORITY_NORMAL {
+		t.Fatalf("Expected priority '%d' but got '%d'.", models.PRIORITY_NORMAL, masterObjectList.Priority)
+	}
+	if masterObjectList.RequestType != models.JOB_REQUEST_TYPE_GET {
+		t.Fatalf("Expected request type '%d' but got '%d'.", models.JOB_REQUEST_TYPE_GET, masterObjectList.RequestType)
+	}
+	ds3Testing.AssertString(t, "StartDate", startDate, masterObjectList.StartDate)
 
-    // verify nodes
-    if len(masterObjectList.Nodes) != 2 {
-        t.Fatalf("Expected there to be 2 nodes but got '%d'.", len(masterObjectList.Nodes))
-    }
+	// verify nodes
+	if len(masterObjectList.Nodes) != 2 {
+		t.Fatalf("Expected there to be 2 nodes but got '%d'.", len(masterObjectList.Nodes))
+	}
 
-    node1 := masterObjectList.Nodes[0]
-    ds3Testing.AssertNonNilStringPtr(t, "EndPoint", "10.1.18.12", node1.EndPoint)
-    ds3Testing.AssertNonNilIntPtr(t, "HttpPort", 80, node1.HttpPort)
-    ds3Testing.AssertNonNilIntPtr(t, "HttpsPort", 443, node1.HttpsPort)
-    ds3Testing.AssertString(t, "Id", "a02053b9-0147-11e4-8d6a-002590c1177c", node1.Id)
+	node1 := masterObjectList.Nodes[0]
+	ds3Testing.AssertNonNilStringPtr(t, "EndPoint", "10.1.18.12", node1.EndPoint)
+	ds3Testing.AssertNonNilIntPtr(t, "HttpPort", 80, node1.HttpPort)
+	ds3Testing.AssertNonNilIntPtr(t, "HttpsPort", 443, node1.HttpsPort)
+	ds3Testing.AssertString(t, "Id", "a02053b9-0147-11e4-8d6a-002590c1177c", node1.Id)
 
-    node2 := masterObjectList.Nodes[1]
-    ds3Testing.AssertNonNilStringPtr(t, "EndPoint", "10.1.18.13", node2.EndPoint)
-    ds3Testing.AssertIntPtrIsNil(t, "HttpPort", node2.HttpPort)
-    ds3Testing.AssertNonNilIntPtr(t, "HttpsPort", 443, node2.HttpsPort)
-    ds3Testing.AssertString(t, "Id", "95e97010-8e70-4733-926c-aeeb21796848", node2.Id)
+	node2 := masterObjectList.Nodes[1]
+	ds3Testing.AssertNonNilStringPtr(t, "EndPoint", "10.1.18.13", node2.EndPoint)
+	ds3Testing.AssertIntPtrIsNil(t, "HttpPort", node2.HttpPort)
+	ds3Testing.AssertNonNilIntPtr(t, "HttpsPort", 443, node2.HttpsPort)
+	ds3Testing.AssertString(t, "Id", "95e97010-8e70-4733-926c-aeeb21796848", node2.Id)
 
-    // verify objects
-    if len(masterObjectList.Objects) != 2 {
-        t.Fatalf("Expected 2 object but got '%d'.", len(masterObjectList.Objects))
-    }
+	// verify objects
+	if len(masterObjectList.Objects) != 2 {
+		t.Fatalf("Expected 2 object but got '%d'.", len(masterObjectList.Objects))
+	}
 
-    obj1 := masterObjectList.Objects[0]
-    ds3Testing.AssertString(t, "ChunkId", "f58370c2-2538-4e78-a9f8-e4d2676bdf44", obj1.ChunkId)
-    ds3Testing.AssertInt(t, "ChunkNumber", 0, obj1.ChunkNumber)
-    ds3Testing.AssertNonNilStringPtr(t, "NodeId", "a02053b9-0147-11e4-8d6a-002590c1177c", obj1.NodeId)
+	obj1 := masterObjectList.Objects[0]
+	ds3Testing.AssertString(t, "ChunkId", "f58370c2-2538-4e78-a9f8-e4d2676bdf44", obj1.ChunkId)
+	ds3Testing.AssertInt(t, "ChunkNumber", 0, obj1.ChunkNumber)
+	ds3Testing.AssertNonNilStringPtr(t, "NodeId", "a02053b9-0147-11e4-8d6a-002590c1177c", obj1.NodeId)
 
-    if len(obj1.Objects) != 2 {
-        t.Fatalf("Expected 2 bulk objects but got '%d'.", len(obj1.Objects))
-    }
+	if len(obj1.Objects) != 2 {
+		t.Fatalf("Expected 2 bulk objects but got '%d'.", len(obj1.Objects))
+	}
 
-    obj1BulkObj1 := obj1.Objects[0]
-    ds3Testing.AssertNonNilStringPtr(t, "Name", "client00obj000004-8000000", obj1BulkObj1.Name)
-    ds3Testing.AssertNonNilBoolPtr(t, "InCache", true, obj1BulkObj1.InCache)
-    ds3Testing.AssertInt64(t, "Length", 5368709120, obj1BulkObj1.Length)
-    ds3Testing.AssertInt64(t, "Offset", 0, obj1BulkObj1.Offset)
+	obj1BulkObj1 := obj1.Objects[0]
+	ds3Testing.AssertNonNilStringPtr(t, "Name", "client00obj000004-8000000", obj1BulkObj1.Name)
+	ds3Testing.AssertNonNilBoolPtr(t, "InCache", true, obj1BulkObj1.InCache)
+	ds3Testing.AssertInt64(t, "Length", 5368709120, obj1BulkObj1.Length)
+	ds3Testing.AssertInt64(t, "Offset", 0, obj1BulkObj1.Offset)
 
-    obj1BulkObj2 := obj1.Objects[1]
-    ds3Testing.AssertNonNilStringPtr(t, "Name", "client00obj000004-8000000", obj1BulkObj2.Name)
-    ds3Testing.AssertNonNilBoolPtr(t, "InCache", true, obj1BulkObj2.InCache)
-    ds3Testing.AssertInt64(t, "Length", 2823290880, obj1BulkObj2.Length)
-    ds3Testing.AssertInt64(t, "Offset", 5368709120, obj1BulkObj2.Offset)
+	obj1BulkObj2 := obj1.Objects[1]
+	ds3Testing.AssertNonNilStringPtr(t, "Name", "client00obj000004-8000000", obj1BulkObj2.Name)
+	ds3Testing.AssertNonNilBoolPtr(t, "InCache", true, obj1BulkObj2.InCache)
+	ds3Testing.AssertInt64(t, "Length", 2823290880, obj1BulkObj2.Length)
+	ds3Testing.AssertInt64(t, "Offset", 5368709120, obj1BulkObj2.Offset)
 
-    obj2 := masterObjectList.Objects[1]
-    ds3Testing.AssertString(t, "ChunkId", "4137d768-25bb-4942-9d36-b92dfbe75e01", obj2.ChunkId)
-    ds3Testing.AssertInt(t, "ChunkNumber", 1, obj2.ChunkNumber)
-    ds3Testing.AssertNonNilStringPtr(t, "NodeId", "95e97010-8e70-4733-926c-aeeb21796848", obj2.NodeId)
-    if len(obj2.Objects) != 2 {
-        t.Fatalf("Expected 2 bulk objects but got '%d'.", len(obj2.Objects))
-    }
+	obj2 := masterObjectList.Objects[1]
+	ds3Testing.AssertString(t, "ChunkId", "4137d768-25bb-4942-9d36-b92dfbe75e01", obj2.ChunkId)
+	ds3Testing.AssertInt(t, "ChunkNumber", 1, obj2.ChunkNumber)
+	ds3Testing.AssertNonNilStringPtr(t, "NodeId", "95e97010-8e70-4733-926c-aeeb21796848", obj2.NodeId)
+	if len(obj2.Objects) != 2 {
+		t.Fatalf("Expected 2 bulk objects but got '%d'.", len(obj2.Objects))
+	}
 
-    obj2BulkObj1 := obj2.Objects[0]
-    ds3Testing.AssertNonNilStringPtr(t, "Name", "client00obj000008-8000000", obj2BulkObj1.Name)
-    ds3Testing.AssertNonNilBoolPtr(t, "InCache", true, obj2BulkObj1.InCache)
-    ds3Testing.AssertInt64(t, "Length", 2823290880, obj2BulkObj1.Length)
-    ds3Testing.AssertInt64(t, "Offset", 5368709120, obj2BulkObj1.Offset)
+	obj2BulkObj1 := obj2.Objects[0]
+	ds3Testing.AssertNonNilStringPtr(t, "Name", "client00obj000008-8000000", obj2BulkObj1.Name)
+	ds3Testing.AssertNonNilBoolPtr(t, "InCache", true, obj2BulkObj1.InCache)
+	ds3Testing.AssertInt64(t, "Length", 2823290880, obj2BulkObj1.Length)
+	ds3Testing.AssertInt64(t, "Offset", 5368709120, obj2BulkObj1.Offset)
 
-    obj2BulkObj2 := obj2.Objects[1]
-    ds3Testing.AssertNonNilStringPtr(t, "Name", "client00obj000008-8000000", obj2BulkObj2.Name)
-    ds3Testing.AssertNonNilBoolPtr(t, "InCache", true, obj2BulkObj2.InCache)
-    ds3Testing.AssertInt64(t, "Length", 5368709120, obj2BulkObj2.Length)
-    ds3Testing.AssertInt64(t, "Offset", 0, obj2BulkObj2.Offset)
+	obj2BulkObj2 := obj2.Objects[1]
+	ds3Testing.AssertNonNilStringPtr(t, "Name", "client00obj000008-8000000", obj2BulkObj2.Name)
+	ds3Testing.AssertNonNilBoolPtr(t, "InCache", true, obj2BulkObj2.InCache)
+	ds3Testing.AssertInt64(t, "Length", 5368709120, obj2BulkObj2.Length)
+	ds3Testing.AssertInt64(t, "Offset", 0, obj2BulkObj2.Offset)
 }
 
 func TestGetJobChunksReadyForClientProcessingSpectraS3(t *testing.T) {
-    qp := &url.Values{"job": []string{test_master_object_list_id}}
+	qp := &url.Values{"job": []string{test_master_object_list_id}}
 
-    request := models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(test_master_object_list_id)
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_GET, "/_rest_/job_chunk", qp, &http.Header{}, nil).
-            Returning(200, test_master_object_list_xml, nil).
-            GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), request)
+	request := models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(test_master_object_list_id)
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/job_chunk", qp, &http.Header{}, nil).
+		Returning(200, test_master_object_list_xml, nil).
+		GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
-    verifyMasterObjectList(t, response.MasterObjectList)
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
+	verifyMasterObjectList(t, response.MasterObjectList)
 }
 
 func TestGetJobSpectraS3(t *testing.T) {
-    request := models.NewGetJobSpectraS3Request(test_master_object_list_id)
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_GET, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
-            Returning(200, test_master_object_list_xml, nil).
-            GetJobSpectraS3(context.Background(), request)
+	request := models.NewGetJobSpectraS3Request(test_master_object_list_id)
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
+		Returning(200, test_master_object_list_xml, nil).
+		GetJobSpectraS3(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 
-    verifyMasterObjectList(t, response.MasterObjectList)
+	verifyMasterObjectList(t, response.MasterObjectList)
 }
 
 func TestModifyJobSpectraS3(t *testing.T) {
-    request := models.NewModifyJobSpectraS3Request(test_master_object_list_id)
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_PUT, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
-            Returning(200, test_master_object_list_xml, nil).
-            ModifyJobSpectraS3(context.Background(), request)
+	request := models.NewModifyJobSpectraS3Request(test_master_object_list_id)
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_PUT, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
+		Returning(200, test_master_object_list_xml, nil).
+		ModifyJobSpectraS3(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 
-    verifyMasterObjectList(t, response.MasterObjectList)
+	verifyMasterObjectList(t, response.MasterObjectList)
 }
 
 func TestGetJobsSpectraS3(t *testing.T) {
-    responseString := "<Jobs>" +
-            "  <Job BucketName=\"bucket_1\" CachedSizeInBytes=\"69880\" ChunkClientProcessingOrderGuarantee=\"IN_ORDER\" CompletedSizeInBytes=\"0\" JobId=\"0807ff11-a9f6-4d55-bb92-b452c1bb00c7\" OriginalSizeInBytes=\"69880\" Priority=\"NORMAL\" RequestType=\"PUT\" StartDate=\"2014-09-04T17:23:45.000Z\" UserId=\"a7d3eff9-e6d2-4e37-8a0b-84e76211a18a\" UserName=\"spectra\">" +
-            "    <Nodes>" +
-            "      <Node EndPoint=\"10.10.10.10\" HttpPort=\"80\" HttpsPort=\"443\" Id=\"edb8cc38-32f2-11e4-bce1-080027ecf0d4\"/>" +
-            "    </Nodes>" +
-            "  </Job>" +
-            "  <Job BucketName=\"bucket_2\" CachedSizeInBytes=\"0\" ChunkClientProcessingOrderGuarantee=\"IN_ORDER\" CompletedSizeInBytes=\"0\" JobId=\"c18554ba-e3a8-4905-91fd-3e6eec71bf45\" OriginalSizeInBytes=\"69880\" Priority=\"HIGH\" RequestType=\"GET\" StartDate=\"2014-09-04T17:24:04.000Z\" UserId=\"a7d3eff9-e6d2-4e37-8a0b-84e76211a18a\" UserName=\"spectra\">" +
-            "    <Nodes>" +
-            "      <Node EndPoint=\"10.10.10.10\" HttpPort=\"80\" HttpsPort=\"443\" Id=\"edb8cc38-32f2-11e4-bce1-080027ecf0d4\"/>" +
-            "    </Nodes>" +
-            "  </Job>" +
-            "</Jobs>"
+	responseString := "<Jobs>" +
+		"  <Job BucketName=\"bucket_1\" CachedSizeInBytes=\"69880\" ChunkClientProcessingOrderGuarantee=\"IN_ORDER\" CompletedSizeInBytes=\"0\" JobId=\"0807ff11-a9f6-4d55-bb92-b452c1bb00c7\" OriginalSizeInBytes=\"69880\" Priority=\"NORMAL\" RequestType=\"PUT\" StartDate=\"2014-09-04T17:23:45.000Z\" UserId=\"a7d3eff9-e6d2-4e37-8a0b-84e76211a18a\" UserName=\"spectra\">" +
+		"    <Nodes>" +
+		"      <Node EndPoint=\"10.10.10.10\" HttpPort=\"80\" HttpsPort=\"443\" Id=\"edb8cc38-32f2-11e4-bce1-080027ecf0d4\"/>" +
+		"    </Nodes>" +
+		"  </Job>" +
+		"  <Job BucketName=\"bucket_2\" CachedSizeInBytes=\"0\" ChunkClientProcessingOrderGuarantee=\"IN_ORDER\" CompletedSizeInBytes=\"0\" JobId=\"c18554ba-e3a8-4905-91fd-3e6eec71bf45\" OriginalSizeInBytes=\"69880\" Priority=\"HIGH\" RequestType=\"GET\" StartDate=\"2014-09-04T17:24:04.000Z\" UserId=\"a7d3eff9-e6d2-4e37-8a0b-84e76211a18a\" UserName=\"spectra\">" +
+		"    <Nodes>" +
+		"      <Node EndPoint=\"10.10.10.10\" HttpPort=\"80\" HttpsPort=\"443\" Id=\"edb8cc38-32f2-11e4-bce1-080027ecf0d4\"/>" +
+		"    </Nodes>" +
+		"  </Job>" +
+		"</Jobs>"
 
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_GET, "/_rest_/job", &url.Values{}, &http.Header{}, nil).
-            Returning(200, responseString, nil).
-            GetJobsSpectraS3(context.Background(), models.NewGetJobsSpectraS3Request())
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/job", &url.Values{}, &http.Header{}, nil).
+		Returning(200, responseString, nil).
+		GetJobsSpectraS3(context.Background(), models.NewGetJobsSpectraS3Request())
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
-    if len(response.JobList.Jobs) != 2 {
-        t.Fatalf("Expected 2 jobs but got '%d'.", len(response.JobList.Jobs))
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
+	if len(response.JobList.Jobs) != 2 {
+		t.Fatalf("Expected 2 jobs but got '%d'.", len(response.JobList.Jobs))
+	}
 
-    job1 := response.JobList.Jobs[0]
-    ds3Testing.AssertNonNilStringPtr(t, "BucketName", "bucket_1", job1.BucketName)
-    ds3Testing.AssertInt64(t, "CachedSizeInBytes", 69880, job1.CachedSizeInBytes)
-    if job1.ChunkClientProcessingOrderGuarantee != models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER {
-        t.Fatalf("Expected chunk client processing order guarantee '%d' but got '%d'.",
-            models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER,
-            job1.ChunkClientProcessingOrderGuarantee,
-        )
-    }
-    ds3Testing.AssertInt64(t, "CompletedSizeInBytes", 0, job1.CompletedSizeInBytes)
-    ds3Testing.AssertString(t, "JobId", "0807ff11-a9f6-4d55-bb92-b452c1bb00c7", job1.JobId)
-    ds3Testing.AssertInt64(t, "OriginalSizeInBytes", 69880, job1.OriginalSizeInBytes)
-    if job1.Priority != models.PRIORITY_NORMAL {
-        t.Fatalf("Expected priority '%d' but got '%d'.", models.PRIORITY_NORMAL, job1.Priority)
-    }
-    if job1.RequestType != models.JOB_REQUEST_TYPE_PUT {
-        t.Fatalf("Expected request type '%d' but got '%d'.", models.JOB_REQUEST_TYPE_PUT, job1.RequestType)
-    }
-    ds3Testing.AssertString(t, "StartDate", "2014-09-04T17:23:45.000Z", job1.StartDate)
-    ds3Testing.AssertString(t, "UserId", "a7d3eff9-e6d2-4e37-8a0b-84e76211a18a", job1.UserId)
-    ds3Testing.AssertNonNilStringPtr(t, "UserName", "spectra", job1.UserName)
-    if len(job1.Nodes) != 1 {
-        t.Fatalf("Expected '1' nodes but got '%d'.", len(job1.Nodes))
-    }
+	job1 := response.JobList.Jobs[0]
+	ds3Testing.AssertNonNilStringPtr(t, "BucketName", "bucket_1", job1.BucketName)
+	ds3Testing.AssertInt64(t, "CachedSizeInBytes", 69880, job1.CachedSizeInBytes)
+	if job1.ChunkClientProcessingOrderGuarantee != models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER {
+		t.Fatalf("Expected chunk client processing order guarantee '%d' but got '%d'.",
+			models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER,
+			job1.ChunkClientProcessingOrderGuarantee,
+		)
+	}
+	ds3Testing.AssertInt64(t, "CompletedSizeInBytes", 0, job1.CompletedSizeInBytes)
+	ds3Testing.AssertString(t, "JobId", "0807ff11-a9f6-4d55-bb92-b452c1bb00c7", job1.JobId)
+	ds3Testing.AssertInt64(t, "OriginalSizeInBytes", 69880, job1.OriginalSizeInBytes)
+	if job1.Priority != models.PRIORITY_NORMAL {
+		t.Fatalf("Expected priority '%d' but got '%d'.", models.PRIORITY_NORMAL, job1.Priority)
+	}
+	if job1.RequestType != models.JOB_REQUEST_TYPE_PUT {
+		t.Fatalf("Expected request type '%d' but got '%d'.", models.JOB_REQUEST_TYPE_PUT, job1.RequestType)
+	}
+	ds3Testing.AssertString(t, "StartDate", "2014-09-04T17:23:45.000Z", job1.StartDate)
+	ds3Testing.AssertString(t, "UserId", "a7d3eff9-e6d2-4e37-8a0b-84e76211a18a", job1.UserId)
+	ds3Testing.AssertNonNilStringPtr(t, "UserName", "spectra", job1.UserName)
+	if len(job1.Nodes) != 1 {
+		t.Fatalf("Expected '1' nodes but got '%d'.", len(job1.Nodes))
+	}
 
-    job1node := job1.Nodes[0]
-    ds3Testing.AssertNonNilStringPtr(t, "EndPoint", "10.10.10.10", job1node.EndPoint)
-    ds3Testing.AssertNonNilIntPtr(t, "HttpPort", 80, job1node.HttpPort)
-    ds3Testing.AssertNonNilIntPtr(t, "HttpsPort", 443, job1node.HttpsPort)
-    ds3Testing.AssertString(t, "Id", "edb8cc38-32f2-11e4-bce1-080027ecf0d4", job1node.Id)
+	job1node := job1.Nodes[0]
+	ds3Testing.AssertNonNilStringPtr(t, "EndPoint", "10.10.10.10", job1node.EndPoint)
+	ds3Testing.AssertNonNilIntPtr(t, "HttpPort", 80, job1node.HttpPort)
+	ds3Testing.AssertNonNilIntPtr(t, "HttpsPort", 443, job1node.HttpsPort)
+	ds3Testing.AssertString(t, "Id", "edb8cc38-32f2-11e4-bce1-080027ecf0d4", job1node.Id)
 
-    job2 := response.JobList.Jobs[1]
-    ds3Testing.AssertNonNilStringPtr(t, "BucketName", "bucket_2", job2.BucketName)
-    ds3Testing.AssertInt64(t, "CachedSizeInBytes", 0, job2.CachedSizeInBytes)
-    if job2.ChunkClientProcessingOrderGuarantee != models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER {
-        t.Fatalf("Expected chunk client processing order guarantee '%d' but got '%d'.",
-            models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER,
-            job2.ChunkClientProcessingOrderGuarantee,
-        )
-    }
-    ds3Testing.AssertInt64(t, "CompletedSizeInBytes", 0, job2.CompletedSizeInBytes)
-    ds3Testing.AssertString(t, "JobId", "c18554ba-e3a8-4905-91fd-3e6eec71bf45", job2.JobId)
-    ds3Testing.AssertInt64(t, "OriginalSizeInBytes", 69880, job2.OriginalSizeInBytes)
-    if job2.Priority != models.PRIORITY_HIGH {
-        t.Fatalf("Expected priority '%d' but got '%d'.", models.PRIORITY_HIGH, job2.Priority)
-    }
-    if job2.RequestType != models.JOB_REQUEST_TYPE_GET {
-        t.Fatalf("Expected request type '%d' but got '%d'.", models.JOB_REQUEST_TYPE_GET, job2.RequestType)
-    }
-    ds3Testing.AssertString(t, "StartDate", "2014-09-04T17:24:04.000Z", job2.StartDate)
-    ds3Testing.AssertString(t, "UserId", "a7d3eff9-e6d2-4e37-8a0b-84e76211a18a", job2.UserId)
-    ds3Testing.AssertNonNilStringPtr(t, "UserName", "spectra", job2.UserName)
-    if len(job2.Nodes) != 1 {
-        t.Fatalf("Expected '1' nodes but got '%d'.", len(job2.Nodes))
-    }
+	job2 := response.JobList.Jobs[1]
+	ds3Testing.AssertNonNilStringPtr(t, "BucketName", "bucket_2", job2.BucketName)
+	ds3Testing.AssertInt64(t, "CachedSizeInBytes", 0, job2.CachedSizeInBytes)
+	if job2.ChunkClientProcessingOrderGuarantee != models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER {
+		t.Fatalf("Expected chunk client processing order guarantee '%d' but got '%d'.",
+			models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER,
+			job2.ChunkClientProcessingOrderGuarantee,
+		)
+	}
+	ds3Testing.AssertInt64(t, "CompletedSizeInBytes", 0, job2.CompletedSizeInBytes)
+	ds3Testing.AssertString(t, "JobId", "c18554ba-e3a8-4905-91fd-3e6eec71bf45", job2.JobId)
+	ds3Testing.AssertInt64(t, "OriginalSizeInBytes", 69880, job2.OriginalSizeInBytes)
+	if job2.Priority != models.PRIORITY_HIGH {
+		t.Fatalf("Expected priority '%d' but got '%d'.", models.PRIORITY_HIGH, job2.Priority)
+	}
+	if job2.RequestType != models.JOB_REQUEST_TYPE_GET {
+		t.Fatalf("Expected request type '%d' but got '%d'.", models.JOB_REQUEST_TYPE_GET, job2.RequestType)
+	}
+	ds3Testing.AssertString(t, "StartDate", "2014-09-04T17:24:04.000Z", job2.StartDate)
+	ds3Testing.AssertString(t, "UserId", "a7d3eff9-e6d2-4e37-8a0b-84e76211a18a", job2.UserId)
+	ds3Testing.AssertNonNilStringPtr(t, "UserName", "spectra", job2.UserName)
+	if len(job2.Nodes) != 1 {
+		t.Fatalf("Expected '1' nodes but got '%d'.", len(job2.Nodes))
+	}
 
-    job2node := job2.Nodes[0]
-    ds3Testing.AssertNonNilStringPtr(t, "EndPoint", "10.10.10.10", job2node.EndPoint)
-    ds3Testing.AssertNonNilIntPtr(t, "HttpPort", 80, job2node.HttpPort)
-    ds3Testing.AssertNonNilIntPtr(t, "HttpsPort", 443, job2node.HttpsPort)
-    ds3Testing.AssertString(t, "Id", "edb8cc38-32f2-11e4-bce1-080027ecf0d4", job2node.Id)
+	job2node := job2.Nodes[0]
+	ds3Testing.AssertNonNilStringPtr(t, "EndPoint", "10.10.10.10", job2node.EndPoint)
+	ds3Testing.AssertNonNilIntPtr(t, "HttpPort", 80, job2node.HttpPort)
+	ds3Testing.AssertNonNilIntPtr(t, "HttpsPort", 443, job2node.HttpsPort)
+	ds3Testing.AssertString(t, "Id", "edb8cc38-32f2-11e4-bce1-080027ecf0d4", job2node.Id)
 }
 
 func TestCancelJobSpectraS3(t *testing.T) {
-    jobId := "1a85e743-ec8f-4789-afec-97e587a26936"
-    qp := &url.Values{"force": []string{""}}
-    request := models.NewCancelJobSpectraS3Request(jobId)
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_DELETE, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", qp, &http.Header{}, nil).
-            Returning(204, "", nil).
-            CancelJobSpectraS3(context.Background(), request)
+	jobId := "1a85e743-ec8f-4789-afec-97e587a26936"
+	qp := &url.Values{"force": []string{""}}
+	request := models.NewCancelJobSpectraS3Request(jobId)
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/_rest_/job/1a85e743-ec8f-4789-afec-97e587a26936", qp, &http.Header{}, nil).
+		Returning(204, "", nil).
+		CancelJobSpectraS3(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 }
 
 func TestDeleteTapeDriveSpectraS3(t *testing.T) {
-    jobId := "1a85e743-ec8f-4789-afec-97e587a26936"
+	jobId := "1a85e743-ec8f-4789-afec-97e587a26936"
 
-    request := models.NewDeleteTapeDriveSpectraS3Request(jobId)
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_DELETE, "/_rest_/tape_drive/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
-            Returning(204, "", nil).
-            DeleteTapeDriveSpectraS3(context.Background(), request)
+	request := models.NewDeleteTapeDriveSpectraS3Request(jobId)
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/_rest_/tape_drive/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
+		Returning(204, "", nil).
+		DeleteTapeDriveSpectraS3(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 }
 
 func TestDeleteTapePartitionSpectraS3(t *testing.T) {
-    id := "1a85e743-ec8f-4789-afec-97e587a26936"
+	id := "1a85e743-ec8f-4789-afec-97e587a26936"
 
-    request := models.NewDeleteTapePartitionSpectraS3Request(id)
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_DELETE, "/_rest_/tape_partition/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
-            Returning(204, "", nil).
-            DeleteTapePartitionSpectraS3(context.Background(), request)
+	request := models.NewDeleteTapePartitionSpectraS3Request(id)
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/_rest_/tape_partition/1a85e743-ec8f-4789-afec-97e587a26936", &url.Values{}, &http.Header{}, nil).
+		Returning(204, "", nil).
+		DeleteTapePartitionSpectraS3(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 }
 
 func TestVerifySystemHealthSpectraS3(t *testing.T) {
-    responsePayload := "<Data><MsRequiredToVerifyDataPlannerHealth>10</MsRequiredToVerifyDataPlannerHealth></Data>"
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_GET, "/_rest_/system_health", &url.Values{}, &http.Header{}, nil).
-            Returning(200, responsePayload, nil).
-            VerifySystemHealthSpectraS3(context.Background(), models.NewVerifySystemHealthSpectraS3Request())
+	responsePayload := "<Data><MsRequiredToVerifyDataPlannerHealth>10</MsRequiredToVerifyDataPlannerHealth></Data>"
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/system_health", &url.Values{}, &http.Header{}, nil).
+		Returning(200, responsePayload, nil).
+		VerifySystemHealthSpectraS3(context.Background(), models.NewVerifySystemHealthSpectraS3Request())
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
-    ds3Testing.AssertInt64(t, "MsRequiredToVerifyDataPlannerHealth", 10, response.HealthVerificationResult.MsRequiredToVerifyDataPlannerHealth)
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
+	ds3Testing.AssertInt64(t, "MsRequiredToVerifyDataPlannerHealth", 10, response.HealthVerificationResult.MsRequiredToVerifyDataPlannerHealth)
 }
 
 func TestGetSystemInformationSpectraS3(t *testing.T) {
-    responsePayload := "<Data>" +
-            "<ApiVersion>518B3F2A95B71AC7325EFB12B2937376.15F3CC0489CBCD4648ECFF0FBF371B8A</ApiVersion>" +
-            "<BuildInformation><Branch/><Revision/><Version/></BuildInformation>" +
-            "<SerialNumber>UNKNOWN</SerialNumber>" +
-            "</Data>"
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_GET, "/_rest_/system_information", &url.Values{}, &http.Header{}, nil).
-            Returning(200, responsePayload, nil).
-            GetSystemInformationSpectraS3(context.Background(), models.NewGetSystemInformationSpectraS3Request())
+	responsePayload := "<Data>" +
+		"<ApiVersion>518B3F2A95B71AC7325EFB12B2937376.15F3CC0489CBCD4648ECFF0FBF371B8A</ApiVersion>" +
+		"<BuildInformation><Branch/><Revision/><Version/></BuildInformation>" +
+		"<SerialNumber>UNKNOWN</SerialNumber>" +
+		"</Data>"
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/system_information", &url.Values{}, &http.Header{}, nil).
+		Returning(200, responsePayload, nil).
+		GetSystemInformationSpectraS3(context.Background(), models.NewGetSystemInformationSpectraS3Request())
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
-    ds3Testing.AssertNonNilStringPtr(t, "ApiVersion", "518B3F2A95B71AC7325EFB12B2937376.15F3CC0489CBCD4648ECFF0FBF371B8A", response.SystemInformation.ApiVersion)
-    ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "UNKNOWN", response.SystemInformation.SerialNumber)
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
+	ds3Testing.AssertNonNilStringPtr(t, "ApiVersion", "518B3F2A95B71AC7325EFB12B2937376.15F3CC0489CBCD4648ECFF0FBF371B8A", response.SystemInformation.ApiVersion)
+	ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "UNKNOWN", response.SystemInformation.SerialNumber)
 }
 
 func TestGetTapeLibrariesSpectraS3(t *testing.T) {
-    responsePayload := "<Data>" +
-            "<TapeLibrary><Id>f4dae25d-e52a-4430-82bd-525e4f15493c</Id><ManagementUrl>a</ManagementUrl><Name>test library</Name><SerialNumber>test library</SerialNumber></TapeLibrary>" +
-            "<TapeLibrary><Id>82bdab72-d79a-4b43-95d7-f2c16cd9aa45</Id><ManagementUrl>a</ManagementUrl><Name>test library 2</Name><SerialNumber>test library 2</SerialNumber></TapeLibrary>" +
-            "</Data>"
+	responsePayload := "<Data>" +
+		"<TapeLibrary><Id>f4dae25d-e52a-4430-82bd-525e4f15493c</Id><ManagementUrl>a</ManagementUrl><Name>test library</Name><SerialNumber>test library</SerialNumber></TapeLibrary>" +
+		"<TapeLibrary><Id>82bdab72-d79a-4b43-95d7-f2c16cd9aa45</Id><ManagementUrl>a</ManagementUrl><Name>test library 2</Name><SerialNumber>test library 2</SerialNumber></TapeLibrary>" +
+		"</Data>"
 
-    responseHeaders := &http.Header{}
-    responseHeaders.Add("Page-Truncated", "2")
-    responseHeaders.Add("Total-Result-Count", "3")
+	responseHeaders := &http.Header{}
+	responseHeaders.Add("Page-Truncated", "2")
+	responseHeaders.Add("Total-Result-Count", "3")
 
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_GET, "/_rest_/tape_library", &url.Values{}, &http.Header{}, nil).
-            Returning(200, responsePayload, responseHeaders).
-            GetTapeLibrariesSpectraS3(context.Background(), models.NewGetTapeLibrariesSpectraS3Request())
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/tape_library", &url.Values{}, &http.Header{}, nil).
+		Returning(200, responsePayload, responseHeaders).
+		GetTapeLibrariesSpectraS3(context.Background(), models.NewGetTapeLibrariesSpectraS3Request())
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 
-    if len(response.TapeLibraryList.TapeLibraries) != 2 {
-        t.Fatalf("Expected '2' tape libraries but got '%d'.", len(response.TapeLibraryList.TapeLibraries))
-    }
+	if len(response.TapeLibraryList.TapeLibraries) != 2 {
+		t.Fatalf("Expected '2' tape libraries but got '%d'.", len(response.TapeLibraryList.TapeLibraries))
+	}
 
-    lib1 := response.TapeLibraryList.TapeLibraries[0]
-    ds3Testing.AssertString(t, "Id", "f4dae25d-e52a-4430-82bd-525e4f15493c", lib1.Id)
-    ds3Testing.AssertNonNilStringPtr(t, "ManagementUrl", "a", lib1.ManagementUrl)
-    ds3Testing.AssertNonNilStringPtr(t, "Name", "test library", lib1.Name)
-    ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "test library", lib1.SerialNumber)
+	lib1 := response.TapeLibraryList.TapeLibraries[0]
+	ds3Testing.AssertString(t, "Id", "f4dae25d-e52a-4430-82bd-525e4f15493c", lib1.Id)
+	ds3Testing.AssertNonNilStringPtr(t, "ManagementUrl", "a", lib1.ManagementUrl)
+	ds3Testing.AssertNonNilStringPtr(t, "Name", "test library", lib1.Name)
+	ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "test library", lib1.SerialNumber)
 
-    lib2 := response.TapeLibraryList.TapeLibraries[1]
-    ds3Testing.AssertString(t, "Id", "82bdab72-d79a-4b43-95d7-f2c16cd9aa45", lib2.Id)
-    ds3Testing.AssertNonNilStringPtr(t, "ManagementUrl", "a", lib2.ManagementUrl)
-    ds3Testing.AssertNonNilStringPtr(t, "Name", "test library 2", lib2.Name)
-    ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "test library 2", lib2.SerialNumber)
+	lib2 := response.TapeLibraryList.TapeLibraries[1]
+	ds3Testing.AssertString(t, "Id", "82bdab72-d79a-4b43-95d7-f2c16cd9aa45", lib2.Id)
+	ds3Testing.AssertNonNilStringPtr(t, "ManagementUrl", "a", lib2.ManagementUrl)
+	ds3Testing.AssertNonNilStringPtr(t, "Name", "test library 2", lib2.Name)
+	ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "test library 2", lib2.SerialNumber)
 
-    ds3Testing.AssertString(t, "Page-Truncated header", "2", response.Headers.Get("Page-Truncated"))
-    ds3Testing.AssertString(t, "Total-Result-Count header", "3", response.Headers.Get("Total-Result-Count"))
+	ds3Testing.AssertString(t, "Page-Truncated header", "2", response.Headers.Get("Page-Truncated"))
+	ds3Testing.AssertString(t, "Total-Result-Count header", "3", response.Headers.Get("Total-Result-Count"))
 }
 
 func TestGetTapeLibrarySpectraS3(t *testing.T) {
-    responsePayload := "<Data><Id>e23030e5-9b8d-4594-bdd1-15d3c45abb9f</Id><ManagementUrl>a</ManagementUrl><Name>125ca16e-60e3-43b2-a26f-0bc81843745f</Name><SerialNumber>test library</SerialNumber></Data>"
+	responsePayload := "<Data><Id>e23030e5-9b8d-4594-bdd1-15d3c45abb9f</Id><ManagementUrl>a</ManagementUrl><Name>125ca16e-60e3-43b2-a26f-0bc81843745f</Name><SerialNumber>test library</SerialNumber></Data>"
 
-    id := "e23030e5-9b8d-4594-bdd1-15d3c45abb9f"
+	id := "e23030e5-9b8d-4594-bdd1-15d3c45abb9f"
 
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_GET, "/_rest_/tape_library/" + id, &url.Values{}, &http.Header{}, nil).
-            Returning(200, responsePayload, nil).
-            GetTapeLibrarySpectraS3(context.Background(), models.NewGetTapeLibrarySpectraS3Request(id))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/tape_library/"+id, &url.Values{}, &http.Header{}, nil).
+		Returning(200, responsePayload, nil).
+		GetTapeLibrarySpectraS3(context.Background(), models.NewGetTapeLibrarySpectraS3Request(id))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 
-    library := response.TapeLibrary
-    ds3Testing.AssertString(t, "Id", id, library.Id)
-    ds3Testing.AssertNonNilStringPtr(t, "ManagementUrl", "a", library.ManagementUrl)
-    ds3Testing.AssertNonNilStringPtr(t, "Name", "125ca16e-60e3-43b2-a26f-0bc81843745f", library.Name)
-    ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "test library", library.SerialNumber)
+	library := response.TapeLibrary
+	ds3Testing.AssertString(t, "Id", id, library.Id)
+	ds3Testing.AssertNonNilStringPtr(t, "ManagementUrl", "a", library.ManagementUrl)
+	ds3Testing.AssertNonNilStringPtr(t, "Name", "125ca16e-60e3-43b2-a26f-0bc81843745f", library.Name)
+	ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "test library", library.SerialNumber)
 }
 
 func TestGetTapeDriveSpectraS3(t *testing.T) {
-    responsePayload := "<Data><ErrorMessage/><ForceTapeRemoval>false</ForceTapeRemoval><Id>ff5df6c8-7e24-4e4f-815d-a8a1a4cddc98</Id><PartitionId>ca69b187-47cf-425e-b92f-c09bacc7d3b3</PartitionId><SerialNumber>test tape drive</SerialNumber><State>NORMAL</State><TapeId>0ea07c32-8ff6-443f-b7c8-420667b0df84</TapeId><Type>UNKNOWN</Type></Data>"
+	responsePayload := "<Data><ErrorMessage/><ForceTapeRemoval>false</ForceTapeRemoval><Id>ff5df6c8-7e24-4e4f-815d-a8a1a4cddc98</Id><PartitionId>ca69b187-47cf-425e-b92f-c09bacc7d3b3</PartitionId><SerialNumber>test tape drive</SerialNumber><State>NORMAL</State><TapeId>0ea07c32-8ff6-443f-b7c8-420667b0df84</TapeId><Type>UNKNOWN</Type></Data>"
 
-    id := "ff5df6c8-7e24-4e4f-815d-a8a1a4cddc98"
+	id := "ff5df6c8-7e24-4e4f-815d-a8a1a4cddc98"
 
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_GET, "/_rest_/tape_drive/" + id, &url.Values{}, &http.Header{}, nil).
-            Returning(200, responsePayload, nil).
-            GetTapeDriveSpectraS3(context.Background(), models.NewGetTapeDriveSpectraS3Request(id))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/tape_drive/"+id, &url.Values{}, &http.Header{}, nil).
+		Returning(200, responsePayload, nil).
+		GetTapeDriveSpectraS3(context.Background(), models.NewGetTapeDriveSpectraS3Request(id))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 
-    drive := response.TapeDrive
-    ds3Testing.AssertStringPtrIsNil(t, "ErrorMessage", drive.ErrorMessage)
-    ds3Testing.AssertBool(t, "ForceTapeRemoval", false, drive.ForceTapeRemoval)
-    ds3Testing.AssertString(t, "Id", id, drive.Id)
-    ds3Testing.AssertString(t, "PartitionId", "ca69b187-47cf-425e-b92f-c09bacc7d3b3", drive.PartitionId)
-    ds3Testing.AssertNonNilStringPtr(t, "Serial Number", "test tape drive", drive.SerialNumber)
-    if drive.State != models.TAPE_DRIVE_STATE_NORMAL {
-        t.Fatalf("Expected drive stat '%d' but was '%d'.", models.TAPE_DRIVE_STATE_NORMAL, drive.State)
-    }
-    ds3Testing.AssertNonNilStringPtr(t, "TapeId", "0ea07c32-8ff6-443f-b7c8-420667b0df84", drive.TapeId)
-    if drive.Type != models.TAPE_DRIVE_TYPE_UNKNOWN {
-        t.Fatalf("Expected tape drive type '%d' but was '%d'.", models.TAPE_DRIVE_TYPE_UNKNOWN, drive.Type)
-    }
+	drive := response.TapeDrive
+	ds3Testing.AssertStringPtrIsNil(t, "ErrorMessage", drive.ErrorMessage)
+	ds3Testing.AssertBool(t, "ForceTapeRemoval", false, drive.ForceTapeRemoval)
+	ds3Testing.AssertString(t, "Id", id, drive.Id)
+	ds3Testing.AssertString(t, "PartitionId", "ca69b187-47cf-425e-b92f-c09bacc7d3b3", drive.PartitionId)
+	ds3Testing.AssertNonNilStringPtr(t, "Serial Number", "test tape drive", drive.SerialNumber)
+	if drive.State != models.TAPE_DRIVE_STATE_NORMAL {
+		t.Fatalf("Expected drive stat '%d' but was '%d'.", models.TAPE_DRIVE_STATE_NORMAL, drive.State)
+	}
+	ds3Testing.AssertNonNilStringPtr(t, "TapeId", "0ea07c32-8ff6-443f-b7c8-420667b0df84", drive.TapeId)
+	if drive.Type != models.TAPE_DRIVE_TYPE_UNKNOWN {
+		t.Fatalf("Expected tape drive type '%d' but was '%d'.", models.TAPE_DRIVE_TYPE_UNKNOWN, drive.Type)
+	}
 }
 
 func TestGetTapesSpectraS3(t *testing.T) {
-    responsePayload := "<Data><Tape>" +
-            "<AssignedToStorageDomain>false</AssignedToStorageDomain>" +
-            "<AvailableRawCapacity>2408082046976</AvailableRawCapacity>" +
-            "<BarCode>101000L6</BarCode>" +
-            "<BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/>" +
-            "<FullOfData>false</FullOfData>" +
-            "<Id>c7c431df-f95d-4533-b350-ffd7a8a5caac</Id>" +
-            "<LastAccessed>2015-09-04T06:53:08.236</LastAccessed>" +
-            "<LastCheckpoint>eb77ea67-3c83-47ec-8714-cd46a97dc392:2</LastCheckpoint>" +
-            "<LastModified>2015-08-21T16:14:30.714</LastModified>" +
-            "<LastVerified/>" +
-            "<PartitionId>4f8a5cbb-9837-41d9-afd1-cebed41f18f7</PartitionId>" +
-            "<PreviousState/>" +
-            "<SerialNumber>HP-W130501213</SerialNumber>" +
-            "<State>NORMAL</State>" +
-            "<TotalRawCapacity>2408088338432</TotalRawCapacity>" +
-            "<Type>LTO6</Type>" +
-            "<WriteProtected>false</WriteProtected>" +
-            "</Tape></Data>"
+	responsePayload := "<Data><Tape>" +
+		"<AssignedToStorageDomain>false</AssignedToStorageDomain>" +
+		"<AvailableRawCapacity>2408082046976</AvailableRawCapacity>" +
+		"<BarCode>101000L6</BarCode>" +
+		"<BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/>" +
+		"<FullOfData>false</FullOfData>" +
+		"<Id>c7c431df-f95d-4533-b350-ffd7a8a5caac</Id>" +
+		"<LastAccessed>2015-09-04T06:53:08.236</LastAccessed>" +
+		"<LastCheckpoint>eb77ea67-3c83-47ec-8714-cd46a97dc392:2</LastCheckpoint>" +
+		"<LastModified>2015-08-21T16:14:30.714</LastModified>" +
+		"<LastVerified/>" +
+		"<PartitionId>4f8a5cbb-9837-41d9-afd1-cebed41f18f7</PartitionId>" +
+		"<PreviousState/>" +
+		"<SerialNumber>HP-W130501213</SerialNumber>" +
+		"<State>NORMAL</State>" +
+		"<TotalRawCapacity>2408088338432</TotalRawCapacity>" +
+		"<Type>LTO6</Type>" +
+		"<WriteProtected>false</WriteProtected>" +
+		"</Tape></Data>"
 
-    responseHeaders := &http.Header{}
-    responseHeaders.Add("Page-Truncated", "2")
-    responseHeaders.Add("Total-Result-Count", "3")
+	responseHeaders := &http.Header{}
+	responseHeaders.Add("Page-Truncated", "2")
+	responseHeaders.Add("Total-Result-Count", "3")
 
-    response, err := mockedClient(t).
-            Expecting(HTTP_VERB_GET, "/_rest_/tape", &url.Values{}, &http.Header{}, nil).
-            Returning(200, responsePayload, responseHeaders).
-            GetTapesSpectraS3(context.Background(), models.NewGetTapesSpectraS3Request())
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/tape", &url.Values{}, &http.Header{}, nil).
+		Returning(200, responsePayload, responseHeaders).
+		GetTapesSpectraS3(context.Background(), models.NewGetTapesSpectraS3Request())
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 
-    if len(response.TapeList.Tapes) != 1 {
-        t.Fatalf("Expected '1' tapes but got '%d'.", len(response.TapeList.Tapes))
-    }
+	if len(response.TapeList.Tapes) != 1 {
+		t.Fatalf("Expected '1' tapes but got '%d'.", len(response.TapeList.Tapes))
+	}
 
-    tape := response.TapeList.Tapes[0]
-    ds3Testing.AssertBool(t, "AssignedToStorageDomain", false, tape.AssignedToStorageDomain)
-    ds3Testing.AssertNonNilInt64Ptr(t, "AvailableRawCapacity", 2408082046976, tape.AvailableRawCapacity)
-    ds3Testing.AssertNonNilStringPtr(t, "BarCode", "101000L6", tape.BarCode)
-    ds3Testing.AssertStringPtrIsNil(t, "BucketId", tape.BucketId)
-    ds3Testing.AssertStringPtrIsNil(t, "DescriptionForIdentification", tape.DescriptionForIdentification)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectDate", tape.EjectDate)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectLabel", tape.EjectLabel)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectLocation", tape.EjectLocation)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectPending", tape.EjectPending)
-    ds3Testing.AssertBool(t, "FullOfData", false, tape.FullOfData)
-    ds3Testing.AssertString(t, "Id", "c7c431df-f95d-4533-b350-ffd7a8a5caac", tape.Id)
-    ds3Testing.AssertNonNilStringPtr(t, "LastAccessed", "2015-09-04T06:53:08.236", tape.LastAccessed)
-    ds3Testing.AssertNonNilStringPtr(t, "LastCheckpoint", "eb77ea67-3c83-47ec-8714-cd46a97dc392:2", tape.LastCheckpoint)
-    ds3Testing.AssertNonNilStringPtr(t, "LastModified", "2015-08-21T16:14:30.714", tape.LastModified)
-    ds3Testing.AssertStringPtrIsNil(t, "LastVerified", tape.LastVerified)
-    ds3Testing.AssertNonNilStringPtr(t, "PartitionId", "4f8a5cbb-9837-41d9-afd1-cebed41f18f7", tape.PartitionId)
-    if tape.PreviousState != nil {
-        t.Fatalf("Expected previous state '%s' but was '%s'.", "nil", tape.PreviousState.String())
-    }
-    ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "HP-W130501213", tape.SerialNumber)
-    ds3Testing.AssertString(t, "State", models.TAPE_STATE_NORMAL.String(), tape.State.String())
-    ds3Testing.AssertNonNilInt64Ptr(t, "TotalRawCapacity", 2408088338432, tape.TotalRawCapacity)
-    ds3Testing.AssertString(t, "Type", "LTO6", tape.Type)
-    ds3Testing.AssertBool(t, "WriteProtected", false, tape.WriteProtected)
+	tape := response.TapeList.Tapes[0]
+	ds3Testing.AssertBool(t, "AssignedToStorageDomain", false, tape.AssignedToStorageDomain)
+	ds3Testing.AssertNonNilInt64Ptr(t, "AvailableRawCapacity", 2408082046976, tape.AvailableRawCapacity)
+	ds3Testing.AssertNonNilStringPtr(t, "BarCode", "101000L6", tape.BarCode)
+	ds3Testing.AssertStringPtrIsNil(t, "BucketId", tape.BucketId)
+	ds3Testing.AssertStringPtrIsNil(t, "DescriptionForIdentification", tape.DescriptionForIdentification)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectDate", tape.EjectDate)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectLabel", tape.EjectLabel)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectLocation", tape.EjectLocation)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectPending", tape.EjectPending)
+	ds3Testing.AssertBool(t, "FullOfData", false, tape.FullOfData)
+	ds3Testing.AssertString(t, "Id", "c7c431df-f95d-4533-b350-ffd7a8a5caac", tape.Id)
+	ds3Testing.AssertNonNilStringPtr(t, "LastAccessed", "2015-09-04T06:53:08.236", tape.LastAccessed)
+	ds3Testing.AssertNonNilStringPtr(t, "LastCheckpoint", "eb77ea67-3c83-47ec-8714-cd46a97dc392:2", tape.LastCheckpoint)
+	ds3Testing.AssertNonNilStringPtr(t, "LastModified", "2015-08-21T16:14:30.714", tape.LastModified)
+	ds3Testing.AssertStringPtrIsNil(t, "LastVerified", tape.LastVerified)
+	ds3Testing.AssertNonNilStringPtr(t, "PartitionId", "4f8a5cbb-9837-41d9-afd1-cebed41f18f7", tape.PartitionId)
+	if tape.PreviousState != nil {
+		t.Fatalf("Expected previous state '%s' but was '%s'.", "nil", tape.PreviousState.String())
+	}
+	ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "HP-W130501213", tape.SerialNumber)
+	ds3Testing.AssertString(t, "State", models.TAPE_STATE_NORMAL.String(), tape.State.String())
+	ds3Testing.AssertNonNilInt64Ptr(t, "TotalRawCapacity", 2408088338432, tape.TotalRawCapacity)
+	ds3Testing.AssertString(t, "Type", "LTO6", tape.Type)
+	ds3Testing.AssertBool(t, "WriteProtected", false, tape.WriteProtected)
 
-    ds3Testing.AssertString(t, "Page-Truncated header", "2", response.Headers.Get("Page-Truncated"))
-    ds3Testing.AssertString(t, "Total-Result-Count header", "3", response.Headers.Get("Total-Result-Count"))
+	ds3Testing.AssertString(t, "Page-Truncated header", "2", response.Headers.Get("Page-Truncated"))
+	ds3Testing.AssertString(t, "Total-Result-Count header", "3", response.Headers.Get("Total-Result-Count"))
 }
 
 func TestDeletePermanentlyLostTapeSpectraS3(t *testing.T) {
-    id := "1a85e743-ec8f-4789-afec-97e587a26936"
+	id := "1a85e743-ec8f-4789-afec-97e587a26936"
 
-    request := models.NewDeletePermanentlyLostTapeSpectraS3Request(id)
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_DELETE, "/_rest_/tape/" + id, &url.Values{}, &http.Header{}, nil).
-        Returning(204, "", nil).
-        DeletePermanentlyLostTapeSpectraS3(context.Background(), request)
+	request := models.NewDeletePermanentlyLostTapeSpectraS3Request(id)
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/_rest_/tape/"+id, &url.Values{}, &http.Header{}, nil).
+		Returning(204, "", nil).
+		DeletePermanentlyLostTapeSpectraS3(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 }
 
 func TestGetTapeSpectraS3(t *testing.T) {
-    id := "c7c431df-f95d-4533-b350-ffd7a8a5caac"
-    responsePayload := "<Data><AssignedToStorageDomain>false</AssignedToStorageDomain><AvailableRawCapacity>2408082046976</AvailableRawCapacity><BarCode>101000L6</BarCode><BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/><FullOfData>false</FullOfData><Id>c7c431df-f95d-4533-b350-ffd7a8a5caac</Id><LastAccessed>2015-09-04T06:53:08.236</LastAccessed><LastCheckpoint>eb77ea67-3c83-47ec-8714-cd46a97dc392:2</LastCheckpoint><LastModified>2015-08-21T16:14:30.714</LastModified><LastVerified/><PartitionId>4f8a5cbb-9837-41d9-afd1-cebed41f18f7</PartitionId><PreviousState/><SerialNumber>HP-W130501213</SerialNumber><State>NORMAL</State><TotalRawCapacity>2408088338432</TotalRawCapacity><Type>LTO6</Type><WriteProtected>false</WriteProtected></Data>"
+	id := "c7c431df-f95d-4533-b350-ffd7a8a5caac"
+	responsePayload := "<Data><AssignedToStorageDomain>false</AssignedToStorageDomain><AvailableRawCapacity>2408082046976</AvailableRawCapacity><BarCode>101000L6</BarCode><BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/><FullOfData>false</FullOfData><Id>c7c431df-f95d-4533-b350-ffd7a8a5caac</Id><LastAccessed>2015-09-04T06:53:08.236</LastAccessed><LastCheckpoint>eb77ea67-3c83-47ec-8714-cd46a97dc392:2</LastCheckpoint><LastModified>2015-08-21T16:14:30.714</LastModified><LastVerified/><PartitionId>4f8a5cbb-9837-41d9-afd1-cebed41f18f7</PartitionId><PreviousState/><SerialNumber>HP-W130501213</SerialNumber><State>NORMAL</State><TotalRawCapacity>2408088338432</TotalRawCapacity><Type>LTO6</Type><WriteProtected>false</WriteProtected></Data>"
 
-    request := models.NewGetTapeSpectraS3Request(id)
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/_rest_/tape/" + id, &url.Values{}, &http.Header{}, nil).
-        Returning(200, responsePayload, nil).
-        GetTapeSpectraS3(context.Background(), request)
+	request := models.NewGetTapeSpectraS3Request(id)
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/tape/"+id, &url.Values{}, &http.Header{}, nil).
+		Returning(200, responsePayload, nil).
+		GetTapeSpectraS3(context.Background(), request)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatal("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatal("Response was unexpectedly nil.")
+	}
 
-    tape := response.Tape
-    ds3Testing.AssertBool(t, "AssignedToStorageDomain", false, tape.AssignedToStorageDomain)
-    ds3Testing.AssertNonNilInt64Ptr(t, "AvailableRawCapacity", 2408082046976, tape.AvailableRawCapacity)
-    ds3Testing.AssertNonNilStringPtr(t, "BarCode", "101000L6", tape.BarCode)
-    ds3Testing.AssertStringPtrIsNil(t, "BucketId", tape.BucketId)
-    ds3Testing.AssertStringPtrIsNil(t, "DescriptionForIdentification", tape.DescriptionForIdentification)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectDate", tape.EjectDate)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectLabel", tape.EjectLabel)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectLocation", tape.EjectLocation)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectPending", tape.EjectPending)
-    ds3Testing.AssertBool(t, "FullOfData", false, tape.FullOfData)
-    ds3Testing.AssertString(t, "Id", "c7c431df-f95d-4533-b350-ffd7a8a5caac", tape.Id)
-    ds3Testing.AssertNonNilStringPtr(t, "LastAccessed", "2015-09-04T06:53:08.236", tape.LastAccessed)
-    ds3Testing.AssertNonNilStringPtr(t, "LastCheckpoint", "eb77ea67-3c83-47ec-8714-cd46a97dc392:2", tape.LastCheckpoint)
-    ds3Testing.AssertNonNilStringPtr(t, "LastModified", "2015-08-21T16:14:30.714", tape.LastModified)
-    ds3Testing.AssertStringPtrIsNil(t, "LastVerified", tape.LastVerified)
-    ds3Testing.AssertNonNilStringPtr(t, "PartitionId", "4f8a5cbb-9837-41d9-afd1-cebed41f18f7", tape.PartitionId)
-    if tape.PreviousState != nil {
-        t.Fatalf("Expected previous state '%s' but was '%s'.", "nil", tape.PreviousState.String())
-    }
-    ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "HP-W130501213", tape.SerialNumber)
-    ds3Testing.AssertString(t, "State", models.TAPE_STATE_NORMAL.String(), tape.State.String())
-    ds3Testing.AssertNonNilInt64Ptr(t, "TotalRawCapacity", 2408088338432, tape.TotalRawCapacity)
-    ds3Testing.AssertString(t, "Type", "LTO6", tape.Type)
-    ds3Testing.AssertBool(t, "WriteProtected", false, tape.WriteProtected)
+	tape := response.Tape
+	ds3Testing.AssertBool(t, "AssignedToStorageDomain", false, tape.AssignedToStorageDomain)
+	ds3Testing.AssertNonNilInt64Ptr(t, "AvailableRawCapacity", 2408082046976, tape.AvailableRawCapacity)
+	ds3Testing.AssertNonNilStringPtr(t, "BarCode", "101000L6", tape.BarCode)
+	ds3Testing.AssertStringPtrIsNil(t, "BucketId", tape.BucketId)
+	ds3Testing.AssertStringPtrIsNil(t, "DescriptionForIdentification", tape.DescriptionForIdentification)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectDate", tape.EjectDate)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectLabel", tape.EjectLabel)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectLocation", tape.EjectLocation)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectPending", tape.EjectPending)
+	ds3Testing.AssertBool(t, "FullOfData", false, tape.FullOfData)
+	ds3Testing.AssertString(t, "Id", "c7c431df-f95d-4533-b350-ffd7a8a5caac", tape.Id)
+	ds3Testing.AssertNonNilStringPtr(t, "LastAccessed", "2015-09-04T06:53:08.236", tape.LastAccessed)
+	ds3Testing.AssertNonNilStringPtr(t, "LastCheckpoint", "eb77ea67-3c83-47ec-8714-cd46a97dc392:2", tape.LastCheckpoint)
+	ds3Testing.AssertNonNilStringPtr(t, "LastModified", "2015-08-21T16:14:30.714", tape.LastModified)
+	ds3Testing.AssertStringPtrIsNil(t, "LastVerified", tape.LastVerified)
+	ds3Testing.AssertNonNilStringPtr(t, "PartitionId", "4f8a5cbb-9837-41d9-afd1-cebed41f18f7", tape.PartitionId)
+	if tape.PreviousState != nil {
+		t.Fatalf("Expected previous state '%s' but was '%s'.", "nil", tape.PreviousState.String())
+	}
+	ds3Testing.AssertNonNilStringPtr(t, "SerialNumber", "HP-W130501213", tape.SerialNumber)
+	ds3Testing.AssertString(t, "State", models.TAPE_STATE_NORMAL.String(), tape.State.String())
+	ds3Testing.AssertNonNilInt64Ptr(t, "TotalRawCapacity", 2408088338432, tape.TotalRawCapacity)
+	ds3Testing.AssertString(t, "Type", "LTO6", tape.Type)
+	ds3Testing.AssertBool(t, "WriteProtected", false, tape.WriteProtected)
 }
 
 func TestClearSuspectBlobAzureTargetsSpectraS3(t *testing.T) {
-    expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
+	expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
 
-    // Create and run the mocked client.
-    ids := []string {"id1", "id2", "id3"}
+	// Create and run the mocked client.
+	ids := []string{"id1", "id2", "id3"}
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_azure_target", &url.Values{}, &http.Header{}, &expectedRequest).
-        Returning(204, "", nil).
-        ClearSuspectBlobAzureTargetsSpectraS3(context.Background(), models.NewClearSuspectBlobAzureTargetsSpectraS3Request(ids))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_azure_target", &url.Values{}, &http.Header{}, &expectedRequest).
+		Returning(204, "", nil).
+		ClearSuspectBlobAzureTargetsSpectraS3(context.Background(), models.NewClearSuspectBlobAzureTargetsSpectraS3Request(ids))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
 }
 
 func TestClearSuspectBlobPoolsSpectraS3(t *testing.T) {
-    expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
+	expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
 
-    // Create and run the mocked client.
-    ids := []string {"id1", "id2", "id3"}
+	// Create and run the mocked client.
+	ids := []string{"id1", "id2", "id3"}
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_pool", &url.Values{}, &http.Header{}, &expectedRequest).
-        Returning(204, "", nil).
-        ClearSuspectBlobPoolsSpectraS3(context.Background(), models.NewClearSuspectBlobPoolsSpectraS3Request(ids))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_pool", &url.Values{}, &http.Header{}, &expectedRequest).
+		Returning(204, "", nil).
+		ClearSuspectBlobPoolsSpectraS3(context.Background(), models.NewClearSuspectBlobPoolsSpectraS3Request(ids))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
 }
 
 func TestClearSuspectBlobS3TargetsSpectraS3(t *testing.T) {
-    expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
+	expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
 
-    // Create and run the mocked client.
-    ids := []string {"id1", "id2", "id3"}
+	// Create and run the mocked client.
+	ids := []string{"id1", "id2", "id3"}
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_s3_target", &url.Values{}, &http.Header{}, &expectedRequest).
-        Returning(204, "", nil).
-        ClearSuspectBlobS3TargetsSpectraS3(context.Background(), models.NewClearSuspectBlobS3TargetsSpectraS3Request(ids))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_s3_target", &url.Values{}, &http.Header{}, &expectedRequest).
+		Returning(204, "", nil).
+		ClearSuspectBlobS3TargetsSpectraS3(context.Background(), models.NewClearSuspectBlobS3TargetsSpectraS3Request(ids))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
 }
 
-
 func TestClearSuspectBlobDs3TargetsSpectraS3(t *testing.T) {
-    expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
+	expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
 
-    // Create and run the mocked client.
-    ids := []string {"id1", "id2", "id3"}
+	// Create and run the mocked client.
+	ids := []string{"id1", "id2", "id3"}
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_ds3_target", &url.Values{}, &http.Header{}, &expectedRequest).
-        Returning(204, "", nil).
-        ClearSuspectBlobDs3TargetsSpectraS3(context.Background(), models.NewClearSuspectBlobDs3TargetsSpectraS3Request(ids))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_ds3_target", &url.Values{}, &http.Header{}, &expectedRequest).
+		Returning(204, "", nil).
+		ClearSuspectBlobDs3TargetsSpectraS3(context.Background(), models.NewClearSuspectBlobDs3TargetsSpectraS3Request(ids))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
 }
 
 func TestClearSuspectBlobTapesSpectraS3(t *testing.T) {
-    expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
+	expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
 
-    // Create and run the mocked client.
-    ids := []string {"id1", "id2", "id3"}
+	// Create and run the mocked client.
+	ids := []string{"id1", "id2", "id3"}
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_tape", &url.Values{}, &http.Header{}, &expectedRequest).
-        Returning(204, "", nil).
-        ClearSuspectBlobTapesSpectraS3(context.Background(), models.NewClearSuspectBlobTapesSpectraS3Request(ids))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_DELETE, "/_rest_/suspect_blob_tape", &url.Values{}, &http.Header{}, &expectedRequest).
+		Returning(204, "", nil).
+		ClearSuspectBlobTapesSpectraS3(context.Background(), models.NewClearSuspectBlobTapesSpectraS3Request(ids))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
 }
 
 func TestEjectStorageDomainBlobsSpectraS3(t *testing.T) {
-    expectedRequest := "<Objects><Object Name=\"obj1\"></Object><Object Name=\"obj2\"></Object><Object Name=\"obj3\"></Object></Objects>"
+	expectedRequest := "<Objects><Object Name=\"obj1\"></Object><Object Name=\"obj2\"></Object><Object Name=\"obj3\"></Object></Objects>"
 
-    // Create and run the mocked client.
-    bucketId := "BucketId"
-    storageDomainId := "StorageDomainId"
-    objectNames := []string {"obj1", "obj2", "obj3"}
+	// Create and run the mocked client.
+	bucketId := "BucketId"
+	storageDomainId := "StorageDomainId"
+	objectNames := []string{"obj1", "obj2", "obj3"}
 
-    qp := &url.Values{
-        "operation": []string{"eject"},
-        "blobs": []string{""},
-        "bucket_id": []string{bucketId},
-        "storage_domain": []string{storageDomainId},
-    }
+	qp := &url.Values{
+		"operation":      []string{"eject"},
+		"blobs":          []string{""},
+		"bucket_id":      []string{bucketId},
+		"storage_domain": []string{storageDomainId},
+	}
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_PUT, "/_rest_/tape", qp, &http.Header{}, &expectedRequest).
-        Returning(204, "", nil).
-        EjectStorageDomainBlobsSpectraS3(context.Background(), models.NewEjectStorageDomainBlobsSpectraS3Request(bucketId, storageDomainId, objectNames))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_PUT, "/_rest_/tape", qp, &http.Header{}, &expectedRequest).
+		Returning(204, "", nil).
+		EjectStorageDomainBlobsSpectraS3(context.Background(), models.NewEjectStorageDomainBlobsSpectraS3Request(bucketId, storageDomainId, objectNames))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
 }
 
 func TestGetBlobsOnAzureTargetSpectraS3(t *testing.T) {
-    target := "AzureTarget"
-    runGetBlobsTest(
-        t,
-        "/_rest_/azure_target/" + target,
-        func(client *Client) (models.BulkObjectList, error) {
-            request, err := client.GetBlobsOnAzureTargetSpectraS3(context.Background(), models.NewGetBlobsOnAzureTargetSpectraS3Request(target))
-            return request.BulkObjectList, err
-        },
-    )
+	target := "AzureTarget"
+	runGetBlobsTest(
+		t,
+		"/_rest_/azure_target/"+target,
+		func(client *Client) (models.BulkObjectList, error) {
+			request, err := client.GetBlobsOnAzureTargetSpectraS3(context.Background(), models.NewGetBlobsOnAzureTargetSpectraS3Request(target))
+			return request.BulkObjectList, err
+		},
+	)
 }
 
 func TestGetBlobsOnDs3TargetSpectraS3(t *testing.T) {
-    target := "Ds3Target"
-    runGetBlobsTest(
-        t,
-        "/_rest_/ds3_target/" + target,
-        func(client *Client) (models.BulkObjectList, error) {
-            request, err := client.GetBlobsOnDs3TargetSpectraS3(context.Background(), models.NewGetBlobsOnDs3TargetSpectraS3Request(target))
-            return request.BulkObjectList, err
-        },
-    )
+	target := "Ds3Target"
+	runGetBlobsTest(
+		t,
+		"/_rest_/ds3_target/"+target,
+		func(client *Client) (models.BulkObjectList, error) {
+			request, err := client.GetBlobsOnDs3TargetSpectraS3(context.Background(), models.NewGetBlobsOnDs3TargetSpectraS3Request(target))
+			return request.BulkObjectList, err
+		},
+	)
 }
 
 func TestGetBlobsOnPoolSpectraS3(t *testing.T) {
-    target := "Pool"
-    runGetBlobsTest(
-        t,
-        "/_rest_/pool/" + target,
-        func(client *Client) (models.BulkObjectList, error) {
-            request, err := client.GetBlobsOnPoolSpectraS3(context.Background(), models.NewGetBlobsOnPoolSpectraS3Request(target))
-            return request.BulkObjectList, err
-        },
-    )
+	target := "Pool"
+	runGetBlobsTest(
+		t,
+		"/_rest_/pool/"+target,
+		func(client *Client) (models.BulkObjectList, error) {
+			request, err := client.GetBlobsOnPoolSpectraS3(context.Background(), models.NewGetBlobsOnPoolSpectraS3Request(target))
+			return request.BulkObjectList, err
+		},
+	)
 }
 
 func TestGetBlobsOnS3TargetSpectraS3(t *testing.T) {
-    target := "S3Target"
-    runGetBlobsTest(
-        t,
-        "/_rest_/s3_target/" + target,
-        func(client *Client) (models.BulkObjectList, error) {
-            request, err := client.GetBlobsOnS3TargetSpectraS3(context.Background(), models.NewGetBlobsOnS3TargetSpectraS3Request(target))
-            return request.BulkObjectList, err
-        },
-    )
+	target := "S3Target"
+	runGetBlobsTest(
+		t,
+		"/_rest_/s3_target/"+target,
+		func(client *Client) (models.BulkObjectList, error) {
+			request, err := client.GetBlobsOnS3TargetSpectraS3(context.Background(), models.NewGetBlobsOnS3TargetSpectraS3Request(target))
+			return request.BulkObjectList, err
+		},
+	)
 }
 
 func TestGetBlobsOnTapeSpectraS3(t *testing.T) {
-    target := "Tape"
-    runGetBlobsTest(
-        t,
-        "/_rest_/tape/" + target,
-        func(client *Client) (models.BulkObjectList, error) {
-            request, err := client.GetBlobsOnTapeSpectraS3(context.Background(), models.NewGetBlobsOnTapeSpectraS3Request(target))
-            return request.BulkObjectList, err
-        },
-    )
+	target := "Tape"
+	runGetBlobsTest(
+		t,
+		"/_rest_/tape/"+target,
+		func(client *Client) (models.BulkObjectList, error) {
+			request, err := client.GetBlobsOnTapeSpectraS3(context.Background(), models.NewGetBlobsOnTapeSpectraS3Request(target))
+			return request.BulkObjectList, err
+		},
+	)
 }
 
 type getBlobsTest func(*Client) (models.BulkObjectList, error)
 
 func runGetBlobsTest(t *testing.T, path string, callToTest getBlobsTest) {
-    expectedResponse := "<Data><Object Bucket=\"default_bucket_name\" Id=\"1bd77dbf-500a-45a1-86ac-d065f026882c\" Latest=\"true\" Length=\"10\" Name=\"obj1\" Offset=\"0\" /><Object Bucket=\"default_bucket_name\" Id=\"9afa66e7-3f5a-4913-bae2-ba7c86e4c4f7\" Latest=\"true\" Length=\"10\" Name=\"obj2\" Offset=\"0\" /></Data>"
+	expectedResponse := "<Data><Object Bucket=\"default_bucket_name\" Id=\"1bd77dbf-500a-45a1-86ac-d065f026882c\" Latest=\"true\" Length=\"10\" Name=\"obj1\" Offset=\"0\" /><Object Bucket=\"default_bucket_name\" Id=\"9afa66e7-3f5a-4913-bae2-ba7c86e4c4f7\" Latest=\"true\" Length=\"10\" Name=\"obj2\" Offset=\"0\" /></Data>"
 
-    // Create and run the mocked client.
-    qp := &url.Values{ "operation": []string{"get_physical_placement"} }
+	// Create and run the mocked client.
+	qp := &url.Values{"operation": []string{"get_physical_placement"}}
 
-    client := mockedClient(t).
-        Expecting(HTTP_VERB_GET, path, qp, &http.Header{}, nil).
-        Returning(200, expectedResponse, nil)
+	client := mockedClient(t).
+		Expecting(HTTP_VERB_GET, path, qp, &http.Header{}, nil).
+		Returning(200, expectedResponse, nil)
 
-    bulkObject, err := callToTest(client)
+	bulkObject, err := callToTest(client)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    obj1 := bulkObject.Objects[0]
-    ds3Testing.AssertNonNilStringPtr(t, "Bucket", "default_bucket_name", obj1.Bucket)
-    ds3Testing.AssertNonNilStringPtr(t, "Id", "1bd77dbf-500a-45a1-86ac-d065f026882c", obj1.Id)
-    ds3Testing.AssertBoolPtrIsNil(t, "InCache", obj1.InCache)
-    ds3Testing.AssertBool(t, "Latest", true, obj1.Latest)
-    ds3Testing.AssertInt64(t, "Length", 10, obj1.Length)
-    ds3Testing.AssertNonNilStringPtr(t, "Name", "obj1", obj1.Name)
-    ds3Testing.AssertInt64(t, "Offset", 0, obj1.Offset)
-    if obj1.PhysicalPlacement != nil {
-        t.Fatalf("Expected nil Physical Placement, but was '%v'.", obj1.PhysicalPlacement)
-    }
+	obj1 := bulkObject.Objects[0]
+	ds3Testing.AssertNonNilStringPtr(t, "Bucket", "default_bucket_name", obj1.Bucket)
+	ds3Testing.AssertNonNilStringPtr(t, "Id", "1bd77dbf-500a-45a1-86ac-d065f026882c", obj1.Id)
+	ds3Testing.AssertBoolPtrIsNil(t, "InCache", obj1.InCache)
+	ds3Testing.AssertBool(t, "Latest", true, obj1.Latest)
+	ds3Testing.AssertInt64(t, "Length", 10, obj1.Length)
+	ds3Testing.AssertNonNilStringPtr(t, "Name", "obj1", obj1.Name)
+	ds3Testing.AssertInt64(t, "Offset", 0, obj1.Offset)
+	if obj1.PhysicalPlacement != nil {
+		t.Fatalf("Expected nil Physical Placement, but was '%v'.", obj1.PhysicalPlacement)
+	}
 
-    obj2 := bulkObject.Objects[1]
-    ds3Testing.AssertNonNilStringPtr(t, "Bucket", "default_bucket_name", obj2.Bucket)
-    ds3Testing.AssertNonNilStringPtr(t, "Id", "9afa66e7-3f5a-4913-bae2-ba7c86e4c4f7", obj2.Id)
-    ds3Testing.AssertBoolPtrIsNil(t, "InCache", obj2.InCache)
-    ds3Testing.AssertBool(t, "Latest", true, obj2.Latest)
-    ds3Testing.AssertInt64(t, "Length", 10, obj2.Length)
-    ds3Testing.AssertNonNilStringPtr(t, "Name", "obj2", obj2.Name)
-    ds3Testing.AssertInt64(t, "Offset", 0, obj2.Offset)
-    if obj2.PhysicalPlacement != nil {
-        t.Fatalf("Expected nil Physical Placement, but was '%v'.", obj2.PhysicalPlacement)
-    }
+	obj2 := bulkObject.Objects[1]
+	ds3Testing.AssertNonNilStringPtr(t, "Bucket", "default_bucket_name", obj2.Bucket)
+	ds3Testing.AssertNonNilStringPtr(t, "Id", "9afa66e7-3f5a-4913-bae2-ba7c86e4c4f7", obj2.Id)
+	ds3Testing.AssertBoolPtrIsNil(t, "InCache", obj2.InCache)
+	ds3Testing.AssertBool(t, "Latest", true, obj2.Latest)
+	ds3Testing.AssertInt64(t, "Length", 10, obj2.Length)
+	ds3Testing.AssertNonNilStringPtr(t, "Name", "obj2", obj2.Name)
+	ds3Testing.AssertInt64(t, "Offset", 0, obj2.Offset)
+	if obj2.PhysicalPlacement != nil {
+		t.Fatalf("Expected nil Physical Placement, but was '%v'.", obj2.PhysicalPlacement)
+	}
 }
 
 func TestGetPhysicalPlacementForObjectsSpectraS3(t *testing.T) {
-    expectedRequest := "<Objects><Object Name=\"obj1\"></Object><Object Name=\"obj2\"></Object><Object Name=\"obj3\"></Object></Objects>"
-    responsePayload := "<Data><AzureTargets/><Ds3Targets/><Pools/><S3Targets/><Tapes/></Data>"
+	expectedRequest := "<Objects><Object Name=\"obj1\"></Object><Object Name=\"obj2\"></Object><Object Name=\"obj3\"></Object></Objects>"
+	responsePayload := "<Data><AzureTargets/><Ds3Targets/><Pools/><S3Targets/><Tapes/></Data>"
 
-    // Create and run the mocked client.
-    bucketName := "BucketName"
-    objectNames := []string {"obj1", "obj2", "obj3"}
+	// Create and run the mocked client.
+	bucketName := "BucketName"
+	objectNames := []string{"obj1", "obj2", "obj3"}
 
-    qp := &url.Values{ "operation": []string{"get_physical_placement"} }
+	qp := &url.Values{"operation": []string{"get_physical_placement"}}
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_PUT, "/_rest_/bucket/" + bucketName, qp, &http.Header{}, &expectedRequest).
-        Returning(200, responsePayload, nil).
-        GetPhysicalPlacementForObjectsSpectraS3(context.Background(), models.NewGetPhysicalPlacementForObjectsSpectraS3Request(bucketName, objectNames))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_PUT, "/_rest_/bucket/"+bucketName, qp, &http.Header{}, &expectedRequest).
+		Returning(200, responsePayload, nil).
+		GetPhysicalPlacementForObjectsSpectraS3(context.Background(), models.NewGetPhysicalPlacementForObjectsSpectraS3Request(bucketName, objectNames))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
 }
 
 func TestGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3(t *testing.T) {
-    expectedRequest := "<Objects><Object Name=\"obj1\"></Object><Object Name=\"obj2\"></Object><Object Name=\"obj3\"></Object></Objects>"
-    responsePayload := "<Data><Object Bucket=\"b1\" Id=\"a2897bbd-3e0b-4c0f-83d7-29e1e7669bdd\" InCache=\"false\" Latest=\"true\" Length=\"10\" Name=\"o4\" Offset=\"0\" ><PhysicalPlacement><AzureTargets/><Ds3Targets/><Pools/><S3Targets/><Tapes/></PhysicalPlacement></Object></Data>"
+	expectedRequest := "<Objects><Object Name=\"obj1\"></Object><Object Name=\"obj2\"></Object><Object Name=\"obj3\"></Object></Objects>"
+	responsePayload := "<Data><Object Bucket=\"b1\" Id=\"a2897bbd-3e0b-4c0f-83d7-29e1e7669bdd\" InCache=\"false\" Latest=\"true\" Length=\"10\" Name=\"o4\" Offset=\"0\" ><PhysicalPlacement><AzureTargets/><Ds3Targets/><Pools/><S3Targets/><Tapes/></PhysicalPlacement></Object></Data>"
 
-    // Create and run the mocked client.
-    bucketName := "BucketName"
-    objectNames := []string {"obj1", "obj2", "obj3"}
+	// Create and run the mocked client.
+	bucketName := "BucketName"
+	objectNames := []string{"obj1", "obj2", "obj3"}
 
-    qp := &url.Values{
-        "operation": []string{"get_physical_placement"},
-        "full_details": []string{""},
-    }
+	qp := &url.Values{
+		"operation":    []string{"get_physical_placement"},
+		"full_details": []string{""},
+	}
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_PUT, "/_rest_/bucket/" + bucketName, qp, &http.Header{}, &expectedRequest).
-        Returning(200, responsePayload, nil).
-        GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3(context.Background(), models.NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName, objectNames))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_PUT, "/_rest_/bucket/"+bucketName, qp, &http.Header{}, &expectedRequest).
+		Returning(200, responsePayload, nil).
+		GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3(context.Background(), models.NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName, objectNames))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
 }
 
 func TestMarkSuspectBlobAzureTargetsAsDegradedSpectraS3(t *testing.T) {
-    runMarkSuspectBlobTest(
-        t,
-        "/_rest_/suspect_blob_azure_target",
-        func(client *Client, ids []string) error {
-            _, err := client.MarkSuspectBlobAzureTargetsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(ids))
-            return err
-        },
-    )
+	runMarkSuspectBlobTest(
+		t,
+		"/_rest_/suspect_blob_azure_target",
+		func(client *Client, ids []string) error {
+			_, err := client.MarkSuspectBlobAzureTargetsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(ids))
+			return err
+		},
+	)
 }
 
 func TestMarkSuspectBlobDs3TargetsAsDegradedSpectraS3(t *testing.T) {
-    runMarkSuspectBlobTest(
-        t,
-        "/_rest_/suspect_blob_ds3_target",
-        func(client *Client, ids []string) error {
-            _, err := client.MarkSuspectBlobDs3TargetsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(ids))
-            return err
-        },
-    )
+	runMarkSuspectBlobTest(
+		t,
+		"/_rest_/suspect_blob_ds3_target",
+		func(client *Client, ids []string) error {
+			_, err := client.MarkSuspectBlobDs3TargetsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(ids))
+			return err
+		},
+	)
 }
 
 func TestMarkSuspectBlobPoolsAsDegradedSpectraS3(t *testing.T) {
-    runMarkSuspectBlobTest(
-        t,
-        "/_rest_/suspect_blob_pool",
-        func(client *Client, ids []string) error {
-            _, err := client.MarkSuspectBlobPoolsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobPoolsAsDegradedSpectraS3Request(ids))
-            return err
-        },
-    )
+	runMarkSuspectBlobTest(
+		t,
+		"/_rest_/suspect_blob_pool",
+		func(client *Client, ids []string) error {
+			_, err := client.MarkSuspectBlobPoolsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobPoolsAsDegradedSpectraS3Request(ids))
+			return err
+		},
+	)
 }
 
 func TestMarkSuspectBlobS3TargetsAsDegradedSpectraS3(t *testing.T) {
-    runMarkSuspectBlobTest(
-        t,
-        "/_rest_/suspect_blob_s3_target",
-        func(client *Client, ids []string) error {
-            _, err := client.MarkSuspectBlobS3TargetsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(ids))
-            return err
-        },
-    )
+	runMarkSuspectBlobTest(
+		t,
+		"/_rest_/suspect_blob_s3_target",
+		func(client *Client, ids []string) error {
+			_, err := client.MarkSuspectBlobS3TargetsAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(ids))
+			return err
+		},
+	)
 }
 
 func TestMarkSuspectBlobTapesAsDegradedSpectraS3(t *testing.T) {
-    runMarkSuspectBlobTest(
-        t,
-        "/_rest_/suspect_blob_tape",
-        func(client *Client, ids []string) error {
-            _, err := client.MarkSuspectBlobTapesAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobTapesAsDegradedSpectraS3Request(ids))
-            return err
-        },
-    )
+	runMarkSuspectBlobTest(
+		t,
+		"/_rest_/suspect_blob_tape",
+		func(client *Client, ids []string) error {
+			_, err := client.MarkSuspectBlobTapesAsDegradedSpectraS3(context.Background(), models.NewMarkSuspectBlobTapesAsDegradedSpectraS3Request(ids))
+			return err
+		},
+	)
 }
 
 type markSuspectBlobTest func(*Client, []string) error
 
 func runMarkSuspectBlobTest(t *testing.T, path string, callToTest markSuspectBlobTest) {
-    expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
+	expectedRequest := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
 
-    // Create and run the mocked client.
-    ids := []string {"id1", "id2", "id3"}
+	// Create and run the mocked client.
+	ids := []string{"id1", "id2", "id3"}
 
-    client := mockedClient(t).
-        Expecting(HTTP_VERB_PUT, path, &url.Values{}, &http.Header{}, &expectedRequest).
-        Returning(204, "", nil)
+	client := mockedClient(t).
+		Expecting(HTTP_VERB_PUT, path, &url.Values{}, &http.Header{}, &expectedRequest).
+		Returning(204, "", nil)
 
-    err := callToTest(client, ids)
+	err := callToTest(client, ids)
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 }
 
 func TestVerifyPhysicalPlacementForObjectsSpectraS3(t *testing.T) {
-    expectedRequest := "<Objects><Object Name=\"o1\"></Object></Objects>"
-    responsePayload := "<Data><AzureTargets/><Ds3Targets/><Pools/><S3Targets/><Tapes><Tape><AssignedToStorageDomain>false</AssignedToStorageDomain><AvailableRawCapacity>10000</AvailableRawCapacity><BarCode>t1</BarCode><BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/><FullOfData>false</FullOfData><Id>48d30ecb-84f1-4721-9832-7aa165a1dd77</Id><LastAccessed/><LastCheckpoint/><LastModified/><LastVerified/><PartiallyVerifiedEndOfTape/><PartitionId>76343269-c32a-4cb0-aec4-57a9dccce6ea</PartitionId><PreviousState/><SerialNumber/><State>PENDING_INSPECTION</State><TakeOwnershipPending>false</TakeOwnershipPending><TotalRawCapacity>20000</TotalRawCapacity><Type>LTO5</Type><VerifyPending/><WriteProtected>false</WriteProtected></Tape></Tapes></Data>"
+	expectedRequest := "<Objects><Object Name=\"o1\"></Object></Objects>"
+	responsePayload := "<Data><AzureTargets/><Ds3Targets/><Pools/><S3Targets/><Tapes><Tape><AssignedToStorageDomain>false</AssignedToStorageDomain><AvailableRawCapacity>10000</AvailableRawCapacity><BarCode>t1</BarCode><BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/><FullOfData>false</FullOfData><Id>48d30ecb-84f1-4721-9832-7aa165a1dd77</Id><LastAccessed/><LastCheckpoint/><LastModified/><LastVerified/><PartiallyVerifiedEndOfTape/><PartitionId>76343269-c32a-4cb0-aec4-57a9dccce6ea</PartitionId><PreviousState/><SerialNumber/><State>PENDING_INSPECTION</State><TakeOwnershipPending>false</TakeOwnershipPending><TotalRawCapacity>20000</TotalRawCapacity><Type>LTO5</Type><VerifyPending/><WriteProtected>false</WriteProtected></Tape></Tapes></Data>"
 
-    // Create and run the mocked client.
-    bucketName := "b1"
-    objectNames := []string {"o1"}
+	// Create and run the mocked client.
+	bucketName := "b1"
+	objectNames := []string{"o1"}
 
-    qp := &url.Values{ "operation": []string{"verify_physical_placement"} }
+	qp := &url.Values{"operation": []string{"verify_physical_placement"}}
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/_rest_/bucket/" + bucketName, qp, &http.Header{}, &expectedRequest).
-        Returning(200, responsePayload, nil).
-        VerifyPhysicalPlacementForObjectsSpectraS3(context.Background(), models.NewVerifyPhysicalPlacementForObjectsSpectraS3Request(bucketName, objectNames))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/bucket/"+bucketName, qp, &http.Header{}, &expectedRequest).
+		Returning(200, responsePayload, nil).
+		VerifyPhysicalPlacementForObjectsSpectraS3(context.Background(), models.NewVerifyPhysicalPlacementForObjectsSpectraS3Request(bucketName, objectNames))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
-    ds3Testing.AssertInt(t, "Number of Tapes", 1, len(response.PhysicalPlacement.Tapes))
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
+	ds3Testing.AssertInt(t, "Number of Tapes", 1, len(response.PhysicalPlacement.Tapes))
 }
 
 func TestVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3(t *testing.T) {
-    expectedRequest := "<Objects><Object Name=\"o1\"></Object></Objects>"
-    responsePayload := "<Data><Object Bucket=\"b1\" Id=\"ad5bfa96-8356-42e5-97c7-091780f9d2a7\" InCache=\"false\" Latest=\"true\" Length=\"10\" Name=\"o1\" Offset=\"0\" ><PhysicalPlacement><AzureTargets/><Ds3Targets/><Pools/><S3Targets/><Tapes><Tape><AssignedToStorageDomain>false</AssignedToStorageDomain><AvailableRawCapacity>10000</AvailableRawCapacity><BarCode>t1</BarCode><BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/><FullOfData>false</FullOfData><Id>3514700d-4d4f-4e64-8ccd-20750b5514fd</Id><LastAccessed/><LastCheckpoint/><LastModified/><LastVerified/><PartiallyVerifiedEndOfTape/><PartitionId>dc681797-927a-4eb0-9652-d19d06534e50</PartitionId><PreviousState/><SerialNumber/><State>PENDING_INSPECTION</State><TakeOwnershipPending>false</TakeOwnershipPending><TotalRawCapacity>20000</TotalRawCapacity><Type>LTO5</Type><VerifyPending/><WriteProtected>false</WriteProtected></Tape></Tapes></PhysicalPlacement></Object></Data>"
+	expectedRequest := "<Objects><Object Name=\"o1\"></Object></Objects>"
+	responsePayload := "<Data><Object Bucket=\"b1\" Id=\"ad5bfa96-8356-42e5-97c7-091780f9d2a7\" InCache=\"false\" Latest=\"true\" Length=\"10\" Name=\"o1\" Offset=\"0\" ><PhysicalPlacement><AzureTargets/><Ds3Targets/><Pools/><S3Targets/><Tapes><Tape><AssignedToStorageDomain>false</AssignedToStorageDomain><AvailableRawCapacity>10000</AvailableRawCapacity><BarCode>t1</BarCode><BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/><FullOfData>false</FullOfData><Id>3514700d-4d4f-4e64-8ccd-20750b5514fd</Id><LastAccessed/><LastCheckpoint/><LastModified/><LastVerified/><PartiallyVerifiedEndOfTape/><PartitionId>dc681797-927a-4eb0-9652-d19d06534e50</PartitionId><PreviousState/><SerialNumber/><State>PENDING_INSPECTION</State><TakeOwnershipPending>false</TakeOwnershipPending><TotalRawCapacity>20000</TotalRawCapacity><Type>LTO5</Type><VerifyPending/><WriteProtected>false</WriteProtected></Tape></Tapes></PhysicalPlacement></Object></Data>"
 
-    // Create and run the mocked client.
-    bucketName := "b1"
-    objectNames := []string {"o1"}
+	// Create and run the mocked client.
+	bucketName := "b1"
+	objectNames := []string{"o1"}
 
-    qp := &url.Values{
-        "operation": []string{"verify_physical_placement"},
-        "full_details": []string{""},
-    }
+	qp := &url.Values{
+		"operation":    []string{"verify_physical_placement"},
+		"full_details": []string{""},
+	}
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_GET, "/_rest_/bucket/" + bucketName, qp, &http.Header{}, &expectedRequest).
-        Returning(200, responsePayload, nil).
-        VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3(context.Background(), models.NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName, objectNames))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_GET, "/_rest_/bucket/"+bucketName, qp, &http.Header{}, &expectedRequest).
+		Returning(200, responsePayload, nil).
+		VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3(context.Background(), models.NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName, objectNames))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
-    ds3Testing.AssertInt(t, "Number of BulkObjects", 1, len(response.BulkObjectList.Objects))
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
+	ds3Testing.AssertInt(t, "Number of BulkObjects", 1, len(response.BulkObjectList.Objects))
 
-    object := response.BulkObjectList.Objects[0]
-    ds3Testing.AssertNonNilStringPtr(t, "Bucket", "b1", object.Bucket)
-    ds3Testing.AssertNonNilStringPtr(t, "Id", "ad5bfa96-8356-42e5-97c7-091780f9d2a7", object.Id)
-    ds3Testing.AssertNonNilBoolPtr(t, "InCache", false, object.InCache)
-    ds3Testing.AssertBool(t, "Latest", true, object.Latest)
-    ds3Testing.AssertInt64(t, "Length", 10, object.Length)
-    ds3Testing.AssertNonNilStringPtr(t, "Name", "o1", object.Name)
-    ds3Testing.AssertInt64(t, "Offset", 0, object.Offset)
-    if object.PhysicalPlacement == nil {
-        t.Fatal("Expected PhysicalPlacement to not be nil")
-    }
+	object := response.BulkObjectList.Objects[0]
+	ds3Testing.AssertNonNilStringPtr(t, "Bucket", "b1", object.Bucket)
+	ds3Testing.AssertNonNilStringPtr(t, "Id", "ad5bfa96-8356-42e5-97c7-091780f9d2a7", object.Id)
+	ds3Testing.AssertNonNilBoolPtr(t, "InCache", false, object.InCache)
+	ds3Testing.AssertBool(t, "Latest", true, object.Latest)
+	ds3Testing.AssertInt64(t, "Length", 10, object.Length)
+	ds3Testing.AssertNonNilStringPtr(t, "Name", "o1", object.Name)
+	ds3Testing.AssertInt64(t, "Offset", 0, object.Offset)
+	if object.PhysicalPlacement == nil {
+		t.Fatal("Expected PhysicalPlacement to not be nil")
+	}
 
-    pp := object.PhysicalPlacement
-    ds3Testing.AssertInt(t, "Number of Azure Targets", 0, len(pp.AzureTargets))
-    ds3Testing.AssertInt(t, "Number of Ds3 Targets", 0, len(pp.Ds3Targets))
-    ds3Testing.AssertInt(t, "Number of Pools", 0, len(pp.Pools))
-    ds3Testing.AssertInt(t, "Number of S3 Targets", 0, len(pp.S3Targets))
-    ds3Testing.AssertInt(t, "Number of Tapes", 1, len(pp.Tapes))
+	pp := object.PhysicalPlacement
+	ds3Testing.AssertInt(t, "Number of Azure Targets", 0, len(pp.AzureTargets))
+	ds3Testing.AssertInt(t, "Number of Ds3 Targets", 0, len(pp.Ds3Targets))
+	ds3Testing.AssertInt(t, "Number of Pools", 0, len(pp.Pools))
+	ds3Testing.AssertInt(t, "Number of S3 Targets", 0, len(pp.S3Targets))
+	ds3Testing.AssertInt(t, "Number of Tapes", 1, len(pp.Tapes))
 
-    tape := pp.Tapes[0]
-    ds3Testing.AssertBool(t, "AssignedToStorageDomain", false, tape.AssignedToStorageDomain)
-    ds3Testing.AssertNonNilInt64Ptr(t, "AvailableRawCapacity", 10000, tape.AvailableRawCapacity)
-    ds3Testing.AssertNonNilStringPtr(t, "BarCode", "t1", tape.BarCode)
-    ds3Testing.AssertStringPtrIsNil(t, "BucketId", tape.BucketId)
-    ds3Testing.AssertStringPtrIsNil(t, "DescriptionForIdentification", tape.DescriptionForIdentification)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectDate", tape.EjectDate)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectLabel", tape.EjectLabel)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectLocation", tape.EjectLocation)
-    ds3Testing.AssertStringPtrIsNil(t, "EjectPending", tape.EjectPending)
-    ds3Testing.AssertBool(t, "FullOfData", false, tape.FullOfData)
-    ds3Testing.AssertString(t, "Id", "3514700d-4d4f-4e64-8ccd-20750b5514fd", tape.Id)
-    ds3Testing.AssertStringPtrIsNil(t, "LastAccessed", tape.LastAccessed)
-    ds3Testing.AssertStringPtrIsNil(t, "LastCheckpoint", tape.LastCheckpoint)
-    ds3Testing.AssertStringPtrIsNil(t, "LastModified", tape.LastModified)
-    ds3Testing.AssertStringPtrIsNil(t, "LastVerified", tape.LastVerified)
-    ds3Testing.AssertStringPtrIsNil(t, "PartiallyVerifiedEndOfTape", tape.PartiallyVerifiedEndOfTape)
-    ds3Testing.AssertNonNilStringPtr(t, "PartitionId", "dc681797-927a-4eb0-9652-d19d06534e50", tape.PartitionId)
-    if tape.PreviousState != nil {
-        t.Fatalf("Expeted previous state to be 'nil' but was '%v'.", tape.PreviousState)
-    }
-    ds3Testing.AssertStringPtrIsNil(t, "SerialNumber", tape.SerialNumber)
-    if tape.State != models.TAPE_STATE_PENDING_INSPECTION {
-        t.Fatalf("Expected tape state 'TAPE_STATE_PENDING_INSPECTION' but got '%v'.", tape.State)
-    }
-    ds3Testing.AssertStringPtrIsNil(t, "StorageDomainId", tape.StorageDomainMemberId)
-    ds3Testing.AssertBool(t, "TakeOwnershipPending", false, tape.TakeOwnershipPending)
-    ds3Testing.AssertNonNilInt64Ptr(t, "TotalRawCapacity", 20000, tape.TotalRawCapacity)
-    ds3Testing.AssertString(t, "TapeType", "LTO5", tape.Type)
-    if tape.VerifyPending != nil {
-        t.Fatalf("Expected Verify Pending to be 'nil' but was '%s'.", tape.VerifyPending.String())
-    }
-    ds3Testing.AssertBool(t, "WriteProtected", false, tape.WriteProtected)
+	tape := pp.Tapes[0]
+	ds3Testing.AssertBool(t, "AssignedToStorageDomain", false, tape.AssignedToStorageDomain)
+	ds3Testing.AssertNonNilInt64Ptr(t, "AvailableRawCapacity", 10000, tape.AvailableRawCapacity)
+	ds3Testing.AssertNonNilStringPtr(t, "BarCode", "t1", tape.BarCode)
+	ds3Testing.AssertStringPtrIsNil(t, "BucketId", tape.BucketId)
+	ds3Testing.AssertStringPtrIsNil(t, "DescriptionForIdentification", tape.DescriptionForIdentification)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectDate", tape.EjectDate)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectLabel", tape.EjectLabel)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectLocation", tape.EjectLocation)
+	ds3Testing.AssertStringPtrIsNil(t, "EjectPending", tape.EjectPending)
+	ds3Testing.AssertBool(t, "FullOfData", false, tape.FullOfData)
+	ds3Testing.AssertString(t, "Id", "3514700d-4d4f-4e64-8ccd-20750b5514fd", tape.Id)
+	ds3Testing.AssertStringPtrIsNil(t, "LastAccessed", tape.LastAccessed)
+	ds3Testing.AssertStringPtrIsNil(t, "LastCheckpoint", tape.LastCheckpoint)
+	ds3Testing.AssertStringPtrIsNil(t, "LastModified", tape.LastModified)
+	ds3Testing.AssertStringPtrIsNil(t, "LastVerified", tape.LastVerified)
+	ds3Testing.AssertStringPtrIsNil(t, "PartiallyVerifiedEndOfTape", tape.PartiallyVerifiedEndOfTape)
+	ds3Testing.AssertNonNilStringPtr(t, "PartitionId", "dc681797-927a-4eb0-9652-d19d06534e50", tape.PartitionId)
+	if tape.PreviousState != nil {
+		t.Fatalf("Expeted previous state to be 'nil' but was '%v'.", tape.PreviousState)
+	}
+	ds3Testing.AssertStringPtrIsNil(t, "SerialNumber", tape.SerialNumber)
+	if tape.State != models.TAPE_STATE_PENDING_INSPECTION {
+		t.Fatalf("Expected tape state 'TAPE_STATE_PENDING_INSPECTION' but got '%v'.", tape.State)
+	}
+	ds3Testing.AssertStringPtrIsNil(t, "StorageDomainId", tape.StorageDomainMemberId)
+	ds3Testing.AssertBool(t, "TakeOwnershipPending", false, tape.TakeOwnershipPending)
+	ds3Testing.AssertNonNilInt64Ptr(t, "TotalRawCapacity", 20000, tape.TotalRawCapacity)
+	ds3Testing.AssertString(t, "TapeType", "LTO5", tape.Type)
+	if tape.VerifyPending != nil {
+		t.Fatalf("Expected Verify Pending to be 'nil' but was '%s'.", tape.VerifyPending.String())
+	}
+	ds3Testing.AssertBool(t, "WriteProtected", false, tape.WriteProtected)
 }
 
 func TestHeadObject(t *testing.T) {
-    bucketName := "bucket1"
-    objectName := "obj1"
+	bucketName := "bucket1"
+	objectName := "obj1"
 
-    responseHeaders := &http.Header{}
-    responseHeaders.Add("x-amz-meta-key", "value")
-    responseHeaders.Add("ds3-blob-checksum-type", "MD5")
-    responseHeaders.Add("ds3-blob-checksum-offset-0", "4nQGNX4nyz0pi8Hvap79PQ==")
-    responseHeaders.Add("ds3-blob-checksum-offset-10485760", "965Aa0/n8DlO1IwXYFh4bg==")
-    responseHeaders.Add("ds3-blob-checksum-offset-20971520", "iV2OqJaXJ/jmqgRSb1HmFA==")
+	responseHeaders := &http.Header{}
+	responseHeaders.Add("x-amz-meta-key", "value")
+	responseHeaders.Add("ds3-blob-checksum-type", "MD5")
+	responseHeaders.Add("ds3-blob-checksum-offset-0", "4nQGNX4nyz0pi8Hvap79PQ==")
+	responseHeaders.Add("ds3-blob-checksum-offset-10485760", "965Aa0/n8DlO1IwXYFh4bg==")
+	responseHeaders.Add("ds3-blob-checksum-offset-20971520", "iV2OqJaXJ/jmqgRSb1HmFA==")
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_HEAD, "/" + bucketName + "/" + objectName, &url.Values{}, &http.Header{}, nil).
-        Returning(200, "", responseHeaders).
-        HeadObject(context.Background(), models.NewHeadObjectRequest(bucketName, objectName))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_HEAD, "/"+bucketName+"/"+objectName, &url.Values{}, &http.Header{}, nil).
+		Returning(200, "", responseHeaders).
+		HeadObject(context.Background(), models.NewHeadObjectRequest(bucketName, objectName))
 
-    ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertNilError(t, err)
 
-    if response.BlobChecksumType != models.CHECKSUM_TYPE_MD5 {
-        t.Fatalf("Expected checksum type to be 'MD5' but was '%s'.", response.BlobChecksumType.String())
-    }
+	if response.BlobChecksumType != models.CHECKSUM_TYPE_MD5 {
+		t.Fatalf("Expected checksum type to be 'MD5' but was '%s'.", response.BlobChecksumType.String())
+	}
 
-    ds3Testing.AssertInt(t, "# of blob checksums", 3, len(response.BlobChecksums))
-    ds3Testing.AssertString(t, "checksum at offset '0'", "4nQGNX4nyz0pi8Hvap79PQ==", response.BlobChecksums[0])
-    ds3Testing.AssertString(t, "checksum at offset '10485760'", "965Aa0/n8DlO1IwXYFh4bg==", response.BlobChecksums[10485760])
-    ds3Testing.AssertString(t, "checksum at offset '20971520'", "iV2OqJaXJ/jmqgRSb1HmFA==", response.BlobChecksums[20971520])
+	ds3Testing.AssertInt(t, "# of blob checksums", 3, len(response.BlobChecksums))
+	ds3Testing.AssertString(t, "checksum at offset '0'", "4nQGNX4nyz0pi8Hvap79PQ==", response.BlobChecksums[0])
+	ds3Testing.AssertString(t, "checksum at offset '10485760'", "965Aa0/n8DlO1IwXYFh4bg==", response.BlobChecksums[10485760])
+	ds3Testing.AssertString(t, "checksum at offset '20971520'", "iV2OqJaXJ/jmqgRSb1HmFA==", response.BlobChecksums[20971520])
 }
 
 func TestStageObjectsJob(t *testing.T) {
-    expectedRequest := "<Objects><Object Name=\"o1\"></Object><Object Name=\"o2\" VersionId=\"v2\"></Object><Object Name=\"o3\" Length=\"10\" Offset=\"20\" VersionId=\"v3\"></Object></Objects>"
-    responsePayload := "<MasterObjectList><Objects><Object Name='file2' Length='1202'/><Object Name='file1' Length='256'/><Object Name='file3' Length='2523'/></Objects></MasterObjectList>"
+	expectedRequest := "<Objects><Object Name=\"o1\"></Object><Object Name=\"o2\" VersionId=\"v2\"></Object><Object Name=\"o3\" Length=\"10\" Offset=\"20\" VersionId=\"v3\"></Object></Objects>"
+	responsePayload := "<MasterObjectList><Objects><Object Name='file2' Length='1202'/><Object Name='file1' Length='256'/><Object Name='file3' Length='2523'/></Objects></MasterObjectList>"
 
-    // Create and run the mocked client.
-    bucketName := "b1"
-    objects := []models.Ds3GetObject {
-        models.NewDs3GetObject("o1"),
-        models.NewDs3GetObjectVersion("o2", "v2"),
-        models.NewPartialDs3GetObjectVersion("o3", 10, 20, "v3"),
-    }
+	// Create and run the mocked client.
+	bucketName := "b1"
+	objects := []models.Ds3GetObject{
+		models.NewDs3GetObject("o1"),
+		models.NewDs3GetObjectVersion("o2", "v2"),
+		models.NewPartialDs3GetObjectVersion("o3", 10, 20, "v3"),
+	}
 
-    qp := &url.Values{ "operation": []string{"start_bulk_stage"} }
+	qp := &url.Values{"operation": []string{"start_bulk_stage"}}
 
-    response, err := mockedClient(t).
-        Expecting(HTTP_VERB_PUT, "/_rest_/bucket/" + bucketName, qp, &http.Header{}, &expectedRequest).
-        Returning(200, responsePayload, nil).
-        StageObjectsJobSpectraS3(context.Background(), models.NewStageObjectsJobSpectraS3RequestWithPartialObjects(bucketName, objects))
+	response, err := mockedClient(t).
+		Expecting(HTTP_VERB_PUT, "/_rest_/bucket/"+bucketName, qp, &http.Header{}, &expectedRequest).
+		Returning(200, responsePayload, nil).
+		StageObjectsJobSpectraS3(context.Background(), models.NewStageObjectsJobSpectraS3RequestWithPartialObjects(bucketName, objects))
 
-    // Check the error result.
-    ds3Testing.AssertNilError(t, err)
+	// Check the error result.
+	ds3Testing.AssertNilError(t, err)
 
-    // Check the response value.
-    if response == nil {
-        t.Fatalf("Response was unexpectedly nil.")
-    }
-    ds3Testing.AssertInt(t, "Number of objects", 1, len(response.MasterObjectList.Objects))
-    ds3Testing.AssertInt(t, "Number of blobs", 3, len(response.MasterObjectList.Objects[0].Objects))
+	// Check the response value.
+	if response == nil {
+		t.Fatalf("Response was unexpectedly nil.")
+	}
+	ds3Testing.AssertInt(t, "Number of objects", 1, len(response.MasterObjectList.Objects))
+	ds3Testing.AssertInt(t, "Number of blobs", 3, len(response.MasterObjectList.Objects[0].Objects))
 }

--- a/ds3/ds3Deletes.go
+++ b/ds3/ds3Deletes.go
@@ -14,1623 +14,1621 @@
 package ds3
 
 import (
-    "context"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+	"context"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
 )
 
 func (client *Client) AbortMultiPartUpload(ctx context.Context, request *models.AbortMultiPartUploadRequest) (*models.AbortMultiPartUploadResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/" + request.BucketName + "/" + request.ObjectName).
-        WithQueryParam("upload_id", request.UploadId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/"+request.BucketName+"/"+request.ObjectName).
+		WithQueryParam("upload_id", request.UploadId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewAbortMultiPartUploadResponse(response)
+	// Create a response object based on the result.
+	return models.NewAbortMultiPartUploadResponse(response)
 }
 
 func (client *Client) DeleteBucket(ctx context.Context, request *models.DeleteBucketRequest) (*models.DeleteBucketResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/" + request.BucketName).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/"+request.BucketName).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteBucketResponse(response)
+	// Create a response object based on the result.
+	return models.NewDeleteBucketResponse(response)
 }
 
 func (client *Client) DeleteObject(ctx context.Context, request *models.DeleteObjectRequest) (*models.DeleteObjectResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/" + request.BucketName + "/" + request.ObjectName).
-        WithOptionalQueryParam("version_id", request.VersionId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/"+request.BucketName+"/"+request.ObjectName).
+		WithOptionalQueryParam("version_id", request.VersionId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteObjectResponse(response)
+	// Create a response object based on the result.
+	return models.NewDeleteObjectResponse(response)
 }
 
 func (client *Client) DeleteBucketAclSpectraS3(ctx context.Context, request *models.DeleteBucketAclSpectraS3Request) (*models.DeleteBucketAclSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/bucket_acl/" + request.BucketAcl).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/bucket_acl/"+request.BucketAcl).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteBucketAclSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteBucketAclSpectraS3Response(response)
 }
 
 func (client *Client) DeleteDataPolicyAclSpectraS3(ctx context.Context, request *models.DeleteDataPolicyAclSpectraS3Request) (*models.DeleteDataPolicyAclSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/data_policy_acl/" + request.DataPolicyAcl).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/data_policy_acl/"+request.DataPolicyAcl).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteDataPolicyAclSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteDataPolicyAclSpectraS3Response(response)
 }
 
 func (client *Client) DeleteBucketSpectraS3(ctx context.Context, request *models.DeleteBucketSpectraS3Request) (*models.DeleteBucketSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithOptionalVoidQueryParam("force", request.Force).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithOptionalVoidQueryParam("force", request.Force).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteBucketSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteBucketSpectraS3Response(response)
 }
 
 func (client *Client) DeleteAzureDataReplicationRuleSpectraS3(ctx context.Context, request *models.DeleteAzureDataReplicationRuleSpectraS3Request) (*models.DeleteAzureDataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/azure_data_replication_rule/" + request.AzureDataReplicationRule).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/azure_data_replication_rule/"+request.AzureDataReplicationRule).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteAzureDataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteAzureDataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) DeleteDataPersistenceRuleSpectraS3(ctx context.Context, request *models.DeleteDataPersistenceRuleSpectraS3Request) (*models.DeleteDataPersistenceRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/data_persistence_rule/" + request.DataPersistenceRuleId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/data_persistence_rule/"+request.DataPersistenceRuleId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteDataPersistenceRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteDataPersistenceRuleSpectraS3Response(response)
 }
 
 func (client *Client) DeleteDataPolicySpectraS3(ctx context.Context, request *models.DeleteDataPolicySpectraS3Request) (*models.DeleteDataPolicySpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/data_policy/" + request.DataPolicyId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/data_policy/"+request.DataPolicyId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteDataPolicySpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteDataPolicySpectraS3Response(response)
 }
 
 func (client *Client) DeleteDs3DataReplicationRuleSpectraS3(ctx context.Context, request *models.DeleteDs3DataReplicationRuleSpectraS3Request) (*models.DeleteDs3DataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/ds3_data_replication_rule/" + request.Ds3DataReplicationRule).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/ds3_data_replication_rule/"+request.Ds3DataReplicationRule).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteDs3DataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteDs3DataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) DeleteS3DataReplicationRuleSpectraS3(ctx context.Context, request *models.DeleteS3DataReplicationRuleSpectraS3Request) (*models.DeleteS3DataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/s3_data_replication_rule/" + request.S3DataReplicationRule).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/s3_data_replication_rule/"+request.S3DataReplicationRule).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteS3DataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteS3DataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) ClearSuspectBlobAzureTargetsSpectraS3(ctx context.Context, request *models.ClearSuspectBlobAzureTargetsSpectraS3Request) (*models.ClearSuspectBlobAzureTargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/suspect_blob_azure_target").
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/suspect_blob_azure_target").
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithReadCloser(buildIdListPayload(request.Ids)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewClearSuspectBlobAzureTargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewClearSuspectBlobAzureTargetsSpectraS3Response(response)
 }
 
 func (client *Client) ClearSuspectBlobDs3TargetsSpectraS3(ctx context.Context, request *models.ClearSuspectBlobDs3TargetsSpectraS3Request) (*models.ClearSuspectBlobDs3TargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/suspect_blob_ds3_target").
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/suspect_blob_ds3_target").
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithReadCloser(buildIdListPayload(request.Ids)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewClearSuspectBlobDs3TargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewClearSuspectBlobDs3TargetsSpectraS3Response(response)
 }
 
 func (client *Client) ClearSuspectBlobPoolsSpectraS3(ctx context.Context, request *models.ClearSuspectBlobPoolsSpectraS3Request) (*models.ClearSuspectBlobPoolsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/suspect_blob_pool").
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/suspect_blob_pool").
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithReadCloser(buildIdListPayload(request.Ids)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewClearSuspectBlobPoolsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewClearSuspectBlobPoolsSpectraS3Response(response)
 }
 
 func (client *Client) ClearSuspectBlobS3TargetsSpectraS3(ctx context.Context, request *models.ClearSuspectBlobS3TargetsSpectraS3Request) (*models.ClearSuspectBlobS3TargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/suspect_blob_s3_target").
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/suspect_blob_s3_target").
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithReadCloser(buildIdListPayload(request.Ids)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewClearSuspectBlobS3TargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewClearSuspectBlobS3TargetsSpectraS3Response(response)
 }
 
 func (client *Client) ClearSuspectBlobTapesSpectraS3(ctx context.Context, request *models.ClearSuspectBlobTapesSpectraS3Request) (*models.ClearSuspectBlobTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/suspect_blob_tape").
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/suspect_blob_tape").
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithReadCloser(buildIdListPayload(request.Ids)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewClearSuspectBlobTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewClearSuspectBlobTapesSpectraS3Response(response)
 }
 
 func (client *Client) DeleteGroupMemberSpectraS3(ctx context.Context, request *models.DeleteGroupMemberSpectraS3Request) (*models.DeleteGroupMemberSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/group_member/" + request.GroupMember).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/group_member/"+request.GroupMember).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteGroupMemberSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteGroupMemberSpectraS3Response(response)
 }
 
 func (client *Client) DeleteGroupSpectraS3(ctx context.Context, request *models.DeleteGroupSpectraS3Request) (*models.DeleteGroupSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/group/" + request.Group).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/group/"+request.Group).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteGroupSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteGroupSpectraS3Response(response)
 }
 
 func (client *Client) CancelActiveJobSpectraS3(ctx context.Context, request *models.CancelActiveJobSpectraS3Request) (*models.CancelActiveJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/active_job/" + request.ActiveJobId).
-        WithQueryParam("force", "").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/active_job/"+request.ActiveJobId).
+		WithQueryParam("force", "").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelActiveJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelActiveJobSpectraS3Response(response)
 }
 
 func (client *Client) CancelAllActiveJobsSpectraS3(ctx context.Context, request *models.CancelAllActiveJobsSpectraS3Request) (*models.CancelAllActiveJobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/active_job").
-        WithQueryParam("force", "").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/active_job").
+		WithQueryParam("force", "").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelAllActiveJobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelAllActiveJobsSpectraS3Response(response)
 }
 
 func (client *Client) CancelAllJobsSpectraS3(ctx context.Context, request *models.CancelAllJobsSpectraS3Request) (*models.CancelAllJobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/job").
-        WithQueryParam("force", "").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/job").
+		WithQueryParam("force", "").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelAllJobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelAllJobsSpectraS3Response(response)
 }
 
 func (client *Client) CancelJobSpectraS3(ctx context.Context, request *models.CancelJobSpectraS3Request) (*models.CancelJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/job/" + request.JobId).
-        WithQueryParam("force", "").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/job/"+request.JobId).
+		WithQueryParam("force", "").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelJobSpectraS3Response(response)
 }
 
 func (client *Client) ClearAllCanceledJobsSpectraS3(ctx context.Context, request *models.ClearAllCanceledJobsSpectraS3Request) (*models.ClearAllCanceledJobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/canceled_job").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/canceled_job").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewClearAllCanceledJobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewClearAllCanceledJobsSpectraS3Response(response)
 }
 
 func (client *Client) ClearAllCompletedJobsSpectraS3(ctx context.Context, request *models.ClearAllCompletedJobsSpectraS3Request) (*models.ClearAllCompletedJobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/completed_job").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/completed_job").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewClearAllCompletedJobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewClearAllCompletedJobsSpectraS3Response(response)
 }
 
 func (client *Client) DeleteJobCreationFailureSpectraS3(ctx context.Context, request *models.DeleteJobCreationFailureSpectraS3Request) (*models.DeleteJobCreationFailureSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/job_creation_failed/" + request.JobCreationFailed).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/job_creation_failed/"+request.JobCreationFailed).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteJobCreationFailureSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteJobCreationFailureSpectraS3Response(response)
 }
 
 func (client *Client) TruncateActiveJobSpectraS3(ctx context.Context, request *models.TruncateActiveJobSpectraS3Request) (*models.TruncateActiveJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/active_job/" + request.ActiveJobId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/active_job/"+request.ActiveJobId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewTruncateActiveJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewTruncateActiveJobSpectraS3Response(response)
 }
 
 func (client *Client) TruncateAllActiveJobsSpectraS3(ctx context.Context, request *models.TruncateAllActiveJobsSpectraS3Request) (*models.TruncateAllActiveJobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/active_job").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/active_job").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewTruncateAllActiveJobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewTruncateAllActiveJobsSpectraS3Response(response)
 }
 
 func (client *Client) TruncateAllJobsSpectraS3(ctx context.Context, request *models.TruncateAllJobsSpectraS3Request) (*models.TruncateAllJobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/job").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/job").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewTruncateAllJobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewTruncateAllJobsSpectraS3Response(response)
 }
 
 func (client *Client) TruncateJobSpectraS3(ctx context.Context, request *models.TruncateJobSpectraS3Request) (*models.TruncateJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/job/" + request.JobId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/job/"+request.JobId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewTruncateJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewTruncateJobSpectraS3Response(response)
 }
 
 func (client *Client) DeleteAzureTargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteAzureTargetFailureNotificationRegistrationSpectraS3Request) (*models.DeleteAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/azure_target_failure_notification_registration/" + request.AzureTargetFailureNotificationRegistration).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/azure_target_failure_notification_registration/"+request.AzureTargetFailureNotificationRegistration).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteAzureTargetFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteAzureTargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteBucketChangesNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteBucketChangesNotificationRegistrationSpectraS3Request) (*models.DeleteBucketChangesNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/bucket_changes_notification_registration/" + request.BucketChangesNotificationRegistration).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/bucket_changes_notification_registration/"+request.BucketChangesNotificationRegistration).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteBucketChangesNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteBucketChangesNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteDs3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteDs3TargetFailureNotificationRegistrationSpectraS3Request) (*models.DeleteDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/ds3_target_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/ds3_target_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteDs3TargetFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteDs3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteJobCompletedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteJobCompletedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCompletedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/job_completed_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/job_completed_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteJobCompletedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteJobCompletedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteJobCreatedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteJobCreatedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/job_created_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/job_created_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteJobCreatedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteJobCreatedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteJobCreationFailedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteJobCreationFailedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/job_creation_failed_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/job_creation_failed_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteJobCreationFailedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteJobCreationFailedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteObjectCachedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteObjectCachedNotificationRegistrationSpectraS3Request) (*models.DeleteObjectCachedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/object_cached_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/object_cached_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteObjectCachedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteObjectCachedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteObjectLostNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteObjectLostNotificationRegistrationSpectraS3Request) (*models.DeleteObjectLostNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/object_lost_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/object_lost_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteObjectLostNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteObjectLostNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteObjectPersistedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteObjectPersistedNotificationRegistrationSpectraS3Request) (*models.DeleteObjectPersistedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/object_persisted_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/object_persisted_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteObjectPersistedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteObjectPersistedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeletePoolFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeletePoolFailureNotificationRegistrationSpectraS3Request) (*models.DeletePoolFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/pool_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/pool_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeletePoolFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeletePoolFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteS3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteS3TargetFailureNotificationRegistrationSpectraS3Request) (*models.DeleteS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/s3_target_failure_notification_registration/" + request.S3TargetFailureNotificationRegistration).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/s3_target_failure_notification_registration/"+request.S3TargetFailureNotificationRegistration).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteS3TargetFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteS3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteStorageDomainFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteStorageDomainFailureNotificationRegistrationSpectraS3Request) (*models.DeleteStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/storage_domain_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/storage_domain_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteStorageDomainFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteStorageDomainFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteSystemFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteSystemFailureNotificationRegistrationSpectraS3Request) (*models.DeleteSystemFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/system_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/system_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteSystemFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteSystemFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteTapeFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteTapeFailureNotificationRegistrationSpectraS3Request) (*models.DeleteTapeFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/tape_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/tape_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteTapeFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteTapeFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteTapePartitionFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteTapePartitionFailureNotificationRegistrationSpectraS3Request) (*models.DeleteTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/tape_partition_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/tape_partition_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteTapePartitionFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteTapePartitionFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) DeleteFolderRecursivelySpectraS3(ctx context.Context, request *models.DeleteFolderRecursivelySpectraS3Request) (*models.DeleteFolderRecursivelySpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/folder/" + request.Folder).
-        WithQueryParam("bucket_id", request.BucketId).
-        WithQueryParam("recursive", "").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/folder/"+request.Folder).
+		WithQueryParam("bucket_id", request.BucketId).
+		WithQueryParam("recursive", "").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteFolderRecursivelySpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteFolderRecursivelySpectraS3Response(response)
 }
 
 func (client *Client) DeletePermanentlyLostPoolSpectraS3(ctx context.Context, request *models.DeletePermanentlyLostPoolSpectraS3Request) (*models.DeletePermanentlyLostPoolSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/pool/" + request.Pool).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/pool/"+request.Pool).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeletePermanentlyLostPoolSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeletePermanentlyLostPoolSpectraS3Response(response)
 }
 
 func (client *Client) DeletePoolFailureSpectraS3(ctx context.Context, request *models.DeletePoolFailureSpectraS3Request) (*models.DeletePoolFailureSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/pool_failure/" + request.PoolFailure).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/pool_failure/"+request.PoolFailure).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeletePoolFailureSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeletePoolFailureSpectraS3Response(response)
 }
 
 func (client *Client) DeletePoolPartitionSpectraS3(ctx context.Context, request *models.DeletePoolPartitionSpectraS3Request) (*models.DeletePoolPartitionSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/pool_partition/" + request.PoolPartition).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/pool_partition/"+request.PoolPartition).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeletePoolPartitionSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeletePoolPartitionSpectraS3Response(response)
 }
 
 func (client *Client) DeleteStorageDomainFailureSpectraS3(ctx context.Context, request *models.DeleteStorageDomainFailureSpectraS3Request) (*models.DeleteStorageDomainFailureSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/storage_domain_failure/" + request.StorageDomainFailure).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/storage_domain_failure/"+request.StorageDomainFailure).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteStorageDomainFailureSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteStorageDomainFailureSpectraS3Response(response)
 }
 
 func (client *Client) DeleteStorageDomainMemberSpectraS3(ctx context.Context, request *models.DeleteStorageDomainMemberSpectraS3Request) (*models.DeleteStorageDomainMemberSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/storage_domain_member/" + request.StorageDomainMember).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/storage_domain_member/"+request.StorageDomainMember).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteStorageDomainMemberSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteStorageDomainMemberSpectraS3Response(response)
 }
 
 func (client *Client) DeleteStorageDomainSpectraS3(ctx context.Context, request *models.DeleteStorageDomainSpectraS3Request) (*models.DeleteStorageDomainSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/storage_domain/" + request.StorageDomain).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/storage_domain/"+request.StorageDomain).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteStorageDomainSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteStorageDomainSpectraS3Response(response)
 }
 
 func (client *Client) DeletePermanentlyLostTapeSpectraS3(ctx context.Context, request *models.DeletePermanentlyLostTapeSpectraS3Request) (*models.DeletePermanentlyLostTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeletePermanentlyLostTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeletePermanentlyLostTapeSpectraS3Response(response)
 }
 
 func (client *Client) DeleteTapeDensityDirectiveSpectraS3(ctx context.Context, request *models.DeleteTapeDensityDirectiveSpectraS3Request) (*models.DeleteTapeDensityDirectiveSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/tape_density_directive/" + request.TapeDensityDirective).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/tape_density_directive/"+request.TapeDensityDirective).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteTapeDensityDirectiveSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteTapeDensityDirectiveSpectraS3Response(response)
 }
 
 func (client *Client) DeleteTapeDriveSpectraS3(ctx context.Context, request *models.DeleteTapeDriveSpectraS3Request) (*models.DeleteTapeDriveSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteTapeDriveSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteTapeDriveSpectraS3Response(response)
 }
 
 func (client *Client) DeleteTapeFailureSpectraS3(ctx context.Context, request *models.DeleteTapeFailureSpectraS3Request) (*models.DeleteTapeFailureSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/tape_failure/" + request.TapeFailure).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/tape_failure/"+request.TapeFailure).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteTapeFailureSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteTapeFailureSpectraS3Response(response)
 }
 
 func (client *Client) DeleteTapePartitionFailureSpectraS3(ctx context.Context, request *models.DeleteTapePartitionFailureSpectraS3Request) (*models.DeleteTapePartitionFailureSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/tape_partition_failure/" + request.TapePartitionFailure).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/tape_partition_failure/"+request.TapePartitionFailure).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteTapePartitionFailureSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteTapePartitionFailureSpectraS3Response(response)
 }
 
 func (client *Client) DeleteTapePartitionSpectraS3(ctx context.Context, request *models.DeleteTapePartitionSpectraS3Request) (*models.DeleteTapePartitionSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/tape_partition/" + request.TapePartition).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/tape_partition/"+request.TapePartition).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteTapePartitionSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteTapePartitionSpectraS3Response(response)
 }
 
 func (client *Client) DeleteAzureTargetBucketNameSpectraS3(ctx context.Context, request *models.DeleteAzureTargetBucketNameSpectraS3Request) (*models.DeleteAzureTargetBucketNameSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/azure_target_bucket_name/" + request.AzureTargetBucketName).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/azure_target_bucket_name/"+request.AzureTargetBucketName).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteAzureTargetBucketNameSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteAzureTargetBucketNameSpectraS3Response(response)
 }
 
 func (client *Client) DeleteAzureTargetFailureSpectraS3(ctx context.Context, request *models.DeleteAzureTargetFailureSpectraS3Request) (*models.DeleteAzureTargetFailureSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/azure_target_failure/" + request.AzureTargetFailure).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/azure_target_failure/"+request.AzureTargetFailure).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteAzureTargetFailureSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteAzureTargetFailureSpectraS3Response(response)
 }
 
 func (client *Client) DeleteAzureTargetReadPreferenceSpectraS3(ctx context.Context, request *models.DeleteAzureTargetReadPreferenceSpectraS3Request) (*models.DeleteAzureTargetReadPreferenceSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/azure_target_read_preference/" + request.AzureTargetReadPreference).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/azure_target_read_preference/"+request.AzureTargetReadPreference).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteAzureTargetReadPreferenceSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteAzureTargetReadPreferenceSpectraS3Response(response)
 }
 
 func (client *Client) DeleteAzureTargetSpectraS3(ctx context.Context, request *models.DeleteAzureTargetSpectraS3Request) (*models.DeleteAzureTargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/azure_target/" + request.AzureTarget).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/azure_target/"+request.AzureTarget).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteAzureTargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteAzureTargetSpectraS3Response(response)
 }
 
 func (client *Client) DeleteDs3TargetFailureSpectraS3(ctx context.Context, request *models.DeleteDs3TargetFailureSpectraS3Request) (*models.DeleteDs3TargetFailureSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/ds3_target_failure/" + request.Ds3TargetFailure).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/ds3_target_failure/"+request.Ds3TargetFailure).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteDs3TargetFailureSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteDs3TargetFailureSpectraS3Response(response)
 }
 
 func (client *Client) DeleteDs3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.DeleteDs3TargetReadPreferenceSpectraS3Request) (*models.DeleteDs3TargetReadPreferenceSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/ds3_target_read_preference/" + request.Ds3TargetReadPreference).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/ds3_target_read_preference/"+request.Ds3TargetReadPreference).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteDs3TargetReadPreferenceSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteDs3TargetReadPreferenceSpectraS3Response(response)
 }
 
 func (client *Client) DeleteDs3TargetSpectraS3(ctx context.Context, request *models.DeleteDs3TargetSpectraS3Request) (*models.DeleteDs3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/ds3_target/" + request.Ds3Target).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/ds3_target/"+request.Ds3Target).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteDs3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteDs3TargetSpectraS3Response(response)
 }
 
 func (client *Client) DeleteS3TargetBucketNameSpectraS3(ctx context.Context, request *models.DeleteS3TargetBucketNameSpectraS3Request) (*models.DeleteS3TargetBucketNameSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/s3_target_bucket_name/" + request.S3TargetBucketName).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/s3_target_bucket_name/"+request.S3TargetBucketName).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteS3TargetBucketNameSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteS3TargetBucketNameSpectraS3Response(response)
 }
 
 func (client *Client) DeleteS3TargetFailureSpectraS3(ctx context.Context, request *models.DeleteS3TargetFailureSpectraS3Request) (*models.DeleteS3TargetFailureSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/s3_target_failure/" + request.S3TargetFailure).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/s3_target_failure/"+request.S3TargetFailure).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteS3TargetFailureSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteS3TargetFailureSpectraS3Response(response)
 }
 
 func (client *Client) DeleteS3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.DeleteS3TargetReadPreferenceSpectraS3Request) (*models.DeleteS3TargetReadPreferenceSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/s3_target_read_preference/" + request.S3TargetReadPreference).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/s3_target_read_preference/"+request.S3TargetReadPreference).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteS3TargetReadPreferenceSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteS3TargetReadPreferenceSpectraS3Response(response)
 }
 
 func (client *Client) DeleteS3TargetSpectraS3(ctx context.Context, request *models.DeleteS3TargetSpectraS3Request) (*models.DeleteS3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/s3_target/" + request.S3Target).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/s3_target/"+request.S3Target).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteS3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeleteS3TargetSpectraS3Response(response)
 }
 
 func (client *Client) DelegateDeleteUserSpectraS3(ctx context.Context, request *models.DelegateDeleteUserSpectraS3Request) (*models.DelegateDeleteUserSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_DELETE).
-        WithPath("/_rest_/user/" + request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_DELETE).
+		WithPath("/_rest_/user/"+request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDelegateDeleteUserSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDelegateDeleteUserSpectraS3Response(response)
 }
-
-

--- a/ds3/ds3Gets.go
+++ b/ds3/ds3Gets.go
@@ -14,4309 +14,4307 @@
 package ds3
 
 import (
-    "context"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+	"context"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
 )
 
 func (client *Client) GetObject(ctx context.Context, request *models.GetObjectRequest) (*models.GetObjectResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/" + request.BucketName + "/" + request.ObjectName).
-        WithOptionalVoidQueryParam("cached_only", request.CachedOnly).
-        WithOptionalQueryParam("job", request.Job).
-        WithOptionalQueryParam("offset", networking.Int64PtrToStrPtr(request.Offset)).
-        WithOptionalQueryParam("version_id", request.VersionId).
-        WithChecksum(request.Checksum).
-        WithHeaders(request.Metadata).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/"+request.BucketName+"/"+request.ObjectName).
+		WithOptionalVoidQueryParam("cached_only", request.CachedOnly).
+		WithOptionalQueryParam("job", request.Job).
+		WithOptionalQueryParam("offset", networking.Int64PtrToStrPtr(request.Offset)).
+		WithOptionalQueryParam("version_id", request.VersionId).
+		WithChecksum(request.Checksum).
+		WithHeaders(request.Metadata).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetObjectResponse(response)
+	// Create a response object based on the result.
+	return models.NewGetObjectResponse(response)
 }
 
-
 func (client *Client) GetBucket(ctx context.Context, request *models.GetBucketRequest) (*models.GetBucketResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/" + request.BucketName).
-        WithOptionalQueryParam("delimiter", request.Delimiter).
-        WithOptionalQueryParam("marker", request.Marker).
-        WithOptionalQueryParam("max_keys", networking.IntPtrToStrPtr(request.MaxKeys)).
-        WithOptionalQueryParam("prefix", request.Prefix).
-        WithOptionalVoidQueryParam("versions", request.Versions).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/"+request.BucketName).
+		WithOptionalQueryParam("delimiter", request.Delimiter).
+		WithOptionalQueryParam("marker", request.Marker).
+		WithOptionalQueryParam("max_keys", networking.IntPtrToStrPtr(request.MaxKeys)).
+		WithOptionalQueryParam("prefix", request.Prefix).
+		WithOptionalVoidQueryParam("versions", request.Versions).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBucketResponse(response)
+	// Create a response object based on the result.
+	return models.NewGetBucketResponse(response)
 }
 
 func (client *Client) GetService(ctx context.Context, request *models.GetServiceRequest) (*models.GetServiceResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetServiceResponse(response)
+	// Create a response object based on the result.
+	return models.NewGetServiceResponse(response)
 }
 
 func (client *Client) ListMultiPartUploadParts(ctx context.Context, request *models.ListMultiPartUploadPartsRequest) (*models.ListMultiPartUploadPartsResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/" + request.BucketName + "/" + request.ObjectName).
-        WithQueryParam("upload_id", request.UploadId).
-        WithOptionalQueryParam("max_parts", networking.IntPtrToStrPtr(request.MaxParts)).
-        WithOptionalQueryParam("part_number_marker", networking.IntPtrToStrPtr(request.PartNumberMarker)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/"+request.BucketName+"/"+request.ObjectName).
+		WithQueryParam("upload_id", request.UploadId).
+		WithOptionalQueryParam("max_parts", networking.IntPtrToStrPtr(request.MaxParts)).
+		WithOptionalQueryParam("part_number_marker", networking.IntPtrToStrPtr(request.PartNumberMarker)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewListMultiPartUploadPartsResponse(response)
+	// Create a response object based on the result.
+	return models.NewListMultiPartUploadPartsResponse(response)
 }
 
 func (client *Client) ListMultiPartUploads(ctx context.Context, request *models.ListMultiPartUploadsRequest) (*models.ListMultiPartUploadsResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/" + request.BucketName).
-        WithQueryParam("uploads", "").
-        WithOptionalQueryParam("delimiter", request.Delimiter).
-        WithOptionalQueryParam("key_marker", request.KeyMarker).
-        WithOptionalQueryParam("max_uploads", networking.IntPtrToStrPtr(request.MaxUploads)).
-        WithOptionalQueryParam("prefix", request.Prefix).
-        WithOptionalQueryParam("upload_id_marker", request.UploadIdMarker).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/"+request.BucketName).
+		WithQueryParam("uploads", "").
+		WithOptionalQueryParam("delimiter", request.Delimiter).
+		WithOptionalQueryParam("key_marker", request.KeyMarker).
+		WithOptionalQueryParam("max_uploads", networking.IntPtrToStrPtr(request.MaxUploads)).
+		WithOptionalQueryParam("prefix", request.Prefix).
+		WithOptionalQueryParam("upload_id_marker", request.UploadIdMarker).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewListMultiPartUploadsResponse(response)
+	// Create a response object based on the result.
+	return models.NewListMultiPartUploadsResponse(response)
 }
 
 func (client *Client) GetBucketAclSpectraS3(ctx context.Context, request *models.GetBucketAclSpectraS3Request) (*models.GetBucketAclSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/bucket_acl/" + request.BucketAcl).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/bucket_acl/"+request.BucketAcl).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBucketAclSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBucketAclSpectraS3Response(response)
 }
 
 func (client *Client) GetBucketAclsSpectraS3(ctx context.Context, request *models.GetBucketAclsSpectraS3Request) (*models.GetBucketAclsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/bucket_acl").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("group_id", request.GroupId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("permission", networking.InterfaceToStrPtr(request.Permission)).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/bucket_acl").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("group_id", request.GroupId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("permission", networking.InterfaceToStrPtr(request.Permission)).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBucketAclsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBucketAclsSpectraS3Response(response)
 }
 
 func (client *Client) GetDataPolicyAclSpectraS3(ctx context.Context, request *models.GetDataPolicyAclSpectraS3Request) (*models.GetDataPolicyAclSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/data_policy_acl/" + request.DataPolicyAcl).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/data_policy_acl/"+request.DataPolicyAcl).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDataPolicyAclSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDataPolicyAclSpectraS3Response(response)
 }
 
 func (client *Client) GetDataPolicyAclsSpectraS3(ctx context.Context, request *models.GetDataPolicyAclsSpectraS3Request) (*models.GetDataPolicyAclsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/data_policy_acl").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("group_id", request.GroupId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/data_policy_acl").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("group_id", request.GroupId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDataPolicyAclsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDataPolicyAclsSpectraS3Response(response)
 }
 
 func (client *Client) GetBucketSpectraS3(ctx context.Context, request *models.GetBucketSpectraS3Request) (*models.GetBucketSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBucketSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBucketSpectraS3Response(response)
 }
 
 func (client *Client) GetBucketsSpectraS3(ctx context.Context, request *models.GetBucketsSpectraS3Request) (*models.GetBucketsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/bucket").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/bucket").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBucketsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBucketsSpectraS3Response(response)
 }
 
 func (client *Client) GetCacheFilesystemSpectraS3(ctx context.Context, request *models.GetCacheFilesystemSpectraS3Request) (*models.GetCacheFilesystemSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/cache_filesystem/" + request.CacheFilesystem).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/cache_filesystem/"+request.CacheFilesystem).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetCacheFilesystemSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetCacheFilesystemSpectraS3Response(response)
 }
 
 func (client *Client) GetCacheFilesystemsSpectraS3(ctx context.Context, request *models.GetCacheFilesystemsSpectraS3Request) (*models.GetCacheFilesystemsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/cache_filesystem").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("node_id", request.NodeId).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/cache_filesystem").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("node_id", request.NodeId).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetCacheFilesystemsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetCacheFilesystemsSpectraS3Response(response)
 }
 
 func (client *Client) GetCacheStateSpectraS3(ctx context.Context, request *models.GetCacheStateSpectraS3Request) (*models.GetCacheStateSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/cache_state").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/cache_state").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetCacheStateSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetCacheStateSpectraS3Response(response)
 }
 
 func (client *Client) GetBucketCapacitySummarySpectraS3(ctx context.Context, request *models.GetBucketCapacitySummarySpectraS3Request) (*models.GetBucketCapacitySummarySpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/capacity_summary").
-        WithQueryParam("bucket_id", request.BucketId).
-        WithQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("pool_health", networking.InterfaceToStrPtr(request.PoolHealth)).
-        WithOptionalQueryParam("pool_state", networking.InterfaceToStrPtr(request.PoolState)).
-        WithOptionalQueryParam("pool_type", networking.InterfaceToStrPtr(request.PoolType)).
-        WithOptionalQueryParam("tape_state", networking.InterfaceToStrPtr(request.TapeState)).
-        WithOptionalQueryParam("tape_type", request.TapeType).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/capacity_summary").
+		WithQueryParam("bucket_id", request.BucketId).
+		WithQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("pool_health", networking.InterfaceToStrPtr(request.PoolHealth)).
+		WithOptionalQueryParam("pool_state", networking.InterfaceToStrPtr(request.PoolState)).
+		WithOptionalQueryParam("pool_type", networking.InterfaceToStrPtr(request.PoolType)).
+		WithOptionalQueryParam("tape_state", networking.InterfaceToStrPtr(request.TapeState)).
+		WithOptionalQueryParam("tape_type", request.TapeType).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBucketCapacitySummarySpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBucketCapacitySummarySpectraS3Response(response)
 }
 
 func (client *Client) GetStorageDomainCapacitySummarySpectraS3(ctx context.Context, request *models.GetStorageDomainCapacitySummarySpectraS3Request) (*models.GetStorageDomainCapacitySummarySpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/capacity_summary").
-        WithQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("pool_health", networking.InterfaceToStrPtr(request.PoolHealth)).
-        WithOptionalQueryParam("pool_state", networking.InterfaceToStrPtr(request.PoolState)).
-        WithOptionalQueryParam("pool_type", networking.InterfaceToStrPtr(request.PoolType)).
-        WithOptionalQueryParam("tape_state", networking.InterfaceToStrPtr(request.TapeState)).
-        WithOptionalQueryParam("tape_type", request.TapeType).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/capacity_summary").
+		WithQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("pool_health", networking.InterfaceToStrPtr(request.PoolHealth)).
+		WithOptionalQueryParam("pool_state", networking.InterfaceToStrPtr(request.PoolState)).
+		WithOptionalQueryParam("pool_type", networking.InterfaceToStrPtr(request.PoolType)).
+		WithOptionalQueryParam("tape_state", networking.InterfaceToStrPtr(request.TapeState)).
+		WithOptionalQueryParam("tape_type", request.TapeType).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetStorageDomainCapacitySummarySpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetStorageDomainCapacitySummarySpectraS3Response(response)
 }
 
 func (client *Client) GetSystemCapacitySummarySpectraS3(ctx context.Context, request *models.GetSystemCapacitySummarySpectraS3Request) (*models.GetSystemCapacitySummarySpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/capacity_summary").
-        WithOptionalQueryParam("pool_health", networking.InterfaceToStrPtr(request.PoolHealth)).
-        WithOptionalQueryParam("pool_state", networking.InterfaceToStrPtr(request.PoolState)).
-        WithOptionalQueryParam("pool_type", networking.InterfaceToStrPtr(request.PoolType)).
-        WithOptionalQueryParam("tape_state", networking.InterfaceToStrPtr(request.TapeState)).
-        WithOptionalQueryParam("tape_type", request.TapeType).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/capacity_summary").
+		WithOptionalQueryParam("pool_health", networking.InterfaceToStrPtr(request.PoolHealth)).
+		WithOptionalQueryParam("pool_state", networking.InterfaceToStrPtr(request.PoolState)).
+		WithOptionalQueryParam("pool_type", networking.InterfaceToStrPtr(request.PoolType)).
+		WithOptionalQueryParam("tape_state", networking.InterfaceToStrPtr(request.TapeState)).
+		WithOptionalQueryParam("tape_type", request.TapeType).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSystemCapacitySummarySpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSystemCapacitySummarySpectraS3Response(response)
 }
 
 func (client *Client) GetDataPathBackendSpectraS3(ctx context.Context, request *models.GetDataPathBackendSpectraS3Request) (*models.GetDataPathBackendSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/data_path_backend").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/data_path_backend").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDataPathBackendSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDataPathBackendSpectraS3Response(response)
 }
 
 func (client *Client) GetDataPlannerBlobStoreTasksSpectraS3(ctx context.Context, request *models.GetDataPlannerBlobStoreTasksSpectraS3Request) (*models.GetDataPlannerBlobStoreTasksSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/blob_store_task").
-        WithOptionalVoidQueryParam("full_details", request.FullDetails).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/blob_store_task").
+		WithOptionalVoidQueryParam("full_details", request.FullDetails).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDataPlannerBlobStoreTasksSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDataPlannerBlobStoreTasksSpectraS3Response(response)
 }
 
 func (client *Client) GetAzureDataReplicationRuleSpectraS3(ctx context.Context, request *models.GetAzureDataReplicationRuleSpectraS3Request) (*models.GetAzureDataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/azure_data_replication_rule/" + request.AzureDataReplicationRule).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/azure_data_replication_rule/"+request.AzureDataReplicationRule).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetAzureDataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetAzureDataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) GetAzureDataReplicationRulesSpectraS3(ctx context.Context, request *models.GetAzureDataReplicationRulesSpectraS3Request) (*models.GetAzureDataReplicationRulesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/azure_data_replication_rule").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/azure_data_replication_rule").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetAzureDataReplicationRulesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetAzureDataReplicationRulesSpectraS3Response(response)
 }
 
 func (client *Client) GetDataPersistenceRuleSpectraS3(ctx context.Context, request *models.GetDataPersistenceRuleSpectraS3Request) (*models.GetDataPersistenceRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/data_persistence_rule/" + request.DataPersistenceRuleId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/data_persistence_rule/"+request.DataPersistenceRuleId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDataPersistenceRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDataPersistenceRuleSpectraS3Response(response)
 }
 
 func (client *Client) GetDataPersistenceRulesSpectraS3(ctx context.Context, request *models.GetDataPersistenceRulesSpectraS3Request) (*models.GetDataPersistenceRulesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/data_persistence_rule").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("isolation_level", networking.InterfaceToStrPtr(request.IsolationLevel)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataPersistenceRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/data_persistence_rule").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("isolation_level", networking.InterfaceToStrPtr(request.IsolationLevel)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataPersistenceRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDataPersistenceRulesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDataPersistenceRulesSpectraS3Response(response)
 }
 
 func (client *Client) GetDataPoliciesSpectraS3(ctx context.Context, request *models.GetDataPoliciesSpectraS3Request) (*models.GetDataPoliciesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/data_policy").
-        WithOptionalQueryParam("always_force_put_job_creation", networking.BoolPtrToStrPtr(request.AlwaysForcePutJobCreation)).
-        WithOptionalQueryParam("always_minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.AlwaysMinimizeSpanningAcrossMedia)).
-        WithOptionalQueryParam("checksum_type", networking.InterfaceToStrPtr(request.ChecksumType)).
-        WithOptionalQueryParam("end_to_end_crc_required", networking.BoolPtrToStrPtr(request.EndToEndCrcRequired)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/data_policy").
+		WithOptionalQueryParam("always_force_put_job_creation", networking.BoolPtrToStrPtr(request.AlwaysForcePutJobCreation)).
+		WithOptionalQueryParam("always_minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.AlwaysMinimizeSpanningAcrossMedia)).
+		WithOptionalQueryParam("checksum_type", networking.InterfaceToStrPtr(request.ChecksumType)).
+		WithOptionalQueryParam("end_to_end_crc_required", networking.BoolPtrToStrPtr(request.EndToEndCrcRequired)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDataPoliciesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDataPoliciesSpectraS3Response(response)
 }
 
 func (client *Client) GetDataPolicySpectraS3(ctx context.Context, request *models.GetDataPolicySpectraS3Request) (*models.GetDataPolicySpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/data_policy/" + request.DataPolicyId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/data_policy/"+request.DataPolicyId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDataPolicySpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDataPolicySpectraS3Response(response)
 }
 
 func (client *Client) GetDs3DataReplicationRuleSpectraS3(ctx context.Context, request *models.GetDs3DataReplicationRuleSpectraS3Request) (*models.GetDs3DataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/ds3_data_replication_rule/" + request.Ds3DataReplicationRule).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/ds3_data_replication_rule/"+request.Ds3DataReplicationRule).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDs3DataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDs3DataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) GetDs3DataReplicationRulesSpectraS3(ctx context.Context, request *models.GetDs3DataReplicationRulesSpectraS3Request) (*models.GetDs3DataReplicationRulesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/ds3_data_replication_rule").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/ds3_data_replication_rule").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDs3DataReplicationRulesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDs3DataReplicationRulesSpectraS3Response(response)
 }
 
 func (client *Client) GetS3DataReplicationRuleSpectraS3(ctx context.Context, request *models.GetS3DataReplicationRuleSpectraS3Request) (*models.GetS3DataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/s3_data_replication_rule/" + request.S3DataReplicationRule).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/s3_data_replication_rule/"+request.S3DataReplicationRule).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetS3DataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetS3DataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) GetS3DataReplicationRulesSpectraS3(ctx context.Context, request *models.GetS3DataReplicationRulesSpectraS3Request) (*models.GetS3DataReplicationRulesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/s3_data_replication_rule").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("initial_data_placement", networking.InterfaceToStrPtr(request.InitialDataPlacement)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/s3_data_replication_rule").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("initial_data_placement", networking.InterfaceToStrPtr(request.InitialDataPlacement)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetS3DataReplicationRulesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetS3DataReplicationRulesSpectraS3Response(response)
 }
 
 func (client *Client) GetDegradedAzureDataReplicationRulesSpectraS3(ctx context.Context, request *models.GetDegradedAzureDataReplicationRulesSpectraS3Request) (*models.GetDegradedAzureDataReplicationRulesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/degraded_azure_data_replication_rule").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/degraded_azure_data_replication_rule").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDegradedAzureDataReplicationRulesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDegradedAzureDataReplicationRulesSpectraS3Response(response)
 }
 
 func (client *Client) GetDegradedBlobsSpectraS3(ctx context.Context, request *models.GetDegradedBlobsSpectraS3Request) (*models.GetDegradedBlobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/degraded_blob").
-        WithOptionalQueryParam("blob_id", request.BlobId).
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("ds3_replication_rule_id", request.Ds3ReplicationRuleId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("persistence_rule_id", request.PersistenceRuleId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/degraded_blob").
+		WithOptionalQueryParam("blob_id", request.BlobId).
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("ds3_replication_rule_id", request.Ds3ReplicationRuleId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("persistence_rule_id", request.PersistenceRuleId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDegradedBlobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDegradedBlobsSpectraS3Response(response)
 }
 
 func (client *Client) GetDegradedBucketsSpectraS3(ctx context.Context, request *models.GetDegradedBucketsSpectraS3Request) (*models.GetDegradedBucketsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/degraded_bucket").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/degraded_bucket").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDegradedBucketsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDegradedBucketsSpectraS3Response(response)
 }
 
 func (client *Client) GetDegradedDataPersistenceRulesSpectraS3(ctx context.Context, request *models.GetDegradedDataPersistenceRulesSpectraS3Request) (*models.GetDegradedDataPersistenceRulesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/degraded_data_persistence_rule").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("isolation_level", networking.InterfaceToStrPtr(request.IsolationLevel)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataPersistenceRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/degraded_data_persistence_rule").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("isolation_level", networking.InterfaceToStrPtr(request.IsolationLevel)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataPersistenceRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDegradedDataPersistenceRulesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDegradedDataPersistenceRulesSpectraS3Response(response)
 }
 
 func (client *Client) GetDegradedDs3DataReplicationRulesSpectraS3(ctx context.Context, request *models.GetDegradedDs3DataReplicationRulesSpectraS3Request) (*models.GetDegradedDs3DataReplicationRulesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/degraded_ds3_data_replication_rule").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/degraded_ds3_data_replication_rule").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDegradedDs3DataReplicationRulesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDegradedDs3DataReplicationRulesSpectraS3Response(response)
 }
 
 func (client *Client) GetDegradedS3DataReplicationRulesSpectraS3(ctx context.Context, request *models.GetDegradedS3DataReplicationRulesSpectraS3Request) (*models.GetDegradedS3DataReplicationRulesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/degraded_s3_data_replication_rule").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/degraded_s3_data_replication_rule").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDegradedS3DataReplicationRulesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDegradedS3DataReplicationRulesSpectraS3Response(response)
 }
 
 func (client *Client) GetSuspectBlobAzureTargetsSpectraS3(ctx context.Context, request *models.GetSuspectBlobAzureTargetsSpectraS3Request) (*models.GetSuspectBlobAzureTargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/suspect_blob_azure_target").
-        WithOptionalQueryParam("blob_id", request.BlobId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/suspect_blob_azure_target").
+		WithOptionalQueryParam("blob_id", request.BlobId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSuspectBlobAzureTargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSuspectBlobAzureTargetsSpectraS3Response(response)
 }
 
 func (client *Client) GetSuspectBlobDs3TargetsSpectraS3(ctx context.Context, request *models.GetSuspectBlobDs3TargetsSpectraS3Request) (*models.GetSuspectBlobDs3TargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/suspect_blob_ds3_target").
-        WithOptionalQueryParam("blob_id", request.BlobId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/suspect_blob_ds3_target").
+		WithOptionalQueryParam("blob_id", request.BlobId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSuspectBlobDs3TargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSuspectBlobDs3TargetsSpectraS3Response(response)
 }
 
 func (client *Client) GetSuspectBlobPoolsSpectraS3(ctx context.Context, request *models.GetSuspectBlobPoolsSpectraS3Request) (*models.GetSuspectBlobPoolsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/suspect_blob_pool").
-        WithOptionalQueryParam("blob_id", request.BlobId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("pool_id", request.PoolId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/suspect_blob_pool").
+		WithOptionalQueryParam("blob_id", request.BlobId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("pool_id", request.PoolId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSuspectBlobPoolsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSuspectBlobPoolsSpectraS3Response(response)
 }
 
 func (client *Client) GetSuspectBlobS3TargetsSpectraS3(ctx context.Context, request *models.GetSuspectBlobS3TargetsSpectraS3Request) (*models.GetSuspectBlobS3TargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/suspect_blob_s3_target").
-        WithOptionalQueryParam("blob_id", request.BlobId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/suspect_blob_s3_target").
+		WithOptionalQueryParam("blob_id", request.BlobId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSuspectBlobS3TargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSuspectBlobS3TargetsSpectraS3Response(response)
 }
 
 func (client *Client) GetSuspectBlobTapesSpectraS3(ctx context.Context, request *models.GetSuspectBlobTapesSpectraS3Request) (*models.GetSuspectBlobTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/suspect_blob_tape").
-        WithOptionalQueryParam("blob_id", request.BlobId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("tape_id", request.TapeId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/suspect_blob_tape").
+		WithOptionalQueryParam("blob_id", request.BlobId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("tape_id", request.TapeId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSuspectBlobTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSuspectBlobTapesSpectraS3Response(response)
 }
 
 func (client *Client) GetSuspectBucketsSpectraS3(ctx context.Context, request *models.GetSuspectBucketsSpectraS3Request) (*models.GetSuspectBucketsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/suspect_bucket").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/suspect_bucket").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSuspectBucketsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSuspectBucketsSpectraS3Response(response)
 }
 
 func (client *Client) GetSuspectObjectsSpectraS3(ctx context.Context, request *models.GetSuspectObjectsSpectraS3Request) (*models.GetSuspectObjectsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/suspect_object").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/suspect_object").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSuspectObjectsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSuspectObjectsSpectraS3Response(response)
 }
 
 func (client *Client) GetSuspectObjectsWithFullDetailsSpectraS3(ctx context.Context, request *models.GetSuspectObjectsWithFullDetailsSpectraS3Request) (*models.GetSuspectObjectsWithFullDetailsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/suspect_object").
-        WithQueryParam("full_details", "").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("storage_domain", request.StorageDomain).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/suspect_object").
+		WithQueryParam("full_details", "").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("storage_domain", request.StorageDomain).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSuspectObjectsWithFullDetailsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSuspectObjectsWithFullDetailsSpectraS3Response(response)
 }
 
 func (client *Client) GetGroupMemberSpectraS3(ctx context.Context, request *models.GetGroupMemberSpectraS3Request) (*models.GetGroupMemberSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/group_member/" + request.GroupMember).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/group_member/"+request.GroupMember).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetGroupMemberSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetGroupMemberSpectraS3Response(response)
 }
 
 func (client *Client) GetGroupMembersSpectraS3(ctx context.Context, request *models.GetGroupMembersSpectraS3Request) (*models.GetGroupMembersSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/group_member").
-        WithOptionalQueryParam("group_id", request.GroupId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("member_group_id", request.MemberGroupId).
-        WithOptionalQueryParam("member_user_id", request.MemberUserId).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/group_member").
+		WithOptionalQueryParam("group_id", request.GroupId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("member_group_id", request.MemberGroupId).
+		WithOptionalQueryParam("member_user_id", request.MemberUserId).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetGroupMembersSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetGroupMembersSpectraS3Response(response)
 }
 
 func (client *Client) GetGroupSpectraS3(ctx context.Context, request *models.GetGroupSpectraS3Request) (*models.GetGroupSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/group/" + request.Group).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/group/"+request.Group).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetGroupSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetGroupSpectraS3Response(response)
 }
 
 func (client *Client) GetGroupsSpectraS3(ctx context.Context, request *models.GetGroupsSpectraS3Request) (*models.GetGroupsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/group").
-        WithOptionalQueryParam("built_in", networking.BoolPtrToStrPtr(request.BuiltIn)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/group").
+		WithOptionalQueryParam("built_in", networking.BoolPtrToStrPtr(request.BuiltIn)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetGroupsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetGroupsSpectraS3Response(response)
 }
 
 func (client *Client) GetActiveJobSpectraS3(ctx context.Context, request *models.GetActiveJobSpectraS3Request) (*models.GetActiveJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/active_job/" + request.ActiveJobId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/active_job/"+request.ActiveJobId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetActiveJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetActiveJobSpectraS3Response(response)
 }
 
 func (client *Client) GetActiveJobsSpectraS3(ctx context.Context, request *models.GetActiveJobsSpectraS3Request) (*models.GetActiveJobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/active_job").
-        WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("chunk_client_processing_order_guarantee", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("rechunked", request.Rechunked).
-        WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
-        WithOptionalQueryParam("truncated", networking.BoolPtrToStrPtr(request.Truncated)).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/active_job").
+		WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("chunk_client_processing_order_guarantee", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("rechunked", request.Rechunked).
+		WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
+		WithOptionalQueryParam("truncated", networking.BoolPtrToStrPtr(request.Truncated)).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetActiveJobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetActiveJobsSpectraS3Response(response)
 }
 
 func (client *Client) GetCanceledJobSpectraS3(ctx context.Context, request *models.GetCanceledJobSpectraS3Request) (*models.GetCanceledJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/canceled_job/" + request.CanceledJob).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/canceled_job/"+request.CanceledJob).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetCanceledJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetCanceledJobSpectraS3Response(response)
 }
 
 func (client *Client) GetCanceledJobsSpectraS3(ctx context.Context, request *models.GetCanceledJobsSpectraS3Request) (*models.GetCanceledJobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/canceled_job").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("canceled_due_to_timeout", networking.BoolPtrToStrPtr(request.CanceledDueToTimeout)).
-        WithOptionalQueryParam("chunk_client_processing_order_guarantee", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("rechunked", request.Rechunked).
-        WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
-        WithOptionalQueryParam("truncated", networking.BoolPtrToStrPtr(request.Truncated)).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/canceled_job").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("canceled_due_to_timeout", networking.BoolPtrToStrPtr(request.CanceledDueToTimeout)).
+		WithOptionalQueryParam("chunk_client_processing_order_guarantee", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("rechunked", request.Rechunked).
+		WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
+		WithOptionalQueryParam("truncated", networking.BoolPtrToStrPtr(request.Truncated)).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetCanceledJobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetCanceledJobsSpectraS3Response(response)
 }
 
 func (client *Client) GetCompletedJobSpectraS3(ctx context.Context, request *models.GetCompletedJobSpectraS3Request) (*models.GetCompletedJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/completed_job/" + request.CompletedJob).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/completed_job/"+request.CompletedJob).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetCompletedJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetCompletedJobSpectraS3Response(response)
 }
 
 func (client *Client) GetCompletedJobsSpectraS3(ctx context.Context, request *models.GetCompletedJobsSpectraS3Request) (*models.GetCompletedJobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/completed_job").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("chunk_client_processing_order_guarantee", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("rechunked", request.Rechunked).
-        WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
-        WithOptionalQueryParam("truncated", networking.BoolPtrToStrPtr(request.Truncated)).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/completed_job").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("chunk_client_processing_order_guarantee", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("rechunked", request.Rechunked).
+		WithOptionalQueryParam("request_type", networking.InterfaceToStrPtr(request.RequestType)).
+		WithOptionalQueryParam("truncated", networking.BoolPtrToStrPtr(request.Truncated)).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetCompletedJobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetCompletedJobsSpectraS3Response(response)
 }
 
 func (client *Client) GetJobChunkDaoSpectraS3(ctx context.Context, request *models.GetJobChunkDaoSpectraS3Request) (*models.GetJobChunkDaoSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job_chunk_dao/" + request.JobChunkDao).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job_chunk_dao/"+request.JobChunkDao).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobChunkDaoSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobChunkDaoSpectraS3Response(response)
 }
 
 func (client *Client) GetJobChunkSpectraS3(ctx context.Context, request *models.GetJobChunkSpectraS3Request) (*models.GetJobChunkSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job_chunk/" + request.JobChunkId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job_chunk/"+request.JobChunkId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobChunkSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobChunkSpectraS3Response(response)
 }
 
 func (client *Client) GetJobChunksReadyForClientProcessingSpectraS3(ctx context.Context, request *models.GetJobChunksReadyForClientProcessingSpectraS3Request) (*models.GetJobChunksReadyForClientProcessingSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job_chunk").
-        WithQueryParam("job", request.Job).
-        WithOptionalQueryParam("job_chunk", request.JobChunk).
-        WithOptionalQueryParam("preferred_number_of_chunks", networking.IntPtrToStrPtr(request.PreferredNumberOfChunks)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job_chunk").
+		WithQueryParam("job", request.Job).
+		WithOptionalQueryParam("job_chunk", request.JobChunk).
+		WithOptionalQueryParam("preferred_number_of_chunks", networking.IntPtrToStrPtr(request.PreferredNumberOfChunks)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobChunksReadyForClientProcessingSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobChunksReadyForClientProcessingSpectraS3Response(response)
 }
 
 func (client *Client) GetJobCreationFailuresSpectraS3(ctx context.Context, request *models.GetJobCreationFailuresSpectraS3Request) (*models.GetJobCreationFailuresSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job_creation_failed").
-        WithOptionalQueryParam("date", request.Date).
-        WithOptionalQueryParam("error_message", request.ErrorMessage).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_name", request.UserName).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job_creation_failed").
+		WithOptionalQueryParam("date", request.Date).
+		WithOptionalQueryParam("error_message", request.ErrorMessage).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_name", request.UserName).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobCreationFailuresSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobCreationFailuresSpectraS3Response(response)
 }
 
 func (client *Client) GetJobSpectraS3(ctx context.Context, request *models.GetJobSpectraS3Request) (*models.GetJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job/" + request.JobId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job/"+request.JobId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobSpectraS3Response(response)
 }
 
 func (client *Client) GetJobToReplicateSpectraS3(ctx context.Context, request *models.GetJobToReplicateSpectraS3Request) (*models.GetJobToReplicateSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job/" + request.JobId).
-        WithQueryParam("replicate", "").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job/"+request.JobId).
+		WithQueryParam("replicate", "").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobToReplicateSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobToReplicateSpectraS3Response(response)
 }
 
 func (client *Client) GetJobsSpectraS3(ctx context.Context, request *models.GetJobsSpectraS3Request) (*models.GetJobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalVoidQueryParam("full_details", request.FullDetails).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalVoidQueryParam("full_details", request.FullDetails).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobsSpectraS3Response(response)
 }
 
 func (client *Client) GetNodeSpectraS3(ctx context.Context, request *models.GetNodeSpectraS3Request) (*models.GetNodeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/node/" + request.Node).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/node/"+request.Node).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetNodeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetNodeSpectraS3Response(response)
 }
 
 func (client *Client) GetNodesSpectraS3(ctx context.Context, request *models.GetNodesSpectraS3Request) (*models.GetNodesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/node").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/node").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetNodesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetNodesSpectraS3Response(response)
 }
 
 func (client *Client) GetAzureTargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetAzureTargetFailureNotificationRegistrationSpectraS3Request) (*models.GetAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/azure_target_failure_notification_registration/" + request.AzureTargetFailureNotificationRegistration).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/azure_target_failure_notification_registration/"+request.AzureTargetFailureNotificationRegistration).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetAzureTargetFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetAzureTargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetAzureTargetFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetAzureTargetFailureNotificationRegistrationsSpectraS3Request) (*models.GetAzureTargetFailureNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/azure_target_failure_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/azure_target_failure_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetAzureTargetFailureNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetAzureTargetFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetBucketChangesNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetBucketChangesNotificationRegistrationSpectraS3Request) (*models.GetBucketChangesNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/bucket_changes_notification_registration/" + request.BucketChangesNotificationRegistration).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/bucket_changes_notification_registration/"+request.BucketChangesNotificationRegistration).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBucketChangesNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBucketChangesNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetBucketChangesNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetBucketChangesNotificationRegistrationsSpectraS3Request) (*models.GetBucketChangesNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/bucket_changes_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/bucket_changes_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBucketChangesNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBucketChangesNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetBucketHistorySpectraS3(ctx context.Context, request *models.GetBucketHistorySpectraS3Request) (*models.GetBucketHistorySpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/bucket_history").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("min_sequence_number", networking.Int64PtrToStrPtr(request.MinSequenceNumber)).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/bucket_history").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("min_sequence_number", networking.Int64PtrToStrPtr(request.MinSequenceNumber)).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBucketHistorySpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBucketHistorySpectraS3Response(response)
 }
 
 func (client *Client) GetDs3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetDs3TargetFailureNotificationRegistrationSpectraS3Request) (*models.GetDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/ds3_target_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/ds3_target_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDs3TargetFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDs3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetDs3TargetFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetDs3TargetFailureNotificationRegistrationsSpectraS3Request) (*models.GetDs3TargetFailureNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/ds3_target_failure_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/ds3_target_failure_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDs3TargetFailureNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDs3TargetFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetJobCompletedNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetJobCompletedNotificationRegistrationSpectraS3Request) (*models.GetJobCompletedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job_completed_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job_completed_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobCompletedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobCompletedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetJobCompletedNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetJobCompletedNotificationRegistrationsSpectraS3Request) (*models.GetJobCompletedNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job_completed_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job_completed_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobCompletedNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobCompletedNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetJobCreatedNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetJobCreatedNotificationRegistrationSpectraS3Request) (*models.GetJobCreatedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job_created_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job_created_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobCreatedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobCreatedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetJobCreatedNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetJobCreatedNotificationRegistrationsSpectraS3Request) (*models.GetJobCreatedNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job_created_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job_created_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobCreatedNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobCreatedNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetJobCreationFailedNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetJobCreationFailedNotificationRegistrationSpectraS3Request) (*models.GetJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job_creation_failed_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job_creation_failed_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobCreationFailedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobCreationFailedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetJobCreationFailedNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetJobCreationFailedNotificationRegistrationsSpectraS3Request) (*models.GetJobCreationFailedNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/job_creation_failed_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/job_creation_failed_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetJobCreationFailedNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetJobCreationFailedNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetObjectCachedNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetObjectCachedNotificationRegistrationSpectraS3Request) (*models.GetObjectCachedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/object_cached_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/object_cached_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetObjectCachedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetObjectCachedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetObjectCachedNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetObjectCachedNotificationRegistrationsSpectraS3Request) (*models.GetObjectCachedNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/object_cached_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/object_cached_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetObjectCachedNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetObjectCachedNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetObjectLostNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetObjectLostNotificationRegistrationSpectraS3Request) (*models.GetObjectLostNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/object_lost_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/object_lost_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetObjectLostNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetObjectLostNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetObjectLostNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetObjectLostNotificationRegistrationsSpectraS3Request) (*models.GetObjectLostNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/object_lost_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/object_lost_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetObjectLostNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetObjectLostNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetObjectPersistedNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetObjectPersistedNotificationRegistrationSpectraS3Request) (*models.GetObjectPersistedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/object_persisted_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/object_persisted_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetObjectPersistedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetObjectPersistedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetObjectPersistedNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetObjectPersistedNotificationRegistrationsSpectraS3Request) (*models.GetObjectPersistedNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/object_persisted_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/object_persisted_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetObjectPersistedNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetObjectPersistedNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetPoolFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetPoolFailureNotificationRegistrationSpectraS3Request) (*models.GetPoolFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/pool_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/pool_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetPoolFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetPoolFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetPoolFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetPoolFailureNotificationRegistrationsSpectraS3Request) (*models.GetPoolFailureNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/pool_failure_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/pool_failure_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetPoolFailureNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetPoolFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetS3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetS3TargetFailureNotificationRegistrationSpectraS3Request) (*models.GetS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/s3_target_failure_notification_registration/" + request.S3TargetFailureNotificationRegistration).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/s3_target_failure_notification_registration/"+request.S3TargetFailureNotificationRegistration).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetS3TargetFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetS3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetS3TargetFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetS3TargetFailureNotificationRegistrationsSpectraS3Request) (*models.GetS3TargetFailureNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/s3_target_failure_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/s3_target_failure_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetS3TargetFailureNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetS3TargetFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetStorageDomainFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetStorageDomainFailureNotificationRegistrationSpectraS3Request) (*models.GetStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/storage_domain_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/storage_domain_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetStorageDomainFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetStorageDomainFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetStorageDomainFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetStorageDomainFailureNotificationRegistrationsSpectraS3Request) (*models.GetStorageDomainFailureNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/storage_domain_failure_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/storage_domain_failure_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetStorageDomainFailureNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetStorageDomainFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetSystemFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetSystemFailureNotificationRegistrationSpectraS3Request) (*models.GetSystemFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/system_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/system_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSystemFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSystemFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetSystemFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetSystemFailureNotificationRegistrationsSpectraS3Request) (*models.GetSystemFailureNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/system_failure_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/system_failure_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSystemFailureNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSystemFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetTapeFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetTapeFailureNotificationRegistrationSpectraS3Request) (*models.GetTapeFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapeFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapeFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetTapeFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetTapeFailureNotificationRegistrationsSpectraS3Request) (*models.GetTapeFailureNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_failure_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_failure_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapeFailureNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapeFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetTapePartitionFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.GetTapePartitionFailureNotificationRegistrationSpectraS3Request) (*models.GetTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_partition_failure_notification_registration/" + request.NotificationId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_partition_failure_notification_registration/"+request.NotificationId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapePartitionFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapePartitionFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) GetTapePartitionFailureNotificationRegistrationsSpectraS3(ctx context.Context, request *models.GetTapePartitionFailureNotificationRegistrationsSpectraS3Request) (*models.GetTapePartitionFailureNotificationRegistrationsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_partition_failure_notification_registration").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_partition_failure_notification_registration").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapePartitionFailureNotificationRegistrationsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapePartitionFailureNotificationRegistrationsSpectraS3Response(response)
 }
 
 func (client *Client) GetBlobPersistenceSpectraS3(ctx context.Context, request *models.GetBlobPersistenceSpectraS3Request) (*models.GetBlobPersistenceSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/blob_persistence").
-        WithReadCloser(buildStreamFromString(request.RequestPayload)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/blob_persistence").
+		WithReadCloser(buildStreamFromString(request.RequestPayload)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBlobPersistenceSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBlobPersistenceSpectraS3Response(response)
 }
 
 func (client *Client) GetObjectDetailsSpectraS3(ctx context.Context, request *models.GetObjectDetailsSpectraS3Request) (*models.GetObjectDetailsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/object/" + request.ObjectName).
-        WithQueryParam("bucket_id", request.BucketId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/object/"+request.ObjectName).
+		WithQueryParam("bucket_id", request.BucketId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetObjectDetailsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetObjectDetailsSpectraS3Response(response)
 }
 
 func (client *Client) GetObjectsDetailsSpectraS3(ctx context.Context, request *models.GetObjectsDetailsSpectraS3Request) (*models.GetObjectsDetailsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/object").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("end_date", networking.Int64PtrToStrPtr(request.EndDate)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("latest", networking.BoolPtrToStrPtr(request.Latest)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("start_date", networking.Int64PtrToStrPtr(request.StartDate)).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.S3ObjectType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/object").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("end_date", networking.Int64PtrToStrPtr(request.EndDate)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("latest", networking.BoolPtrToStrPtr(request.Latest)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("start_date", networking.Int64PtrToStrPtr(request.StartDate)).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.S3ObjectType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetObjectsDetailsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetObjectsDetailsSpectraS3Response(response)
 }
 
 func (client *Client) GetObjectsWithFullDetailsSpectraS3(ctx context.Context, request *models.GetObjectsWithFullDetailsSpectraS3Request) (*models.GetObjectsWithFullDetailsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/object").
-        WithQueryParam("full_details", "").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("end_date", networking.Int64PtrToStrPtr(request.EndDate)).
-        WithOptionalVoidQueryParam("include_physical_placement", request.IncludePhysicalPlacement).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("latest", networking.BoolPtrToStrPtr(request.Latest)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("start_date", networking.Int64PtrToStrPtr(request.StartDate)).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.S3ObjectType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/object").
+		WithQueryParam("full_details", "").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("end_date", networking.Int64PtrToStrPtr(request.EndDate)).
+		WithOptionalVoidQueryParam("include_physical_placement", request.IncludePhysicalPlacement).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("latest", networking.BoolPtrToStrPtr(request.Latest)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("start_date", networking.Int64PtrToStrPtr(request.StartDate)).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.S3ObjectType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetObjectsWithFullDetailsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetObjectsWithFullDetailsSpectraS3Response(response)
 }
 
 func (client *Client) VerifyPhysicalPlacementForObjectsSpectraS3(ctx context.Context, request *models.VerifyPhysicalPlacementForObjectsSpectraS3Request) (*models.VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithOptionalQueryParam("storage_domain", request.StorageDomain).
-        WithQueryParam("operation", "verify_physical_placement").
-        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithOptionalQueryParam("storage_domain", request.StorageDomain).
+		WithQueryParam("operation", "verify_physical_placement").
+		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifyPhysicalPlacementForObjectsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifyPhysicalPlacementForObjectsSpectraS3Response(response)
 }
 
 func (client *Client) VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3(ctx context.Context, request *models.VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request) (*models.VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithQueryParam("full_details", "").
-        WithOptionalQueryParam("storage_domain", request.StorageDomain).
-        WithQueryParam("operation", "verify_physical_placement").
-        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithQueryParam("full_details", "").
+		WithOptionalQueryParam("storage_domain", request.StorageDomain).
+		WithQueryParam("operation", "verify_physical_placement").
+		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response(response)
 }
 
 func (client *Client) GetBlobsOnPoolSpectraS3(ctx context.Context, request *models.GetBlobsOnPoolSpectraS3Request) (*models.GetBlobsOnPoolSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/pool/" + request.Pool).
-        WithQueryParam("operation", "get_physical_placement").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/pool/"+request.Pool).
+		WithQueryParam("operation", "get_physical_placement").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBlobsOnPoolSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBlobsOnPoolSpectraS3Response(response)
 }
 
 func (client *Client) GetPoolFailuresSpectraS3(ctx context.Context, request *models.GetPoolFailuresSpectraS3Request) (*models.GetPoolFailuresSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/pool_failure").
-        WithOptionalQueryParam("error_message", request.ErrorMessage).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("pool_id", request.PoolId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.PoolFailureType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/pool_failure").
+		WithOptionalQueryParam("error_message", request.ErrorMessage).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("pool_id", request.PoolId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.PoolFailureType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetPoolFailuresSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetPoolFailuresSpectraS3Response(response)
 }
 
 func (client *Client) GetPoolPartitionSpectraS3(ctx context.Context, request *models.GetPoolPartitionSpectraS3Request) (*models.GetPoolPartitionSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/pool_partition/" + request.PoolPartition).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/pool_partition/"+request.PoolPartition).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetPoolPartitionSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetPoolPartitionSpectraS3Response(response)
 }
 
 func (client *Client) GetPoolPartitionsSpectraS3(ctx context.Context, request *models.GetPoolPartitionsSpectraS3Request) (*models.GetPoolPartitionsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/pool_partition").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.PoolType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/pool_partition").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.PoolType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetPoolPartitionsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetPoolPartitionsSpectraS3Response(response)
 }
 
 func (client *Client) GetPoolSpectraS3(ctx context.Context, request *models.GetPoolSpectraS3Request) (*models.GetPoolSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/pool/" + request.Pool).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/pool/"+request.Pool).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetPoolSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetPoolSpectraS3Response(response)
 }
 
 func (client *Client) GetPoolsSpectraS3(ctx context.Context, request *models.GetPoolsSpectraS3Request) (*models.GetPoolsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/pool").
-        WithOptionalQueryParam("assigned_to_storage_domain", networking.BoolPtrToStrPtr(request.AssignedToStorageDomain)).
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("guid", request.Guid).
-        WithOptionalQueryParam("health", networking.InterfaceToStrPtr(request.Health)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("last_verified", request.LastVerified).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("partition_id", request.PartitionId).
-        WithOptionalQueryParam("powered_on", networking.BoolPtrToStrPtr(request.PoweredOn)).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("storage_domain_member_id", request.StorageDomainMemberId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.PoolType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/pool").
+		WithOptionalQueryParam("assigned_to_storage_domain", networking.BoolPtrToStrPtr(request.AssignedToStorageDomain)).
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("guid", request.Guid).
+		WithOptionalQueryParam("health", networking.InterfaceToStrPtr(request.Health)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("last_verified", request.LastVerified).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("partition_id", request.PartitionId).
+		WithOptionalQueryParam("powered_on", networking.BoolPtrToStrPtr(request.PoweredOn)).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("storage_domain_member_id", request.StorageDomainMemberId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.PoolType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetPoolsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetPoolsSpectraS3Response(response)
 }
 
 func (client *Client) GetStorageDomainFailuresSpectraS3(ctx context.Context, request *models.GetStorageDomainFailuresSpectraS3Request) (*models.GetStorageDomainFailuresSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/storage_domain_failure").
-        WithOptionalQueryParam("error_message", request.ErrorMessage).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.StorageDomainFailureType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/storage_domain_failure").
+		WithOptionalQueryParam("error_message", request.ErrorMessage).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.StorageDomainFailureType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetStorageDomainFailuresSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetStorageDomainFailuresSpectraS3Response(response)
 }
 
 func (client *Client) GetStorageDomainMemberSpectraS3(ctx context.Context, request *models.GetStorageDomainMemberSpectraS3Request) (*models.GetStorageDomainMemberSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/storage_domain_member/" + request.StorageDomainMember).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/storage_domain_member/"+request.StorageDomainMember).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetStorageDomainMemberSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetStorageDomainMemberSpectraS3Response(response)
 }
 
 func (client *Client) GetStorageDomainMembersSpectraS3(ctx context.Context, request *models.GetStorageDomainMembersSpectraS3Request) (*models.GetStorageDomainMembersSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/storage_domain_member").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("pool_partition_id", request.PoolPartitionId).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("tape_partition_id", request.TapePartitionId).
-        WithOptionalQueryParam("tape_type", request.TapeType).
-        WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/storage_domain_member").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("pool_partition_id", request.PoolPartitionId).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("tape_partition_id", request.TapePartitionId).
+		WithOptionalQueryParam("tape_type", request.TapeType).
+		WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetStorageDomainMembersSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetStorageDomainMembersSpectraS3Response(response)
 }
 
 func (client *Client) GetStorageDomainSpectraS3(ctx context.Context, request *models.GetStorageDomainSpectraS3Request) (*models.GetStorageDomainSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/storage_domain/" + request.StorageDomain).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/storage_domain/"+request.StorageDomain).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetStorageDomainSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetStorageDomainSpectraS3Response(response)
 }
 
 func (client *Client) GetStorageDomainsSpectraS3(ctx context.Context, request *models.GetStorageDomainsSpectraS3Request) (*models.GetStorageDomainsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/storage_domain").
-        WithOptionalQueryParam("auto_eject_upon_cron", request.AutoEjectUponCron).
-        WithOptionalQueryParam("auto_eject_upon_job_cancellation", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCancellation)).
-        WithOptionalQueryParam("auto_eject_upon_job_completion", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCompletion)).
-        WithOptionalQueryParam("auto_eject_upon_media_full", networking.BoolPtrToStrPtr(request.AutoEjectUponMediaFull)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("media_ejection_allowed", networking.BoolPtrToStrPtr(request.MediaEjectionAllowed)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("secure_media_allocation", networking.BoolPtrToStrPtr(request.SecureMediaAllocation)).
-        WithOptionalQueryParam("write_optimization", networking.InterfaceToStrPtr(request.WriteOptimization)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/storage_domain").
+		WithOptionalQueryParam("auto_eject_upon_cron", request.AutoEjectUponCron).
+		WithOptionalQueryParam("auto_eject_upon_job_cancellation", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCancellation)).
+		WithOptionalQueryParam("auto_eject_upon_job_completion", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCompletion)).
+		WithOptionalQueryParam("auto_eject_upon_media_full", networking.BoolPtrToStrPtr(request.AutoEjectUponMediaFull)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("media_ejection_allowed", networking.BoolPtrToStrPtr(request.MediaEjectionAllowed)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("secure_media_allocation", networking.BoolPtrToStrPtr(request.SecureMediaAllocation)).
+		WithOptionalQueryParam("write_optimization", networking.InterfaceToStrPtr(request.WriteOptimization)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetStorageDomainsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetStorageDomainsSpectraS3Response(response)
 }
 
 func (client *Client) GetFeatureKeysSpectraS3(ctx context.Context, request *models.GetFeatureKeysSpectraS3Request) (*models.GetFeatureKeysSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/feature_key").
-        WithOptionalQueryParam("error_message", request.ErrorMessage).
-        WithOptionalQueryParam("expiration_date", request.ExpirationDate).
-        WithOptionalQueryParam("key", networking.InterfaceToStrPtr(request.Key)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/feature_key").
+		WithOptionalQueryParam("error_message", request.ErrorMessage).
+		WithOptionalQueryParam("expiration_date", request.ExpirationDate).
+		WithOptionalQueryParam("key", networking.InterfaceToStrPtr(request.Key)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetFeatureKeysSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetFeatureKeysSpectraS3Response(response)
 }
 
 func (client *Client) GetSystemFailuresSpectraS3(ctx context.Context, request *models.GetSystemFailuresSpectraS3Request) (*models.GetSystemFailuresSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/system_failure").
-        WithOptionalQueryParam("error_message", request.ErrorMessage).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.SystemFailureType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/system_failure").
+		WithOptionalQueryParam("error_message", request.ErrorMessage).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.SystemFailureType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSystemFailuresSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSystemFailuresSpectraS3Response(response)
 }
 
 func (client *Client) GetSystemInformationSpectraS3(ctx context.Context, request *models.GetSystemInformationSpectraS3Request) (*models.GetSystemInformationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/system_information").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/system_information").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetSystemInformationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetSystemInformationSpectraS3Response(response)
 }
 
 func (client *Client) VerifySystemHealthSpectraS3(ctx context.Context, request *models.VerifySystemHealthSpectraS3Request) (*models.VerifySystemHealthSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/system_health").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/system_health").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifySystemHealthSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifySystemHealthSpectraS3Response(response)
 }
 
 func (client *Client) GetBlobsOnTapeSpectraS3(ctx context.Context, request *models.GetBlobsOnTapeSpectraS3Request) (*models.GetBlobsOnTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithQueryParam("operation", "get_physical_placement").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithQueryParam("operation", "get_physical_placement").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBlobsOnTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBlobsOnTapeSpectraS3Response(response)
 }
 
 func (client *Client) GetTapeDensityDirectiveSpectraS3(ctx context.Context, request *models.GetTapeDensityDirectiveSpectraS3Request) (*models.GetTapeDensityDirectiveSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_density_directive/" + request.TapeDensityDirective).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_density_directive/"+request.TapeDensityDirective).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapeDensityDirectiveSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapeDensityDirectiveSpectraS3Response(response)
 }
 
 func (client *Client) GetTapeDensityDirectivesSpectraS3(ctx context.Context, request *models.GetTapeDensityDirectivesSpectraS3Request) (*models.GetTapeDensityDirectivesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_density_directive").
-        WithOptionalQueryParam("density", networking.InterfaceToStrPtr(request.Density)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("partition_id", request.PartitionId).
-        WithOptionalQueryParam("tape_type", request.TapeType).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_density_directive").
+		WithOptionalQueryParam("density", networking.InterfaceToStrPtr(request.Density)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("partition_id", request.PartitionId).
+		WithOptionalQueryParam("tape_type", request.TapeType).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapeDensityDirectivesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapeDensityDirectivesSpectraS3Response(response)
 }
 
 func (client *Client) GetTapeDriveSpectraS3(ctx context.Context, request *models.GetTapeDriveSpectraS3Request) (*models.GetTapeDriveSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapeDriveSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapeDriveSpectraS3Response(response)
 }
 
 func (client *Client) GetTapeDrivesSpectraS3(ctx context.Context, request *models.GetTapeDrivesSpectraS3Request) (*models.GetTapeDrivesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_drive").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("minimum_task_priority", networking.InterfaceToStrPtr(request.MinimumTaskPriority)).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("partition_id", request.PartitionId).
-        WithOptionalQueryParam("reserved_task_type", networking.InterfaceToStrPtr(request.ReservedTaskType)).
-        WithOptionalQueryParam("serial_number", request.SerialNumber).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TapeDriveType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_drive").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("minimum_task_priority", networking.InterfaceToStrPtr(request.MinimumTaskPriority)).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("partition_id", request.PartitionId).
+		WithOptionalQueryParam("reserved_task_type", networking.InterfaceToStrPtr(request.ReservedTaskType)).
+		WithOptionalQueryParam("serial_number", request.SerialNumber).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TapeDriveType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapeDrivesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapeDrivesSpectraS3Response(response)
 }
 
 func (client *Client) GetTapeFailuresSpectraS3(ctx context.Context, request *models.GetTapeFailuresSpectraS3Request) (*models.GetTapeFailuresSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_failure").
-        WithOptionalQueryParam("error_message", request.ErrorMessage).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("tape_drive_id", request.TapeDriveId).
-        WithOptionalQueryParam("tape_id", request.TapeId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TapeFailureType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_failure").
+		WithOptionalQueryParam("error_message", request.ErrorMessage).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("tape_drive_id", request.TapeDriveId).
+		WithOptionalQueryParam("tape_id", request.TapeId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TapeFailureType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapeFailuresSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapeFailuresSpectraS3Response(response)
 }
 
 func (client *Client) GetTapeLibrariesSpectraS3(ctx context.Context, request *models.GetTapeLibrariesSpectraS3Request) (*models.GetTapeLibrariesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_library").
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("management_url", request.ManagementUrl).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("serial_number", request.SerialNumber).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_library").
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("management_url", request.ManagementUrl).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("serial_number", request.SerialNumber).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapeLibrariesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapeLibrariesSpectraS3Response(response)
 }
 
 func (client *Client) GetTapeLibrarySpectraS3(ctx context.Context, request *models.GetTapeLibrarySpectraS3Request) (*models.GetTapeLibrarySpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_library/" + request.TapeLibraryId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_library/"+request.TapeLibraryId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapeLibrarySpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapeLibrarySpectraS3Response(response)
 }
 
 func (client *Client) GetTapePartitionFailuresSpectraS3(ctx context.Context, request *models.GetTapePartitionFailuresSpectraS3Request) (*models.GetTapePartitionFailuresSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_partition_failure").
-        WithOptionalQueryParam("error_message", request.ErrorMessage).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("partition_id", request.PartitionId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TapePartitionFailureType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_partition_failure").
+		WithOptionalQueryParam("error_message", request.ErrorMessage).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("partition_id", request.PartitionId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TapePartitionFailureType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapePartitionFailuresSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapePartitionFailuresSpectraS3Response(response)
 }
 
 func (client *Client) GetTapePartitionSpectraS3(ctx context.Context, request *models.GetTapePartitionSpectraS3Request) (*models.GetTapePartitionSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_partition/" + request.TapePartition).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_partition/"+request.TapePartition).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapePartitionSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapePartitionSpectraS3Response(response)
 }
 
 func (client *Client) GetTapePartitionWithFullDetailsSpectraS3(ctx context.Context, request *models.GetTapePartitionWithFullDetailsSpectraS3Request) (*models.GetTapePartitionWithFullDetailsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_partition/" + request.TapePartition).
-        WithQueryParam("full_details", "").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_partition/"+request.TapePartition).
+		WithQueryParam("full_details", "").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapePartitionWithFullDetailsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapePartitionWithFullDetailsSpectraS3Response(response)
 }
 
 func (client *Client) GetTapePartitionsSpectraS3(ctx context.Context, request *models.GetTapePartitionsSpectraS3Request) (*models.GetTapePartitionsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_partition").
-        WithOptionalQueryParam("import_export_configuration", networking.InterfaceToStrPtr(request.ImportExportConfiguration)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("library_id", request.LibraryId).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-        WithOptionalQueryParam("serial_number", request.SerialNumber).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_partition").
+		WithOptionalQueryParam("import_export_configuration", networking.InterfaceToStrPtr(request.ImportExportConfiguration)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("library_id", request.LibraryId).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+		WithOptionalQueryParam("serial_number", request.SerialNumber).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapePartitionsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapePartitionsSpectraS3Response(response)
 }
 
 func (client *Client) GetTapePartitionsWithFullDetailsSpectraS3(ctx context.Context, request *models.GetTapePartitionsWithFullDetailsSpectraS3Request) (*models.GetTapePartitionsWithFullDetailsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape_partition").
-        WithQueryParam("full_details", "").
-        WithOptionalQueryParam("import_export_configuration", networking.InterfaceToStrPtr(request.ImportExportConfiguration)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("library_id", request.LibraryId).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-        WithOptionalQueryParam("serial_number", request.SerialNumber).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape_partition").
+		WithQueryParam("full_details", "").
+		WithOptionalQueryParam("import_export_configuration", networking.InterfaceToStrPtr(request.ImportExportConfiguration)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("library_id", request.LibraryId).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+		WithOptionalQueryParam("serial_number", request.SerialNumber).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapePartitionsWithFullDetailsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapePartitionsWithFullDetailsSpectraS3Response(response)
 }
 
 func (client *Client) GetTapeSpectraS3(ctx context.Context, request *models.GetTapeSpectraS3Request) (*models.GetTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapeSpectraS3Response(response)
 }
 
 func (client *Client) GetTapesSpectraS3(ctx context.Context, request *models.GetTapesSpectraS3Request) (*models.GetTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/tape").
-        WithOptionalQueryParam("assigned_to_storage_domain", networking.BoolPtrToStrPtr(request.AssignedToStorageDomain)).
-        WithOptionalQueryParam("available_raw_capacity", networking.Int64PtrToStrPtr(request.AvailableRawCapacity)).
-        WithOptionalQueryParam("bar_code", request.BarCode).
-        WithOptionalQueryParam("bucket", request.Bucket).
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("eject_label", request.EjectLabel).
-        WithOptionalQueryParam("eject_location", request.EjectLocation).
-        WithOptionalQueryParam("full_of_data", networking.BoolPtrToStrPtr(request.FullOfData)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("last_verified", request.LastVerified).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("partially_verified_end_of_tape", request.PartiallyVerifiedEndOfTape).
-        WithOptionalQueryParam("partition", request.Partition).
-        WithOptionalQueryParam("partition_id", request.PartitionId).
-        WithOptionalQueryParam("previous_state", networking.InterfaceToStrPtr(request.PreviousState)).
-        WithOptionalQueryParam("serial_number", request.SerialNumber).
-        WithOptionalQueryParam("sort_by", request.SortBy).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("storage_domain", request.StorageDomain).
-        WithOptionalQueryParam("storage_domain_member_id", request.StorageDomainMemberId).
-        WithOptionalQueryParam("type", request.String).
-        WithOptionalQueryParam("verify_pending", networking.InterfaceToStrPtr(request.VerifyPending)).
-        WithOptionalQueryParam("write_protected", networking.BoolPtrToStrPtr(request.WriteProtected)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/tape").
+		WithOptionalQueryParam("assigned_to_storage_domain", networking.BoolPtrToStrPtr(request.AssignedToStorageDomain)).
+		WithOptionalQueryParam("available_raw_capacity", networking.Int64PtrToStrPtr(request.AvailableRawCapacity)).
+		WithOptionalQueryParam("bar_code", request.BarCode).
+		WithOptionalQueryParam("bucket", request.Bucket).
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("eject_label", request.EjectLabel).
+		WithOptionalQueryParam("eject_location", request.EjectLocation).
+		WithOptionalQueryParam("full_of_data", networking.BoolPtrToStrPtr(request.FullOfData)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("last_verified", request.LastVerified).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("partially_verified_end_of_tape", request.PartiallyVerifiedEndOfTape).
+		WithOptionalQueryParam("partition", request.Partition).
+		WithOptionalQueryParam("partition_id", request.PartitionId).
+		WithOptionalQueryParam("previous_state", networking.InterfaceToStrPtr(request.PreviousState)).
+		WithOptionalQueryParam("serial_number", request.SerialNumber).
+		WithOptionalQueryParam("sort_by", request.SortBy).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("storage_domain", request.StorageDomain).
+		WithOptionalQueryParam("storage_domain_member_id", request.StorageDomainMemberId).
+		WithOptionalQueryParam("type", request.String).
+		WithOptionalQueryParam("verify_pending", networking.InterfaceToStrPtr(request.VerifyPending)).
+		WithOptionalQueryParam("write_protected", networking.BoolPtrToStrPtr(request.WriteProtected)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetTapesSpectraS3Response(response)
 }
 
 func (client *Client) GetAzureTargetBucketNamesSpectraS3(ctx context.Context, request *models.GetAzureTargetBucketNamesSpectraS3Request) (*models.GetAzureTargetBucketNamesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/azure_target_bucket_name").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/azure_target_bucket_name").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetAzureTargetBucketNamesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetAzureTargetBucketNamesSpectraS3Response(response)
 }
 
 func (client *Client) GetAzureTargetFailuresSpectraS3(ctx context.Context, request *models.GetAzureTargetFailuresSpectraS3Request) (*models.GetAzureTargetFailuresSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/azure_target_failure").
-        WithOptionalQueryParam("error_message", request.ErrorMessage).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TargetFailureType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/azure_target_failure").
+		WithOptionalQueryParam("error_message", request.ErrorMessage).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TargetFailureType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetAzureTargetFailuresSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetAzureTargetFailuresSpectraS3Response(response)
 }
 
 func (client *Client) GetAzureTargetReadPreferenceSpectraS3(ctx context.Context, request *models.GetAzureTargetReadPreferenceSpectraS3Request) (*models.GetAzureTargetReadPreferenceSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/azure_target_read_preference/" + request.AzureTargetReadPreference).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/azure_target_read_preference/"+request.AzureTargetReadPreference).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetAzureTargetReadPreferenceSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetAzureTargetReadPreferenceSpectraS3Response(response)
 }
 
 func (client *Client) GetAzureTargetReadPreferencesSpectraS3(ctx context.Context, request *models.GetAzureTargetReadPreferencesSpectraS3Request) (*models.GetAzureTargetReadPreferencesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/azure_target_read_preference").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("read_preference", networking.InterfaceToStrPtr(request.ReadPreference)).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/azure_target_read_preference").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("read_preference", networking.InterfaceToStrPtr(request.ReadPreference)).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetAzureTargetReadPreferencesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetAzureTargetReadPreferencesSpectraS3Response(response)
 }
 
 func (client *Client) GetAzureTargetSpectraS3(ctx context.Context, request *models.GetAzureTargetSpectraS3Request) (*models.GetAzureTargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/azure_target/" + request.AzureTarget).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/azure_target/"+request.AzureTarget).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetAzureTargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetAzureTargetSpectraS3Response(response)
 }
 
 func (client *Client) GetAzureTargetsSpectraS3(ctx context.Context, request *models.GetAzureTargetsSpectraS3Request) (*models.GetAzureTargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/azure_target").
-        WithOptionalQueryParam("account_name", request.AccountName).
-        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-        WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/azure_target").
+		WithOptionalQueryParam("account_name", request.AccountName).
+		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+		WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetAzureTargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetAzureTargetsSpectraS3Response(response)
 }
 
 func (client *Client) GetBlobsOnAzureTargetSpectraS3(ctx context.Context, request *models.GetBlobsOnAzureTargetSpectraS3Request) (*models.GetBlobsOnAzureTargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/azure_target/" + request.AzureTarget).
-        WithQueryParam("operation", "get_physical_placement").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/azure_target/"+request.AzureTarget).
+		WithQueryParam("operation", "get_physical_placement").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBlobsOnAzureTargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBlobsOnAzureTargetSpectraS3Response(response)
 }
 
 func (client *Client) GetBlobsOnDs3TargetSpectraS3(ctx context.Context, request *models.GetBlobsOnDs3TargetSpectraS3Request) (*models.GetBlobsOnDs3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/ds3_target/" + request.Ds3Target).
-        WithQueryParam("operation", "get_physical_placement").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/ds3_target/"+request.Ds3Target).
+		WithQueryParam("operation", "get_physical_placement").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBlobsOnDs3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBlobsOnDs3TargetSpectraS3Response(response)
 }
 
 func (client *Client) GetDs3TargetDataPoliciesSpectraS3(ctx context.Context, request *models.GetDs3TargetDataPoliciesSpectraS3Request) (*models.GetDs3TargetDataPoliciesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/ds3_target_data_policies/" + request.Ds3TargetDataPolicies).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/ds3_target_data_policies/"+request.Ds3TargetDataPolicies).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDs3TargetDataPoliciesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDs3TargetDataPoliciesSpectraS3Response(response)
 }
 
 func (client *Client) GetDs3TargetFailuresSpectraS3(ctx context.Context, request *models.GetDs3TargetFailuresSpectraS3Request) (*models.GetDs3TargetFailuresSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/ds3_target_failure").
-        WithOptionalQueryParam("error_message", request.ErrorMessage).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TargetFailureType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/ds3_target_failure").
+		WithOptionalQueryParam("error_message", request.ErrorMessage).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TargetFailureType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDs3TargetFailuresSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDs3TargetFailuresSpectraS3Response(response)
 }
 
 func (client *Client) GetDs3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.GetDs3TargetReadPreferenceSpectraS3Request) (*models.GetDs3TargetReadPreferenceSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/ds3_target_read_preference/" + request.Ds3TargetReadPreference).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/ds3_target_read_preference/"+request.Ds3TargetReadPreference).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDs3TargetReadPreferenceSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDs3TargetReadPreferenceSpectraS3Response(response)
 }
 
 func (client *Client) GetDs3TargetReadPreferencesSpectraS3(ctx context.Context, request *models.GetDs3TargetReadPreferencesSpectraS3Request) (*models.GetDs3TargetReadPreferencesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/ds3_target_read_preference").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("read_preference", networking.InterfaceToStrPtr(request.ReadPreference)).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/ds3_target_read_preference").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("read_preference", networking.InterfaceToStrPtr(request.ReadPreference)).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDs3TargetReadPreferencesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDs3TargetReadPreferencesSpectraS3Response(response)
 }
 
 func (client *Client) GetDs3TargetSpectraS3(ctx context.Context, request *models.GetDs3TargetSpectraS3Request) (*models.GetDs3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/ds3_target/" + request.Ds3Target).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/ds3_target/"+request.Ds3Target).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDs3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDs3TargetSpectraS3Response(response)
 }
 
 func (client *Client) GetDs3TargetsSpectraS3(ctx context.Context, request *models.GetDs3TargetsSpectraS3Request) (*models.GetDs3TargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/ds3_target").
-        WithOptionalQueryParam("admin_auth_id", request.AdminAuthId).
-        WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
-        WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
-        WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
-        WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
-        WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
-        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/ds3_target").
+		WithOptionalQueryParam("admin_auth_id", request.AdminAuthId).
+		WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
+		WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
+		WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
+		WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
+		WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
+		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetDs3TargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetDs3TargetsSpectraS3Response(response)
 }
 
 func (client *Client) GetBlobsOnS3TargetSpectraS3(ctx context.Context, request *models.GetBlobsOnS3TargetSpectraS3Request) (*models.GetBlobsOnS3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/s3_target/" + request.S3Target).
-        WithQueryParam("operation", "get_physical_placement").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/s3_target/"+request.S3Target).
+		WithQueryParam("operation", "get_physical_placement").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBlobsOnS3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBlobsOnS3TargetSpectraS3Response(response)
 }
 
 func (client *Client) GetS3TargetBucketNamesSpectraS3(ctx context.Context, request *models.GetS3TargetBucketNamesSpectraS3Request) (*models.GetS3TargetBucketNamesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/s3_target_bucket_name").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/s3_target_bucket_name").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetS3TargetBucketNamesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetS3TargetBucketNamesSpectraS3Response(response)
 }
 
 func (client *Client) GetS3TargetFailuresSpectraS3(ctx context.Context, request *models.GetS3TargetFailuresSpectraS3Request) (*models.GetS3TargetFailuresSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/s3_target_failure").
-        WithOptionalQueryParam("error_message", request.ErrorMessage).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TargetFailureType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/s3_target_failure").
+		WithOptionalQueryParam("error_message", request.ErrorMessage).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.TargetFailureType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetS3TargetFailuresSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetS3TargetFailuresSpectraS3Response(response)
 }
 
 func (client *Client) GetS3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.GetS3TargetReadPreferenceSpectraS3Request) (*models.GetS3TargetReadPreferenceSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/s3_target_read_preference/" + request.S3TargetReadPreference).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/s3_target_read_preference/"+request.S3TargetReadPreference).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetS3TargetReadPreferenceSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetS3TargetReadPreferenceSpectraS3Response(response)
 }
 
 func (client *Client) GetS3TargetReadPreferencesSpectraS3(ctx context.Context, request *models.GetS3TargetReadPreferencesSpectraS3Request) (*models.GetS3TargetReadPreferencesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/s3_target_read_preference").
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("read_preference", networking.InterfaceToStrPtr(request.ReadPreference)).
-        WithOptionalQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/s3_target_read_preference").
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("read_preference", networking.InterfaceToStrPtr(request.ReadPreference)).
+		WithOptionalQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetS3TargetReadPreferencesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetS3TargetReadPreferencesSpectraS3Response(response)
 }
 
 func (client *Client) GetS3TargetSpectraS3(ctx context.Context, request *models.GetS3TargetSpectraS3Request) (*models.GetS3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/s3_target/" + request.S3Target).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/s3_target/"+request.S3Target).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetS3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetS3TargetSpectraS3Response(response)
 }
 
 func (client *Client) GetS3TargetsSpectraS3(ctx context.Context, request *models.GetS3TargetsSpectraS3Request) (*models.GetS3TargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/s3_target").
-        WithOptionalQueryParam("access_key", request.AccessKey).
-        WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
-        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-        WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("naming_mode", networking.InterfaceToStrPtr(request.NamingMode)).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-        WithOptionalQueryParam("region", networking.InterfaceToStrPtr(request.Region)).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/s3_target").
+		WithOptionalQueryParam("access_key", request.AccessKey).
+		WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
+		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+		WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("naming_mode", networking.InterfaceToStrPtr(request.NamingMode)).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+		WithOptionalQueryParam("region", networking.InterfaceToStrPtr(request.Region)).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetS3TargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetS3TargetsSpectraS3Response(response)
 }
 
 func (client *Client) GetUserSpectraS3(ctx context.Context, request *models.GetUserSpectraS3Request) (*models.GetUserSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/user/" + request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/user/"+request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetUserSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetUserSpectraS3Response(response)
 }
 
 func (client *Client) GetUsersSpectraS3(ctx context.Context, request *models.GetUsersSpectraS3Request) (*models.GetUsersSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_GET).
-        WithPath("/_rest_/user").
-        WithOptionalQueryParam("auth_id", request.AuthId).
-        WithOptionalQueryParam("default_data_policy_id", request.DefaultDataPolicyId).
-        WithOptionalVoidQueryParam("last_page", request.LastPage).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
-        WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
-        WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_GET).
+		WithPath("/_rest_/user").
+		WithOptionalQueryParam("auth_id", request.AuthId).
+		WithOptionalQueryParam("default_data_policy_id", request.DefaultDataPolicyId).
+		WithOptionalVoidQueryParam("last_page", request.LastPage).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("page_length", networking.IntPtrToStrPtr(request.PageLength)).
+		WithOptionalQueryParam("page_offset", networking.IntPtrToStrPtr(request.PageOffset)).
+		WithOptionalQueryParam("page_start_marker", request.PageStartMarker).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetUsersSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetUsersSpectraS3Response(response)
 }
-

--- a/ds3/ds3Heads.go
+++ b/ds3/ds3Heads.go
@@ -14,56 +14,54 @@
 package ds3
 
 import (
-    "context"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+	"context"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
 )
 
 func (client *Client) HeadBucket(ctx context.Context, request *models.HeadBucketRequest) (*models.HeadBucketResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_HEAD).
-        WithPath("/" + request.BucketName).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_HEAD).
+		WithPath("/"+request.BucketName).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewHeadBucketResponse(response)
+	// Create a response object based on the result.
+	return models.NewHeadBucketResponse(response)
 }
 
 func (client *Client) HeadObject(ctx context.Context, request *models.HeadObjectRequest) (*models.HeadObjectResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_HEAD).
-        WithPath("/" + request.BucketName + "/" + request.ObjectName).
-        WithOptionalQueryParam("version_id", request.VersionId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_HEAD).
+		WithPath("/"+request.BucketName+"/"+request.ObjectName).
+		WithOptionalQueryParam("version_id", request.VersionId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewHeadObjectResponse(response)
+	// Create a response object based on the result.
+	return models.NewHeadObjectResponse(response)
 }
-
-

--- a/ds3/ds3Mocks_test.go
+++ b/ds3/ds3Mocks_test.go
@@ -1,150 +1,149 @@
 package ds3
 
 import (
-    "io"
-    "io/ioutil"
-    "testing"
-    "net/url"
-    "net/http"
-    "reflect"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
 )
 
 func mockedClient(t *testing.T) mockedClientWithTest {
-    return &mockedNet{t: t}
+	return &mockedNet{t: t}
 }
 
 type mockedClientWithTest interface {
-    Expecting(verb string, path string, queryParams *url.Values, requestHeaders *http.Header, request *string) mockedClientWithExpectation
+	Expecting(verb string, path string, queryParams *url.Values, requestHeaders *http.Header, request *string) mockedClientWithExpectation
 }
 
 type mockedClientWithExpectation interface {
-    Returning(statusCode int, response string, headers *http.Header) *Client
+	Returning(statusCode int, response string, headers *http.Header) *Client
 }
 
 type mockedNet struct {
-    // Test manager.
-    t *testing.T
+	// Test manager.
+	t *testing.T
 
-    // Expected data to validate.
-    verb string
-    path string
-    queryParams *url.Values
-    requestHeaders *http.Header
-    request *string
+	// Expected data to validate.
+	verb           string
+	path           string
+	queryParams    *url.Values
+	requestHeaders *http.Header
+	request        *string
 
-    // Response data to return.
-    statusCode int
-    response string
-    headers *http.Header
+	// Response data to return.
+	statusCode int
+	response   string
+	headers    *http.Header
 }
 
 func (mockedNet *mockedNet) Expecting(verb string, path string, queryParams *url.Values, requestHeaders *http.Header, request *string) mockedClientWithExpectation {
-    mockedNet.verb = verb
-    mockedNet.path = path
-    mockedNet.queryParams = queryParams
-    mockedNet.requestHeaders = requestHeaders
-    mockedNet.request = request
-    return mockedNet
+	mockedNet.verb = verb
+	mockedNet.path = path
+	mockedNet.queryParams = queryParams
+	mockedNet.requestHeaders = requestHeaders
+	mockedNet.request = request
+	return mockedNet
 }
 
 func (mockedNet *mockedNet) Returning(statusCode int, response string, headers *http.Header) *Client {
-    mockedNet.statusCode = statusCode
-    mockedNet.response = response
-    mockedNet.headers = headers
-    var url url.URL
-    var endpointUrl, _ = url.Parse("/")
-    return &Client{
-        sendNetwork: mockedNet,
-        clientPolicy: &ClientPolicy{5, 5},
-        connectionInfo: &networking.ConnectionInfo{
-            Endpoint: endpointUrl,
-            Credentials: &networking.Credentials{AccessId: "AccessId", Key: "Key"},
-        },
-    }
+	mockedNet.statusCode = statusCode
+	mockedNet.response = response
+	mockedNet.headers = headers
+	var url url.URL
+	var endpointUrl, _ = url.Parse("/")
+	return &Client{
+		sendNetwork:  mockedNet,
+		clientPolicy: &ClientPolicy{5, 5},
+		connectionInfo: &networking.ConnectionInfo{
+			Endpoint:    endpointUrl,
+			Credentials: &networking.Credentials{AccessId: "AccessId", Key: "Key"},
+		},
+	}
 }
 
 func (mockedNet *mockedNet) Invoke(httpRequest *http.Request) (models.WebResponse, error) {
-    // Verify the verb.
-    if httpRequest.Method != mockedNet.verb {
-        mockedNet.t.Errorf("Expected verb '%s' but got '%s'.", mockedNet.verb, httpRequest.Method)
-    }
+	// Verify the verb.
+	if httpRequest.Method != mockedNet.verb {
+		mockedNet.t.Errorf("Expected verb '%s' but got '%s'.", mockedNet.verb, httpRequest.Method)
+	}
 
-    // Verify the path.
-    if httpRequest.URL.Path != mockedNet.path {
-        mockedNet.t.Errorf("Expected path '%s' but got '%s'.", mockedNet.path, httpRequest.URL.Path)
-    }
+	// Verify the path.
+	if httpRequest.URL.Path != mockedNet.path {
+		mockedNet.t.Errorf("Expected path '%s' but got '%s'.", mockedNet.path, httpRequest.URL.Path)
+	}
 
-    // Verify the query parameters.
-    actualQueryParams := httpRequest.URL.RawQuery
-    expectedQueryParams := mockedNet.queryParams.Encode()
-    if actualQueryParams != expectedQueryParams {
-        mockedNet.t.Errorf(
-            "Expected query params '%s' but got '%s'.",
-            expectedQueryParams,
-            actualQueryParams,
-        )
-    }
+	// Verify the query parameters.
+	actualQueryParams := httpRequest.URL.RawQuery
+	expectedQueryParams := mockedNet.queryParams.Encode()
+	if actualQueryParams != expectedQueryParams {
+		mockedNet.t.Errorf(
+			"Expected query params '%s' but got '%s'.",
+			expectedQueryParams,
+			actualQueryParams,
+		)
+	}
 
-    // Verify request headers
-    actualRequestHeaders := httpRequest.Header
-    actualRequestHeaders.Del("Date") //remove date
-    actualRequestHeaders.Del("Authorization") //remove authorization
-    expectedRequestHeaders := *mockedNet.requestHeaders
-    if len(actualRequestHeaders) != len(expectedRequestHeaders) {
-        mockedNet.t.Errorf(
-            "Expected request headers '%s' but got '%s'.",
-            expectedRequestHeaders,
-            actualRequestHeaders,
-        )
-    } else {
-        for key, expectedValues := range expectedRequestHeaders {
-            actualValues := actualRequestHeaders[key]
-            if !reflect.DeepEqual(actualValues, expectedValues) {
-                mockedNet.t.Errorf(
-                    "For request header with key '%s', expected values '%v' but got '%v'.",
-                    key,
-                    expectedValues,
-                    actualValues,
-                )
-            }
-        }
-    }
+	// Verify request headers
+	actualRequestHeaders := httpRequest.Header
+	actualRequestHeaders.Del("Date")          //remove date
+	actualRequestHeaders.Del("Authorization") //remove authorization
+	expectedRequestHeaders := *mockedNet.requestHeaders
+	if len(actualRequestHeaders) != len(expectedRequestHeaders) {
+		mockedNet.t.Errorf(
+			"Expected request headers '%s' but got '%s'.",
+			expectedRequestHeaders,
+			actualRequestHeaders,
+		)
+	} else {
+		for key, expectedValues := range expectedRequestHeaders {
+			actualValues := actualRequestHeaders[key]
+			if !reflect.DeepEqual(actualValues, expectedValues) {
+				mockedNet.t.Errorf(
+					"For request header with key '%s', expected values '%v' but got '%v'.",
+					key,
+					expectedValues,
+					actualValues,
+				)
+			}
+		}
+	}
 
-    // Verify the request contents.
-    if mockedNet.request != nil {
-        contentStream := httpRequest.Body
-        if contentStream == nil {
-            mockedNet.t.Error("Expected a non-nil content stream, but got nil.")
-        } else {
-            defer contentStream.Close()
-            bs, readErr := ioutil.ReadAll(contentStream)
-            if readErr != nil {
-                mockedNet.t.Errorf("Unexpected error '%s' while reading content stream.", readErr.Error())
-            } else if string(bs) != *mockedNet.request {
-                mockedNet.t.Errorf("Expected '%s' but got '%s'.", *mockedNet.request, string(bs))
-            }
-        }
-    }
+	// Verify the request contents.
+	if mockedNet.request != nil {
+		contentStream := httpRequest.Body
+		if contentStream == nil {
+			mockedNet.t.Error("Expected a non-nil content stream, but got nil.")
+		} else {
+			defer contentStream.Close()
+			bs, readErr := ioutil.ReadAll(contentStream)
+			if readErr != nil {
+				mockedNet.t.Errorf("Unexpected error '%s' while reading content stream.", readErr.Error())
+			} else if string(bs) != *mockedNet.request {
+				mockedNet.t.Errorf("Expected '%s' but got '%s'.", *mockedNet.request, string(bs))
+			}
+		}
+	}
 
-    // Return the net.WebResponse interface, which we just made mockedNet also implement.
-    return mockedNet, nil
+	// Return the net.WebResponse interface, which we just made mockedNet also implement.
+	return mockedNet, nil
 }
 
 func (mockedNet *mockedNet) StatusCode() int {
-    return mockedNet.statusCode
+	return mockedNet.statusCode
 }
 
 func (mockedNet *mockedNet) Body() io.ReadCloser {
-    return BuildByteReaderWithSizeDecorator([]byte(mockedNet.response))
+	return BuildByteReaderWithSizeDecorator([]byte(mockedNet.response))
 }
 
 func (mockedNet *mockedNet) Header() *http.Header {
-    if mockedNet.headers == nil {
-        return &http.Header{}
-    } else {
-        return mockedNet.headers
-    }
+	if mockedNet.headers == nil {
+		return &http.Header{}
+	} else {
+		return mockedNet.headers
+	}
 }
-

--- a/ds3/ds3Posts.go
+++ b/ds3/ds3Posts.go
@@ -14,1381 +14,1379 @@
 package ds3
 
 import (
-    "context"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+	"context"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
 )
 
 func (client *Client) CompleteBlob(ctx context.Context, request *models.CompleteBlobRequest) (*models.CompleteBlobResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/" + request.BucketName + "/" + request.ObjectName).
-        WithQueryParam("blob", request.Blob).
-        WithQueryParam("job", request.Job).
-        WithOptionalQueryParam("size", networking.Int64PtrToStrPtr(request.Size)).
-        WithChecksum(request.Checksum).
-        WithHeaders(request.Metadata).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/"+request.BucketName+"/"+request.ObjectName).
+		WithQueryParam("blob", request.Blob).
+		WithQueryParam("job", request.Job).
+		WithOptionalQueryParam("size", networking.Int64PtrToStrPtr(request.Size)).
+		WithChecksum(request.Checksum).
+		WithHeaders(request.Metadata).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCompleteBlobResponse(response)
+	// Create a response object based on the result.
+	return models.NewCompleteBlobResponse(response)
 }
 
 func (client *Client) CompleteMultiPartUpload(ctx context.Context, request *models.CompleteMultiPartUploadRequest) (*models.CompleteMultiPartUploadResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/" + request.BucketName + "/" + request.ObjectName).
-        WithQueryParam("upload_id", request.UploadId).
-        WithReadCloser(buildPartsListStream(request.Parts)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/"+request.BucketName+"/"+request.ObjectName).
+		WithQueryParam("upload_id", request.UploadId).
+		WithReadCloser(buildPartsListStream(request.Parts)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCompleteMultiPartUploadResponse(response)
+	// Create a response object based on the result.
+	return models.NewCompleteMultiPartUploadResponse(response)
 }
 
 func (client *Client) DeleteObjects(ctx context.Context, request *models.DeleteObjectsRequest) (*models.DeleteObjectsResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/" + request.BucketName).
-        WithQueryParam("delete", "").
-        WithReadCloser(buildDeleteObjectsPayload(request.ObjectNames)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/"+request.BucketName).
+		WithQueryParam("delete", "").
+		WithReadCloser(buildDeleteObjectsPayload(request.ObjectNames)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeleteObjectsResponse(response)
+	// Create a response object based on the result.
+	return models.NewDeleteObjectsResponse(response)
 }
 
 func (client *Client) InitiateMultiPartUpload(ctx context.Context, request *models.InitiateMultiPartUploadRequest) (*models.InitiateMultiPartUploadResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/" + request.BucketName + "/" + request.ObjectName).
-        WithQueryParam("uploads", "").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/"+request.BucketName+"/"+request.ObjectName).
+		WithQueryParam("uploads", "").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewInitiateMultiPartUploadResponse(response)
+	// Create a response object based on the result.
+	return models.NewInitiateMultiPartUploadResponse(response)
 }
 
 func (client *Client) PutBucketAclForGroupSpectraS3(ctx context.Context, request *models.PutBucketAclForGroupSpectraS3Request) (*models.PutBucketAclForGroupSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/bucket_acl").
-        WithQueryParam("bucket_id", request.BucketId).
-        WithQueryParam("group_id", request.GroupId).
-        WithQueryParam("permission", request.Permission.String()).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/bucket_acl").
+		WithQueryParam("bucket_id", request.BucketId).
+		WithQueryParam("group_id", request.GroupId).
+		WithQueryParam("permission", request.Permission.String()).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutBucketAclForGroupSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutBucketAclForGroupSpectraS3Response(response)
 }
 
 func (client *Client) PutBucketAclForUserSpectraS3(ctx context.Context, request *models.PutBucketAclForUserSpectraS3Request) (*models.PutBucketAclForUserSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/bucket_acl").
-        WithQueryParam("bucket_id", request.BucketId).
-        WithQueryParam("permission", request.Permission.String()).
-        WithQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/bucket_acl").
+		WithQueryParam("bucket_id", request.BucketId).
+		WithQueryParam("permission", request.Permission.String()).
+		WithQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutBucketAclForUserSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutBucketAclForUserSpectraS3Response(response)
 }
 
 func (client *Client) PutDataPolicyAclForGroupSpectraS3(ctx context.Context, request *models.PutDataPolicyAclForGroupSpectraS3Request) (*models.PutDataPolicyAclForGroupSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/data_policy_acl").
-        WithQueryParam("data_policy_id", request.DataPolicyId).
-        WithQueryParam("group_id", request.GroupId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/data_policy_acl").
+		WithQueryParam("data_policy_id", request.DataPolicyId).
+		WithQueryParam("group_id", request.GroupId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutDataPolicyAclForGroupSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutDataPolicyAclForGroupSpectraS3Response(response)
 }
 
 func (client *Client) PutDataPolicyAclForUserSpectraS3(ctx context.Context, request *models.PutDataPolicyAclForUserSpectraS3Request) (*models.PutDataPolicyAclForUserSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/data_policy_acl").
-        WithQueryParam("data_policy_id", request.DataPolicyId).
-        WithQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/data_policy_acl").
+		WithQueryParam("data_policy_id", request.DataPolicyId).
+		WithQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutDataPolicyAclForUserSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutDataPolicyAclForUserSpectraS3Response(response)
 }
 
 func (client *Client) PutGlobalBucketAclForGroupSpectraS3(ctx context.Context, request *models.PutGlobalBucketAclForGroupSpectraS3Request) (*models.PutGlobalBucketAclForGroupSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/bucket_acl").
-        WithQueryParam("group_id", request.GroupId).
-        WithQueryParam("permission", request.Permission.String()).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/bucket_acl").
+		WithQueryParam("group_id", request.GroupId).
+		WithQueryParam("permission", request.Permission.String()).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutGlobalBucketAclForGroupSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutGlobalBucketAclForGroupSpectraS3Response(response)
 }
 
 func (client *Client) PutGlobalBucketAclForUserSpectraS3(ctx context.Context, request *models.PutGlobalBucketAclForUserSpectraS3Request) (*models.PutGlobalBucketAclForUserSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/bucket_acl").
-        WithQueryParam("permission", request.Permission.String()).
-        WithQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/bucket_acl").
+		WithQueryParam("permission", request.Permission.String()).
+		WithQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutGlobalBucketAclForUserSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutGlobalBucketAclForUserSpectraS3Response(response)
 }
 
 func (client *Client) PutGlobalDataPolicyAclForGroupSpectraS3(ctx context.Context, request *models.PutGlobalDataPolicyAclForGroupSpectraS3Request) (*models.PutGlobalDataPolicyAclForGroupSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/data_policy_acl").
-        WithQueryParam("group_id", request.GroupId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/data_policy_acl").
+		WithQueryParam("group_id", request.GroupId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutGlobalDataPolicyAclForGroupSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutGlobalDataPolicyAclForGroupSpectraS3Response(response)
 }
 
 func (client *Client) PutGlobalDataPolicyAclForUserSpectraS3(ctx context.Context, request *models.PutGlobalDataPolicyAclForUserSpectraS3Request) (*models.PutGlobalDataPolicyAclForUserSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/data_policy_acl").
-        WithQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/data_policy_acl").
+		WithQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutGlobalDataPolicyAclForUserSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutGlobalDataPolicyAclForUserSpectraS3Response(response)
 }
 
 func (client *Client) PutBucketSpectraS3(ctx context.Context, request *models.PutBucketSpectraS3Request) (*models.PutBucketSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/bucket").
-        WithQueryParam("name", request.Name).
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("id", request.Id).
-        WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/bucket").
+		WithQueryParam("name", request.Name).
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("id", request.Id).
+		WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutBucketSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutBucketSpectraS3Response(response)
 }
 
 func (client *Client) PutAzureDataReplicationRuleSpectraS3(ctx context.Context, request *models.PutAzureDataReplicationRuleSpectraS3Request) (*models.PutAzureDataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/azure_data_replication_rule").
-        WithQueryParam("data_policy_id", request.DataPolicyId).
-        WithQueryParam("target_id", request.TargetId).
-        WithQueryParam("type", request.DataReplicationRuleType.String()).
-        WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
-        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/azure_data_replication_rule").
+		WithQueryParam("data_policy_id", request.DataPolicyId).
+		WithQueryParam("target_id", request.TargetId).
+		WithQueryParam("type", request.DataReplicationRuleType.String()).
+		WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
+		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutAzureDataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutAzureDataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) PutDataPersistenceRuleSpectraS3(ctx context.Context, request *models.PutDataPersistenceRuleSpectraS3Request) (*models.PutDataPersistenceRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/data_persistence_rule").
-        WithQueryParam("data_policy_id", request.DataPolicyId).
-        WithQueryParam("isolation_level", request.IsolationLevel.String()).
-        WithQueryParam("storage_domain_id", request.StorageDomainId).
-        WithQueryParam("type", request.DataPersistenceRuleType.String()).
-        WithOptionalQueryParam("minimum_days_to_retain", networking.IntPtrToStrPtr(request.MinimumDaysToRetain)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/data_persistence_rule").
+		WithQueryParam("data_policy_id", request.DataPolicyId).
+		WithQueryParam("isolation_level", request.IsolationLevel.String()).
+		WithQueryParam("storage_domain_id", request.StorageDomainId).
+		WithQueryParam("type", request.DataPersistenceRuleType.String()).
+		WithOptionalQueryParam("minimum_days_to_retain", networking.IntPtrToStrPtr(request.MinimumDaysToRetain)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutDataPersistenceRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutDataPersistenceRuleSpectraS3Response(response)
 }
 
 func (client *Client) PutDataPolicySpectraS3(ctx context.Context, request *models.PutDataPolicySpectraS3Request) (*models.PutDataPolicySpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/data_policy").
-        WithQueryParam("name", request.Name).
-        WithOptionalQueryParam("always_force_put_job_creation", networking.BoolPtrToStrPtr(request.AlwaysForcePutJobCreation)).
-        WithOptionalQueryParam("always_minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.AlwaysMinimizeSpanningAcrossMedia)).
-        WithOptionalQueryParam("blobbing_enabled", networking.BoolPtrToStrPtr(request.BlobbingEnabled)).
-        WithOptionalQueryParam("checksum_type", networking.InterfaceToStrPtr(request.ChecksumType)).
-        WithOptionalQueryParam("default_blob_size", networking.Int64PtrToStrPtr(request.DefaultBlobSize)).
-        WithOptionalQueryParam("default_get_job_priority", networking.InterfaceToStrPtr(request.DefaultGetJobPriority)).
-        WithOptionalQueryParam("default_put_job_priority", networking.InterfaceToStrPtr(request.DefaultPutJobPriority)).
-        WithOptionalQueryParam("default_verify_after_write", networking.BoolPtrToStrPtr(request.DefaultVerifyAfterWrite)).
-        WithOptionalQueryParam("default_verify_job_priority", networking.InterfaceToStrPtr(request.DefaultVerifyJobPriority)).
-        WithOptionalQueryParam("end_to_end_crc_required", networking.BoolPtrToStrPtr(request.EndToEndCrcRequired)).
-        WithOptionalQueryParam("max_versions_to_keep", networking.IntPtrToStrPtr(request.MaxVersionsToKeep)).
-        WithOptionalQueryParam("rebuild_priority", networking.InterfaceToStrPtr(request.RebuildPriority)).
-        WithOptionalQueryParam("versioning", networking.InterfaceToStrPtr(request.Versioning)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/data_policy").
+		WithQueryParam("name", request.Name).
+		WithOptionalQueryParam("always_force_put_job_creation", networking.BoolPtrToStrPtr(request.AlwaysForcePutJobCreation)).
+		WithOptionalQueryParam("always_minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.AlwaysMinimizeSpanningAcrossMedia)).
+		WithOptionalQueryParam("blobbing_enabled", networking.BoolPtrToStrPtr(request.BlobbingEnabled)).
+		WithOptionalQueryParam("checksum_type", networking.InterfaceToStrPtr(request.ChecksumType)).
+		WithOptionalQueryParam("default_blob_size", networking.Int64PtrToStrPtr(request.DefaultBlobSize)).
+		WithOptionalQueryParam("default_get_job_priority", networking.InterfaceToStrPtr(request.DefaultGetJobPriority)).
+		WithOptionalQueryParam("default_put_job_priority", networking.InterfaceToStrPtr(request.DefaultPutJobPriority)).
+		WithOptionalQueryParam("default_verify_after_write", networking.BoolPtrToStrPtr(request.DefaultVerifyAfterWrite)).
+		WithOptionalQueryParam("default_verify_job_priority", networking.InterfaceToStrPtr(request.DefaultVerifyJobPriority)).
+		WithOptionalQueryParam("end_to_end_crc_required", networking.BoolPtrToStrPtr(request.EndToEndCrcRequired)).
+		WithOptionalQueryParam("max_versions_to_keep", networking.IntPtrToStrPtr(request.MaxVersionsToKeep)).
+		WithOptionalQueryParam("rebuild_priority", networking.InterfaceToStrPtr(request.RebuildPriority)).
+		WithOptionalQueryParam("versioning", networking.InterfaceToStrPtr(request.Versioning)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutDataPolicySpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutDataPolicySpectraS3Response(response)
 }
 
 func (client *Client) PutDs3DataReplicationRuleSpectraS3(ctx context.Context, request *models.PutDs3DataReplicationRuleSpectraS3Request) (*models.PutDs3DataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/ds3_data_replication_rule").
-        WithQueryParam("data_policy_id", request.DataPolicyId).
-        WithQueryParam("target_id", request.TargetId).
-        WithQueryParam("type", request.DataReplicationRuleType.String()).
-        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-        WithOptionalQueryParam("target_data_policy", request.TargetDataPolicy).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/ds3_data_replication_rule").
+		WithQueryParam("data_policy_id", request.DataPolicyId).
+		WithQueryParam("target_id", request.TargetId).
+		WithQueryParam("type", request.DataReplicationRuleType.String()).
+		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+		WithOptionalQueryParam("target_data_policy", request.TargetDataPolicy).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutDs3DataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutDs3DataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) PutS3DataReplicationRuleSpectraS3(ctx context.Context, request *models.PutS3DataReplicationRuleSpectraS3Request) (*models.PutS3DataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/s3_data_replication_rule").
-        WithQueryParam("data_policy_id", request.DataPolicyId).
-        WithQueryParam("target_id", request.TargetId).
-        WithQueryParam("type", request.DataReplicationRuleType.String()).
-        WithOptionalQueryParam("initial_data_placement", networking.InterfaceToStrPtr(request.InitialDataPlacement)).
-        WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
-        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/s3_data_replication_rule").
+		WithQueryParam("data_policy_id", request.DataPolicyId).
+		WithQueryParam("target_id", request.TargetId).
+		WithQueryParam("type", request.DataReplicationRuleType.String()).
+		WithOptionalQueryParam("initial_data_placement", networking.InterfaceToStrPtr(request.InitialDataPlacement)).
+		WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
+		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutS3DataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutS3DataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) PutGroupGroupMemberSpectraS3(ctx context.Context, request *models.PutGroupGroupMemberSpectraS3Request) (*models.PutGroupGroupMemberSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/group_member").
-        WithQueryParam("group_id", request.GroupId).
-        WithQueryParam("member_group_id", request.MemberGroupId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/group_member").
+		WithQueryParam("group_id", request.GroupId).
+		WithQueryParam("member_group_id", request.MemberGroupId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutGroupGroupMemberSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutGroupGroupMemberSpectraS3Response(response)
 }
 
 func (client *Client) PutGroupSpectraS3(ctx context.Context, request *models.PutGroupSpectraS3Request) (*models.PutGroupSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/group").
-        WithQueryParam("name", request.Name).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/group").
+		WithQueryParam("name", request.Name).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutGroupSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutGroupSpectraS3Response(response)
 }
 
 func (client *Client) PutUserGroupMemberSpectraS3(ctx context.Context, request *models.PutUserGroupMemberSpectraS3Request) (*models.PutUserGroupMemberSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/group_member").
-        WithQueryParam("group_id", request.GroupId).
-        WithQueryParam("member_user_id", request.MemberUserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/group_member").
+		WithQueryParam("group_id", request.GroupId).
+		WithQueryParam("member_user_id", request.MemberUserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutUserGroupMemberSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutUserGroupMemberSpectraS3Response(response)
 }
 
 func (client *Client) PutAzureTargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutAzureTargetFailureNotificationRegistrationSpectraS3Request) (*models.PutAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/azure_target_failure_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/azure_target_failure_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutAzureTargetFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutAzureTargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutBucketChangesNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutBucketChangesNotificationRegistrationSpectraS3Request) (*models.PutBucketChangesNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/bucket_changes_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/bucket_changes_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutBucketChangesNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutBucketChangesNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutDs3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutDs3TargetFailureNotificationRegistrationSpectraS3Request) (*models.PutDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/ds3_target_failure_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/ds3_target_failure_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutDs3TargetFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutDs3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutJobCompletedNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutJobCompletedNotificationRegistrationSpectraS3Request) (*models.PutJobCompletedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/job_completed_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("job_id", request.JobId).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/job_completed_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("job_id", request.JobId).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutJobCompletedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutJobCompletedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutJobCreatedNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutJobCreatedNotificationRegistrationSpectraS3Request) (*models.PutJobCreatedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/job_created_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/job_created_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutJobCreatedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutJobCreatedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutJobCreationFailedNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutJobCreationFailedNotificationRegistrationSpectraS3Request) (*models.PutJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/job_creation_failed_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/job_creation_failed_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutJobCreationFailedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutJobCreationFailedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutObjectCachedNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutObjectCachedNotificationRegistrationSpectraS3Request) (*models.PutObjectCachedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/object_cached_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("job_id", request.JobId).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/object_cached_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("job_id", request.JobId).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutObjectCachedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutObjectCachedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutObjectLostNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutObjectLostNotificationRegistrationSpectraS3Request) (*models.PutObjectLostNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/object_lost_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/object_lost_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutObjectLostNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutObjectLostNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutObjectPersistedNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutObjectPersistedNotificationRegistrationSpectraS3Request) (*models.PutObjectPersistedNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/object_persisted_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("job_id", request.JobId).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/object_persisted_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("job_id", request.JobId).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutObjectPersistedNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutObjectPersistedNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutPoolFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutPoolFailureNotificationRegistrationSpectraS3Request) (*models.PutPoolFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/pool_failure_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/pool_failure_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutPoolFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutPoolFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutS3TargetFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutS3TargetFailureNotificationRegistrationSpectraS3Request) (*models.PutS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/s3_target_failure_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/s3_target_failure_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutS3TargetFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutS3TargetFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutStorageDomainFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutStorageDomainFailureNotificationRegistrationSpectraS3Request) (*models.PutStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/storage_domain_failure_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/storage_domain_failure_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutStorageDomainFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutStorageDomainFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutSystemFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutSystemFailureNotificationRegistrationSpectraS3Request) (*models.PutSystemFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/system_failure_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/system_failure_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutSystemFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutSystemFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutTapeFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutTapeFailureNotificationRegistrationSpectraS3Request) (*models.PutTapeFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/tape_failure_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/tape_failure_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutTapeFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutTapeFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutTapePartitionFailureNotificationRegistrationSpectraS3(ctx context.Context, request *models.PutTapePartitionFailureNotificationRegistrationSpectraS3Request) (*models.PutTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/tape_partition_failure_notification_registration").
-        WithQueryParam("notification_end_point", request.NotificationEndPoint).
-        WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
-        WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
-        WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/tape_partition_failure_notification_registration").
+		WithQueryParam("notification_end_point", request.NotificationEndPoint).
+		WithOptionalQueryParam("format", networking.InterfaceToStrPtr(request.Format)).
+		WithOptionalQueryParam("naming_convention", networking.InterfaceToStrPtr(request.NamingConvention)).
+		WithOptionalQueryParam("notification_http_method", networking.InterfaceToStrPtr(request.NotificationHttpMethod)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutTapePartitionFailureNotificationRegistrationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutTapePartitionFailureNotificationRegistrationSpectraS3Response(response)
 }
 
 func (client *Client) PutPoolPartitionSpectraS3(ctx context.Context, request *models.PutPoolPartitionSpectraS3Request) (*models.PutPoolPartitionSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/pool_partition").
-        WithQueryParam("name", request.Name).
-        WithQueryParam("type", request.PoolType.String()).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/pool_partition").
+		WithQueryParam("name", request.Name).
+		WithQueryParam("type", request.PoolType.String()).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutPoolPartitionSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutPoolPartitionSpectraS3Response(response)
 }
 
 func (client *Client) PutPoolStorageDomainMemberSpectraS3(ctx context.Context, request *models.PutPoolStorageDomainMemberSpectraS3Request) (*models.PutPoolStorageDomainMemberSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/storage_domain_member").
-        WithQueryParam("pool_partition_id", request.PoolPartitionId).
-        WithQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/storage_domain_member").
+		WithQueryParam("pool_partition_id", request.PoolPartitionId).
+		WithQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutPoolStorageDomainMemberSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutPoolStorageDomainMemberSpectraS3Response(response)
 }
 
 func (client *Client) PutStorageDomainSpectraS3(ctx context.Context, request *models.PutStorageDomainSpectraS3Request) (*models.PutStorageDomainSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/storage_domain").
-        WithQueryParam("name", request.Name).
-        WithOptionalQueryParam("auto_eject_media_full_threshold", networking.Int64PtrToStrPtr(request.AutoEjectMediaFullThreshold)).
-        WithOptionalQueryParam("auto_eject_upon_cron", request.AutoEjectUponCron).
-        WithOptionalQueryParam("auto_eject_upon_job_cancellation", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCancellation)).
-        WithOptionalQueryParam("auto_eject_upon_job_completion", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCompletion)).
-        WithOptionalQueryParam("auto_eject_upon_media_full", networking.BoolPtrToStrPtr(request.AutoEjectUponMediaFull)).
-        WithOptionalQueryParam("ltfs_file_naming", networking.InterfaceToStrPtr(request.LtfsFileNaming)).
-        WithOptionalQueryParam("max_tape_fragmentation_percent", networking.IntPtrToStrPtr(request.MaxTapeFragmentationPercent)).
-        WithOptionalQueryParam("maximum_auto_verification_frequency_in_days", networking.IntPtrToStrPtr(request.MaximumAutoVerificationFrequencyInDays)).
-        WithOptionalQueryParam("media_ejection_allowed", networking.BoolPtrToStrPtr(request.MediaEjectionAllowed)).
-        WithOptionalQueryParam("secure_media_allocation", networking.BoolPtrToStrPtr(request.SecureMediaAllocation)).
-        WithOptionalQueryParam("verify_prior_to_auto_eject", networking.InterfaceToStrPtr(request.VerifyPriorToAutoEject)).
-        WithOptionalQueryParam("write_optimization", networking.InterfaceToStrPtr(request.WriteOptimization)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/storage_domain").
+		WithQueryParam("name", request.Name).
+		WithOptionalQueryParam("auto_eject_media_full_threshold", networking.Int64PtrToStrPtr(request.AutoEjectMediaFullThreshold)).
+		WithOptionalQueryParam("auto_eject_upon_cron", request.AutoEjectUponCron).
+		WithOptionalQueryParam("auto_eject_upon_job_cancellation", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCancellation)).
+		WithOptionalQueryParam("auto_eject_upon_job_completion", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCompletion)).
+		WithOptionalQueryParam("auto_eject_upon_media_full", networking.BoolPtrToStrPtr(request.AutoEjectUponMediaFull)).
+		WithOptionalQueryParam("ltfs_file_naming", networking.InterfaceToStrPtr(request.LtfsFileNaming)).
+		WithOptionalQueryParam("max_tape_fragmentation_percent", networking.IntPtrToStrPtr(request.MaxTapeFragmentationPercent)).
+		WithOptionalQueryParam("maximum_auto_verification_frequency_in_days", networking.IntPtrToStrPtr(request.MaximumAutoVerificationFrequencyInDays)).
+		WithOptionalQueryParam("media_ejection_allowed", networking.BoolPtrToStrPtr(request.MediaEjectionAllowed)).
+		WithOptionalQueryParam("secure_media_allocation", networking.BoolPtrToStrPtr(request.SecureMediaAllocation)).
+		WithOptionalQueryParam("verify_prior_to_auto_eject", networking.InterfaceToStrPtr(request.VerifyPriorToAutoEject)).
+		WithOptionalQueryParam("write_optimization", networking.InterfaceToStrPtr(request.WriteOptimization)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutStorageDomainSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutStorageDomainSpectraS3Response(response)
 }
 
 func (client *Client) PutTapeStorageDomainMemberSpectraS3(ctx context.Context, request *models.PutTapeStorageDomainMemberSpectraS3Request) (*models.PutTapeStorageDomainMemberSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/storage_domain_member").
-        WithQueryParam("storage_domain_id", request.StorageDomainId).
-        WithQueryParam("tape_partition_id", request.TapePartitionId).
-        WithQueryParam("tape_type", request.TapeType).
-        WithOptionalQueryParam("auto_compaction_threshold", networking.IntPtrToStrPtr(request.AutoCompactionThreshold)).
-        WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/storage_domain_member").
+		WithQueryParam("storage_domain_id", request.StorageDomainId).
+		WithQueryParam("tape_partition_id", request.TapePartitionId).
+		WithQueryParam("tape_type", request.TapeType).
+		WithOptionalQueryParam("auto_compaction_threshold", networking.IntPtrToStrPtr(request.AutoCompactionThreshold)).
+		WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutTapeStorageDomainMemberSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutTapeStorageDomainMemberSpectraS3Response(response)
 }
 
 func (client *Client) PutTapeDensityDirectiveSpectraS3(ctx context.Context, request *models.PutTapeDensityDirectiveSpectraS3Request) (*models.PutTapeDensityDirectiveSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/tape_density_directive").
-        WithQueryParam("density", request.Density.String()).
-        WithQueryParam("partition_id", request.PartitionId).
-        WithQueryParam("tape_type", request.TapeType).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/tape_density_directive").
+		WithQueryParam("density", request.Density.String()).
+		WithQueryParam("partition_id", request.PartitionId).
+		WithQueryParam("tape_type", request.TapeType).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutTapeDensityDirectiveSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutTapeDensityDirectiveSpectraS3Response(response)
 }
 
 func (client *Client) PutAzureTargetBucketNameSpectraS3(ctx context.Context, request *models.PutAzureTargetBucketNameSpectraS3Request) (*models.PutAzureTargetBucketNameSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/azure_target_bucket_name").
-        WithQueryParam("bucket_id", request.BucketId).
-        WithQueryParam("name", request.Name).
-        WithQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/azure_target_bucket_name").
+		WithQueryParam("bucket_id", request.BucketId).
+		WithQueryParam("name", request.Name).
+		WithQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutAzureTargetBucketNameSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutAzureTargetBucketNameSpectraS3Response(response)
 }
 
 func (client *Client) PutAzureTargetReadPreferenceSpectraS3(ctx context.Context, request *models.PutAzureTargetReadPreferenceSpectraS3Request) (*models.PutAzureTargetReadPreferenceSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/azure_target_read_preference").
-        WithQueryParam("bucket_id", request.BucketId).
-        WithQueryParam("read_preference", request.ReadPreference.String()).
-        WithQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/azure_target_read_preference").
+		WithQueryParam("bucket_id", request.BucketId).
+		WithQueryParam("read_preference", request.ReadPreference.String()).
+		WithQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutAzureTargetReadPreferenceSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutAzureTargetReadPreferenceSpectraS3Response(response)
 }
 
 func (client *Client) RegisterAzureTargetSpectraS3(ctx context.Context, request *models.RegisterAzureTargetSpectraS3Request) (*models.RegisterAzureTargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/azure_target").
-        WithQueryParam("account_key", request.AccountKey).
-        WithQueryParam("account_name", request.AccountName).
-        WithQueryParam("name", request.Name).
-        WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
-        WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
-        WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
-        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-        WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
-        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/azure_target").
+		WithQueryParam("account_key", request.AccountKey).
+		WithQueryParam("account_name", request.AccountName).
+		WithQueryParam("name", request.Name).
+		WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
+		WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
+		WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
+		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+		WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
+		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewRegisterAzureTargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewRegisterAzureTargetSpectraS3Response(response)
 }
 
 func (client *Client) PutDs3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.PutDs3TargetReadPreferenceSpectraS3Request) (*models.PutDs3TargetReadPreferenceSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/ds3_target_read_preference").
-        WithQueryParam("bucket_id", request.BucketId).
-        WithQueryParam("read_preference", request.ReadPreference.String()).
-        WithQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/ds3_target_read_preference").
+		WithQueryParam("bucket_id", request.BucketId).
+		WithQueryParam("read_preference", request.ReadPreference.String()).
+		WithQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutDs3TargetReadPreferenceSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutDs3TargetReadPreferenceSpectraS3Response(response)
 }
 
 func (client *Client) RegisterDs3TargetSpectraS3(ctx context.Context, request *models.RegisterDs3TargetSpectraS3Request) (*models.RegisterDs3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/ds3_target").
-        WithQueryParam("admin_auth_id", request.AdminAuthId).
-        WithQueryParam("admin_secret_key", request.AdminSecretKey).
-        WithQueryParam("data_path_end_point", request.DataPathEndPoint).
-        WithQueryParam("name", request.Name).
-        WithOptionalQueryParam("access_control_replication", networking.InterfaceToStrPtr(request.AccessControlReplication)).
-        WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
-        WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
-        WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
-        WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
-        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-        WithOptionalQueryParam("replicated_user_default_data_policy", request.ReplicatedUserDefaultDataPolicy).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/ds3_target").
+		WithQueryParam("admin_auth_id", request.AdminAuthId).
+		WithQueryParam("admin_secret_key", request.AdminSecretKey).
+		WithQueryParam("data_path_end_point", request.DataPathEndPoint).
+		WithQueryParam("name", request.Name).
+		WithOptionalQueryParam("access_control_replication", networking.InterfaceToStrPtr(request.AccessControlReplication)).
+		WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
+		WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
+		WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
+		WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
+		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+		WithOptionalQueryParam("replicated_user_default_data_policy", request.ReplicatedUserDefaultDataPolicy).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewRegisterDs3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewRegisterDs3TargetSpectraS3Response(response)
 }
 
 func (client *Client) PutS3TargetBucketNameSpectraS3(ctx context.Context, request *models.PutS3TargetBucketNameSpectraS3Request) (*models.PutS3TargetBucketNameSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/s3_target_bucket_name").
-        WithQueryParam("bucket_id", request.BucketId).
-        WithQueryParam("name", request.Name).
-        WithQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/s3_target_bucket_name").
+		WithQueryParam("bucket_id", request.BucketId).
+		WithQueryParam("name", request.Name).
+		WithQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutS3TargetBucketNameSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutS3TargetBucketNameSpectraS3Response(response)
 }
 
 func (client *Client) PutS3TargetReadPreferenceSpectraS3(ctx context.Context, request *models.PutS3TargetReadPreferenceSpectraS3Request) (*models.PutS3TargetReadPreferenceSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/s3_target_read_preference").
-        WithQueryParam("bucket_id", request.BucketId).
-        WithQueryParam("read_preference", request.ReadPreference.String()).
-        WithQueryParam("target_id", request.TargetId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/s3_target_read_preference").
+		WithQueryParam("bucket_id", request.BucketId).
+		WithQueryParam("read_preference", request.ReadPreference.String()).
+		WithQueryParam("target_id", request.TargetId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutS3TargetReadPreferenceSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutS3TargetReadPreferenceSpectraS3Response(response)
 }
 
 func (client *Client) RegisterS3TargetSpectraS3(ctx context.Context, request *models.RegisterS3TargetSpectraS3Request) (*models.RegisterS3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/s3_target").
-        WithQueryParam("access_key", request.AccessKey).
-        WithQueryParam("name", request.Name).
-        WithQueryParam("secret_key", request.SecretKey).
-        WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
-        WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
-        WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
-        WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
-        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-        WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
-        WithOptionalQueryParam("naming_mode", networking.InterfaceToStrPtr(request.NamingMode)).
-        WithOptionalQueryParam("offline_data_staging_window_in_tb", networking.IntPtrToStrPtr(request.OfflineDataStagingWindowInTb)).
-        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-        WithOptionalQueryParam("proxy_domain", request.ProxyDomain).
-        WithOptionalQueryParam("proxy_host", request.ProxyHost).
-        WithOptionalQueryParam("proxy_password", request.ProxyPassword).
-        WithOptionalQueryParam("proxy_port", networking.IntPtrToStrPtr(request.ProxyPort)).
-        WithOptionalQueryParam("proxy_username", request.ProxyUsername).
-        WithOptionalQueryParam("region", networking.InterfaceToStrPtr(request.Region)).
-        WithOptionalQueryParam("restricted_access", networking.BoolPtrToStrPtr(request.RestrictedAccess)).
-        WithOptionalQueryParam("staged_data_expiration_in_days", networking.IntPtrToStrPtr(request.StagedDataExpirationInDays)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/s3_target").
+		WithQueryParam("access_key", request.AccessKey).
+		WithQueryParam("name", request.Name).
+		WithQueryParam("secret_key", request.SecretKey).
+		WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
+		WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
+		WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
+		WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
+		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+		WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
+		WithOptionalQueryParam("naming_mode", networking.InterfaceToStrPtr(request.NamingMode)).
+		WithOptionalQueryParam("offline_data_staging_window_in_tb", networking.IntPtrToStrPtr(request.OfflineDataStagingWindowInTb)).
+		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+		WithOptionalQueryParam("proxy_domain", request.ProxyDomain).
+		WithOptionalQueryParam("proxy_host", request.ProxyHost).
+		WithOptionalQueryParam("proxy_password", request.ProxyPassword).
+		WithOptionalQueryParam("proxy_port", networking.IntPtrToStrPtr(request.ProxyPort)).
+		WithOptionalQueryParam("proxy_username", request.ProxyUsername).
+		WithOptionalQueryParam("region", networking.InterfaceToStrPtr(request.Region)).
+		WithOptionalQueryParam("restricted_access", networking.BoolPtrToStrPtr(request.RestrictedAccess)).
+		WithOptionalQueryParam("staged_data_expiration_in_days", networking.IntPtrToStrPtr(request.StagedDataExpirationInDays)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewRegisterS3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewRegisterS3TargetSpectraS3Response(response)
 }
 
 func (client *Client) DelegateCreateUserSpectraS3(ctx context.Context, request *models.DelegateCreateUserSpectraS3Request) (*models.DelegateCreateUserSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_POST).
-        WithPath("/_rest_/user").
-        WithQueryParam("name", request.Name).
-        WithOptionalQueryParam("default_data_policy_id", request.DefaultDataPolicyId).
-        WithOptionalQueryParam("id", request.Id).
-        WithOptionalQueryParam("max_buckets", networking.IntPtrToStrPtr(request.MaxBuckets)).
-        WithOptionalQueryParam("secret_key", request.SecretKey).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_POST).
+		WithPath("/_rest_/user").
+		WithQueryParam("name", request.Name).
+		WithOptionalQueryParam("default_data_policy_id", request.DefaultDataPolicyId).
+		WithOptionalQueryParam("id", request.Id).
+		WithOptionalQueryParam("max_buckets", networking.IntPtrToStrPtr(request.MaxBuckets)).
+		WithOptionalQueryParam("secret_key", request.SecretKey).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDelegateCreateUserSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDelegateCreateUserSpectraS3Response(response)
 }
-
-

--- a/ds3/ds3Puts.go
+++ b/ds3/ds3Puts.go
@@ -14,2802 +14,2800 @@
 package ds3
 
 import (
-    "context"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
-    "strconv"
+	"context"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+	"strconv"
 )
 
 func (client *Client) PutBucket(ctx context.Context, request *models.PutBucketRequest) (*models.PutBucketResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/" + request.BucketName).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/"+request.BucketName).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutBucketResponse(response)
+	// Create a response object based on the result.
+	return models.NewPutBucketResponse(response)
 }
 
 func (client *Client) PutMultiPartUploadPart(ctx context.Context, request *models.PutMultiPartUploadPartRequest) (*models.PutMultiPartUploadPartResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/" + request.BucketName + "/" + request.ObjectName).
-        WithQueryParam("part_number", strconv.Itoa(request.PartNumber)).
-        WithQueryParam("upload_id", request.UploadId).
-        WithReader(request.Content).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/"+request.BucketName+"/"+request.ObjectName).
+		WithQueryParam("part_number", strconv.Itoa(request.PartNumber)).
+		WithQueryParam("upload_id", request.UploadId).
+		WithReader(request.Content).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutMultiPartUploadPartResponse(response)
+	// Create a response object based on the result.
+	return models.NewPutMultiPartUploadPartResponse(response)
 }
 
 func (client *Client) PutObject(ctx context.Context, request *models.PutObjectRequest) (*models.PutObjectResponse, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/" + request.BucketName + "/" + request.ObjectName).
-        WithOptionalQueryParam("job", request.Job).
-        WithOptionalQueryParam("offset", networking.Int64PtrToStrPtr(request.Offset)).
-        WithReader(request.Content).
-        WithChecksum(request.Checksum).
-        WithHeaders(request.Metadata).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/"+request.BucketName+"/"+request.ObjectName).
+		WithOptionalQueryParam("job", request.Job).
+		WithOptionalQueryParam("offset", networking.Int64PtrToStrPtr(request.Offset)).
+		WithReader(request.Content).
+		WithChecksum(request.Checksum).
+		WithHeaders(request.Metadata).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutObjectResponse(response)
+	// Create a response object based on the result.
+	return models.NewPutObjectResponse(response)
 }
 
 func (client *Client) ModifyBucketSpectraS3(ctx context.Context, request *models.ModifyBucketSpectraS3Request) (*models.ModifyBucketSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
-        WithOptionalQueryParam("user_id", request.UserId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
+		WithOptionalQueryParam("user_id", request.UserId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyBucketSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyBucketSpectraS3Response(response)
 }
 
 func (client *Client) ForceFullCacheReclaimSpectraS3(ctx context.Context, request *models.ForceFullCacheReclaimSpectraS3Request) (*models.ForceFullCacheReclaimSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/cache_filesystem").
-        WithQueryParam("reclaim", "").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/cache_filesystem").
+		WithQueryParam("reclaim", "").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewForceFullCacheReclaimSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewForceFullCacheReclaimSpectraS3Response(response)
 }
 
 func (client *Client) ModifyCacheFilesystemSpectraS3(ctx context.Context, request *models.ModifyCacheFilesystemSpectraS3Request) (*models.ModifyCacheFilesystemSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/cache_filesystem/" + request.CacheFilesystem).
-        WithOptionalQueryParam("auto_reclaim_initiate_threshold", networking.Float64PtrToStrPtr(request.AutoReclaimInitiateThreshold)).
-        WithOptionalQueryParam("auto_reclaim_terminate_threshold", networking.Float64PtrToStrPtr(request.AutoReclaimTerminateThreshold)).
-        WithOptionalQueryParam("burst_threshold", networking.Float64PtrToStrPtr(request.BurstThreshold)).
-        WithOptionalQueryParam("cache_safety_enabled", networking.BoolPtrToStrPtr(request.CacheSafetyEnabled)).
-        WithOptionalQueryParam("max_capacity_in_bytes", networking.Int64PtrToStrPtr(request.MaxCapacityInBytes)).
-        WithOptionalQueryParam("needs_reconcile", networking.BoolPtrToStrPtr(request.NeedsReconcile)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/cache_filesystem/"+request.CacheFilesystem).
+		WithOptionalQueryParam("auto_reclaim_initiate_threshold", networking.Float64PtrToStrPtr(request.AutoReclaimInitiateThreshold)).
+		WithOptionalQueryParam("auto_reclaim_terminate_threshold", networking.Float64PtrToStrPtr(request.AutoReclaimTerminateThreshold)).
+		WithOptionalQueryParam("burst_threshold", networking.Float64PtrToStrPtr(request.BurstThreshold)).
+		WithOptionalQueryParam("cache_safety_enabled", networking.BoolPtrToStrPtr(request.CacheSafetyEnabled)).
+		WithOptionalQueryParam("max_capacity_in_bytes", networking.Int64PtrToStrPtr(request.MaxCapacityInBytes)).
+		WithOptionalQueryParam("needs_reconcile", networking.BoolPtrToStrPtr(request.NeedsReconcile)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyCacheFilesystemSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyCacheFilesystemSpectraS3Response(response)
 }
 
 func (client *Client) ModifyDataPathBackendSpectraS3(ctx context.Context, request *models.ModifyDataPathBackendSpectraS3Request) (*models.ModifyDataPathBackendSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/data_path_backend").
-        WithOptionalQueryParam("activated", networking.BoolPtrToStrPtr(request.Activated)).
-        WithOptionalQueryParam("allow_new_job_requests", networking.BoolPtrToStrPtr(request.AllowNewJobRequests)).
-        WithOptionalQueryParam("auto_activate_timeout_in_mins", networking.IntPtrToStrPtr(request.AutoActivateTimeoutInMins)).
-        WithOptionalQueryParam("auto_inspect", networking.InterfaceToStrPtr(request.AutoInspect)).
-        WithOptionalQueryParam("cache_available_retry_after_in_seconds", networking.IntPtrToStrPtr(request.CacheAvailableRetryAfterInSeconds)).
-        WithOptionalQueryParam("default_verify_data_after_import", networking.InterfaceToStrPtr(request.DefaultVerifyDataAfterImport)).
-        WithOptionalQueryParam("default_verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.DefaultVerifyDataPriorToImport)).
-        WithOptionalQueryParam("iom_cache_limitation_percent", networking.Float64PtrToStrPtr(request.IomCacheLimitationPercent)).
-        WithOptionalQueryParam("iom_enabled", networking.BoolPtrToStrPtr(request.IomEnabled)).
-        WithOptionalQueryParam("max_aggregated_blobs_per_chunk", networking.IntPtrToStrPtr(request.MaxAggregatedBlobsPerChunk)).
-        WithOptionalQueryParam("max_number_of_concurrent_jobs", networking.IntPtrToStrPtr(request.MaxNumberOfConcurrentJobs)).
-        WithOptionalQueryParam("partially_verify_last_percent_of_tapes", networking.IntPtrToStrPtr(request.PartiallyVerifyLastPercentOfTapes)).
-        WithOptionalQueryParam("pool_safety_enabled", networking.BoolPtrToStrPtr(request.PoolSafetyEnabled)).
-        WithOptionalQueryParam("unavailable_media_policy", networking.InterfaceToStrPtr(request.UnavailableMediaPolicy)).
-        WithOptionalQueryParam("unavailable_pool_max_job_retry_in_mins", networking.IntPtrToStrPtr(request.UnavailablePoolMaxJobRetryInMins)).
-        WithOptionalQueryParam("unavailable_tape_partition_max_job_retry_in_mins", networking.IntPtrToStrPtr(request.UnavailableTapePartitionMaxJobRetryInMins)).
-        WithOptionalQueryParam("verify_checkpoint_before_read", networking.BoolPtrToStrPtr(request.VerifyCheckpointBeforeRead)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/data_path_backend").
+		WithOptionalQueryParam("activated", networking.BoolPtrToStrPtr(request.Activated)).
+		WithOptionalQueryParam("allow_new_job_requests", networking.BoolPtrToStrPtr(request.AllowNewJobRequests)).
+		WithOptionalQueryParam("auto_activate_timeout_in_mins", networking.IntPtrToStrPtr(request.AutoActivateTimeoutInMins)).
+		WithOptionalQueryParam("auto_inspect", networking.InterfaceToStrPtr(request.AutoInspect)).
+		WithOptionalQueryParam("cache_available_retry_after_in_seconds", networking.IntPtrToStrPtr(request.CacheAvailableRetryAfterInSeconds)).
+		WithOptionalQueryParam("default_verify_data_after_import", networking.InterfaceToStrPtr(request.DefaultVerifyDataAfterImport)).
+		WithOptionalQueryParam("default_verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.DefaultVerifyDataPriorToImport)).
+		WithOptionalQueryParam("iom_cache_limitation_percent", networking.Float64PtrToStrPtr(request.IomCacheLimitationPercent)).
+		WithOptionalQueryParam("iom_enabled", networking.BoolPtrToStrPtr(request.IomEnabled)).
+		WithOptionalQueryParam("max_aggregated_blobs_per_chunk", networking.IntPtrToStrPtr(request.MaxAggregatedBlobsPerChunk)).
+		WithOptionalQueryParam("max_number_of_concurrent_jobs", networking.IntPtrToStrPtr(request.MaxNumberOfConcurrentJobs)).
+		WithOptionalQueryParam("partially_verify_last_percent_of_tapes", networking.IntPtrToStrPtr(request.PartiallyVerifyLastPercentOfTapes)).
+		WithOptionalQueryParam("pool_safety_enabled", networking.BoolPtrToStrPtr(request.PoolSafetyEnabled)).
+		WithOptionalQueryParam("unavailable_media_policy", networking.InterfaceToStrPtr(request.UnavailableMediaPolicy)).
+		WithOptionalQueryParam("unavailable_pool_max_job_retry_in_mins", networking.IntPtrToStrPtr(request.UnavailablePoolMaxJobRetryInMins)).
+		WithOptionalQueryParam("unavailable_tape_partition_max_job_retry_in_mins", networking.IntPtrToStrPtr(request.UnavailableTapePartitionMaxJobRetryInMins)).
+		WithOptionalQueryParam("verify_checkpoint_before_read", networking.BoolPtrToStrPtr(request.VerifyCheckpointBeforeRead)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyDataPathBackendSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyDataPathBackendSpectraS3Response(response)
 }
 
 func (client *Client) ModifyAzureDataReplicationRuleSpectraS3(ctx context.Context, request *models.ModifyAzureDataReplicationRuleSpectraS3Request) (*models.ModifyAzureDataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/azure_data_replication_rule/" + request.AzureDataReplicationRule).
-        WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
-        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/azure_data_replication_rule/"+request.AzureDataReplicationRule).
+		WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
+		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyAzureDataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyAzureDataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) ModifyDataPersistenceRuleSpectraS3(ctx context.Context, request *models.ModifyDataPersistenceRuleSpectraS3Request) (*models.ModifyDataPersistenceRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/data_persistence_rule/" + request.DataPersistenceRuleId).
-        WithOptionalQueryParam("isolation_level", networking.InterfaceToStrPtr(request.IsolationLevel)).
-        WithOptionalQueryParam("minimum_days_to_retain", networking.IntPtrToStrPtr(request.MinimumDaysToRetain)).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataPersistenceRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/data_persistence_rule/"+request.DataPersistenceRuleId).
+		WithOptionalQueryParam("isolation_level", networking.InterfaceToStrPtr(request.IsolationLevel)).
+		WithOptionalQueryParam("minimum_days_to_retain", networking.IntPtrToStrPtr(request.MinimumDaysToRetain)).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataPersistenceRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyDataPersistenceRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyDataPersistenceRuleSpectraS3Response(response)
 }
 
 func (client *Client) ModifyDataPolicySpectraS3(ctx context.Context, request *models.ModifyDataPolicySpectraS3Request) (*models.ModifyDataPolicySpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/data_policy/" + request.DataPolicyId).
-        WithOptionalQueryParam("always_force_put_job_creation", networking.BoolPtrToStrPtr(request.AlwaysForcePutJobCreation)).
-        WithOptionalQueryParam("always_minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.AlwaysMinimizeSpanningAcrossMedia)).
-        WithOptionalQueryParam("blobbing_enabled", networking.BoolPtrToStrPtr(request.BlobbingEnabled)).
-        WithOptionalQueryParam("checksum_type", networking.InterfaceToStrPtr(request.ChecksumType)).
-        WithOptionalQueryParam("default_blob_size", networking.Int64PtrToStrPtr(request.DefaultBlobSize)).
-        WithOptionalQueryParam("default_get_job_priority", networking.InterfaceToStrPtr(request.DefaultGetJobPriority)).
-        WithOptionalQueryParam("default_put_job_priority", networking.InterfaceToStrPtr(request.DefaultPutJobPriority)).
-        WithOptionalQueryParam("default_verify_after_write", networking.BoolPtrToStrPtr(request.DefaultVerifyAfterWrite)).
-        WithOptionalQueryParam("default_verify_job_priority", networking.InterfaceToStrPtr(request.DefaultVerifyJobPriority)).
-        WithOptionalQueryParam("end_to_end_crc_required", networking.BoolPtrToStrPtr(request.EndToEndCrcRequired)).
-        WithOptionalQueryParam("max_versions_to_keep", networking.IntPtrToStrPtr(request.MaxVersionsToKeep)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("rebuild_priority", networking.InterfaceToStrPtr(request.RebuildPriority)).
-        WithOptionalQueryParam("versioning", networking.InterfaceToStrPtr(request.Versioning)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/data_policy/"+request.DataPolicyId).
+		WithOptionalQueryParam("always_force_put_job_creation", networking.BoolPtrToStrPtr(request.AlwaysForcePutJobCreation)).
+		WithOptionalQueryParam("always_minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.AlwaysMinimizeSpanningAcrossMedia)).
+		WithOptionalQueryParam("blobbing_enabled", networking.BoolPtrToStrPtr(request.BlobbingEnabled)).
+		WithOptionalQueryParam("checksum_type", networking.InterfaceToStrPtr(request.ChecksumType)).
+		WithOptionalQueryParam("default_blob_size", networking.Int64PtrToStrPtr(request.DefaultBlobSize)).
+		WithOptionalQueryParam("default_get_job_priority", networking.InterfaceToStrPtr(request.DefaultGetJobPriority)).
+		WithOptionalQueryParam("default_put_job_priority", networking.InterfaceToStrPtr(request.DefaultPutJobPriority)).
+		WithOptionalQueryParam("default_verify_after_write", networking.BoolPtrToStrPtr(request.DefaultVerifyAfterWrite)).
+		WithOptionalQueryParam("default_verify_job_priority", networking.InterfaceToStrPtr(request.DefaultVerifyJobPriority)).
+		WithOptionalQueryParam("end_to_end_crc_required", networking.BoolPtrToStrPtr(request.EndToEndCrcRequired)).
+		WithOptionalQueryParam("max_versions_to_keep", networking.IntPtrToStrPtr(request.MaxVersionsToKeep)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("rebuild_priority", networking.InterfaceToStrPtr(request.RebuildPriority)).
+		WithOptionalQueryParam("versioning", networking.InterfaceToStrPtr(request.Versioning)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyDataPolicySpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyDataPolicySpectraS3Response(response)
 }
 
 func (client *Client) ModifyDs3DataReplicationRuleSpectraS3(ctx context.Context, request *models.ModifyDs3DataReplicationRuleSpectraS3Request) (*models.ModifyDs3DataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/ds3_data_replication_rule/" + request.Ds3DataReplicationRule).
-        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-        WithOptionalQueryParam("target_data_policy", request.TargetDataPolicy).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/ds3_data_replication_rule/"+request.Ds3DataReplicationRule).
+		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+		WithOptionalQueryParam("target_data_policy", request.TargetDataPolicy).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyDs3DataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyDs3DataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) ModifyS3DataReplicationRuleSpectraS3(ctx context.Context, request *models.ModifyS3DataReplicationRuleSpectraS3Request) (*models.ModifyS3DataReplicationRuleSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/s3_data_replication_rule/" + request.S3DataReplicationRule).
-        WithOptionalQueryParam("initial_data_placement", networking.InterfaceToStrPtr(request.InitialDataPlacement)).
-        WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
-        WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
-        WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/s3_data_replication_rule/"+request.S3DataReplicationRule).
+		WithOptionalQueryParam("initial_data_placement", networking.InterfaceToStrPtr(request.InitialDataPlacement)).
+		WithOptionalQueryParam("max_blob_part_size_in_bytes", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes)).
+		WithOptionalQueryParam("replicate_deletes", networking.BoolPtrToStrPtr(request.ReplicateDeletes)).
+		WithOptionalQueryParam("type", networking.InterfaceToStrPtr(request.DataReplicationRuleType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyS3DataReplicationRuleSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyS3DataReplicationRuleSpectraS3Response(response)
 }
 
 func (client *Client) MarkSuspectBlobAzureTargetsAsDegradedSpectraS3(ctx context.Context, request *models.MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/suspect_blob_azure_target").
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/suspect_blob_azure_target").
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithReadCloser(buildIdListPayload(request.Ids)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response(response)
 }
 
 func (client *Client) MarkSuspectBlobDs3TargetsAsDegradedSpectraS3(ctx context.Context, request *models.MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/suspect_blob_ds3_target").
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/suspect_blob_ds3_target").
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithReadCloser(buildIdListPayload(request.Ids)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response(response)
 }
 
 func (client *Client) MarkSuspectBlobPoolsAsDegradedSpectraS3(ctx context.Context, request *models.MarkSuspectBlobPoolsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobPoolsAsDegradedSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/suspect_blob_pool").
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/suspect_blob_pool").
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithReadCloser(buildIdListPayload(request.Ids)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewMarkSuspectBlobPoolsAsDegradedSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewMarkSuspectBlobPoolsAsDegradedSpectraS3Response(response)
 }
 
 func (client *Client) MarkSuspectBlobS3TargetsAsDegradedSpectraS3(ctx context.Context, request *models.MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request) (*models.MarkSuspectBlobS3TargetsAsDegradedSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/suspect_blob_s3_target").
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/suspect_blob_s3_target").
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithReadCloser(buildIdListPayload(request.Ids)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Response(response)
 }
 
 func (client *Client) MarkSuspectBlobTapesAsDegradedSpectraS3(ctx context.Context, request *models.MarkSuspectBlobTapesAsDegradedSpectraS3Request) (*models.MarkSuspectBlobTapesAsDegradedSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/suspect_blob_tape").
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithReadCloser(buildIdListPayload(request.Ids)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/suspect_blob_tape").
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithReadCloser(buildIdListPayload(request.Ids)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewMarkSuspectBlobTapesAsDegradedSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewMarkSuspectBlobTapesAsDegradedSpectraS3Response(response)
 }
 
 func (client *Client) ModifyGroupSpectraS3(ctx context.Context, request *models.ModifyGroupSpectraS3Request) (*models.ModifyGroupSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/group/" + request.Group).
-        WithOptionalQueryParam("name", request.Name).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/group/"+request.Group).
+		WithOptionalQueryParam("name", request.Name).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyGroupSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyGroupSpectraS3Response(response)
 }
 
 func (client *Client) VerifyUserIsMemberOfGroupSpectraS3(ctx context.Context, request *models.VerifyUserIsMemberOfGroupSpectraS3Request) (*models.VerifyUserIsMemberOfGroupSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/group/" + request.Group).
-        WithOptionalQueryParam("user_id", request.UserId).
-        WithQueryParam("operation", "verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/group/"+request.Group).
+		WithOptionalQueryParam("user_id", request.UserId).
+		WithQueryParam("operation", "verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifyUserIsMemberOfGroupSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifyUserIsMemberOfGroupSpectraS3Response(response)
 }
 
 func (client *Client) AllocateJobChunkSpectraS3(ctx context.Context, request *models.AllocateJobChunkSpectraS3Request) (*models.AllocateJobChunkSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/job_chunk/" + request.JobChunkId).
-        WithQueryParam("operation", "allocate").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/job_chunk/"+request.JobChunkId).
+		WithQueryParam("operation", "allocate").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewAllocateJobChunkSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewAllocateJobChunkSpectraS3Response(response)
 }
 
 func (client *Client) CloseAggregatingJobSpectraS3(ctx context.Context, request *models.CloseAggregatingJobSpectraS3Request) (*models.CloseAggregatingJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/job/" + request.JobId).
-        WithQueryParam("close_aggregating_job", "").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/job/"+request.JobId).
+		WithQueryParam("close_aggregating_job", "").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCloseAggregatingJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCloseAggregatingJobSpectraS3Response(response)
 }
 
 func (client *Client) GetBulkJobSpectraS3(ctx context.Context, request *models.GetBulkJobSpectraS3Request) (*models.GetBulkJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
-        WithOptionalQueryParam("chunk_client_processing_order_guarantee", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)).
-        WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
-        WithOptionalQueryParam("implicit_job_id_resolution", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
-        WithQueryParam("operation", "start_bulk_get").
-        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
+		WithOptionalQueryParam("chunk_client_processing_order_guarantee", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)).
+		WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
+		WithOptionalQueryParam("implicit_job_id_resolution", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
+		WithQueryParam("operation", "start_bulk_get").
+		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetBulkJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetBulkJobSpectraS3Response(response)
 }
 
 func (client *Client) PutBulkJobSpectraS3(ctx context.Context, request *models.PutBulkJobSpectraS3Request) (*models.PutBulkJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
-        WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithOptionalVoidQueryParam("ignore_naming_conflicts", request.IgnoreNamingConflicts).
-        WithOptionalQueryParam("implicit_job_id_resolution", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution)).
-        WithOptionalQueryParam("max_upload_size", networking.Int64PtrToStrPtr(request.MaxUploadSize)).
-        WithOptionalQueryParam("minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.MinimizeSpanningAcrossMedia)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalVoidQueryParam("pre_allocate_job_space", request.PreAllocateJobSpace).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
-        WithOptionalQueryParam("verify_after_write", networking.BoolPtrToStrPtr(request.VerifyAfterWrite)).
-        WithQueryParam("operation", "start_bulk_put").
-        WithReadCloser(buildDs3PutObjectListStream(request.Objects)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
+		WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithOptionalVoidQueryParam("ignore_naming_conflicts", request.IgnoreNamingConflicts).
+		WithOptionalQueryParam("implicit_job_id_resolution", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution)).
+		WithOptionalQueryParam("max_upload_size", networking.Int64PtrToStrPtr(request.MaxUploadSize)).
+		WithOptionalQueryParam("minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.MinimizeSpanningAcrossMedia)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalVoidQueryParam("pre_allocate_job_space", request.PreAllocateJobSpace).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
+		WithOptionalQueryParam("verify_after_write", networking.BoolPtrToStrPtr(request.VerifyAfterWrite)).
+		WithQueryParam("operation", "start_bulk_put").
+		WithReadCloser(buildDs3PutObjectListStream(request.Objects)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutBulkJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutBulkJobSpectraS3Response(response)
 }
 
 func (client *Client) VerifyBulkJobSpectraS3(ctx context.Context, request *models.VerifyBulkJobSpectraS3Request) (*models.VerifyBulkJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithQueryParam("operation", "start_bulk_verify").
-        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithQueryParam("operation", "start_bulk_verify").
+		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifyBulkJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifyBulkJobSpectraS3Response(response)
 }
 
 func (client *Client) ModifyActiveJobSpectraS3(ctx context.Context, request *models.ModifyActiveJobSpectraS3Request) (*models.ModifyActiveJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/active_job/" + request.ActiveJobId).
-        WithOptionalQueryParam("created_at", request.CreatedAt).
-        WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/active_job/"+request.ActiveJobId).
+		WithOptionalQueryParam("created_at", request.CreatedAt).
+		WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyActiveJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyActiveJobSpectraS3Response(response)
 }
 
 func (client *Client) ModifyJobSpectraS3(ctx context.Context, request *models.ModifyJobSpectraS3Request) (*models.ModifyJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/job/" + request.JobId).
-        WithOptionalQueryParam("created_at", request.CreatedAt).
-        WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/job/"+request.JobId).
+		WithOptionalQueryParam("created_at", request.CreatedAt).
+		WithOptionalQueryParam("dead_job_cleanup_allowed", networking.BoolPtrToStrPtr(request.DeadJobCleanupAllowed)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("protected", networking.BoolPtrToStrPtr(request.Protected)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyJobSpectraS3Response(response)
 }
 
 func (client *Client) ReplicatePutJobSpectraS3(ctx context.Context, request *models.ReplicatePutJobSpectraS3Request) (*models.ReplicatePutJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithQueryParam("replicate", "").
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithQueryParam("operation", "start_bulk_put").
-        WithReadCloser(buildStreamFromString(request.RequestPayload)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithQueryParam("replicate", "").
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithQueryParam("operation", "start_bulk_put").
+		WithReadCloser(buildStreamFromString(request.RequestPayload)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewReplicatePutJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewReplicatePutJobSpectraS3Response(response)
 }
 
 func (client *Client) StageObjectsJobSpectraS3(ctx context.Context, request *models.StageObjectsJobSpectraS3Request) (*models.StageObjectsJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithQueryParam("operation", "start_bulk_stage").
-        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithQueryParam("operation", "start_bulk_stage").
+		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewStageObjectsJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewStageObjectsJobSpectraS3Response(response)
 }
 
 func (client *Client) VerifySafeToCreatePutJobSpectraS3(ctx context.Context, request *models.VerifySafeToCreatePutJobSpectraS3Request) (*models.VerifySafeToCreatePutJobSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithQueryParam("operation", "verify_safe_to_start_bulk_put").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithQueryParam("operation", "verify_safe_to_start_bulk_put").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifySafeToCreatePutJobSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifySafeToCreatePutJobSpectraS3Response(response)
 }
 
 func (client *Client) ModifyNodeSpectraS3(ctx context.Context, request *models.ModifyNodeSpectraS3Request) (*models.ModifyNodeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/node/" + request.Node).
-        WithOptionalQueryParam("dns_name", request.DnsName).
-        WithOptionalQueryParam("name", request.Name).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/node/"+request.Node).
+		WithOptionalQueryParam("dns_name", request.DnsName).
+		WithOptionalQueryParam("name", request.Name).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyNodeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyNodeSpectraS3Response(response)
 }
 
 func (client *Client) GetPhysicalPlacementForObjectsSpectraS3(ctx context.Context, request *models.GetPhysicalPlacementForObjectsSpectraS3Request) (*models.GetPhysicalPlacementForObjectsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithOptionalQueryParam("storage_domain", request.StorageDomain).
-        WithQueryParam("operation", "get_physical_placement").
-        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithOptionalQueryParam("storage_domain", request.StorageDomain).
+		WithQueryParam("operation", "get_physical_placement").
+		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetPhysicalPlacementForObjectsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetPhysicalPlacementForObjectsSpectraS3Response(response)
 }
 
 func (client *Client) GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3(ctx context.Context, request *models.GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request) (*models.GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/bucket/" + request.BucketName).
-        WithQueryParam("full_details", "").
-        WithOptionalQueryParam("storage_domain", request.StorageDomain).
-        WithQueryParam("operation", "get_physical_placement").
-        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/bucket/"+request.BucketName).
+		WithQueryParam("full_details", "").
+		WithOptionalQueryParam("storage_domain", request.StorageDomain).
+		WithQueryParam("operation", "get_physical_placement").
+		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response(response)
 }
 
 func (client *Client) UndeleteObjectSpectraS3(ctx context.Context, request *models.UndeleteObjectSpectraS3Request) (*models.UndeleteObjectSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/object").
-        WithQueryParam("bucket_id", request.BucketId).
-        WithQueryParam("name", request.Name).
-        WithOptionalQueryParam("version_id", request.VersionId).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/object").
+		WithQueryParam("bucket_id", request.BucketId).
+		WithQueryParam("name", request.Name).
+		WithOptionalQueryParam("version_id", request.VersionId).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewUndeleteObjectSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewUndeleteObjectSpectraS3Response(response)
 }
 
 func (client *Client) CancelImportOnAllPoolsSpectraS3(ctx context.Context, request *models.CancelImportOnAllPoolsSpectraS3Request) (*models.CancelImportOnAllPoolsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool").
-        WithQueryParam("operation", "cancel_import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool").
+		WithQueryParam("operation", "cancel_import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelImportOnAllPoolsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelImportOnAllPoolsSpectraS3Response(response)
 }
 
 func (client *Client) CancelImportPoolSpectraS3(ctx context.Context, request *models.CancelImportPoolSpectraS3Request) (*models.CancelImportPoolSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool/" + request.Pool).
-        WithQueryParam("operation", "cancel_import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool/"+request.Pool).
+		WithQueryParam("operation", "cancel_import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelImportPoolSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelImportPoolSpectraS3Response(response)
 }
 
 func (client *Client) CancelVerifyOnAllPoolsSpectraS3(ctx context.Context, request *models.CancelVerifyOnAllPoolsSpectraS3Request) (*models.CancelVerifyOnAllPoolsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool").
-        WithQueryParam("operation", "cancel_verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool").
+		WithQueryParam("operation", "cancel_verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelVerifyOnAllPoolsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelVerifyOnAllPoolsSpectraS3Response(response)
 }
 
 func (client *Client) CancelVerifyPoolSpectraS3(ctx context.Context, request *models.CancelVerifyPoolSpectraS3Request) (*models.CancelVerifyPoolSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool/" + request.Pool).
-        WithQueryParam("operation", "cancel_verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool/"+request.Pool).
+		WithQueryParam("operation", "cancel_verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelVerifyPoolSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelVerifyPoolSpectraS3Response(response)
 }
 
 func (client *Client) CompactAllPoolsSpectraS3(ctx context.Context, request *models.CompactAllPoolsSpectraS3Request) (*models.CompactAllPoolsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool").
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithQueryParam("operation", "compact").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool").
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithQueryParam("operation", "compact").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCompactAllPoolsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCompactAllPoolsSpectraS3Response(response)
 }
 
 func (client *Client) CompactPoolSpectraS3(ctx context.Context, request *models.CompactPoolSpectraS3Request) (*models.CompactPoolSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool/" + request.Pool).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithQueryParam("operation", "compact").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool/"+request.Pool).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithQueryParam("operation", "compact").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCompactPoolSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCompactPoolSpectraS3Response(response)
 }
 
 func (client *Client) DeallocatePoolSpectraS3(ctx context.Context, request *models.DeallocatePoolSpectraS3Request) (*models.DeallocatePoolSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool/" + request.Pool).
-        WithQueryParam("operation", "deallocate").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool/"+request.Pool).
+		WithQueryParam("operation", "deallocate").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewDeallocatePoolSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewDeallocatePoolSpectraS3Response(response)
 }
 
 func (client *Client) ForcePoolEnvironmentRefreshSpectraS3(ctx context.Context, request *models.ForcePoolEnvironmentRefreshSpectraS3Request) (*models.ForcePoolEnvironmentRefreshSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool_environment").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool_environment").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewForcePoolEnvironmentRefreshSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewForcePoolEnvironmentRefreshSpectraS3Response(response)
 }
 
 func (client *Client) FormatAllForeignPoolsSpectraS3(ctx context.Context, request *models.FormatAllForeignPoolsSpectraS3Request) (*models.FormatAllForeignPoolsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool").
-        WithQueryParam("operation", "format").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool").
+		WithQueryParam("operation", "format").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewFormatAllForeignPoolsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewFormatAllForeignPoolsSpectraS3Response(response)
 }
 
 func (client *Client) FormatForeignPoolSpectraS3(ctx context.Context, request *models.FormatForeignPoolSpectraS3Request) (*models.FormatForeignPoolSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool/" + request.Pool).
-        WithQueryParam("operation", "format").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool/"+request.Pool).
+		WithQueryParam("operation", "format").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewFormatForeignPoolSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewFormatForeignPoolSpectraS3Response(response)
 }
 
 func (client *Client) ImportAllPoolsSpectraS3(ctx context.Context, request *models.ImportAllPoolsSpectraS3Request) (*models.ImportAllPoolsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("user_id", request.UserId).
-        WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
-        WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
-        WithQueryParam("operation", "import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("user_id", request.UserId).
+		WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
+		WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
+		WithQueryParam("operation", "import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewImportAllPoolsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewImportAllPoolsSpectraS3Response(response)
 }
 
 func (client *Client) ImportPoolSpectraS3(ctx context.Context, request *models.ImportPoolSpectraS3Request) (*models.ImportPoolSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool/" + request.Pool).
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("user_id", request.UserId).
-        WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
-        WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
-        WithQueryParam("operation", "import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool/"+request.Pool).
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("user_id", request.UserId).
+		WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
+		WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
+		WithQueryParam("operation", "import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewImportPoolSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewImportPoolSpectraS3Response(response)
 }
 
 func (client *Client) ModifyAllPoolsSpectraS3(ctx context.Context, request *models.ModifyAllPoolsSpectraS3Request) (*models.ModifyAllPoolsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool").
-        WithQueryParam("quiesced", request.Quiesced.String()).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool").
+		WithQueryParam("quiesced", request.Quiesced.String()).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyAllPoolsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyAllPoolsSpectraS3Response(response)
 }
 
 func (client *Client) ModifyPoolPartitionSpectraS3(ctx context.Context, request *models.ModifyPoolPartitionSpectraS3Request) (*models.ModifyPoolPartitionSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool_partition/" + request.PoolPartition).
-        WithOptionalQueryParam("name", request.Name).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool_partition/"+request.PoolPartition).
+		WithOptionalQueryParam("name", request.Name).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyPoolPartitionSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyPoolPartitionSpectraS3Response(response)
 }
 
 func (client *Client) ModifyPoolSpectraS3(ctx context.Context, request *models.ModifyPoolSpectraS3Request) (*models.ModifyPoolSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool/" + request.Pool).
-        WithOptionalQueryParam("partition_id", request.PartitionId).
-        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool/"+request.Pool).
+		WithOptionalQueryParam("partition_id", request.PartitionId).
+		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyPoolSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyPoolSpectraS3Response(response)
 }
 
 func (client *Client) VerifyAllPoolsSpectraS3(ctx context.Context, request *models.VerifyAllPoolsSpectraS3Request) (*models.VerifyAllPoolsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool").
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithQueryParam("operation", "verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool").
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithQueryParam("operation", "verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifyAllPoolsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifyAllPoolsSpectraS3Response(response)
 }
 
 func (client *Client) VerifyPoolSpectraS3(ctx context.Context, request *models.VerifyPoolSpectraS3Request) (*models.VerifyPoolSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/pool/" + request.Pool).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithQueryParam("operation", "verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/pool/"+request.Pool).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithQueryParam("operation", "verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifyPoolSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifyPoolSpectraS3Response(response)
 }
 
 func (client *Client) ConvertStorageDomainToDs3TargetSpectraS3(ctx context.Context, request *models.ConvertStorageDomainToDs3TargetSpectraS3Request) (*models.ConvertStorageDomainToDs3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/storage_domain/" + request.StorageDomain).
-        WithQueryParam("convert_to_ds3_target", request.ConvertToDs3Target).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/storage_domain/"+request.StorageDomain).
+		WithQueryParam("convert_to_ds3_target", request.ConvertToDs3Target).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewConvertStorageDomainToDs3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewConvertStorageDomainToDs3TargetSpectraS3Response(response)
 }
 
 func (client *Client) ModifyStorageDomainMemberSpectraS3(ctx context.Context, request *models.ModifyStorageDomainMemberSpectraS3Request) (*models.ModifyStorageDomainMemberSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/storage_domain_member/" + request.StorageDomainMember).
-        WithOptionalQueryParam("auto_compaction_threshold", networking.IntPtrToStrPtr(request.AutoCompactionThreshold)).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/storage_domain_member/"+request.StorageDomainMember).
+		WithOptionalQueryParam("auto_compaction_threshold", networking.IntPtrToStrPtr(request.AutoCompactionThreshold)).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		WithOptionalQueryParam("write_preference", networking.InterfaceToStrPtr(request.WritePreference)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyStorageDomainMemberSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyStorageDomainMemberSpectraS3Response(response)
 }
 
 func (client *Client) ModifyStorageDomainSpectraS3(ctx context.Context, request *models.ModifyStorageDomainSpectraS3Request) (*models.ModifyStorageDomainSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/storage_domain/" + request.StorageDomain).
-        WithOptionalQueryParam("auto_eject_media_full_threshold", networking.Int64PtrToStrPtr(request.AutoEjectMediaFullThreshold)).
-        WithOptionalQueryParam("auto_eject_upon_cron", request.AutoEjectUponCron).
-        WithOptionalQueryParam("auto_eject_upon_job_cancellation", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCancellation)).
-        WithOptionalQueryParam("auto_eject_upon_job_completion", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCompletion)).
-        WithOptionalQueryParam("auto_eject_upon_media_full", networking.BoolPtrToStrPtr(request.AutoEjectUponMediaFull)).
-        WithOptionalQueryParam("ltfs_file_naming", networking.InterfaceToStrPtr(request.LtfsFileNaming)).
-        WithOptionalQueryParam("max_tape_fragmentation_percent", networking.IntPtrToStrPtr(request.MaxTapeFragmentationPercent)).
-        WithOptionalQueryParam("maximum_auto_verification_frequency_in_days", networking.IntPtrToStrPtr(request.MaximumAutoVerificationFrequencyInDays)).
-        WithOptionalQueryParam("media_ejection_allowed", networking.BoolPtrToStrPtr(request.MediaEjectionAllowed)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("secure_media_allocation", networking.BoolPtrToStrPtr(request.SecureMediaAllocation)).
-        WithOptionalQueryParam("verify_prior_to_auto_eject", networking.InterfaceToStrPtr(request.VerifyPriorToAutoEject)).
-        WithOptionalQueryParam("write_optimization", networking.InterfaceToStrPtr(request.WriteOptimization)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/storage_domain/"+request.StorageDomain).
+		WithOptionalQueryParam("auto_eject_media_full_threshold", networking.Int64PtrToStrPtr(request.AutoEjectMediaFullThreshold)).
+		WithOptionalQueryParam("auto_eject_upon_cron", request.AutoEjectUponCron).
+		WithOptionalQueryParam("auto_eject_upon_job_cancellation", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCancellation)).
+		WithOptionalQueryParam("auto_eject_upon_job_completion", networking.BoolPtrToStrPtr(request.AutoEjectUponJobCompletion)).
+		WithOptionalQueryParam("auto_eject_upon_media_full", networking.BoolPtrToStrPtr(request.AutoEjectUponMediaFull)).
+		WithOptionalQueryParam("ltfs_file_naming", networking.InterfaceToStrPtr(request.LtfsFileNaming)).
+		WithOptionalQueryParam("max_tape_fragmentation_percent", networking.IntPtrToStrPtr(request.MaxTapeFragmentationPercent)).
+		WithOptionalQueryParam("maximum_auto_verification_frequency_in_days", networking.IntPtrToStrPtr(request.MaximumAutoVerificationFrequencyInDays)).
+		WithOptionalQueryParam("media_ejection_allowed", networking.BoolPtrToStrPtr(request.MediaEjectionAllowed)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("secure_media_allocation", networking.BoolPtrToStrPtr(request.SecureMediaAllocation)).
+		WithOptionalQueryParam("verify_prior_to_auto_eject", networking.InterfaceToStrPtr(request.VerifyPriorToAutoEject)).
+		WithOptionalQueryParam("write_optimization", networking.InterfaceToStrPtr(request.WriteOptimization)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyStorageDomainSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyStorageDomainSpectraS3Response(response)
 }
 
 func (client *Client) ForceFeatureKeyValidationSpectraS3(ctx context.Context, request *models.ForceFeatureKeyValidationSpectraS3Request) (*models.ForceFeatureKeyValidationSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/feature_key").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/feature_key").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewForceFeatureKeyValidationSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewForceFeatureKeyValidationSpectraS3Response(response)
 }
 
 func (client *Client) ResetInstanceIdentifierSpectraS3(ctx context.Context, request *models.ResetInstanceIdentifierSpectraS3Request) (*models.ResetInstanceIdentifierSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/instance_identifier").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/instance_identifier").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewResetInstanceIdentifierSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewResetInstanceIdentifierSpectraS3Response(response)
 }
 
 func (client *Client) CancelEjectOnAllTapesSpectraS3(ctx context.Context, request *models.CancelEjectOnAllTapesSpectraS3Request) (*models.CancelEjectOnAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithQueryParam("operation", "cancel_eject").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithQueryParam("operation", "cancel_eject").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelEjectOnAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelEjectOnAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) CancelEjectTapeSpectraS3(ctx context.Context, request *models.CancelEjectTapeSpectraS3Request) (*models.CancelEjectTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithQueryParam("operation", "cancel_eject").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithQueryParam("operation", "cancel_eject").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelEjectTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelEjectTapeSpectraS3Response(response)
 }
 
 func (client *Client) CancelFormatOnAllTapesSpectraS3(ctx context.Context, request *models.CancelFormatOnAllTapesSpectraS3Request) (*models.CancelFormatOnAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithQueryParam("operation", "cancel_format").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithQueryParam("operation", "cancel_format").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelFormatOnAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelFormatOnAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) CancelFormatTapeSpectraS3(ctx context.Context, request *models.CancelFormatTapeSpectraS3Request) (*models.CancelFormatTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithQueryParam("operation", "cancel_format").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithQueryParam("operation", "cancel_format").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelFormatTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelFormatTapeSpectraS3Response(response)
 }
 
 func (client *Client) CancelImportOnAllTapesSpectraS3(ctx context.Context, request *models.CancelImportOnAllTapesSpectraS3Request) (*models.CancelImportOnAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithQueryParam("operation", "cancel_import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithQueryParam("operation", "cancel_import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelImportOnAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelImportOnAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) CancelImportTapeSpectraS3(ctx context.Context, request *models.CancelImportTapeSpectraS3Request) (*models.CancelImportTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithQueryParam("operation", "cancel_import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithQueryParam("operation", "cancel_import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelImportTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelImportTapeSpectraS3Response(response)
 }
 
 func (client *Client) CancelOnlineOnAllTapesSpectraS3(ctx context.Context, request *models.CancelOnlineOnAllTapesSpectraS3Request) (*models.CancelOnlineOnAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithQueryParam("operation", "cancel_online").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithQueryParam("operation", "cancel_online").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelOnlineOnAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelOnlineOnAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) CancelOnlineTapeSpectraS3(ctx context.Context, request *models.CancelOnlineTapeSpectraS3Request) (*models.CancelOnlineTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithQueryParam("operation", "cancel_online").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithQueryParam("operation", "cancel_online").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelOnlineTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelOnlineTapeSpectraS3Response(response)
 }
 
 func (client *Client) CancelTestTapeDriveSpectraS3(ctx context.Context, request *models.CancelTestTapeDriveSpectraS3Request) (*models.CancelTestTapeDriveSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
-        WithQueryParam("operation", "cancel_test").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
+		WithQueryParam("operation", "cancel_test").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelTestTapeDriveSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelTestTapeDriveSpectraS3Response(response)
 }
 
 func (client *Client) CancelVerifyOnAllTapesSpectraS3(ctx context.Context, request *models.CancelVerifyOnAllTapesSpectraS3Request) (*models.CancelVerifyOnAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithQueryParam("operation", "cancel_verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithQueryParam("operation", "cancel_verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelVerifyOnAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelVerifyOnAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) CancelVerifyTapeSpectraS3(ctx context.Context, request *models.CancelVerifyTapeSpectraS3Request) (*models.CancelVerifyTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithQueryParam("operation", "cancel_verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithQueryParam("operation", "cancel_verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCancelVerifyTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCancelVerifyTapeSpectraS3Response(response)
 }
 
 func (client *Client) CleanTapeDriveSpectraS3(ctx context.Context, request *models.CleanTapeDriveSpectraS3Request) (*models.CleanTapeDriveSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
-        WithQueryParam("operation", "clean").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
+		WithQueryParam("operation", "clean").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewCleanTapeDriveSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewCleanTapeDriveSpectraS3Response(response)
 }
 
 func (client *Client) PutDriveDumpSpectraS3(ctx context.Context, request *models.PutDriveDumpSpectraS3Request) (*models.PutDriveDumpSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
-        WithQueryParam("operation", "dump").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
+		WithQueryParam("operation", "dump").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPutDriveDumpSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPutDriveDumpSpectraS3Response(response)
 }
 
 func (client *Client) EjectAllTapesSpectraS3(ctx context.Context, request *models.EjectAllTapesSpectraS3Request) (*models.EjectAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithOptionalQueryParam("eject_label", request.EjectLabel).
-        WithOptionalQueryParam("eject_location", request.EjectLocation).
-        WithQueryParam("operation", "eject").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithOptionalQueryParam("eject_label", request.EjectLabel).
+		WithOptionalQueryParam("eject_location", request.EjectLocation).
+		WithQueryParam("operation", "eject").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewEjectAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewEjectAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) EjectStorageDomainBlobsSpectraS3(ctx context.Context, request *models.EjectStorageDomainBlobsSpectraS3Request) (*models.EjectStorageDomainBlobsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithQueryParam("blobs", "").
-        WithQueryParam("bucket_id", request.BucketId).
-        WithQueryParam("storage_domain", request.StorageDomain).
-        WithOptionalQueryParam("eject_label", request.EjectLabel).
-        WithOptionalQueryParam("eject_location", request.EjectLocation).
-        WithQueryParam("operation", "eject").
-        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithQueryParam("blobs", "").
+		WithQueryParam("bucket_id", request.BucketId).
+		WithQueryParam("storage_domain", request.StorageDomain).
+		WithOptionalQueryParam("eject_label", request.EjectLabel).
+		WithOptionalQueryParam("eject_location", request.EjectLocation).
+		WithQueryParam("operation", "eject").
+		WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewEjectStorageDomainBlobsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewEjectStorageDomainBlobsSpectraS3Response(response)
 }
 
 func (client *Client) EjectStorageDomainSpectraS3(ctx context.Context, request *models.EjectStorageDomainSpectraS3Request) (*models.EjectStorageDomainSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithQueryParam("storage_domain", request.StorageDomain).
-        WithOptionalQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("eject_label", request.EjectLabel).
-        WithOptionalQueryParam("eject_location", request.EjectLocation).
-        WithQueryParam("operation", "eject").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithQueryParam("storage_domain", request.StorageDomain).
+		WithOptionalQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("eject_label", request.EjectLabel).
+		WithOptionalQueryParam("eject_location", request.EjectLocation).
+		WithQueryParam("operation", "eject").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewEjectStorageDomainSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewEjectStorageDomainSpectraS3Response(response)
 }
 
 func (client *Client) EjectTapeSpectraS3(ctx context.Context, request *models.EjectTapeSpectraS3Request) (*models.EjectTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithOptionalQueryParam("eject_label", request.EjectLabel).
-        WithOptionalQueryParam("eject_location", request.EjectLocation).
-        WithQueryParam("operation", "eject").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithOptionalQueryParam("eject_label", request.EjectLabel).
+		WithOptionalQueryParam("eject_location", request.EjectLocation).
+		WithQueryParam("operation", "eject").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewEjectTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewEjectTapeSpectraS3Response(response)
 }
 
 func (client *Client) ForceTapeEnvironmentRefreshSpectraS3(ctx context.Context, request *models.ForceTapeEnvironmentRefreshSpectraS3Request) (*models.ForceTapeEnvironmentRefreshSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape_environment").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape_environment").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewForceTapeEnvironmentRefreshSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewForceTapeEnvironmentRefreshSpectraS3Response(response)
 }
 
 func (client *Client) FormatAllTapesSpectraS3(ctx context.Context, request *models.FormatAllTapesSpectraS3Request) (*models.FormatAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithQueryParam("operation", "format").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithQueryParam("operation", "format").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewFormatAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewFormatAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) FormatTapeSpectraS3(ctx context.Context, request *models.FormatTapeSpectraS3Request) (*models.FormatTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithOptionalVoidQueryParam("force", request.Force).
-        WithQueryParam("operation", "format").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithOptionalVoidQueryParam("force", request.Force).
+		WithQueryParam("operation", "format").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewFormatTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewFormatTapeSpectraS3Response(response)
 }
 
 func (client *Client) ImportAllTapesSpectraS3(ctx context.Context, request *models.ImportAllTapesSpectraS3Request) (*models.ImportAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("user_id", request.UserId).
-        WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
-        WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
-        WithQueryParam("operation", "import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("user_id", request.UserId).
+		WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
+		WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
+		WithQueryParam("operation", "import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewImportAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewImportAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) ImportTapeSpectraS3(ctx context.Context, request *models.ImportTapeSpectraS3Request) (*models.ImportTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("user_id", request.UserId).
-        WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
-        WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
-        WithQueryParam("operation", "import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("user_id", request.UserId).
+		WithOptionalQueryParam("verify_data_after_import", networking.InterfaceToStrPtr(request.VerifyDataAfterImport)).
+		WithOptionalQueryParam("verify_data_prior_to_import", networking.BoolPtrToStrPtr(request.VerifyDataPriorToImport)).
+		WithQueryParam("operation", "import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewImportTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewImportTapeSpectraS3Response(response)
 }
 
 func (client *Client) InspectAllTapesSpectraS3(ctx context.Context, request *models.InspectAllTapesSpectraS3Request) (*models.InspectAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-        WithQueryParam("operation", "inspect").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+		WithQueryParam("operation", "inspect").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewInspectAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewInspectAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) InspectTapeSpectraS3(ctx context.Context, request *models.InspectTapeSpectraS3Request) (*models.InspectTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-        WithQueryParam("operation", "inspect").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+		WithQueryParam("operation", "inspect").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewInspectTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewInspectTapeSpectraS3Response(response)
 }
 
 func (client *Client) MarkTapeForCompactionSpectraS3(ctx context.Context, request *models.MarkTapeForCompactionSpectraS3Request) (*models.MarkTapeForCompactionSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithQueryParam("operation", "mark_for_compaction").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithQueryParam("operation", "mark_for_compaction").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewMarkTapeForCompactionSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewMarkTapeForCompactionSpectraS3Response(response)
 }
 
 func (client *Client) ModifyAllTapePartitionsSpectraS3(ctx context.Context, request *models.ModifyAllTapePartitionsSpectraS3Request) (*models.ModifyAllTapePartitionsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape_partition").
-        WithQueryParam("quiesced", request.Quiesced.String()).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape_partition").
+		WithQueryParam("quiesced", request.Quiesced.String()).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyAllTapePartitionsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyAllTapePartitionsSpectraS3Response(response)
 }
 
 func (client *Client) ModifyTapeDriveSpectraS3(ctx context.Context, request *models.ModifyTapeDriveSpectraS3Request) (*models.ModifyTapeDriveSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
-        WithOptionalQueryParam("max_failed_tapes", networking.IntPtrToStrPtr(request.MaxFailedTapes)).
-        WithOptionalQueryParam("minimum_task_priority", networking.InterfaceToStrPtr(request.MinimumTaskPriority)).
-        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-        WithOptionalQueryParam("reserved_task_type", networking.InterfaceToStrPtr(request.ReservedTaskType)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
+		WithOptionalQueryParam("max_failed_tapes", networking.IntPtrToStrPtr(request.MaxFailedTapes)).
+		WithOptionalQueryParam("minimum_task_priority", networking.InterfaceToStrPtr(request.MinimumTaskPriority)).
+		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+		WithOptionalQueryParam("reserved_task_type", networking.InterfaceToStrPtr(request.ReservedTaskType)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyTapeDriveSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyTapeDriveSpectraS3Response(response)
 }
 
 func (client *Client) ModifyTapePartitionSpectraS3(ctx context.Context, request *models.ModifyTapePartitionSpectraS3Request) (*models.ModifyTapePartitionSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape_partition/" + request.TapePartition).
-        WithOptionalQueryParam("auto_compaction_enabled", networking.BoolPtrToStrPtr(request.AutoCompactionEnabled)).
-        WithOptionalQueryParam("auto_quiesce_enabled", networking.BoolPtrToStrPtr(request.AutoQuiesceEnabled)).
-        WithOptionalQueryParam("drive_idle_timeout_in_minutes", networking.IntPtrToStrPtr(request.DriveIdleTimeoutInMinutes)).
-        WithOptionalQueryParam("minimum_read_reserved_drives", networking.IntPtrToStrPtr(request.MinimumReadReservedDrives)).
-        WithOptionalQueryParam("minimum_write_reserved_drives", networking.IntPtrToStrPtr(request.MinimumWriteReservedDrives)).
-        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-        WithOptionalQueryParam("serial_number", request.SerialNumber).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape_partition/"+request.TapePartition).
+		WithOptionalQueryParam("auto_compaction_enabled", networking.BoolPtrToStrPtr(request.AutoCompactionEnabled)).
+		WithOptionalQueryParam("auto_quiesce_enabled", networking.BoolPtrToStrPtr(request.AutoQuiesceEnabled)).
+		WithOptionalQueryParam("drive_idle_timeout_in_minutes", networking.IntPtrToStrPtr(request.DriveIdleTimeoutInMinutes)).
+		WithOptionalQueryParam("minimum_read_reserved_drives", networking.IntPtrToStrPtr(request.MinimumReadReservedDrives)).
+		WithOptionalQueryParam("minimum_write_reserved_drives", networking.IntPtrToStrPtr(request.MinimumWriteReservedDrives)).
+		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+		WithOptionalQueryParam("serial_number", request.SerialNumber).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyTapePartitionSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyTapePartitionSpectraS3Response(response)
 }
 
 func (client *Client) ModifyTapeSpectraS3(ctx context.Context, request *models.ModifyTapeSpectraS3Request) (*models.ModifyTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithOptionalQueryParam("eject_label", request.EjectLabel).
-        WithOptionalQueryParam("eject_location", request.EjectLocation).
-        WithOptionalQueryParam("role", networking.InterfaceToStrPtr(request.Role)).
-        WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithOptionalQueryParam("eject_label", request.EjectLabel).
+		WithOptionalQueryParam("eject_location", request.EjectLocation).
+		WithOptionalQueryParam("role", networking.InterfaceToStrPtr(request.Role)).
+		WithOptionalQueryParam("state", networking.InterfaceToStrPtr(request.State)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyTapeSpectraS3Response(response)
 }
 
 func (client *Client) OnlineAllTapesSpectraS3(ctx context.Context, request *models.OnlineAllTapesSpectraS3Request) (*models.OnlineAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithQueryParam("operation", "online").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithQueryParam("operation", "online").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewOnlineAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewOnlineAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) OnlineTapeSpectraS3(ctx context.Context, request *models.OnlineTapeSpectraS3Request) (*models.OnlineTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithQueryParam("operation", "online").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithQueryParam("operation", "online").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewOnlineTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewOnlineTapeSpectraS3Response(response)
 }
 
 func (client *Client) RawImportAllTapesSpectraS3(ctx context.Context, request *models.RawImportAllTapesSpectraS3Request) (*models.RawImportAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-        WithQueryParam("operation", "import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+		WithQueryParam("operation", "import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewRawImportAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewRawImportAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) RawImportTapeSpectraS3(ctx context.Context, request *models.RawImportTapeSpectraS3Request) (*models.RawImportTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithQueryParam("bucket_id", request.BucketId).
-        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
-        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-        WithQueryParam("operation", "import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithQueryParam("bucket_id", request.BucketId).
+		WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
+		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+		WithQueryParam("operation", "import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewRawImportTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewRawImportTapeSpectraS3Response(response)
 }
 
 func (client *Client) TestTapeDriveSpectraS3(ctx context.Context, request *models.TestTapeDriveSpectraS3Request) (*models.TestTapeDriveSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape_drive/" + request.TapeDriveId).
-        WithOptionalVoidQueryParam("skip_clean", request.SkipClean).
-        WithOptionalQueryParam("tape_id", request.TapeId).
-        WithQueryParam("operation", "test").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape_drive/"+request.TapeDriveId).
+		WithOptionalVoidQueryParam("skip_clean", request.SkipClean).
+		WithOptionalQueryParam("tape_id", request.TapeId).
+		WithQueryParam("operation", "test").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewTestTapeDriveSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewTestTapeDriveSpectraS3Response(response)
 }
 
 func (client *Client) VerifyAllTapesSpectraS3(ctx context.Context, request *models.VerifyAllTapesSpectraS3Request) (*models.VerifyAllTapesSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape").
-        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-        WithQueryParam("operation", "verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape").
+		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+		WithQueryParam("operation", "verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifyAllTapesSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifyAllTapesSpectraS3Response(response)
 }
 
 func (client *Client) VerifyTapeSpectraS3(ctx context.Context, request *models.VerifyTapeSpectraS3Request) (*models.VerifyTapeSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/tape/" + request.TapeId).
-        WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
-        WithQueryParam("operation", "verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/tape/"+request.TapeId).
+		WithOptionalQueryParam("task_priority", networking.InterfaceToStrPtr(request.TaskPriority)).
+		WithQueryParam("operation", "verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifyTapeSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifyTapeSpectraS3Response(response)
 }
 
 func (client *Client) ForceTargetEnvironmentRefreshSpectraS3(ctx context.Context, request *models.ForceTargetEnvironmentRefreshSpectraS3Request) (*models.ForceTargetEnvironmentRefreshSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/target_environment").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/target_environment").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewForceTargetEnvironmentRefreshSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewForceTargetEnvironmentRefreshSpectraS3Response(response)
 }
 
 func (client *Client) ImportAzureTargetSpectraS3(ctx context.Context, request *models.ImportAzureTargetSpectraS3Request) (*models.ImportAzureTargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/azure_target/" + request.AzureTarget).
-        WithQueryParam("cloud_bucket_name", request.CloudBucketName).
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("user_id", request.UserId).
-        WithQueryParam("operation", "import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/azure_target/"+request.AzureTarget).
+		WithQueryParam("cloud_bucket_name", request.CloudBucketName).
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("user_id", request.UserId).
+		WithQueryParam("operation", "import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewImportAzureTargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewImportAzureTargetSpectraS3Response(response)
 }
 
 func (client *Client) ModifyAllAzureTargetsSpectraS3(ctx context.Context, request *models.ModifyAllAzureTargetsSpectraS3Request) (*models.ModifyAllAzureTargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/azure_target").
-        WithQueryParam("quiesced", request.Quiesced.String()).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/azure_target").
+		WithQueryParam("quiesced", request.Quiesced.String()).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyAllAzureTargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyAllAzureTargetsSpectraS3Response(response)
 }
 
 func (client *Client) ModifyAzureTargetSpectraS3(ctx context.Context, request *models.ModifyAzureTargetSpectraS3Request) (*models.ModifyAzureTargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/azure_target/" + request.AzureTarget).
-        WithOptionalQueryParam("account_key", request.AccountKey).
-        WithOptionalQueryParam("account_name", request.AccountName).
-        WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
-        WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
-        WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
-        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-        WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/azure_target/"+request.AzureTarget).
+		WithOptionalQueryParam("account_key", request.AccountKey).
+		WithOptionalQueryParam("account_name", request.AccountName).
+		WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
+		WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
+		WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
+		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+		WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyAzureTargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyAzureTargetSpectraS3Response(response)
 }
 
 func (client *Client) VerifyAzureTargetSpectraS3(ctx context.Context, request *models.VerifyAzureTargetSpectraS3Request) (*models.VerifyAzureTargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/azure_target/" + request.AzureTarget).
-        WithOptionalVoidQueryParam("full_details", request.FullDetails).
-        WithQueryParam("operation", "verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/azure_target/"+request.AzureTarget).
+		WithOptionalVoidQueryParam("full_details", request.FullDetails).
+		WithQueryParam("operation", "verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifyAzureTargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifyAzureTargetSpectraS3Response(response)
 }
 
 func (client *Client) ModifyAllDs3TargetsSpectraS3(ctx context.Context, request *models.ModifyAllDs3TargetsSpectraS3Request) (*models.ModifyAllDs3TargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/ds3_target").
-        WithQueryParam("quiesced", request.Quiesced.String()).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/ds3_target").
+		WithQueryParam("quiesced", request.Quiesced.String()).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyAllDs3TargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyAllDs3TargetsSpectraS3Response(response)
 }
 
 func (client *Client) ModifyDs3TargetSpectraS3(ctx context.Context, request *models.ModifyDs3TargetSpectraS3Request) (*models.ModifyDs3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/ds3_target/" + request.Ds3Target).
-        WithOptionalQueryParam("access_control_replication", networking.InterfaceToStrPtr(request.AccessControlReplication)).
-        WithOptionalQueryParam("admin_auth_id", request.AdminAuthId).
-        WithOptionalQueryParam("admin_secret_key", request.AdminSecretKey).
-        WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
-        WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
-        WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
-        WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
-        WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
-        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-        WithOptionalQueryParam("replicated_user_default_data_policy", request.ReplicatedUserDefaultDataPolicy).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/ds3_target/"+request.Ds3Target).
+		WithOptionalQueryParam("access_control_replication", networking.InterfaceToStrPtr(request.AccessControlReplication)).
+		WithOptionalQueryParam("admin_auth_id", request.AdminAuthId).
+		WithOptionalQueryParam("admin_secret_key", request.AdminSecretKey).
+		WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
+		WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
+		WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
+		WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
+		WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
+		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+		WithOptionalQueryParam("replicated_user_default_data_policy", request.ReplicatedUserDefaultDataPolicy).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyDs3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyDs3TargetSpectraS3Response(response)
 }
 
 func (client *Client) PairBackRegisteredDs3TargetSpectraS3(ctx context.Context, request *models.PairBackRegisteredDs3TargetSpectraS3Request) (*models.PairBackRegisteredDs3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/ds3_target/" + request.Ds3Target).
-        WithOptionalQueryParam("access_control_replication", networking.InterfaceToStrPtr(request.AccessControlReplication)).
-        WithOptionalQueryParam("admin_auth_id", request.AdminAuthId).
-        WithOptionalQueryParam("admin_secret_key", request.AdminSecretKey).
-        WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
-        WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
-        WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
-        WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
-        WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
-        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-        WithOptionalQueryParam("replicated_user_default_data_policy", request.ReplicatedUserDefaultDataPolicy).
-        WithQueryParam("operation", "pair_back").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/ds3_target/"+request.Ds3Target).
+		WithOptionalQueryParam("access_control_replication", networking.InterfaceToStrPtr(request.AccessControlReplication)).
+		WithOptionalQueryParam("admin_auth_id", request.AdminAuthId).
+		WithOptionalQueryParam("admin_secret_key", request.AdminSecretKey).
+		WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
+		WithOptionalQueryParam("data_path_https", networking.BoolPtrToStrPtr(request.DataPathHttps)).
+		WithOptionalQueryParam("data_path_port", networking.IntPtrToStrPtr(request.DataPathPort)).
+		WithOptionalQueryParam("data_path_proxy", request.DataPathProxy).
+		WithOptionalQueryParam("data_path_verify_certificate", networking.BoolPtrToStrPtr(request.DataPathVerifyCertificate)).
+		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+		WithOptionalQueryParam("replicated_user_default_data_policy", request.ReplicatedUserDefaultDataPolicy).
+		WithQueryParam("operation", "pair_back").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewPairBackRegisteredDs3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewPairBackRegisteredDs3TargetSpectraS3Response(response)
 }
 
 func (client *Client) VerifyDs3TargetSpectraS3(ctx context.Context, request *models.VerifyDs3TargetSpectraS3Request) (*models.VerifyDs3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/ds3_target/" + request.Ds3Target).
-        WithOptionalVoidQueryParam("full_details", request.FullDetails).
-        WithQueryParam("operation", "verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/ds3_target/"+request.Ds3Target).
+		WithOptionalVoidQueryParam("full_details", request.FullDetails).
+		WithQueryParam("operation", "verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifyDs3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifyDs3TargetSpectraS3Response(response)
 }
 
 func (client *Client) ImportS3TargetSpectraS3(ctx context.Context, request *models.ImportS3TargetSpectraS3Request) (*models.ImportS3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/s3_target/" + request.S3Target).
-        WithQueryParam("cloud_bucket_name", request.CloudBucketName).
-        WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
-        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
-        WithOptionalQueryParam("user_id", request.UserId).
-        WithQueryParam("operation", "import").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/s3_target/"+request.S3Target).
+		WithQueryParam("cloud_bucket_name", request.CloudBucketName).
+		WithOptionalQueryParam("data_policy_id", request.DataPolicyId).
+		WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
+		WithOptionalQueryParam("user_id", request.UserId).
+		WithQueryParam("operation", "import").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewImportS3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewImportS3TargetSpectraS3Response(response)
 }
 
 func (client *Client) ModifyAllS3TargetsSpectraS3(ctx context.Context, request *models.ModifyAllS3TargetsSpectraS3Request) (*models.ModifyAllS3TargetsSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/s3_target").
-        WithQueryParam("quiesced", request.Quiesced.String()).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/s3_target").
+		WithQueryParam("quiesced", request.Quiesced.String()).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyAllS3TargetsSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyAllS3TargetsSpectraS3Response(response)
 }
 
 func (client *Client) ModifyS3TargetSpectraS3(ctx context.Context, request *models.ModifyS3TargetSpectraS3Request) (*models.ModifyS3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/s3_target/" + request.S3Target).
-        WithOptionalQueryParam("access_key", request.AccessKey).
-        WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
-        WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
-        WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
-        WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
-        WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
-        WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("naming_mode", networking.InterfaceToStrPtr(request.NamingMode)).
-        WithOptionalQueryParam("offline_data_staging_window_in_tb", networking.IntPtrToStrPtr(request.OfflineDataStagingWindowInTb)).
-        WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
-        WithOptionalQueryParam("proxy_domain", request.ProxyDomain).
-        WithOptionalQueryParam("proxy_host", request.ProxyHost).
-        WithOptionalQueryParam("proxy_password", request.ProxyPassword).
-        WithOptionalQueryParam("proxy_port", networking.IntPtrToStrPtr(request.ProxyPort)).
-        WithOptionalQueryParam("proxy_username", request.ProxyUsername).
-        WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
-        WithOptionalQueryParam("region", networking.InterfaceToStrPtr(request.Region)).
-        WithOptionalQueryParam("restricted_access", networking.BoolPtrToStrPtr(request.RestrictedAccess)).
-        WithOptionalQueryParam("secret_key", request.SecretKey).
-        WithOptionalQueryParam("staged_data_expiration_in_days", networking.IntPtrToStrPtr(request.StagedDataExpirationInDays)).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/s3_target/"+request.S3Target).
+		WithOptionalQueryParam("access_key", request.AccessKey).
+		WithOptionalQueryParam("auto_verify_frequency_in_days", networking.IntPtrToStrPtr(request.AutoVerifyFrequencyInDays)).
+		WithOptionalQueryParam("cloud_bucket_prefix", request.CloudBucketPrefix).
+		WithOptionalQueryParam("cloud_bucket_suffix", request.CloudBucketSuffix).
+		WithOptionalQueryParam("data_path_end_point", request.DataPathEndPoint).
+		WithOptionalQueryParam("default_read_preference", networking.InterfaceToStrPtr(request.DefaultReadPreference)).
+		WithOptionalQueryParam("https", networking.BoolPtrToStrPtr(request.Https)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("naming_mode", networking.InterfaceToStrPtr(request.NamingMode)).
+		WithOptionalQueryParam("offline_data_staging_window_in_tb", networking.IntPtrToStrPtr(request.OfflineDataStagingWindowInTb)).
+		WithOptionalQueryParam("permit_going_out_of_sync", networking.BoolPtrToStrPtr(request.PermitGoingOutOfSync)).
+		WithOptionalQueryParam("proxy_domain", request.ProxyDomain).
+		WithOptionalQueryParam("proxy_host", request.ProxyHost).
+		WithOptionalQueryParam("proxy_password", request.ProxyPassword).
+		WithOptionalQueryParam("proxy_port", networking.IntPtrToStrPtr(request.ProxyPort)).
+		WithOptionalQueryParam("proxy_username", request.ProxyUsername).
+		WithOptionalQueryParam("quiesced", networking.InterfaceToStrPtr(request.Quiesced)).
+		WithOptionalQueryParam("region", networking.InterfaceToStrPtr(request.Region)).
+		WithOptionalQueryParam("restricted_access", networking.BoolPtrToStrPtr(request.RestrictedAccess)).
+		WithOptionalQueryParam("secret_key", request.SecretKey).
+		WithOptionalQueryParam("staged_data_expiration_in_days", networking.IntPtrToStrPtr(request.StagedDataExpirationInDays)).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyS3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyS3TargetSpectraS3Response(response)
 }
 
 func (client *Client) VerifyS3TargetSpectraS3(ctx context.Context, request *models.VerifyS3TargetSpectraS3Request) (*models.VerifyS3TargetSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/s3_target/" + request.S3Target).
-        WithOptionalVoidQueryParam("full_details", request.FullDetails).
-        WithQueryParam("operation", "verify").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/s3_target/"+request.S3Target).
+		WithOptionalVoidQueryParam("full_details", request.FullDetails).
+		WithQueryParam("operation", "verify").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewVerifyS3TargetSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewVerifyS3TargetSpectraS3Response(response)
 }
 
 func (client *Client) ModifyUserSpectraS3(ctx context.Context, request *models.ModifyUserSpectraS3Request) (*models.ModifyUserSpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/user/" + request.UserId).
-        WithOptionalQueryParam("default_data_policy_id", request.DefaultDataPolicyId).
-        WithOptionalQueryParam("max_buckets", networking.IntPtrToStrPtr(request.MaxBuckets)).
-        WithOptionalQueryParam("name", request.Name).
-        WithOptionalQueryParam("secret_key", request.SecretKey).
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/user/"+request.UserId).
+		WithOptionalQueryParam("default_data_policy_id", request.DefaultDataPolicyId).
+		WithOptionalQueryParam("max_buckets", networking.IntPtrToStrPtr(request.MaxBuckets)).
+		WithOptionalQueryParam("name", request.Name).
+		WithOptionalQueryParam("secret_key", request.SecretKey).
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewModifyUserSpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewModifyUserSpectraS3Response(response)
 }
 
 func (client *Client) RegenerateUserSecretKeySpectraS3(ctx context.Context, request *models.RegenerateUserSecretKeySpectraS3Request) (*models.RegenerateUserSecretKeySpectraS3Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(HTTP_VERB_PUT).
-        WithPath("/_rest_/user/" + request.UserId).
-        WithQueryParam("operation", "regenerate_secret_key").
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(HTTP_VERB_PUT).
+		WithPath("/_rest_/user/"+request.UserId).
+		WithQueryParam("operation", "regenerate_secret_key").
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.NewRegenerateUserSecretKeySpectraS3Response(response)
+	// Create a response object based on the result.
+	return models.NewRegenerateUserSecretKeySpectraS3Response(response)
 }
-
-

--- a/ds3/models/aggregateError.go
+++ b/ds3/models/aggregateError.go
@@ -12,46 +12,46 @@
 package models
 
 import (
-    "fmt"
-    "sync"
+	"fmt"
+	"sync"
 )
 
 // AggregateError is an error that aggregates multiple errors and is multi thread safe.
 type AggregateError struct {
-    Errors []error
-    mux sync.RWMutex
+	Errors []error
+	mux    sync.RWMutex
 }
 
 func (aggregateError *AggregateError) Error() string {
-    aggregateError.mux.RLock()
-    defer aggregateError.mux.RUnlock()
+	aggregateError.mux.RLock()
+	defer aggregateError.mux.RUnlock()
 
-    msg := fmt.Sprintf("%d error(s) occurred:\n", len(aggregateError.Errors))
+	msg := fmt.Sprintf("%d error(s) occurred:\n", len(aggregateError.Errors))
 
-    for i, err := range aggregateError.Errors {
-        msg += fmt.Sprintf("%d) %s\n", i + 1, err.Error())
-    }
+	for i, err := range aggregateError.Errors {
+		msg += fmt.Sprintf("%d) %s\n", i+1, err.Error())
+	}
 
-    return msg
+	return msg
 }
 
 // Returns the aggregate error if at least one error exists,
 // else returns nil
 func (aggregateError *AggregateError) GetErrors() error {
-    aggregateError.mux.RLock()
-    defer aggregateError.mux.RUnlock()
+	aggregateError.mux.RLock()
+	defer aggregateError.mux.RUnlock()
 
-    if len (aggregateError.Errors) == 0 {
-        return nil
-    }
-    return aggregateError
+	if len(aggregateError.Errors) == 0 {
+		return nil
+	}
+	return aggregateError
 }
 
 func (aggregateError *AggregateError) Append(err error) {
-    aggregateError.mux.Lock()
-    defer aggregateError.mux.Unlock()
+	aggregateError.mux.Lock()
+	defer aggregateError.mux.Unlock()
 
-    if err != nil {
-        aggregateError.Errors = append(aggregateError.Errors, err)
-    }
+	if err != nil {
+		aggregateError.Errors = append(aggregateError.Errors, err)
+	}
 }

--- a/ds3/models/badStatusCodeError.go
+++ b/ds3/models/badStatusCodeError.go
@@ -1,64 +1,64 @@
 package models
 
 import (
-    "fmt"
-    "io"
-    "io/ioutil"
-    "encoding/xml"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"io/ioutil"
 )
 
 type BadStatusCodeError struct {
-    ExpectedStatusCode []int
-    ActualStatusCode int
-    ErrorBody *Error
+	ExpectedStatusCode []int
+	ActualStatusCode   int
+	ErrorBody          *Error
 }
 
 func buildBadStatusCodeError(webResponse WebResponse, expectedStatusCodes []int) *BadStatusCodeError {
-    var errorBody Error
-    var errorBodyPtr *Error
+	var errorBody Error
+	var errorBodyPtr *Error
 
-    // Parse the body and if it worked then use the structure.
-    err := parseErrorResponseBody(webResponse.Body(), &errorBody)
-    if err == nil {
-        errorBodyPtr = &errorBody
-    }
+	// Parse the body and if it worked then use the structure.
+	err := parseErrorResponseBody(webResponse.Body(), &errorBody)
+	if err == nil {
+		errorBodyPtr = &errorBody
+	}
 
-    // Return the bad status code entity.
-    return &BadStatusCodeError{
-        expectedStatusCodes,
-        webResponse.StatusCode(),
-        errorBodyPtr,
-    }
+	// Return the bad status code entity.
+	return &BadStatusCodeError{
+		expectedStatusCodes,
+		webResponse.StatusCode(),
+		errorBodyPtr,
+	}
 }
 
 func parseErrorResponseBody(reader io.ReadCloser, body interface{}) error {
-    // Get the bytes or forward the error.
-    bytes, err := ioutil.ReadAll(reader)
-    if err != nil {
-        return err
-    }
+	// Get the bytes or forward the error.
+	bytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
 
-    // Deserialize or forward the error.
-    if err = xml.Unmarshal(bytes, body); err != nil {
-        return err
-    }
+	// Deserialize or forward the error.
+	if err = xml.Unmarshal(bytes, body); err != nil {
+		return err
+	}
 
-    return nil
+	return nil
 }
 
 func (err BadStatusCodeError) Error() string {
-    if err.ErrorBody != nil && err.ErrorBody.Message != nil {
-        return fmt.Sprintf(
-            "Received a status code of %d when %v was expected. Error message: \"%s\"",
-            err.ActualStatusCode,
-            err.ExpectedStatusCode,
-            *err.ErrorBody.Message,
-        )
-    } else {
-        return fmt.Sprintf(
-            "Received a status code of %d when %v was expected. Could not parse the response for additional information.",
-            err.ActualStatusCode,
-            err.ExpectedStatusCode,
-        )
-    }
+	if err.ErrorBody != nil && err.ErrorBody.Message != nil {
+		return fmt.Sprintf(
+			"Received a status code of %d when %v was expected. Error message: \"%s\"",
+			err.ActualStatusCode,
+			err.ExpectedStatusCode,
+			*err.ErrorBody.Message,
+		)
+	} else {
+		return fmt.Sprintf(
+			"Received a status code of %d when %v was expected. Could not parse the response for additional information.",
+			err.ActualStatusCode,
+			err.ExpectedStatusCode,
+		)
+	}
 }

--- a/ds3/models/checksum.go
+++ b/ds3/models/checksum.go
@@ -1,12 +1,12 @@
 package models
 
 type Checksum struct {
-    ContentHash string
-    Type        ChecksumType
+	ContentHash string
+	Type        ChecksumType
 }
 
 func NewNoneChecksum() Checksum {
-    return Checksum{
-        Type: NONE,
-        ContentHash: "" }
+	return Checksum{
+		Type:        NONE,
+		ContentHash: ""}
 }

--- a/ds3/models/ds3Response.go
+++ b/ds3/models/ds3Response.go
@@ -1,38 +1,37 @@
 package models
 
 import (
-    "io"
-    "net/http"
+	"io"
+	"net/http"
 )
 
 type WebResponse interface {
-    StatusCode() int
-    Body() io.ReadCloser
-    Header() *http.Header
+	StatusCode() int
+	Body() io.ReadCloser
+	Header() *http.Header
 }
 
 type WrappedHttpResponse struct {
-    rawResponse *http.Response
+	rawResponse *http.Response
 }
 
 func NewWrappedHttpResponse(rawResponse *http.Response) *WrappedHttpResponse {
-    return &WrappedHttpResponse{rawResponse: rawResponse}
+	return &WrappedHttpResponse{rawResponse: rawResponse}
 }
 
 func (wrappedHttpResponse *WrappedHttpResponse) StatusCode() int {
-    return wrappedHttpResponse.rawResponse.StatusCode
+	return wrappedHttpResponse.rawResponse.StatusCode
 }
 
 func (wrappedHttpResponse *WrappedHttpResponse) Body() io.ReadCloser {
-    return wrappedHttpResponse.rawResponse.Body
+	return wrappedHttpResponse.rawResponse.Body
 }
 
 func (wrappedHttpResponse *WrappedHttpResponse) Header() *http.Header {
-    result := make(http.Header)
-    header := wrappedHttpResponse.rawResponse.Header
-    for k, v := range header {
-        result[k] = v
-    }
-    return &result
+	result := make(http.Header)
+	header := wrappedHttpResponse.rawResponse.Header
+	for k, v := range header {
+		result[k] = v
+	}
+	return &result
 }
-

--- a/ds3/models/enum.go
+++ b/ds3/models/enum.go
@@ -3,9 +3,9 @@ package models
 type Enum int
 
 func (enum Enum) String() string {
-    return "something..."
+	return "something..."
 }
 
 const (
-    UNDEFINED = 0
+	UNDEFINED = 0
 )

--- a/ds3/models/metadataCarrier.go
+++ b/ds3/models/metadataCarrier.go
@@ -11,7 +11,9 @@
 
 package models
 
-const ( AMZ_META_HEADER = "x-amz-meta-" )
+const (
+	AMZ_META_HEADER = "x-amz-meta-"
+)
 
 type MetadataCarrier interface {
 	WithMetaData(key string, values ...string) interface{}

--- a/ds3/models/readerWithSizeDecorator.go
+++ b/ds3/models/readerWithSizeDecorator.go
@@ -8,13 +8,13 @@ import "io"
 // Also hides the Close function from http library which prevents automatic
 // closing of stream within http library.
 type ReaderWithSizeDecorator interface {
-    io.Reader
-    Size() (int64, error)
+	io.Reader
+	Size() (int64, error)
 }
 
 // ReadCloser with size knowledge. Networking layer will automatically close
 // the reader when finished transmitting request.
 type ReadCloserWithSizeDecorator interface {
-    io.ReadCloser
-    Size() (int64, error)
+	io.ReadCloser
+	Size() (int64, error)
 }

--- a/ds3/models/requestPayloadModels.go
+++ b/ds3/models/requestPayloadModels.go
@@ -1,61 +1,61 @@
 package models
 
 type CompleteMultipartUpload struct {
-    Parts []Part `xml:"Part"`
+	Parts []Part `xml:"Part"`
 }
 
 type Part struct {
-    PartNumber int
-    ETag string
+	PartNumber int
+	ETag       string
 }
 
 type Ds3PutObject struct {
-    Name string `xml:"Name,attr"`
-    Size int64 `xml:"Size,attr"`
+	Name string `xml:"Name,attr"`
+	Size int64  `xml:"Size,attr"`
 }
 
 type Ds3GetObject struct {
-    Name string `xml:"Name,attr"`
-    Length *int64 `xml:"Length,attr,omitempty"`
-    Offset *int64 `xml:"Offset,attr,omitempty"`
-    VersionId *string `xml:"VersionId,attr,omitempty"`
+	Name      string  `xml:"Name,attr"`
+	Length    *int64  `xml:"Length,attr,omitempty"`
+	Offset    *int64  `xml:"Offset,attr,omitempty"`
+	VersionId *string `xml:"VersionId,attr,omitempty"`
 }
 
 func NewDs3GetObject(name string) Ds3GetObject {
-    return Ds3GetObject{Name:name}
+	return Ds3GetObject{Name: name}
 }
 
 // Creates a Ds3GetObject used for partial objects
 func NewPartialDs3GetObject(name string, length int64, offset int64) Ds3GetObject {
-    return Ds3GetObject{
-        Name:name,
-        Length:&length,
-        Offset:&offset,
-    }
+	return Ds3GetObject{
+		Name:   name,
+		Length: &length,
+		Offset: &offset,
+	}
 }
 
 func NewDs3GetObjectVersion(name string, versionId string) Ds3GetObject {
-    return Ds3GetObject{
-        Name:name,
-        VersionId:&versionId,
-    }
+	return Ds3GetObject{
+		Name:      name,
+		VersionId: &versionId,
+	}
 }
 
 func NewPartialDs3GetObjectVersion(name string, length int64, offset int64, versionId string) Ds3GetObject {
-    return Ds3GetObject{
-        Name:name,
-        Length:&length,
-        Offset:&offset,
-        VersionId:&versionId,
-    }
+	return Ds3GetObject{
+		Name:      name,
+		Length:    &length,
+		Offset:    &offset,
+		VersionId: &versionId,
+	}
 }
 
 // Converts a list of names into a list of Ds3GetObjects
 func buildDs3GetObjectSliceFromNames(objectNames []string) []Ds3GetObject {
-    // Build the ds3 get object list entity.
-    var objects []Ds3GetObject
-    for _, name := range objectNames {
-        objects = append(objects, NewDs3GetObject(name))
-    }
-    return objects
+	// Build the ds3 get object list entity.
+	var objects []Ds3GetObject
+	for _, name := range objectNames {
+		objects = append(objects, NewDs3GetObject(name))
+	}
+	return objects
 }

--- a/ds3/models/requests.go
+++ b/ds3/models/requests.go
@@ -14,10006 +14,9891 @@
 package models
 
 import (
-    "fmt"
-    "strings"
+	"fmt"
+	"strings"
 )
 
 type AbortMultiPartUploadRequest struct {
-    BucketName string
-    ObjectName string
-    UploadId string
+	BucketName string
+	ObjectName string
+	UploadId   string
 }
 
 func NewAbortMultiPartUploadRequest(bucketName string, objectName string, uploadId string) *AbortMultiPartUploadRequest {
-    return &AbortMultiPartUploadRequest{
-        BucketName: bucketName,
-        ObjectName: objectName,
-        UploadId: uploadId,
-    }
+	return &AbortMultiPartUploadRequest{
+		BucketName: bucketName,
+		ObjectName: objectName,
+		UploadId:   uploadId,
+	}
 }
 
 type CompleteBlobRequest struct {
-    BucketName string
-    ObjectName string
-    Blob string
-    Checksum Checksum
-    Job string
-    Metadata map[string]string
-    Size *int64
+	BucketName string
+	ObjectName string
+	Blob       string
+	Checksum   Checksum
+	Job        string
+	Metadata   map[string]string
+	Size       *int64
 }
 
 func NewCompleteBlobRequest(bucketName string, objectName string, blob string, job string) *CompleteBlobRequest {
-    return &CompleteBlobRequest{
-        BucketName: bucketName,
-        ObjectName: objectName,
-        Blob: blob,
-        Job: job,
-        Checksum: NewNoneChecksum(),
-        Metadata: make(map[string]string),
-    }
+	return &CompleteBlobRequest{
+		BucketName: bucketName,
+		ObjectName: objectName,
+		Blob:       blob,
+		Job:        job,
+		Checksum:   NewNoneChecksum(),
+		Metadata:   make(map[string]string),
+	}
 }
 
 func (completeBlobRequest *CompleteBlobRequest) WithSize(size int64) *CompleteBlobRequest {
-    completeBlobRequest.Size = &size
-    return completeBlobRequest
+	completeBlobRequest.Size = &size
+	return completeBlobRequest
 }
 
-
 func (completeBlobRequest *CompleteBlobRequest) WithChecksum(contentHash string, checksumType ChecksumType) *CompleteBlobRequest {
-    completeBlobRequest.Checksum.ContentHash = contentHash
-    completeBlobRequest.Checksum.Type = checksumType
-    return completeBlobRequest
+	completeBlobRequest.Checksum.ContentHash = contentHash
+	completeBlobRequest.Checksum.Type = checksumType
+	return completeBlobRequest
 }
 
 func (completeBlobRequest *CompleteBlobRequest) WithMetaData(key string, values ...string) *CompleteBlobRequest {
-    if strings.HasPrefix(strings.ToLower(key), AMZ_META_HEADER) {
-        completeBlobRequest.Metadata[key] = strings.Join(values, ",")
-    } else {
-        completeBlobRequest.Metadata[strings.ToLower(AMZ_META_HEADER + key)] = strings.Join(values, ",")
-    }
-    return completeBlobRequest
+	if strings.HasPrefix(strings.ToLower(key), AMZ_META_HEADER) {
+		completeBlobRequest.Metadata[key] = strings.Join(values, ",")
+	} else {
+		completeBlobRequest.Metadata[strings.ToLower(AMZ_META_HEADER+key)] = strings.Join(values, ",")
+	}
+	return completeBlobRequest
 }
+
 type CompleteMultiPartUploadRequest struct {
-    BucketName string
-    ObjectName string
-    Parts []Part
-    UploadId string
+	BucketName string
+	ObjectName string
+	Parts      []Part
+	UploadId   string
 }
 
 func NewCompleteMultiPartUploadRequest(bucketName string, objectName string, parts []Part, uploadId string) *CompleteMultiPartUploadRequest {
-    return &CompleteMultiPartUploadRequest{
-        BucketName: bucketName,
-        ObjectName: objectName,
-        UploadId: uploadId,
-        Parts: parts,
-    }
+	return &CompleteMultiPartUploadRequest{
+		BucketName: bucketName,
+		ObjectName: objectName,
+		UploadId:   uploadId,
+		Parts:      parts,
+	}
 }
 
 type PutBucketRequest struct {
-    BucketName string
+	BucketName string
 }
 
 func NewPutBucketRequest(bucketName string) *PutBucketRequest {
-    return &PutBucketRequest{
-        BucketName: bucketName,
-    }
+	return &PutBucketRequest{
+		BucketName: bucketName,
+	}
 }
 
 type PutMultiPartUploadPartRequest struct {
-    BucketName string
-    ObjectName string
-    Content ReaderWithSizeDecorator
-    PartNumber int
-    UploadId string
+	BucketName string
+	ObjectName string
+	Content    ReaderWithSizeDecorator
+	PartNumber int
+	UploadId   string
 }
 
 func NewPutMultiPartUploadPartRequest(bucketName string, objectName string, content ReaderWithSizeDecorator, partNumber int, uploadId string) *PutMultiPartUploadPartRequest {
-    return &PutMultiPartUploadPartRequest{
-        BucketName: bucketName,
-        ObjectName: objectName,
-        PartNumber: partNumber,
-        UploadId: uploadId,
-        Content: content,
-    }
+	return &PutMultiPartUploadPartRequest{
+		BucketName: bucketName,
+		ObjectName: objectName,
+		PartNumber: partNumber,
+		UploadId:   uploadId,
+		Content:    content,
+	}
 }
 
 type PutObjectRequest struct {
-    BucketName string
-    ObjectName string
-    Checksum Checksum
-    Content ReaderWithSizeDecorator
-    Job *string
-    Metadata map[string]string
-    Offset *int64
+	BucketName string
+	ObjectName string
+	Checksum   Checksum
+	Content    ReaderWithSizeDecorator
+	Job        *string
+	Metadata   map[string]string
+	Offset     *int64
 }
 
 func NewPutObjectRequest(bucketName string, objectName string, content ReaderWithSizeDecorator) *PutObjectRequest {
-    return &PutObjectRequest{
-        BucketName: bucketName,
-        ObjectName: objectName,
-        Content: content,
-        Checksum: NewNoneChecksum(),
-        Metadata: make(map[string]string),
-    }
+	return &PutObjectRequest{
+		BucketName: bucketName,
+		ObjectName: objectName,
+		Content:    content,
+		Checksum:   NewNoneChecksum(),
+		Metadata:   make(map[string]string),
+	}
 }
 
 func (putObjectRequest *PutObjectRequest) WithJob(job string) *PutObjectRequest {
-    putObjectRequest.Job = &job
-    return putObjectRequest
+	putObjectRequest.Job = &job
+	return putObjectRequest
 }
 
 func (putObjectRequest *PutObjectRequest) WithOffset(offset int64) *PutObjectRequest {
-    putObjectRequest.Offset = &offset
-    return putObjectRequest
+	putObjectRequest.Offset = &offset
+	return putObjectRequest
 }
 
-
 func (putObjectRequest *PutObjectRequest) WithChecksum(contentHash string, checksumType ChecksumType) *PutObjectRequest {
-    putObjectRequest.Checksum.ContentHash = contentHash
-    putObjectRequest.Checksum.Type = checksumType
-    return putObjectRequest
+	putObjectRequest.Checksum.ContentHash = contentHash
+	putObjectRequest.Checksum.Type = checksumType
+	return putObjectRequest
 }
 
 func (putObjectRequest *PutObjectRequest) WithMetaData(key string, values ...string) *PutObjectRequest {
-    if strings.HasPrefix(strings.ToLower(key), AMZ_META_HEADER) {
-        putObjectRequest.Metadata[key] = strings.Join(values, ",")
-    } else {
-        putObjectRequest.Metadata[strings.ToLower(AMZ_META_HEADER + key)] = strings.Join(values, ",")
-    }
-    return putObjectRequest
+	if strings.HasPrefix(strings.ToLower(key), AMZ_META_HEADER) {
+		putObjectRequest.Metadata[key] = strings.Join(values, ",")
+	} else {
+		putObjectRequest.Metadata[strings.ToLower(AMZ_META_HEADER+key)] = strings.Join(values, ",")
+	}
+	return putObjectRequest
 }
+
 type DeleteBucketRequest struct {
-    BucketName string
+	BucketName string
 }
 
 func NewDeleteBucketRequest(bucketName string) *DeleteBucketRequest {
-    return &DeleteBucketRequest{
-        BucketName: bucketName,
-    }
+	return &DeleteBucketRequest{
+		BucketName: bucketName,
+	}
 }
 
 type DeleteObjectRequest struct {
-    BucketName string
-    ObjectName string
-    VersionId *string
+	BucketName string
+	ObjectName string
+	VersionId  *string
 }
 
 func NewDeleteObjectRequest(bucketName string, objectName string) *DeleteObjectRequest {
-    return &DeleteObjectRequest{
-        BucketName: bucketName,
-        ObjectName: objectName,
-    }
+	return &DeleteObjectRequest{
+		BucketName: bucketName,
+		ObjectName: objectName,
+	}
 }
 
 func (deleteObjectRequest *DeleteObjectRequest) WithVersionId(versionId string) *DeleteObjectRequest {
-    deleteObjectRequest.VersionId = &versionId
-    return deleteObjectRequest
+	deleteObjectRequest.VersionId = &versionId
+	return deleteObjectRequest
 }
 
 type DeleteObjectsRequest struct {
-    BucketName string
-    ObjectNames []string
+	BucketName  string
+	ObjectNames []string
 }
 
 func NewDeleteObjectsRequest(bucketName string, objectNames []string) *DeleteObjectsRequest {
-    return &DeleteObjectsRequest{
-        BucketName: bucketName,
-        ObjectNames: objectNames,
-    }
+	return &DeleteObjectsRequest{
+		BucketName:  bucketName,
+		ObjectNames: objectNames,
+	}
 }
 
 type GetBucketRequest struct {
-    BucketName string
-    Delimiter *string
-    Marker *string
-    MaxKeys *int
-    Prefix *string
-    Versions bool
+	BucketName string
+	Delimiter  *string
+	Marker     *string
+	MaxKeys    *int
+	Prefix     *string
+	Versions   bool
 }
 
 func NewGetBucketRequest(bucketName string) *GetBucketRequest {
-    return &GetBucketRequest{
-        BucketName: bucketName,
-    }
+	return &GetBucketRequest{
+		BucketName: bucketName,
+	}
 }
 
 func (getBucketRequest *GetBucketRequest) WithDelimiter(delimiter string) *GetBucketRequest {
-    getBucketRequest.Delimiter = &delimiter
-    return getBucketRequest
+	getBucketRequest.Delimiter = &delimiter
+	return getBucketRequest
 }
 
 func (getBucketRequest *GetBucketRequest) WithMarker(marker string) *GetBucketRequest {
-    getBucketRequest.Marker = &marker
-    return getBucketRequest
+	getBucketRequest.Marker = &marker
+	return getBucketRequest
 }
 
 func (getBucketRequest *GetBucketRequest) WithMaxKeys(maxKeys int) *GetBucketRequest {
-    getBucketRequest.MaxKeys = &maxKeys
-    return getBucketRequest
+	getBucketRequest.MaxKeys = &maxKeys
+	return getBucketRequest
 }
 
 func (getBucketRequest *GetBucketRequest) WithPrefix(prefix string) *GetBucketRequest {
-    getBucketRequest.Prefix = &prefix
-    return getBucketRequest
+	getBucketRequest.Prefix = &prefix
+	return getBucketRequest
 }
 
 func (getBucketRequest *GetBucketRequest) WithVersions() *GetBucketRequest {
-    getBucketRequest.Versions = true
-    return getBucketRequest
+	getBucketRequest.Versions = true
+	return getBucketRequest
 }
 
 type GetServiceRequest struct {
 }
 
 func NewGetServiceRequest() *GetServiceRequest {
-    return &GetServiceRequest{
-    }
+	return &GetServiceRequest{}
 }
 
 type Range struct {
-    Start int64
-    End int64
+	Start int64
+	End   int64
 }
 
 type GetObjectRequest struct {
-    BucketName string
-    ObjectName string
-    CachedOnly bool
-    Checksum Checksum
-    Job *string
-    Metadata map[string]string
-    Offset *int64
-    VersionId *string
+	BucketName string
+	ObjectName string
+	CachedOnly bool
+	Checksum   Checksum
+	Job        *string
+	Metadata   map[string]string
+	Offset     *int64
+	VersionId  *string
 }
 
 func NewGetObjectRequest(bucketName string, objectName string) *GetObjectRequest {
-    return &GetObjectRequest{
-        BucketName: bucketName,
-        ObjectName: objectName,
-        Checksum: NewNoneChecksum(),
-        Metadata: make(map[string]string),
-    }
+	return &GetObjectRequest{
+		BucketName: bucketName,
+		ObjectName: objectName,
+		Checksum:   NewNoneChecksum(),
+		Metadata:   make(map[string]string),
+	}
 }
 
 func (getObjectRequest *GetObjectRequest) WithCachedOnly() *GetObjectRequest {
-    getObjectRequest.CachedOnly = true
-    return getObjectRequest
+	getObjectRequest.CachedOnly = true
+	return getObjectRequest
 }
 
 func (getObjectRequest *GetObjectRequest) WithJob(job string) *GetObjectRequest {
-    getObjectRequest.Job = &job
-    return getObjectRequest
+	getObjectRequest.Job = &job
+	return getObjectRequest
 }
 
 func (getObjectRequest *GetObjectRequest) WithOffset(offset int64) *GetObjectRequest {
-    getObjectRequest.Offset = &offset
-    return getObjectRequest
+	getObjectRequest.Offset = &offset
+	return getObjectRequest
 }
 
 func (getObjectRequest *GetObjectRequest) WithVersionId(versionId string) *GetObjectRequest {
-    getObjectRequest.VersionId = &versionId
-    return getObjectRequest
+	getObjectRequest.VersionId = &versionId
+	return getObjectRequest
 }
 
-
 func (getObjectRequest *GetObjectRequest) WithChecksum(contentHash string, checksumType ChecksumType) *GetObjectRequest {
-    getObjectRequest.Checksum.ContentHash = contentHash
-    getObjectRequest.Checksum.Type = checksumType
-    return getObjectRequest
+	getObjectRequest.Checksum.ContentHash = contentHash
+	getObjectRequest.Checksum.Type = checksumType
+	return getObjectRequest
 }
 
 func (getObjectRequest *GetObjectRequest) WithRanges(ranges ...Range) *GetObjectRequest {
-    var rangeElements []string
-    for _, cur := range ranges {
-        rangeElements = append(rangeElements, fmt.Sprintf("%d-%d", cur.Start, cur.End))
-    }
-    getObjectRequest.Metadata["Range"] = fmt.Sprintf("bytes=%s", strings.Join(rangeElements[:], ","))
-    return getObjectRequest
+	var rangeElements []string
+	for _, cur := range ranges {
+		rangeElements = append(rangeElements, fmt.Sprintf("%d-%d", cur.Start, cur.End))
+	}
+	getObjectRequest.Metadata["Range"] = fmt.Sprintf("bytes=%s", strings.Join(rangeElements[:], ","))
+	return getObjectRequest
 }
+
 type HeadBucketRequest struct {
-    BucketName string
+	BucketName string
 }
 
 func NewHeadBucketRequest(bucketName string) *HeadBucketRequest {
-    return &HeadBucketRequest{
-        BucketName: bucketName,
-    }
+	return &HeadBucketRequest{
+		BucketName: bucketName,
+	}
 }
 
 type HeadObjectRequest struct {
-    BucketName string
-    ObjectName string
-    VersionId *string
+	BucketName string
+	ObjectName string
+	VersionId  *string
 }
 
 func NewHeadObjectRequest(bucketName string, objectName string) *HeadObjectRequest {
-    return &HeadObjectRequest{
-        BucketName: bucketName,
-        ObjectName: objectName,
-    }
+	return &HeadObjectRequest{
+		BucketName: bucketName,
+		ObjectName: objectName,
+	}
 }
 
 func (headObjectRequest *HeadObjectRequest) WithVersionId(versionId string) *HeadObjectRequest {
-    headObjectRequest.VersionId = &versionId
-    return headObjectRequest
+	headObjectRequest.VersionId = &versionId
+	return headObjectRequest
 }
 
 type InitiateMultiPartUploadRequest struct {
-    BucketName string
-    ObjectName string
+	BucketName string
+	ObjectName string
 }
 
 func NewInitiateMultiPartUploadRequest(bucketName string, objectName string) *InitiateMultiPartUploadRequest {
-    return &InitiateMultiPartUploadRequest{
-        BucketName: bucketName,
-        ObjectName: objectName,
-    }
+	return &InitiateMultiPartUploadRequest{
+		BucketName: bucketName,
+		ObjectName: objectName,
+	}
 }
 
 type ListMultiPartUploadPartsRequest struct {
-    BucketName string
-    ObjectName string
-    MaxParts *int
-    PartNumberMarker *int
-    UploadId string
+	BucketName       string
+	ObjectName       string
+	MaxParts         *int
+	PartNumberMarker *int
+	UploadId         string
 }
 
 func NewListMultiPartUploadPartsRequest(bucketName string, objectName string, uploadId string) *ListMultiPartUploadPartsRequest {
-    return &ListMultiPartUploadPartsRequest{
-        BucketName: bucketName,
-        ObjectName: objectName,
-        UploadId: uploadId,
-    }
+	return &ListMultiPartUploadPartsRequest{
+		BucketName: bucketName,
+		ObjectName: objectName,
+		UploadId:   uploadId,
+	}
 }
 
 func (listMultiPartUploadPartsRequest *ListMultiPartUploadPartsRequest) WithMaxParts(maxParts int) *ListMultiPartUploadPartsRequest {
-    listMultiPartUploadPartsRequest.MaxParts = &maxParts
-    return listMultiPartUploadPartsRequest
+	listMultiPartUploadPartsRequest.MaxParts = &maxParts
+	return listMultiPartUploadPartsRequest
 }
 
 func (listMultiPartUploadPartsRequest *ListMultiPartUploadPartsRequest) WithPartNumberMarker(partNumberMarker int) *ListMultiPartUploadPartsRequest {
-    listMultiPartUploadPartsRequest.PartNumberMarker = &partNumberMarker
-    return listMultiPartUploadPartsRequest
+	listMultiPartUploadPartsRequest.PartNumberMarker = &partNumberMarker
+	return listMultiPartUploadPartsRequest
 }
 
 type ListMultiPartUploadsRequest struct {
-    BucketName string
-    Delimiter *string
-    KeyMarker *string
-    MaxUploads *int
-    Prefix *string
-    UploadIdMarker *string
+	BucketName     string
+	Delimiter      *string
+	KeyMarker      *string
+	MaxUploads     *int
+	Prefix         *string
+	UploadIdMarker *string
 }
 
 func NewListMultiPartUploadsRequest(bucketName string) *ListMultiPartUploadsRequest {
-    return &ListMultiPartUploadsRequest{
-        BucketName: bucketName,
-    }
+	return &ListMultiPartUploadsRequest{
+		BucketName: bucketName,
+	}
 }
 
 func (listMultiPartUploadsRequest *ListMultiPartUploadsRequest) WithDelimiter(delimiter string) *ListMultiPartUploadsRequest {
-    listMultiPartUploadsRequest.Delimiter = &delimiter
-    return listMultiPartUploadsRequest
+	listMultiPartUploadsRequest.Delimiter = &delimiter
+	return listMultiPartUploadsRequest
 }
 
 func (listMultiPartUploadsRequest *ListMultiPartUploadsRequest) WithKeyMarker(keyMarker string) *ListMultiPartUploadsRequest {
-    listMultiPartUploadsRequest.KeyMarker = &keyMarker
-    return listMultiPartUploadsRequest
+	listMultiPartUploadsRequest.KeyMarker = &keyMarker
+	return listMultiPartUploadsRequest
 }
 
 func (listMultiPartUploadsRequest *ListMultiPartUploadsRequest) WithMaxUploads(maxUploads int) *ListMultiPartUploadsRequest {
-    listMultiPartUploadsRequest.MaxUploads = &maxUploads
-    return listMultiPartUploadsRequest
+	listMultiPartUploadsRequest.MaxUploads = &maxUploads
+	return listMultiPartUploadsRequest
 }
 
 func (listMultiPartUploadsRequest *ListMultiPartUploadsRequest) WithPrefix(prefix string) *ListMultiPartUploadsRequest {
-    listMultiPartUploadsRequest.Prefix = &prefix
-    return listMultiPartUploadsRequest
+	listMultiPartUploadsRequest.Prefix = &prefix
+	return listMultiPartUploadsRequest
 }
 
 func (listMultiPartUploadsRequest *ListMultiPartUploadsRequest) WithUploadIdMarker(uploadIdMarker string) *ListMultiPartUploadsRequest {
-    listMultiPartUploadsRequest.UploadIdMarker = &uploadIdMarker
-    return listMultiPartUploadsRequest
+	listMultiPartUploadsRequest.UploadIdMarker = &uploadIdMarker
+	return listMultiPartUploadsRequest
 }
 
 type PutBucketAclForGroupSpectraS3Request struct {
-    BucketId string
-    GroupId string
-    Permission BucketAclPermission
+	BucketId   string
+	GroupId    string
+	Permission BucketAclPermission
 }
 
 func NewPutBucketAclForGroupSpectraS3Request(bucketId string, groupId string, permission BucketAclPermission) *PutBucketAclForGroupSpectraS3Request {
-    return &PutBucketAclForGroupSpectraS3Request{
-        BucketId: bucketId,
-        GroupId: groupId,
-        Permission: permission,
-    }
+	return &PutBucketAclForGroupSpectraS3Request{
+		BucketId:   bucketId,
+		GroupId:    groupId,
+		Permission: permission,
+	}
 }
 
 type PutBucketAclForUserSpectraS3Request struct {
-    BucketId string
-    Permission BucketAclPermission
-    UserId string
+	BucketId   string
+	Permission BucketAclPermission
+	UserId     string
 }
 
 func NewPutBucketAclForUserSpectraS3Request(bucketId string, permission BucketAclPermission, userId string) *PutBucketAclForUserSpectraS3Request {
-    return &PutBucketAclForUserSpectraS3Request{
-        BucketId: bucketId,
-        Permission: permission,
-        UserId: userId,
-    }
+	return &PutBucketAclForUserSpectraS3Request{
+		BucketId:   bucketId,
+		Permission: permission,
+		UserId:     userId,
+	}
 }
 
 type PutDataPolicyAclForGroupSpectraS3Request struct {
-    DataPolicyId string
-    GroupId string
+	DataPolicyId string
+	GroupId      string
 }
 
 func NewPutDataPolicyAclForGroupSpectraS3Request(dataPolicyId string, groupId string) *PutDataPolicyAclForGroupSpectraS3Request {
-    return &PutDataPolicyAclForGroupSpectraS3Request{
-        DataPolicyId: dataPolicyId,
-        GroupId: groupId,
-    }
+	return &PutDataPolicyAclForGroupSpectraS3Request{
+		DataPolicyId: dataPolicyId,
+		GroupId:      groupId,
+	}
 }
 
 type PutDataPolicyAclForUserSpectraS3Request struct {
-    DataPolicyId string
-    UserId string
+	DataPolicyId string
+	UserId       string
 }
 
 func NewPutDataPolicyAclForUserSpectraS3Request(dataPolicyId string, userId string) *PutDataPolicyAclForUserSpectraS3Request {
-    return &PutDataPolicyAclForUserSpectraS3Request{
-        DataPolicyId: dataPolicyId,
-        UserId: userId,
-    }
+	return &PutDataPolicyAclForUserSpectraS3Request{
+		DataPolicyId: dataPolicyId,
+		UserId:       userId,
+	}
 }
 
 type PutGlobalBucketAclForGroupSpectraS3Request struct {
-    GroupId string
-    Permission BucketAclPermission
+	GroupId    string
+	Permission BucketAclPermission
 }
 
 func NewPutGlobalBucketAclForGroupSpectraS3Request(groupId string, permission BucketAclPermission) *PutGlobalBucketAclForGroupSpectraS3Request {
-    return &PutGlobalBucketAclForGroupSpectraS3Request{
-        GroupId: groupId,
-        Permission: permission,
-    }
+	return &PutGlobalBucketAclForGroupSpectraS3Request{
+		GroupId:    groupId,
+		Permission: permission,
+	}
 }
 
 type PutGlobalBucketAclForUserSpectraS3Request struct {
-    Permission BucketAclPermission
-    UserId string
+	Permission BucketAclPermission
+	UserId     string
 }
 
 func NewPutGlobalBucketAclForUserSpectraS3Request(permission BucketAclPermission, userId string) *PutGlobalBucketAclForUserSpectraS3Request {
-    return &PutGlobalBucketAclForUserSpectraS3Request{
-        Permission: permission,
-        UserId: userId,
-    }
+	return &PutGlobalBucketAclForUserSpectraS3Request{
+		Permission: permission,
+		UserId:     userId,
+	}
 }
 
 type PutGlobalDataPolicyAclForGroupSpectraS3Request struct {
-    GroupId string
+	GroupId string
 }
 
 func NewPutGlobalDataPolicyAclForGroupSpectraS3Request(groupId string) *PutGlobalDataPolicyAclForGroupSpectraS3Request {
-    return &PutGlobalDataPolicyAclForGroupSpectraS3Request{
-        GroupId: groupId,
-    }
+	return &PutGlobalDataPolicyAclForGroupSpectraS3Request{
+		GroupId: groupId,
+	}
 }
 
 type PutGlobalDataPolicyAclForUserSpectraS3Request struct {
-    UserId string
+	UserId string
 }
 
 func NewPutGlobalDataPolicyAclForUserSpectraS3Request(userId string) *PutGlobalDataPolicyAclForUserSpectraS3Request {
-    return &PutGlobalDataPolicyAclForUserSpectraS3Request{
-        UserId: userId,
-    }
+	return &PutGlobalDataPolicyAclForUserSpectraS3Request{
+		UserId: userId,
+	}
 }
 
 type DeleteBucketAclSpectraS3Request struct {
-    BucketAcl string
+	BucketAcl string
 }
 
 func NewDeleteBucketAclSpectraS3Request(bucketAcl string) *DeleteBucketAclSpectraS3Request {
-    return &DeleteBucketAclSpectraS3Request{
-        BucketAcl: bucketAcl,
-    }
+	return &DeleteBucketAclSpectraS3Request{
+		BucketAcl: bucketAcl,
+	}
 }
 
 type DeleteDataPolicyAclSpectraS3Request struct {
-    DataPolicyAcl string
+	DataPolicyAcl string
 }
 
 func NewDeleteDataPolicyAclSpectraS3Request(dataPolicyAcl string) *DeleteDataPolicyAclSpectraS3Request {
-    return &DeleteDataPolicyAclSpectraS3Request{
-        DataPolicyAcl: dataPolicyAcl,
-    }
+	return &DeleteDataPolicyAclSpectraS3Request{
+		DataPolicyAcl: dataPolicyAcl,
+	}
 }
 
 type GetBucketAclSpectraS3Request struct {
-    BucketAcl string
+	BucketAcl string
 }
 
 func NewGetBucketAclSpectraS3Request(bucketAcl string) *GetBucketAclSpectraS3Request {
-    return &GetBucketAclSpectraS3Request{
-        BucketAcl: bucketAcl,
-    }
+	return &GetBucketAclSpectraS3Request{
+		BucketAcl: bucketAcl,
+	}
 }
 
 type GetBucketAclsSpectraS3Request struct {
-    BucketId *string
-    GroupId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    Permission BucketAclPermission
-    UserId *string
+	BucketId        *string
+	GroupId         *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	Permission      BucketAclPermission
+	UserId          *string
 }
 
 func NewGetBucketAclsSpectraS3Request() *GetBucketAclsSpectraS3Request {
-    return &GetBucketAclsSpectraS3Request{
-    }
+	return &GetBucketAclsSpectraS3Request{}
 }
 
 func (getBucketAclsSpectraS3Request *GetBucketAclsSpectraS3Request) WithBucketId(bucketId string) *GetBucketAclsSpectraS3Request {
-    getBucketAclsSpectraS3Request.BucketId = &bucketId
-    return getBucketAclsSpectraS3Request
+	getBucketAclsSpectraS3Request.BucketId = &bucketId
+	return getBucketAclsSpectraS3Request
 }
 
 func (getBucketAclsSpectraS3Request *GetBucketAclsSpectraS3Request) WithGroupId(groupId string) *GetBucketAclsSpectraS3Request {
-    getBucketAclsSpectraS3Request.GroupId = &groupId
-    return getBucketAclsSpectraS3Request
+	getBucketAclsSpectraS3Request.GroupId = &groupId
+	return getBucketAclsSpectraS3Request
 }
 
 func (getBucketAclsSpectraS3Request *GetBucketAclsSpectraS3Request) WithLastPage() *GetBucketAclsSpectraS3Request {
-    getBucketAclsSpectraS3Request.LastPage = true
-    return getBucketAclsSpectraS3Request
+	getBucketAclsSpectraS3Request.LastPage = true
+	return getBucketAclsSpectraS3Request
 }
 
 func (getBucketAclsSpectraS3Request *GetBucketAclsSpectraS3Request) WithPageLength(pageLength int) *GetBucketAclsSpectraS3Request {
-    getBucketAclsSpectraS3Request.PageLength = &pageLength
-    return getBucketAclsSpectraS3Request
+	getBucketAclsSpectraS3Request.PageLength = &pageLength
+	return getBucketAclsSpectraS3Request
 }
 
 func (getBucketAclsSpectraS3Request *GetBucketAclsSpectraS3Request) WithPageOffset(pageOffset int) *GetBucketAclsSpectraS3Request {
-    getBucketAclsSpectraS3Request.PageOffset = &pageOffset
-    return getBucketAclsSpectraS3Request
+	getBucketAclsSpectraS3Request.PageOffset = &pageOffset
+	return getBucketAclsSpectraS3Request
 }
 
 func (getBucketAclsSpectraS3Request *GetBucketAclsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetBucketAclsSpectraS3Request {
-    getBucketAclsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getBucketAclsSpectraS3Request
+	getBucketAclsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getBucketAclsSpectraS3Request
 }
 
 func (getBucketAclsSpectraS3Request *GetBucketAclsSpectraS3Request) WithPermission(permission BucketAclPermission) *GetBucketAclsSpectraS3Request {
-    getBucketAclsSpectraS3Request.Permission = permission
-    return getBucketAclsSpectraS3Request
+	getBucketAclsSpectraS3Request.Permission = permission
+	return getBucketAclsSpectraS3Request
 }
 
 func (getBucketAclsSpectraS3Request *GetBucketAclsSpectraS3Request) WithUserId(userId string) *GetBucketAclsSpectraS3Request {
-    getBucketAclsSpectraS3Request.UserId = &userId
-    return getBucketAclsSpectraS3Request
+	getBucketAclsSpectraS3Request.UserId = &userId
+	return getBucketAclsSpectraS3Request
 }
 
 type GetDataPolicyAclSpectraS3Request struct {
-    DataPolicyAcl string
+	DataPolicyAcl string
 }
 
 func NewGetDataPolicyAclSpectraS3Request(dataPolicyAcl string) *GetDataPolicyAclSpectraS3Request {
-    return &GetDataPolicyAclSpectraS3Request{
-        DataPolicyAcl: dataPolicyAcl,
-    }
+	return &GetDataPolicyAclSpectraS3Request{
+		DataPolicyAcl: dataPolicyAcl,
+	}
 }
 
 type GetDataPolicyAclsSpectraS3Request struct {
-    DataPolicyId *string
-    GroupId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	DataPolicyId    *string
+	GroupId         *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetDataPolicyAclsSpectraS3Request() *GetDataPolicyAclsSpectraS3Request {
-    return &GetDataPolicyAclsSpectraS3Request{
-    }
+	return &GetDataPolicyAclsSpectraS3Request{}
 }
 
 func (getDataPolicyAclsSpectraS3Request *GetDataPolicyAclsSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetDataPolicyAclsSpectraS3Request {
-    getDataPolicyAclsSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getDataPolicyAclsSpectraS3Request
+	getDataPolicyAclsSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getDataPolicyAclsSpectraS3Request
 }
 
 func (getDataPolicyAclsSpectraS3Request *GetDataPolicyAclsSpectraS3Request) WithGroupId(groupId string) *GetDataPolicyAclsSpectraS3Request {
-    getDataPolicyAclsSpectraS3Request.GroupId = &groupId
-    return getDataPolicyAclsSpectraS3Request
+	getDataPolicyAclsSpectraS3Request.GroupId = &groupId
+	return getDataPolicyAclsSpectraS3Request
 }
 
 func (getDataPolicyAclsSpectraS3Request *GetDataPolicyAclsSpectraS3Request) WithLastPage() *GetDataPolicyAclsSpectraS3Request {
-    getDataPolicyAclsSpectraS3Request.LastPage = true
-    return getDataPolicyAclsSpectraS3Request
+	getDataPolicyAclsSpectraS3Request.LastPage = true
+	return getDataPolicyAclsSpectraS3Request
 }
 
 func (getDataPolicyAclsSpectraS3Request *GetDataPolicyAclsSpectraS3Request) WithPageLength(pageLength int) *GetDataPolicyAclsSpectraS3Request {
-    getDataPolicyAclsSpectraS3Request.PageLength = &pageLength
-    return getDataPolicyAclsSpectraS3Request
+	getDataPolicyAclsSpectraS3Request.PageLength = &pageLength
+	return getDataPolicyAclsSpectraS3Request
 }
 
 func (getDataPolicyAclsSpectraS3Request *GetDataPolicyAclsSpectraS3Request) WithPageOffset(pageOffset int) *GetDataPolicyAclsSpectraS3Request {
-    getDataPolicyAclsSpectraS3Request.PageOffset = &pageOffset
-    return getDataPolicyAclsSpectraS3Request
+	getDataPolicyAclsSpectraS3Request.PageOffset = &pageOffset
+	return getDataPolicyAclsSpectraS3Request
 }
 
 func (getDataPolicyAclsSpectraS3Request *GetDataPolicyAclsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDataPolicyAclsSpectraS3Request {
-    getDataPolicyAclsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDataPolicyAclsSpectraS3Request
+	getDataPolicyAclsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDataPolicyAclsSpectraS3Request
 }
 
 func (getDataPolicyAclsSpectraS3Request *GetDataPolicyAclsSpectraS3Request) WithUserId(userId string) *GetDataPolicyAclsSpectraS3Request {
-    getDataPolicyAclsSpectraS3Request.UserId = &userId
-    return getDataPolicyAclsSpectraS3Request
+	getDataPolicyAclsSpectraS3Request.UserId = &userId
+	return getDataPolicyAclsSpectraS3Request
 }
 
 type PutBucketSpectraS3Request struct {
-    DataPolicyId *string
-    Id *string
-    Name string
-    Protected *bool
-    UserId *string
+	DataPolicyId *string
+	Id           *string
+	Name         string
+	Protected    *bool
+	UserId       *string
 }
 
 func NewPutBucketSpectraS3Request(name string) *PutBucketSpectraS3Request {
-    return &PutBucketSpectraS3Request{
-        Name: name,
-    }
+	return &PutBucketSpectraS3Request{
+		Name: name,
+	}
 }
 
 func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithDataPolicyId(dataPolicyId string) *PutBucketSpectraS3Request {
-    putBucketSpectraS3Request.DataPolicyId = &dataPolicyId
-    return putBucketSpectraS3Request
+	putBucketSpectraS3Request.DataPolicyId = &dataPolicyId
+	return putBucketSpectraS3Request
 }
 
 func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithId(id string) *PutBucketSpectraS3Request {
-    putBucketSpectraS3Request.Id = &id
-    return putBucketSpectraS3Request
+	putBucketSpectraS3Request.Id = &id
+	return putBucketSpectraS3Request
 }
 
 func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithProtected(protected bool) *PutBucketSpectraS3Request {
-    putBucketSpectraS3Request.Protected = &protected
-    return putBucketSpectraS3Request
+	putBucketSpectraS3Request.Protected = &protected
+	return putBucketSpectraS3Request
 }
 
 func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithUserId(userId string) *PutBucketSpectraS3Request {
-    putBucketSpectraS3Request.UserId = &userId
-    return putBucketSpectraS3Request
+	putBucketSpectraS3Request.UserId = &userId
+	return putBucketSpectraS3Request
 }
 
 type DeleteBucketSpectraS3Request struct {
-    BucketName string
-    Force bool
+	BucketName string
+	Force      bool
 }
 
 func NewDeleteBucketSpectraS3Request(bucketName string) *DeleteBucketSpectraS3Request {
-    return &DeleteBucketSpectraS3Request{
-        BucketName: bucketName,
-    }
+	return &DeleteBucketSpectraS3Request{
+		BucketName: bucketName,
+	}
 }
 
 func (deleteBucketSpectraS3Request *DeleteBucketSpectraS3Request) WithForce() *DeleteBucketSpectraS3Request {
-    deleteBucketSpectraS3Request.Force = true
-    return deleteBucketSpectraS3Request
+	deleteBucketSpectraS3Request.Force = true
+	return deleteBucketSpectraS3Request
 }
 
 type GetBucketSpectraS3Request struct {
-    BucketName string
+	BucketName string
 }
 
 func NewGetBucketSpectraS3Request(bucketName string) *GetBucketSpectraS3Request {
-    return &GetBucketSpectraS3Request{
-        BucketName: bucketName,
-    }
+	return &GetBucketSpectraS3Request{
+		BucketName: bucketName,
+	}
 }
 
 type GetBucketsSpectraS3Request struct {
-    DataPolicyId *string
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	DataPolicyId    *string
+	LastPage        bool
+	Name            *string
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetBucketsSpectraS3Request() *GetBucketsSpectraS3Request {
-    return &GetBucketsSpectraS3Request{
-    }
+	return &GetBucketsSpectraS3Request{}
 }
 
 func (getBucketsSpectraS3Request *GetBucketsSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetBucketsSpectraS3Request {
-    getBucketsSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getBucketsSpectraS3Request
+	getBucketsSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getBucketsSpectraS3Request
 }
 
 func (getBucketsSpectraS3Request *GetBucketsSpectraS3Request) WithLastPage() *GetBucketsSpectraS3Request {
-    getBucketsSpectraS3Request.LastPage = true
-    return getBucketsSpectraS3Request
+	getBucketsSpectraS3Request.LastPage = true
+	return getBucketsSpectraS3Request
 }
 
 func (getBucketsSpectraS3Request *GetBucketsSpectraS3Request) WithName(name string) *GetBucketsSpectraS3Request {
-    getBucketsSpectraS3Request.Name = &name
-    return getBucketsSpectraS3Request
+	getBucketsSpectraS3Request.Name = &name
+	return getBucketsSpectraS3Request
 }
 
 func (getBucketsSpectraS3Request *GetBucketsSpectraS3Request) WithPageLength(pageLength int) *GetBucketsSpectraS3Request {
-    getBucketsSpectraS3Request.PageLength = &pageLength
-    return getBucketsSpectraS3Request
+	getBucketsSpectraS3Request.PageLength = &pageLength
+	return getBucketsSpectraS3Request
 }
 
 func (getBucketsSpectraS3Request *GetBucketsSpectraS3Request) WithPageOffset(pageOffset int) *GetBucketsSpectraS3Request {
-    getBucketsSpectraS3Request.PageOffset = &pageOffset
-    return getBucketsSpectraS3Request
+	getBucketsSpectraS3Request.PageOffset = &pageOffset
+	return getBucketsSpectraS3Request
 }
 
 func (getBucketsSpectraS3Request *GetBucketsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetBucketsSpectraS3Request {
-    getBucketsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getBucketsSpectraS3Request
+	getBucketsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getBucketsSpectraS3Request
 }
 
 func (getBucketsSpectraS3Request *GetBucketsSpectraS3Request) WithUserId(userId string) *GetBucketsSpectraS3Request {
-    getBucketsSpectraS3Request.UserId = &userId
-    return getBucketsSpectraS3Request
+	getBucketsSpectraS3Request.UserId = &userId
+	return getBucketsSpectraS3Request
 }
 
 type ModifyBucketSpectraS3Request struct {
-    BucketName string
-    DataPolicyId *string
-    Protected *bool
-    UserId *string
+	BucketName   string
+	DataPolicyId *string
+	Protected    *bool
+	UserId       *string
 }
 
 func NewModifyBucketSpectraS3Request(bucketName string) *ModifyBucketSpectraS3Request {
-    return &ModifyBucketSpectraS3Request{
-        BucketName: bucketName,
-    }
+	return &ModifyBucketSpectraS3Request{
+		BucketName: bucketName,
+	}
 }
 
 func (modifyBucketSpectraS3Request *ModifyBucketSpectraS3Request) WithDataPolicyId(dataPolicyId string) *ModifyBucketSpectraS3Request {
-    modifyBucketSpectraS3Request.DataPolicyId = &dataPolicyId
-    return modifyBucketSpectraS3Request
+	modifyBucketSpectraS3Request.DataPolicyId = &dataPolicyId
+	return modifyBucketSpectraS3Request
 }
 
 func (modifyBucketSpectraS3Request *ModifyBucketSpectraS3Request) WithProtected(protected bool) *ModifyBucketSpectraS3Request {
-    modifyBucketSpectraS3Request.Protected = &protected
-    return modifyBucketSpectraS3Request
+	modifyBucketSpectraS3Request.Protected = &protected
+	return modifyBucketSpectraS3Request
 }
 
 func (modifyBucketSpectraS3Request *ModifyBucketSpectraS3Request) WithUserId(userId string) *ModifyBucketSpectraS3Request {
-    modifyBucketSpectraS3Request.UserId = &userId
-    return modifyBucketSpectraS3Request
+	modifyBucketSpectraS3Request.UserId = &userId
+	return modifyBucketSpectraS3Request
 }
 
 type ForceFullCacheReclaimSpectraS3Request struct {
 }
 
 func NewForceFullCacheReclaimSpectraS3Request() *ForceFullCacheReclaimSpectraS3Request {
-    return &ForceFullCacheReclaimSpectraS3Request{
-    }
+	return &ForceFullCacheReclaimSpectraS3Request{}
 }
 
 type GetCacheFilesystemSpectraS3Request struct {
-    CacheFilesystem string
+	CacheFilesystem string
 }
 
 func NewGetCacheFilesystemSpectraS3Request(cacheFilesystem string) *GetCacheFilesystemSpectraS3Request {
-    return &GetCacheFilesystemSpectraS3Request{
-        CacheFilesystem: cacheFilesystem,
-    }
+	return &GetCacheFilesystemSpectraS3Request{
+		CacheFilesystem: cacheFilesystem,
+	}
 }
 
 type GetCacheFilesystemsSpectraS3Request struct {
-    LastPage bool
-    NodeId *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
+	LastPage        bool
+	NodeId          *string
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
 }
 
 func NewGetCacheFilesystemsSpectraS3Request() *GetCacheFilesystemsSpectraS3Request {
-    return &GetCacheFilesystemsSpectraS3Request{
-    }
+	return &GetCacheFilesystemsSpectraS3Request{}
 }
 
 func (getCacheFilesystemsSpectraS3Request *GetCacheFilesystemsSpectraS3Request) WithLastPage() *GetCacheFilesystemsSpectraS3Request {
-    getCacheFilesystemsSpectraS3Request.LastPage = true
-    return getCacheFilesystemsSpectraS3Request
+	getCacheFilesystemsSpectraS3Request.LastPage = true
+	return getCacheFilesystemsSpectraS3Request
 }
 
 func (getCacheFilesystemsSpectraS3Request *GetCacheFilesystemsSpectraS3Request) WithNodeId(nodeId string) *GetCacheFilesystemsSpectraS3Request {
-    getCacheFilesystemsSpectraS3Request.NodeId = &nodeId
-    return getCacheFilesystemsSpectraS3Request
+	getCacheFilesystemsSpectraS3Request.NodeId = &nodeId
+	return getCacheFilesystemsSpectraS3Request
 }
 
 func (getCacheFilesystemsSpectraS3Request *GetCacheFilesystemsSpectraS3Request) WithPageLength(pageLength int) *GetCacheFilesystemsSpectraS3Request {
-    getCacheFilesystemsSpectraS3Request.PageLength = &pageLength
-    return getCacheFilesystemsSpectraS3Request
+	getCacheFilesystemsSpectraS3Request.PageLength = &pageLength
+	return getCacheFilesystemsSpectraS3Request
 }
 
 func (getCacheFilesystemsSpectraS3Request *GetCacheFilesystemsSpectraS3Request) WithPageOffset(pageOffset int) *GetCacheFilesystemsSpectraS3Request {
-    getCacheFilesystemsSpectraS3Request.PageOffset = &pageOffset
-    return getCacheFilesystemsSpectraS3Request
+	getCacheFilesystemsSpectraS3Request.PageOffset = &pageOffset
+	return getCacheFilesystemsSpectraS3Request
 }
 
 func (getCacheFilesystemsSpectraS3Request *GetCacheFilesystemsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetCacheFilesystemsSpectraS3Request {
-    getCacheFilesystemsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getCacheFilesystemsSpectraS3Request
+	getCacheFilesystemsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getCacheFilesystemsSpectraS3Request
 }
 
 type GetCacheStateSpectraS3Request struct {
 }
 
 func NewGetCacheStateSpectraS3Request() *GetCacheStateSpectraS3Request {
-    return &GetCacheStateSpectraS3Request{
-    }
+	return &GetCacheStateSpectraS3Request{}
 }
 
 type ModifyCacheFilesystemSpectraS3Request struct {
-    AutoReclaimInitiateThreshold *float64
-    AutoReclaimTerminateThreshold *float64
-    BurstThreshold *float64
-    CacheFilesystem string
-    CacheSafetyEnabled *bool
-    MaxCapacityInBytes *int64
-    NeedsReconcile *bool
+	AutoReclaimInitiateThreshold  *float64
+	AutoReclaimTerminateThreshold *float64
+	BurstThreshold                *float64
+	CacheFilesystem               string
+	CacheSafetyEnabled            *bool
+	MaxCapacityInBytes            *int64
+	NeedsReconcile                *bool
 }
 
 func NewModifyCacheFilesystemSpectraS3Request(cacheFilesystem string) *ModifyCacheFilesystemSpectraS3Request {
-    return &ModifyCacheFilesystemSpectraS3Request{
-        CacheFilesystem: cacheFilesystem,
-    }
+	return &ModifyCacheFilesystemSpectraS3Request{
+		CacheFilesystem: cacheFilesystem,
+	}
 }
 
 func (modifyCacheFilesystemSpectraS3Request *ModifyCacheFilesystemSpectraS3Request) WithAutoReclaimInitiateThreshold(autoReclaimInitiateThreshold float64) *ModifyCacheFilesystemSpectraS3Request {
-    modifyCacheFilesystemSpectraS3Request.AutoReclaimInitiateThreshold = &autoReclaimInitiateThreshold
-    return modifyCacheFilesystemSpectraS3Request
+	modifyCacheFilesystemSpectraS3Request.AutoReclaimInitiateThreshold = &autoReclaimInitiateThreshold
+	return modifyCacheFilesystemSpectraS3Request
 }
 
 func (modifyCacheFilesystemSpectraS3Request *ModifyCacheFilesystemSpectraS3Request) WithAutoReclaimTerminateThreshold(autoReclaimTerminateThreshold float64) *ModifyCacheFilesystemSpectraS3Request {
-    modifyCacheFilesystemSpectraS3Request.AutoReclaimTerminateThreshold = &autoReclaimTerminateThreshold
-    return modifyCacheFilesystemSpectraS3Request
+	modifyCacheFilesystemSpectraS3Request.AutoReclaimTerminateThreshold = &autoReclaimTerminateThreshold
+	return modifyCacheFilesystemSpectraS3Request
 }
 
 func (modifyCacheFilesystemSpectraS3Request *ModifyCacheFilesystemSpectraS3Request) WithBurstThreshold(burstThreshold float64) *ModifyCacheFilesystemSpectraS3Request {
-    modifyCacheFilesystemSpectraS3Request.BurstThreshold = &burstThreshold
-    return modifyCacheFilesystemSpectraS3Request
+	modifyCacheFilesystemSpectraS3Request.BurstThreshold = &burstThreshold
+	return modifyCacheFilesystemSpectraS3Request
 }
 
 func (modifyCacheFilesystemSpectraS3Request *ModifyCacheFilesystemSpectraS3Request) WithCacheSafetyEnabled(cacheSafetyEnabled bool) *ModifyCacheFilesystemSpectraS3Request {
-    modifyCacheFilesystemSpectraS3Request.CacheSafetyEnabled = &cacheSafetyEnabled
-    return modifyCacheFilesystemSpectraS3Request
+	modifyCacheFilesystemSpectraS3Request.CacheSafetyEnabled = &cacheSafetyEnabled
+	return modifyCacheFilesystemSpectraS3Request
 }
 
 func (modifyCacheFilesystemSpectraS3Request *ModifyCacheFilesystemSpectraS3Request) WithMaxCapacityInBytes(maxCapacityInBytes int64) *ModifyCacheFilesystemSpectraS3Request {
-    modifyCacheFilesystemSpectraS3Request.MaxCapacityInBytes = &maxCapacityInBytes
-    return modifyCacheFilesystemSpectraS3Request
+	modifyCacheFilesystemSpectraS3Request.MaxCapacityInBytes = &maxCapacityInBytes
+	return modifyCacheFilesystemSpectraS3Request
 }
 
 func (modifyCacheFilesystemSpectraS3Request *ModifyCacheFilesystemSpectraS3Request) WithNeedsReconcile(needsReconcile bool) *ModifyCacheFilesystemSpectraS3Request {
-    modifyCacheFilesystemSpectraS3Request.NeedsReconcile = &needsReconcile
-    return modifyCacheFilesystemSpectraS3Request
+	modifyCacheFilesystemSpectraS3Request.NeedsReconcile = &needsReconcile
+	return modifyCacheFilesystemSpectraS3Request
 }
 
 type GetBucketCapacitySummarySpectraS3Request struct {
-    BucketId string
-    PoolHealth PoolHealth
-    PoolState PoolState
-    PoolType PoolType
-    StorageDomainId string
-    TapeState TapeState
-    TapeType *string
+	BucketId        string
+	PoolHealth      PoolHealth
+	PoolState       PoolState
+	PoolType        PoolType
+	StorageDomainId string
+	TapeState       TapeState
+	TapeType        *string
 }
 
 func NewGetBucketCapacitySummarySpectraS3Request(bucketId string, storageDomainId string) *GetBucketCapacitySummarySpectraS3Request {
-    return &GetBucketCapacitySummarySpectraS3Request{
-        BucketId: bucketId,
-        StorageDomainId: storageDomainId,
-    }
+	return &GetBucketCapacitySummarySpectraS3Request{
+		BucketId:        bucketId,
+		StorageDomainId: storageDomainId,
+	}
 }
 
 func (getBucketCapacitySummarySpectraS3Request *GetBucketCapacitySummarySpectraS3Request) WithPoolHealth(poolHealth PoolHealth) *GetBucketCapacitySummarySpectraS3Request {
-    getBucketCapacitySummarySpectraS3Request.PoolHealth = poolHealth
-    return getBucketCapacitySummarySpectraS3Request
+	getBucketCapacitySummarySpectraS3Request.PoolHealth = poolHealth
+	return getBucketCapacitySummarySpectraS3Request
 }
 
 func (getBucketCapacitySummarySpectraS3Request *GetBucketCapacitySummarySpectraS3Request) WithPoolState(poolState PoolState) *GetBucketCapacitySummarySpectraS3Request {
-    getBucketCapacitySummarySpectraS3Request.PoolState = poolState
-    return getBucketCapacitySummarySpectraS3Request
+	getBucketCapacitySummarySpectraS3Request.PoolState = poolState
+	return getBucketCapacitySummarySpectraS3Request
 }
 
 func (getBucketCapacitySummarySpectraS3Request *GetBucketCapacitySummarySpectraS3Request) WithPoolType(poolType PoolType) *GetBucketCapacitySummarySpectraS3Request {
-    getBucketCapacitySummarySpectraS3Request.PoolType = poolType
-    return getBucketCapacitySummarySpectraS3Request
+	getBucketCapacitySummarySpectraS3Request.PoolType = poolType
+	return getBucketCapacitySummarySpectraS3Request
 }
 
 func (getBucketCapacitySummarySpectraS3Request *GetBucketCapacitySummarySpectraS3Request) WithTapeState(tapeState TapeState) *GetBucketCapacitySummarySpectraS3Request {
-    getBucketCapacitySummarySpectraS3Request.TapeState = tapeState
-    return getBucketCapacitySummarySpectraS3Request
+	getBucketCapacitySummarySpectraS3Request.TapeState = tapeState
+	return getBucketCapacitySummarySpectraS3Request
 }
 
 func (getBucketCapacitySummarySpectraS3Request *GetBucketCapacitySummarySpectraS3Request) WithTapeType(tapeType string) *GetBucketCapacitySummarySpectraS3Request {
-    getBucketCapacitySummarySpectraS3Request.TapeType = &tapeType
-    return getBucketCapacitySummarySpectraS3Request
+	getBucketCapacitySummarySpectraS3Request.TapeType = &tapeType
+	return getBucketCapacitySummarySpectraS3Request
 }
 
 type GetStorageDomainCapacitySummarySpectraS3Request struct {
-    PoolHealth PoolHealth
-    PoolState PoolState
-    PoolType PoolType
-    StorageDomainId string
-    TapeState TapeState
-    TapeType *string
+	PoolHealth      PoolHealth
+	PoolState       PoolState
+	PoolType        PoolType
+	StorageDomainId string
+	TapeState       TapeState
+	TapeType        *string
 }
 
 func NewGetStorageDomainCapacitySummarySpectraS3Request(storageDomainId string) *GetStorageDomainCapacitySummarySpectraS3Request {
-    return &GetStorageDomainCapacitySummarySpectraS3Request{
-        StorageDomainId: storageDomainId,
-    }
+	return &GetStorageDomainCapacitySummarySpectraS3Request{
+		StorageDomainId: storageDomainId,
+	}
 }
 
 func (getStorageDomainCapacitySummarySpectraS3Request *GetStorageDomainCapacitySummarySpectraS3Request) WithPoolHealth(poolHealth PoolHealth) *GetStorageDomainCapacitySummarySpectraS3Request {
-    getStorageDomainCapacitySummarySpectraS3Request.PoolHealth = poolHealth
-    return getStorageDomainCapacitySummarySpectraS3Request
+	getStorageDomainCapacitySummarySpectraS3Request.PoolHealth = poolHealth
+	return getStorageDomainCapacitySummarySpectraS3Request
 }
 
 func (getStorageDomainCapacitySummarySpectraS3Request *GetStorageDomainCapacitySummarySpectraS3Request) WithPoolState(poolState PoolState) *GetStorageDomainCapacitySummarySpectraS3Request {
-    getStorageDomainCapacitySummarySpectraS3Request.PoolState = poolState
-    return getStorageDomainCapacitySummarySpectraS3Request
+	getStorageDomainCapacitySummarySpectraS3Request.PoolState = poolState
+	return getStorageDomainCapacitySummarySpectraS3Request
 }
 
 func (getStorageDomainCapacitySummarySpectraS3Request *GetStorageDomainCapacitySummarySpectraS3Request) WithPoolType(poolType PoolType) *GetStorageDomainCapacitySummarySpectraS3Request {
-    getStorageDomainCapacitySummarySpectraS3Request.PoolType = poolType
-    return getStorageDomainCapacitySummarySpectraS3Request
+	getStorageDomainCapacitySummarySpectraS3Request.PoolType = poolType
+	return getStorageDomainCapacitySummarySpectraS3Request
 }
 
 func (getStorageDomainCapacitySummarySpectraS3Request *GetStorageDomainCapacitySummarySpectraS3Request) WithTapeState(tapeState TapeState) *GetStorageDomainCapacitySummarySpectraS3Request {
-    getStorageDomainCapacitySummarySpectraS3Request.TapeState = tapeState
-    return getStorageDomainCapacitySummarySpectraS3Request
+	getStorageDomainCapacitySummarySpectraS3Request.TapeState = tapeState
+	return getStorageDomainCapacitySummarySpectraS3Request
 }
 
 func (getStorageDomainCapacitySummarySpectraS3Request *GetStorageDomainCapacitySummarySpectraS3Request) WithTapeType(tapeType string) *GetStorageDomainCapacitySummarySpectraS3Request {
-    getStorageDomainCapacitySummarySpectraS3Request.TapeType = &tapeType
-    return getStorageDomainCapacitySummarySpectraS3Request
+	getStorageDomainCapacitySummarySpectraS3Request.TapeType = &tapeType
+	return getStorageDomainCapacitySummarySpectraS3Request
 }
 
 type GetSystemCapacitySummarySpectraS3Request struct {
-    PoolHealth PoolHealth
-    PoolState PoolState
-    PoolType PoolType
-    TapeState TapeState
-    TapeType *string
+	PoolHealth PoolHealth
+	PoolState  PoolState
+	PoolType   PoolType
+	TapeState  TapeState
+	TapeType   *string
 }
 
 func NewGetSystemCapacitySummarySpectraS3Request() *GetSystemCapacitySummarySpectraS3Request {
-    return &GetSystemCapacitySummarySpectraS3Request{
-    }
+	return &GetSystemCapacitySummarySpectraS3Request{}
 }
 
 func (getSystemCapacitySummarySpectraS3Request *GetSystemCapacitySummarySpectraS3Request) WithPoolHealth(poolHealth PoolHealth) *GetSystemCapacitySummarySpectraS3Request {
-    getSystemCapacitySummarySpectraS3Request.PoolHealth = poolHealth
-    return getSystemCapacitySummarySpectraS3Request
+	getSystemCapacitySummarySpectraS3Request.PoolHealth = poolHealth
+	return getSystemCapacitySummarySpectraS3Request
 }
 
 func (getSystemCapacitySummarySpectraS3Request *GetSystemCapacitySummarySpectraS3Request) WithPoolState(poolState PoolState) *GetSystemCapacitySummarySpectraS3Request {
-    getSystemCapacitySummarySpectraS3Request.PoolState = poolState
-    return getSystemCapacitySummarySpectraS3Request
+	getSystemCapacitySummarySpectraS3Request.PoolState = poolState
+	return getSystemCapacitySummarySpectraS3Request
 }
 
 func (getSystemCapacitySummarySpectraS3Request *GetSystemCapacitySummarySpectraS3Request) WithPoolType(poolType PoolType) *GetSystemCapacitySummarySpectraS3Request {
-    getSystemCapacitySummarySpectraS3Request.PoolType = poolType
-    return getSystemCapacitySummarySpectraS3Request
+	getSystemCapacitySummarySpectraS3Request.PoolType = poolType
+	return getSystemCapacitySummarySpectraS3Request
 }
 
 func (getSystemCapacitySummarySpectraS3Request *GetSystemCapacitySummarySpectraS3Request) WithTapeState(tapeState TapeState) *GetSystemCapacitySummarySpectraS3Request {
-    getSystemCapacitySummarySpectraS3Request.TapeState = tapeState
-    return getSystemCapacitySummarySpectraS3Request
+	getSystemCapacitySummarySpectraS3Request.TapeState = tapeState
+	return getSystemCapacitySummarySpectraS3Request
 }
 
 func (getSystemCapacitySummarySpectraS3Request *GetSystemCapacitySummarySpectraS3Request) WithTapeType(tapeType string) *GetSystemCapacitySummarySpectraS3Request {
-    getSystemCapacitySummarySpectraS3Request.TapeType = &tapeType
-    return getSystemCapacitySummarySpectraS3Request
+	getSystemCapacitySummarySpectraS3Request.TapeType = &tapeType
+	return getSystemCapacitySummarySpectraS3Request
 }
 
 type GetDataPathBackendSpectraS3Request struct {
 }
 
 func NewGetDataPathBackendSpectraS3Request() *GetDataPathBackendSpectraS3Request {
-    return &GetDataPathBackendSpectraS3Request{
-    }
+	return &GetDataPathBackendSpectraS3Request{}
 }
 
 type GetDataPlannerBlobStoreTasksSpectraS3Request struct {
-    FullDetails bool
+	FullDetails bool
 }
 
 func NewGetDataPlannerBlobStoreTasksSpectraS3Request() *GetDataPlannerBlobStoreTasksSpectraS3Request {
-    return &GetDataPlannerBlobStoreTasksSpectraS3Request{
-    }
+	return &GetDataPlannerBlobStoreTasksSpectraS3Request{}
 }
 
 func (getDataPlannerBlobStoreTasksSpectraS3Request *GetDataPlannerBlobStoreTasksSpectraS3Request) WithFullDetails() *GetDataPlannerBlobStoreTasksSpectraS3Request {
-    getDataPlannerBlobStoreTasksSpectraS3Request.FullDetails = true
-    return getDataPlannerBlobStoreTasksSpectraS3Request
+	getDataPlannerBlobStoreTasksSpectraS3Request.FullDetails = true
+	return getDataPlannerBlobStoreTasksSpectraS3Request
 }
 
 type ModifyDataPathBackendSpectraS3Request struct {
-    Activated *bool
-    AllowNewJobRequests *bool
-    AutoActivateTimeoutInMins *int
-    AutoInspect AutoInspectMode
-    CacheAvailableRetryAfterInSeconds *int
-    DefaultVerifyDataAfterImport Priority
-    DefaultVerifyDataPriorToImport *bool
-    IomCacheLimitationPercent *float64
-    IomEnabled *bool
-    MaxAggregatedBlobsPerChunk *int
-    MaxNumberOfConcurrentJobs *int
-    PartiallyVerifyLastPercentOfTapes *int
-    PoolSafetyEnabled *bool
-    UnavailableMediaPolicy UnavailableMediaUsagePolicy
-    UnavailablePoolMaxJobRetryInMins *int
-    UnavailableTapePartitionMaxJobRetryInMins *int
-    VerifyCheckpointBeforeRead *bool
+	Activated                                 *bool
+	AllowNewJobRequests                       *bool
+	AutoActivateTimeoutInMins                 *int
+	AutoInspect                               AutoInspectMode
+	CacheAvailableRetryAfterInSeconds         *int
+	DefaultVerifyDataAfterImport              Priority
+	DefaultVerifyDataPriorToImport            *bool
+	IomCacheLimitationPercent                 *float64
+	IomEnabled                                *bool
+	MaxAggregatedBlobsPerChunk                *int
+	MaxNumberOfConcurrentJobs                 *int
+	PartiallyVerifyLastPercentOfTapes         *int
+	PoolSafetyEnabled                         *bool
+	UnavailableMediaPolicy                    UnavailableMediaUsagePolicy
+	UnavailablePoolMaxJobRetryInMins          *int
+	UnavailableTapePartitionMaxJobRetryInMins *int
+	VerifyCheckpointBeforeRead                *bool
 }
 
 func NewModifyDataPathBackendSpectraS3Request() *ModifyDataPathBackendSpectraS3Request {
-    return &ModifyDataPathBackendSpectraS3Request{
-    }
+	return &ModifyDataPathBackendSpectraS3Request{}
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithActivated(activated bool) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.Activated = &activated
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.Activated = &activated
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithAllowNewJobRequests(allowNewJobRequests bool) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.AllowNewJobRequests = &allowNewJobRequests
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.AllowNewJobRequests = &allowNewJobRequests
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithAutoActivateTimeoutInMins(autoActivateTimeoutInMins int) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.AutoActivateTimeoutInMins = &autoActivateTimeoutInMins
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.AutoActivateTimeoutInMins = &autoActivateTimeoutInMins
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithAutoInspect(autoInspect AutoInspectMode) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.AutoInspect = autoInspect
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.AutoInspect = autoInspect
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithCacheAvailableRetryAfterInSeconds(cacheAvailableRetryAfterInSeconds int) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.CacheAvailableRetryAfterInSeconds = &cacheAvailableRetryAfterInSeconds
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.CacheAvailableRetryAfterInSeconds = &cacheAvailableRetryAfterInSeconds
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithDefaultVerifyDataAfterImport(defaultVerifyDataAfterImport Priority) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.DefaultVerifyDataAfterImport = defaultVerifyDataAfterImport
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.DefaultVerifyDataAfterImport = defaultVerifyDataAfterImport
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithDefaultVerifyDataPriorToImport(defaultVerifyDataPriorToImport bool) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.DefaultVerifyDataPriorToImport = &defaultVerifyDataPriorToImport
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.DefaultVerifyDataPriorToImport = &defaultVerifyDataPriorToImport
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithIomCacheLimitationPercent(iomCacheLimitationPercent float64) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.IomCacheLimitationPercent = &iomCacheLimitationPercent
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.IomCacheLimitationPercent = &iomCacheLimitationPercent
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithIomEnabled(iomEnabled bool) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.IomEnabled = &iomEnabled
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.IomEnabled = &iomEnabled
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithMaxAggregatedBlobsPerChunk(maxAggregatedBlobsPerChunk int) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.MaxAggregatedBlobsPerChunk = &maxAggregatedBlobsPerChunk
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.MaxAggregatedBlobsPerChunk = &maxAggregatedBlobsPerChunk
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithMaxNumberOfConcurrentJobs(maxNumberOfConcurrentJobs int) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.MaxNumberOfConcurrentJobs = &maxNumberOfConcurrentJobs
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.MaxNumberOfConcurrentJobs = &maxNumberOfConcurrentJobs
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithPartiallyVerifyLastPercentOfTapes(partiallyVerifyLastPercentOfTapes int) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.PartiallyVerifyLastPercentOfTapes = &partiallyVerifyLastPercentOfTapes
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.PartiallyVerifyLastPercentOfTapes = &partiallyVerifyLastPercentOfTapes
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithPoolSafetyEnabled(poolSafetyEnabled bool) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.PoolSafetyEnabled = &poolSafetyEnabled
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.PoolSafetyEnabled = &poolSafetyEnabled
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithUnavailableMediaPolicy(unavailableMediaPolicy UnavailableMediaUsagePolicy) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.UnavailableMediaPolicy = unavailableMediaPolicy
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.UnavailableMediaPolicy = unavailableMediaPolicy
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithUnavailablePoolMaxJobRetryInMins(unavailablePoolMaxJobRetryInMins int) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.UnavailablePoolMaxJobRetryInMins = &unavailablePoolMaxJobRetryInMins
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.UnavailablePoolMaxJobRetryInMins = &unavailablePoolMaxJobRetryInMins
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithUnavailableTapePartitionMaxJobRetryInMins(unavailableTapePartitionMaxJobRetryInMins int) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.UnavailableTapePartitionMaxJobRetryInMins = &unavailableTapePartitionMaxJobRetryInMins
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.UnavailableTapePartitionMaxJobRetryInMins = &unavailableTapePartitionMaxJobRetryInMins
+	return modifyDataPathBackendSpectraS3Request
 }
 
 func (modifyDataPathBackendSpectraS3Request *ModifyDataPathBackendSpectraS3Request) WithVerifyCheckpointBeforeRead(verifyCheckpointBeforeRead bool) *ModifyDataPathBackendSpectraS3Request {
-    modifyDataPathBackendSpectraS3Request.VerifyCheckpointBeforeRead = &verifyCheckpointBeforeRead
-    return modifyDataPathBackendSpectraS3Request
+	modifyDataPathBackendSpectraS3Request.VerifyCheckpointBeforeRead = &verifyCheckpointBeforeRead
+	return modifyDataPathBackendSpectraS3Request
 }
 
 type PutAzureDataReplicationRuleSpectraS3Request struct {
-    DataPolicyId string
-    DataReplicationRuleType DataReplicationRuleType
-    MaxBlobPartSizeInBytes *int64
-    ReplicateDeletes *bool
-    TargetId string
+	DataPolicyId            string
+	DataReplicationRuleType DataReplicationRuleType
+	MaxBlobPartSizeInBytes  *int64
+	ReplicateDeletes        *bool
+	TargetId                string
 }
 
 func NewPutAzureDataReplicationRuleSpectraS3Request(dataPolicyId string, dataReplicationRuleType DataReplicationRuleType, targetId string) *PutAzureDataReplicationRuleSpectraS3Request {
-    return &PutAzureDataReplicationRuleSpectraS3Request{
-        DataPolicyId: dataPolicyId,
-        TargetId: targetId,
-        DataReplicationRuleType: dataReplicationRuleType,
-    }
+	return &PutAzureDataReplicationRuleSpectraS3Request{
+		DataPolicyId:            dataPolicyId,
+		TargetId:                targetId,
+		DataReplicationRuleType: dataReplicationRuleType,
+	}
 }
 
 func (putAzureDataReplicationRuleSpectraS3Request *PutAzureDataReplicationRuleSpectraS3Request) WithMaxBlobPartSizeInBytes(maxBlobPartSizeInBytes int64) *PutAzureDataReplicationRuleSpectraS3Request {
-    putAzureDataReplicationRuleSpectraS3Request.MaxBlobPartSizeInBytes = &maxBlobPartSizeInBytes
-    return putAzureDataReplicationRuleSpectraS3Request
+	putAzureDataReplicationRuleSpectraS3Request.MaxBlobPartSizeInBytes = &maxBlobPartSizeInBytes
+	return putAzureDataReplicationRuleSpectraS3Request
 }
 
 func (putAzureDataReplicationRuleSpectraS3Request *PutAzureDataReplicationRuleSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *PutAzureDataReplicationRuleSpectraS3Request {
-    putAzureDataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
-    return putAzureDataReplicationRuleSpectraS3Request
+	putAzureDataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
+	return putAzureDataReplicationRuleSpectraS3Request
 }
 
 type PutDataPersistenceRuleSpectraS3Request struct {
-    DataPersistenceRuleType DataPersistenceRuleType
-    DataPolicyId string
-    IsolationLevel DataIsolationLevel
-    MinimumDaysToRetain *int
-    StorageDomainId string
+	DataPersistenceRuleType DataPersistenceRuleType
+	DataPolicyId            string
+	IsolationLevel          DataIsolationLevel
+	MinimumDaysToRetain     *int
+	StorageDomainId         string
 }
 
 func NewPutDataPersistenceRuleSpectraS3Request(dataPersistenceRuleType DataPersistenceRuleType, dataPolicyId string, isolationLevel DataIsolationLevel, storageDomainId string) *PutDataPersistenceRuleSpectraS3Request {
-    return &PutDataPersistenceRuleSpectraS3Request{
-        DataPolicyId: dataPolicyId,
-        IsolationLevel: isolationLevel,
-        StorageDomainId: storageDomainId,
-        DataPersistenceRuleType: dataPersistenceRuleType,
-    }
+	return &PutDataPersistenceRuleSpectraS3Request{
+		DataPolicyId:            dataPolicyId,
+		IsolationLevel:          isolationLevel,
+		StorageDomainId:         storageDomainId,
+		DataPersistenceRuleType: dataPersistenceRuleType,
+	}
 }
 
 func (putDataPersistenceRuleSpectraS3Request *PutDataPersistenceRuleSpectraS3Request) WithMinimumDaysToRetain(minimumDaysToRetain int) *PutDataPersistenceRuleSpectraS3Request {
-    putDataPersistenceRuleSpectraS3Request.MinimumDaysToRetain = &minimumDaysToRetain
-    return putDataPersistenceRuleSpectraS3Request
+	putDataPersistenceRuleSpectraS3Request.MinimumDaysToRetain = &minimumDaysToRetain
+	return putDataPersistenceRuleSpectraS3Request
 }
 
 type PutDataPolicySpectraS3Request struct {
-    AlwaysForcePutJobCreation *bool
-    AlwaysMinimizeSpanningAcrossMedia *bool
-    BlobbingEnabled *bool
-    ChecksumType ChecksumType
-    DefaultBlobSize *int64
-    DefaultGetJobPriority Priority
-    DefaultPutJobPriority Priority
-    DefaultVerifyAfterWrite *bool
-    DefaultVerifyJobPriority Priority
-    EndToEndCrcRequired *bool
-    MaxVersionsToKeep *int
-    Name string
-    RebuildPriority Priority
-    Versioning VersioningLevel
+	AlwaysForcePutJobCreation         *bool
+	AlwaysMinimizeSpanningAcrossMedia *bool
+	BlobbingEnabled                   *bool
+	ChecksumType                      ChecksumType
+	DefaultBlobSize                   *int64
+	DefaultGetJobPriority             Priority
+	DefaultPutJobPriority             Priority
+	DefaultVerifyAfterWrite           *bool
+	DefaultVerifyJobPriority          Priority
+	EndToEndCrcRequired               *bool
+	MaxVersionsToKeep                 *int
+	Name                              string
+	RebuildPriority                   Priority
+	Versioning                        VersioningLevel
 }
 
 func NewPutDataPolicySpectraS3Request(name string) *PutDataPolicySpectraS3Request {
-    return &PutDataPolicySpectraS3Request{
-        Name: name,
-    }
+	return &PutDataPolicySpectraS3Request{
+		Name: name,
+	}
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithAlwaysForcePutJobCreation(alwaysForcePutJobCreation bool) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.AlwaysForcePutJobCreation = &alwaysForcePutJobCreation
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.AlwaysForcePutJobCreation = &alwaysForcePutJobCreation
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithAlwaysMinimizeSpanningAcrossMedia(alwaysMinimizeSpanningAcrossMedia bool) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.AlwaysMinimizeSpanningAcrossMedia = &alwaysMinimizeSpanningAcrossMedia
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.AlwaysMinimizeSpanningAcrossMedia = &alwaysMinimizeSpanningAcrossMedia
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithBlobbingEnabled(blobbingEnabled bool) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.BlobbingEnabled = &blobbingEnabled
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.BlobbingEnabled = &blobbingEnabled
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithChecksumType(checksumType ChecksumType) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.ChecksumType = checksumType
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.ChecksumType = checksumType
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithDefaultBlobSize(defaultBlobSize int64) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.DefaultBlobSize = &defaultBlobSize
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.DefaultBlobSize = &defaultBlobSize
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithDefaultGetJobPriority(defaultGetJobPriority Priority) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.DefaultGetJobPriority = defaultGetJobPriority
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.DefaultGetJobPriority = defaultGetJobPriority
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithDefaultPutJobPriority(defaultPutJobPriority Priority) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.DefaultPutJobPriority = defaultPutJobPriority
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.DefaultPutJobPriority = defaultPutJobPriority
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithDefaultVerifyAfterWrite(defaultVerifyAfterWrite bool) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.DefaultVerifyAfterWrite = &defaultVerifyAfterWrite
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.DefaultVerifyAfterWrite = &defaultVerifyAfterWrite
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithDefaultVerifyJobPriority(defaultVerifyJobPriority Priority) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.DefaultVerifyJobPriority = defaultVerifyJobPriority
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.DefaultVerifyJobPriority = defaultVerifyJobPriority
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithEndToEndCrcRequired(endToEndCrcRequired bool) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.EndToEndCrcRequired = &endToEndCrcRequired
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.EndToEndCrcRequired = &endToEndCrcRequired
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithMaxVersionsToKeep(maxVersionsToKeep int) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.MaxVersionsToKeep = &maxVersionsToKeep
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.MaxVersionsToKeep = &maxVersionsToKeep
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithRebuildPriority(rebuildPriority Priority) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.RebuildPriority = rebuildPriority
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.RebuildPriority = rebuildPriority
+	return putDataPolicySpectraS3Request
 }
 
 func (putDataPolicySpectraS3Request *PutDataPolicySpectraS3Request) WithVersioning(versioning VersioningLevel) *PutDataPolicySpectraS3Request {
-    putDataPolicySpectraS3Request.Versioning = versioning
-    return putDataPolicySpectraS3Request
+	putDataPolicySpectraS3Request.Versioning = versioning
+	return putDataPolicySpectraS3Request
 }
 
 type PutDs3DataReplicationRuleSpectraS3Request struct {
-    DataPolicyId string
-    DataReplicationRuleType DataReplicationRuleType
-    ReplicateDeletes *bool
-    TargetDataPolicy *string
-    TargetId string
+	DataPolicyId            string
+	DataReplicationRuleType DataReplicationRuleType
+	ReplicateDeletes        *bool
+	TargetDataPolicy        *string
+	TargetId                string
 }
 
 func NewPutDs3DataReplicationRuleSpectraS3Request(dataPolicyId string, dataReplicationRuleType DataReplicationRuleType, targetId string) *PutDs3DataReplicationRuleSpectraS3Request {
-    return &PutDs3DataReplicationRuleSpectraS3Request{
-        DataPolicyId: dataPolicyId,
-        TargetId: targetId,
-        DataReplicationRuleType: dataReplicationRuleType,
-    }
+	return &PutDs3DataReplicationRuleSpectraS3Request{
+		DataPolicyId:            dataPolicyId,
+		TargetId:                targetId,
+		DataReplicationRuleType: dataReplicationRuleType,
+	}
 }
 
 func (putDs3DataReplicationRuleSpectraS3Request *PutDs3DataReplicationRuleSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *PutDs3DataReplicationRuleSpectraS3Request {
-    putDs3DataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
-    return putDs3DataReplicationRuleSpectraS3Request
+	putDs3DataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
+	return putDs3DataReplicationRuleSpectraS3Request
 }
 
 func (putDs3DataReplicationRuleSpectraS3Request *PutDs3DataReplicationRuleSpectraS3Request) WithTargetDataPolicy(targetDataPolicy string) *PutDs3DataReplicationRuleSpectraS3Request {
-    putDs3DataReplicationRuleSpectraS3Request.TargetDataPolicy = &targetDataPolicy
-    return putDs3DataReplicationRuleSpectraS3Request
+	putDs3DataReplicationRuleSpectraS3Request.TargetDataPolicy = &targetDataPolicy
+	return putDs3DataReplicationRuleSpectraS3Request
 }
 
 type PutS3DataReplicationRuleSpectraS3Request struct {
-    DataPolicyId string
-    DataReplicationRuleType DataReplicationRuleType
-    InitialDataPlacement S3InitialDataPlacementPolicy
-    MaxBlobPartSizeInBytes *int64
-    ReplicateDeletes *bool
-    TargetId string
+	DataPolicyId            string
+	DataReplicationRuleType DataReplicationRuleType
+	InitialDataPlacement    S3InitialDataPlacementPolicy
+	MaxBlobPartSizeInBytes  *int64
+	ReplicateDeletes        *bool
+	TargetId                string
 }
 
 func NewPutS3DataReplicationRuleSpectraS3Request(dataPolicyId string, dataReplicationRuleType DataReplicationRuleType, targetId string) *PutS3DataReplicationRuleSpectraS3Request {
-    return &PutS3DataReplicationRuleSpectraS3Request{
-        DataPolicyId: dataPolicyId,
-        TargetId: targetId,
-        DataReplicationRuleType: dataReplicationRuleType,
-    }
+	return &PutS3DataReplicationRuleSpectraS3Request{
+		DataPolicyId:            dataPolicyId,
+		TargetId:                targetId,
+		DataReplicationRuleType: dataReplicationRuleType,
+	}
 }
 
 func (putS3DataReplicationRuleSpectraS3Request *PutS3DataReplicationRuleSpectraS3Request) WithInitialDataPlacement(initialDataPlacement S3InitialDataPlacementPolicy) *PutS3DataReplicationRuleSpectraS3Request {
-    putS3DataReplicationRuleSpectraS3Request.InitialDataPlacement = initialDataPlacement
-    return putS3DataReplicationRuleSpectraS3Request
+	putS3DataReplicationRuleSpectraS3Request.InitialDataPlacement = initialDataPlacement
+	return putS3DataReplicationRuleSpectraS3Request
 }
 
 func (putS3DataReplicationRuleSpectraS3Request *PutS3DataReplicationRuleSpectraS3Request) WithMaxBlobPartSizeInBytes(maxBlobPartSizeInBytes int64) *PutS3DataReplicationRuleSpectraS3Request {
-    putS3DataReplicationRuleSpectraS3Request.MaxBlobPartSizeInBytes = &maxBlobPartSizeInBytes
-    return putS3DataReplicationRuleSpectraS3Request
+	putS3DataReplicationRuleSpectraS3Request.MaxBlobPartSizeInBytes = &maxBlobPartSizeInBytes
+	return putS3DataReplicationRuleSpectraS3Request
 }
 
 func (putS3DataReplicationRuleSpectraS3Request *PutS3DataReplicationRuleSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *PutS3DataReplicationRuleSpectraS3Request {
-    putS3DataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
-    return putS3DataReplicationRuleSpectraS3Request
+	putS3DataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
+	return putS3DataReplicationRuleSpectraS3Request
 }
 
 type DeleteAzureDataReplicationRuleSpectraS3Request struct {
-    AzureDataReplicationRule string
+	AzureDataReplicationRule string
 }
 
 func NewDeleteAzureDataReplicationRuleSpectraS3Request(azureDataReplicationRule string) *DeleteAzureDataReplicationRuleSpectraS3Request {
-    return &DeleteAzureDataReplicationRuleSpectraS3Request{
-        AzureDataReplicationRule: azureDataReplicationRule,
-    }
+	return &DeleteAzureDataReplicationRuleSpectraS3Request{
+		AzureDataReplicationRule: azureDataReplicationRule,
+	}
 }
 
 type DeleteDataPersistenceRuleSpectraS3Request struct {
-    DataPersistenceRuleId string
+	DataPersistenceRuleId string
 }
 
 func NewDeleteDataPersistenceRuleSpectraS3Request(dataPersistenceRuleId string) *DeleteDataPersistenceRuleSpectraS3Request {
-    return &DeleteDataPersistenceRuleSpectraS3Request{
-        DataPersistenceRuleId: dataPersistenceRuleId,
-    }
+	return &DeleteDataPersistenceRuleSpectraS3Request{
+		DataPersistenceRuleId: dataPersistenceRuleId,
+	}
 }
 
 type DeleteDataPolicySpectraS3Request struct {
-    DataPolicyId string
+	DataPolicyId string
 }
 
 func NewDeleteDataPolicySpectraS3Request(dataPolicyId string) *DeleteDataPolicySpectraS3Request {
-    return &DeleteDataPolicySpectraS3Request{
-        DataPolicyId: dataPolicyId,
-    }
+	return &DeleteDataPolicySpectraS3Request{
+		DataPolicyId: dataPolicyId,
+	}
 }
 
 type DeleteDs3DataReplicationRuleSpectraS3Request struct {
-    Ds3DataReplicationRule string
+	Ds3DataReplicationRule string
 }
 
 func NewDeleteDs3DataReplicationRuleSpectraS3Request(ds3DataReplicationRule string) *DeleteDs3DataReplicationRuleSpectraS3Request {
-    return &DeleteDs3DataReplicationRuleSpectraS3Request{
-        Ds3DataReplicationRule: ds3DataReplicationRule,
-    }
+	return &DeleteDs3DataReplicationRuleSpectraS3Request{
+		Ds3DataReplicationRule: ds3DataReplicationRule,
+	}
 }
 
 type DeleteS3DataReplicationRuleSpectraS3Request struct {
-    S3DataReplicationRule string
+	S3DataReplicationRule string
 }
 
 func NewDeleteS3DataReplicationRuleSpectraS3Request(s3DataReplicationRule string) *DeleteS3DataReplicationRuleSpectraS3Request {
-    return &DeleteS3DataReplicationRuleSpectraS3Request{
-        S3DataReplicationRule: s3DataReplicationRule,
-    }
+	return &DeleteS3DataReplicationRuleSpectraS3Request{
+		S3DataReplicationRule: s3DataReplicationRule,
+	}
 }
 
 type GetAzureDataReplicationRuleSpectraS3Request struct {
-    AzureDataReplicationRule string
+	AzureDataReplicationRule string
 }
 
 func NewGetAzureDataReplicationRuleSpectraS3Request(azureDataReplicationRule string) *GetAzureDataReplicationRuleSpectraS3Request {
-    return &GetAzureDataReplicationRuleSpectraS3Request{
-        AzureDataReplicationRule: azureDataReplicationRule,
-    }
+	return &GetAzureDataReplicationRuleSpectraS3Request{
+		AzureDataReplicationRule: azureDataReplicationRule,
+	}
 }
 
 type GetAzureDataReplicationRulesSpectraS3Request struct {
-    DataPolicyId *string
-    DataReplicationRuleType DataReplicationRuleType
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    ReplicateDeletes *bool
-    State DataPlacementRuleState
-    TargetId *string
+	DataPolicyId            *string
+	DataReplicationRuleType DataReplicationRuleType
+	LastPage                bool
+	PageLength              *int
+	PageOffset              *int
+	PageStartMarker         *string
+	ReplicateDeletes        *bool
+	State                   DataPlacementRuleState
+	TargetId                *string
 }
 
 func NewGetAzureDataReplicationRulesSpectraS3Request() *GetAzureDataReplicationRulesSpectraS3Request {
-    return &GetAzureDataReplicationRulesSpectraS3Request{
-    }
+	return &GetAzureDataReplicationRulesSpectraS3Request{}
 }
 
 func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetAzureDataReplicationRulesSpectraS3Request {
-    getAzureDataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getAzureDataReplicationRulesSpectraS3Request
+	getAzureDataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithLastPage() *GetAzureDataReplicationRulesSpectraS3Request {
-    getAzureDataReplicationRulesSpectraS3Request.LastPage = true
-    return getAzureDataReplicationRulesSpectraS3Request
+	getAzureDataReplicationRulesSpectraS3Request.LastPage = true
+	return getAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageLength(pageLength int) *GetAzureDataReplicationRulesSpectraS3Request {
-    getAzureDataReplicationRulesSpectraS3Request.PageLength = &pageLength
-    return getAzureDataReplicationRulesSpectraS3Request
+	getAzureDataReplicationRulesSpectraS3Request.PageLength = &pageLength
+	return getAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageOffset(pageOffset int) *GetAzureDataReplicationRulesSpectraS3Request {
-    getAzureDataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
-    return getAzureDataReplicationRulesSpectraS3Request
+	getAzureDataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
+	return getAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetAzureDataReplicationRulesSpectraS3Request {
-    getAzureDataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getAzureDataReplicationRulesSpectraS3Request
+	getAzureDataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *GetAzureDataReplicationRulesSpectraS3Request {
-    getAzureDataReplicationRulesSpectraS3Request.ReplicateDeletes = &replicateDeletes
-    return getAzureDataReplicationRulesSpectraS3Request
+	getAzureDataReplicationRulesSpectraS3Request.ReplicateDeletes = &replicateDeletes
+	return getAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithState(state DataPlacementRuleState) *GetAzureDataReplicationRulesSpectraS3Request {
-    getAzureDataReplicationRulesSpectraS3Request.State = state
-    return getAzureDataReplicationRulesSpectraS3Request
+	getAzureDataReplicationRulesSpectraS3Request.State = state
+	return getAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithTargetId(targetId string) *GetAzureDataReplicationRulesSpectraS3Request {
-    getAzureDataReplicationRulesSpectraS3Request.TargetId = &targetId
-    return getAzureDataReplicationRulesSpectraS3Request
+	getAzureDataReplicationRulesSpectraS3Request.TargetId = &targetId
+	return getAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *GetAzureDataReplicationRulesSpectraS3Request {
-    getAzureDataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
-    return getAzureDataReplicationRulesSpectraS3Request
+	getAzureDataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
+	return getAzureDataReplicationRulesSpectraS3Request
 }
 
 type GetDataPersistenceRuleSpectraS3Request struct {
-    DataPersistenceRuleId string
+	DataPersistenceRuleId string
 }
 
 func NewGetDataPersistenceRuleSpectraS3Request(dataPersistenceRuleId string) *GetDataPersistenceRuleSpectraS3Request {
-    return &GetDataPersistenceRuleSpectraS3Request{
-        DataPersistenceRuleId: dataPersistenceRuleId,
-    }
+	return &GetDataPersistenceRuleSpectraS3Request{
+		DataPersistenceRuleId: dataPersistenceRuleId,
+	}
 }
 
 type GetDataPersistenceRulesSpectraS3Request struct {
-    DataPersistenceRuleType DataPersistenceRuleType
-    DataPolicyId *string
-    IsolationLevel DataIsolationLevel
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    State DataPlacementRuleState
-    StorageDomainId *string
+	DataPersistenceRuleType DataPersistenceRuleType
+	DataPolicyId            *string
+	IsolationLevel          DataIsolationLevel
+	LastPage                bool
+	PageLength              *int
+	PageOffset              *int
+	PageStartMarker         *string
+	State                   DataPlacementRuleState
+	StorageDomainId         *string
 }
 
 func NewGetDataPersistenceRulesSpectraS3Request() *GetDataPersistenceRulesSpectraS3Request {
-    return &GetDataPersistenceRulesSpectraS3Request{
-    }
+	return &GetDataPersistenceRulesSpectraS3Request{}
 }
 
 func (getDataPersistenceRulesSpectraS3Request *GetDataPersistenceRulesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetDataPersistenceRulesSpectraS3Request {
-    getDataPersistenceRulesSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getDataPersistenceRulesSpectraS3Request
+	getDataPersistenceRulesSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getDataPersistenceRulesSpectraS3Request
 }
 
 func (getDataPersistenceRulesSpectraS3Request *GetDataPersistenceRulesSpectraS3Request) WithIsolationLevel(isolationLevel DataIsolationLevel) *GetDataPersistenceRulesSpectraS3Request {
-    getDataPersistenceRulesSpectraS3Request.IsolationLevel = isolationLevel
-    return getDataPersistenceRulesSpectraS3Request
+	getDataPersistenceRulesSpectraS3Request.IsolationLevel = isolationLevel
+	return getDataPersistenceRulesSpectraS3Request
 }
 
 func (getDataPersistenceRulesSpectraS3Request *GetDataPersistenceRulesSpectraS3Request) WithLastPage() *GetDataPersistenceRulesSpectraS3Request {
-    getDataPersistenceRulesSpectraS3Request.LastPage = true
-    return getDataPersistenceRulesSpectraS3Request
+	getDataPersistenceRulesSpectraS3Request.LastPage = true
+	return getDataPersistenceRulesSpectraS3Request
 }
 
 func (getDataPersistenceRulesSpectraS3Request *GetDataPersistenceRulesSpectraS3Request) WithPageLength(pageLength int) *GetDataPersistenceRulesSpectraS3Request {
-    getDataPersistenceRulesSpectraS3Request.PageLength = &pageLength
-    return getDataPersistenceRulesSpectraS3Request
+	getDataPersistenceRulesSpectraS3Request.PageLength = &pageLength
+	return getDataPersistenceRulesSpectraS3Request
 }
 
 func (getDataPersistenceRulesSpectraS3Request *GetDataPersistenceRulesSpectraS3Request) WithPageOffset(pageOffset int) *GetDataPersistenceRulesSpectraS3Request {
-    getDataPersistenceRulesSpectraS3Request.PageOffset = &pageOffset
-    return getDataPersistenceRulesSpectraS3Request
+	getDataPersistenceRulesSpectraS3Request.PageOffset = &pageOffset
+	return getDataPersistenceRulesSpectraS3Request
 }
 
 func (getDataPersistenceRulesSpectraS3Request *GetDataPersistenceRulesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDataPersistenceRulesSpectraS3Request {
-    getDataPersistenceRulesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDataPersistenceRulesSpectraS3Request
+	getDataPersistenceRulesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDataPersistenceRulesSpectraS3Request
 }
 
 func (getDataPersistenceRulesSpectraS3Request *GetDataPersistenceRulesSpectraS3Request) WithState(state DataPlacementRuleState) *GetDataPersistenceRulesSpectraS3Request {
-    getDataPersistenceRulesSpectraS3Request.State = state
-    return getDataPersistenceRulesSpectraS3Request
+	getDataPersistenceRulesSpectraS3Request.State = state
+	return getDataPersistenceRulesSpectraS3Request
 }
 
 func (getDataPersistenceRulesSpectraS3Request *GetDataPersistenceRulesSpectraS3Request) WithStorageDomainId(storageDomainId string) *GetDataPersistenceRulesSpectraS3Request {
-    getDataPersistenceRulesSpectraS3Request.StorageDomainId = &storageDomainId
-    return getDataPersistenceRulesSpectraS3Request
+	getDataPersistenceRulesSpectraS3Request.StorageDomainId = &storageDomainId
+	return getDataPersistenceRulesSpectraS3Request
 }
 
 func (getDataPersistenceRulesSpectraS3Request *GetDataPersistenceRulesSpectraS3Request) WithDataPersistenceRuleType(dataPersistenceRuleType DataPersistenceRuleType) *GetDataPersistenceRulesSpectraS3Request {
-    getDataPersistenceRulesSpectraS3Request.DataPersistenceRuleType = dataPersistenceRuleType
-    return getDataPersistenceRulesSpectraS3Request
+	getDataPersistenceRulesSpectraS3Request.DataPersistenceRuleType = dataPersistenceRuleType
+	return getDataPersistenceRulesSpectraS3Request
 }
 
 type GetDataPoliciesSpectraS3Request struct {
-    AlwaysForcePutJobCreation *bool
-    AlwaysMinimizeSpanningAcrossMedia *bool
-    ChecksumType ChecksumType
-    EndToEndCrcRequired *bool
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
+	AlwaysForcePutJobCreation         *bool
+	AlwaysMinimizeSpanningAcrossMedia *bool
+	ChecksumType                      ChecksumType
+	EndToEndCrcRequired               *bool
+	LastPage                          bool
+	Name                              *string
+	PageLength                        *int
+	PageOffset                        *int
+	PageStartMarker                   *string
 }
 
 func NewGetDataPoliciesSpectraS3Request() *GetDataPoliciesSpectraS3Request {
-    return &GetDataPoliciesSpectraS3Request{
-    }
+	return &GetDataPoliciesSpectraS3Request{}
 }
 
 func (getDataPoliciesSpectraS3Request *GetDataPoliciesSpectraS3Request) WithAlwaysForcePutJobCreation(alwaysForcePutJobCreation bool) *GetDataPoliciesSpectraS3Request {
-    getDataPoliciesSpectraS3Request.AlwaysForcePutJobCreation = &alwaysForcePutJobCreation
-    return getDataPoliciesSpectraS3Request
+	getDataPoliciesSpectraS3Request.AlwaysForcePutJobCreation = &alwaysForcePutJobCreation
+	return getDataPoliciesSpectraS3Request
 }
 
 func (getDataPoliciesSpectraS3Request *GetDataPoliciesSpectraS3Request) WithAlwaysMinimizeSpanningAcrossMedia(alwaysMinimizeSpanningAcrossMedia bool) *GetDataPoliciesSpectraS3Request {
-    getDataPoliciesSpectraS3Request.AlwaysMinimizeSpanningAcrossMedia = &alwaysMinimizeSpanningAcrossMedia
-    return getDataPoliciesSpectraS3Request
+	getDataPoliciesSpectraS3Request.AlwaysMinimizeSpanningAcrossMedia = &alwaysMinimizeSpanningAcrossMedia
+	return getDataPoliciesSpectraS3Request
 }
 
 func (getDataPoliciesSpectraS3Request *GetDataPoliciesSpectraS3Request) WithChecksumType(checksumType ChecksumType) *GetDataPoliciesSpectraS3Request {
-    getDataPoliciesSpectraS3Request.ChecksumType = checksumType
-    return getDataPoliciesSpectraS3Request
+	getDataPoliciesSpectraS3Request.ChecksumType = checksumType
+	return getDataPoliciesSpectraS3Request
 }
 
 func (getDataPoliciesSpectraS3Request *GetDataPoliciesSpectraS3Request) WithEndToEndCrcRequired(endToEndCrcRequired bool) *GetDataPoliciesSpectraS3Request {
-    getDataPoliciesSpectraS3Request.EndToEndCrcRequired = &endToEndCrcRequired
-    return getDataPoliciesSpectraS3Request
+	getDataPoliciesSpectraS3Request.EndToEndCrcRequired = &endToEndCrcRequired
+	return getDataPoliciesSpectraS3Request
 }
 
 func (getDataPoliciesSpectraS3Request *GetDataPoliciesSpectraS3Request) WithLastPage() *GetDataPoliciesSpectraS3Request {
-    getDataPoliciesSpectraS3Request.LastPage = true
-    return getDataPoliciesSpectraS3Request
+	getDataPoliciesSpectraS3Request.LastPage = true
+	return getDataPoliciesSpectraS3Request
 }
 
 func (getDataPoliciesSpectraS3Request *GetDataPoliciesSpectraS3Request) WithName(name string) *GetDataPoliciesSpectraS3Request {
-    getDataPoliciesSpectraS3Request.Name = &name
-    return getDataPoliciesSpectraS3Request
+	getDataPoliciesSpectraS3Request.Name = &name
+	return getDataPoliciesSpectraS3Request
 }
 
 func (getDataPoliciesSpectraS3Request *GetDataPoliciesSpectraS3Request) WithPageLength(pageLength int) *GetDataPoliciesSpectraS3Request {
-    getDataPoliciesSpectraS3Request.PageLength = &pageLength
-    return getDataPoliciesSpectraS3Request
+	getDataPoliciesSpectraS3Request.PageLength = &pageLength
+	return getDataPoliciesSpectraS3Request
 }
 
 func (getDataPoliciesSpectraS3Request *GetDataPoliciesSpectraS3Request) WithPageOffset(pageOffset int) *GetDataPoliciesSpectraS3Request {
-    getDataPoliciesSpectraS3Request.PageOffset = &pageOffset
-    return getDataPoliciesSpectraS3Request
+	getDataPoliciesSpectraS3Request.PageOffset = &pageOffset
+	return getDataPoliciesSpectraS3Request
 }
 
 func (getDataPoliciesSpectraS3Request *GetDataPoliciesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDataPoliciesSpectraS3Request {
-    getDataPoliciesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDataPoliciesSpectraS3Request
+	getDataPoliciesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDataPoliciesSpectraS3Request
 }
 
 type GetDataPolicySpectraS3Request struct {
-    DataPolicyId string
+	DataPolicyId string
 }
 
 func NewGetDataPolicySpectraS3Request(dataPolicyId string) *GetDataPolicySpectraS3Request {
-    return &GetDataPolicySpectraS3Request{
-        DataPolicyId: dataPolicyId,
-    }
+	return &GetDataPolicySpectraS3Request{
+		DataPolicyId: dataPolicyId,
+	}
 }
 
 type GetDs3DataReplicationRuleSpectraS3Request struct {
-    Ds3DataReplicationRule string
+	Ds3DataReplicationRule string
 }
 
 func NewGetDs3DataReplicationRuleSpectraS3Request(ds3DataReplicationRule string) *GetDs3DataReplicationRuleSpectraS3Request {
-    return &GetDs3DataReplicationRuleSpectraS3Request{
-        Ds3DataReplicationRule: ds3DataReplicationRule,
-    }
+	return &GetDs3DataReplicationRuleSpectraS3Request{
+		Ds3DataReplicationRule: ds3DataReplicationRule,
+	}
 }
 
 type GetDs3DataReplicationRulesSpectraS3Request struct {
-    DataPolicyId *string
-    DataReplicationRuleType DataReplicationRuleType
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    ReplicateDeletes *bool
-    State DataPlacementRuleState
-    TargetId *string
+	DataPolicyId            *string
+	DataReplicationRuleType DataReplicationRuleType
+	LastPage                bool
+	PageLength              *int
+	PageOffset              *int
+	PageStartMarker         *string
+	ReplicateDeletes        *bool
+	State                   DataPlacementRuleState
+	TargetId                *string
 }
 
 func NewGetDs3DataReplicationRulesSpectraS3Request() *GetDs3DataReplicationRulesSpectraS3Request {
-    return &GetDs3DataReplicationRulesSpectraS3Request{
-    }
+	return &GetDs3DataReplicationRulesSpectraS3Request{}
 }
 
 func (getDs3DataReplicationRulesSpectraS3Request *GetDs3DataReplicationRulesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetDs3DataReplicationRulesSpectraS3Request {
-    getDs3DataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getDs3DataReplicationRulesSpectraS3Request
+	getDs3DataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDs3DataReplicationRulesSpectraS3Request *GetDs3DataReplicationRulesSpectraS3Request) WithLastPage() *GetDs3DataReplicationRulesSpectraS3Request {
-    getDs3DataReplicationRulesSpectraS3Request.LastPage = true
-    return getDs3DataReplicationRulesSpectraS3Request
+	getDs3DataReplicationRulesSpectraS3Request.LastPage = true
+	return getDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDs3DataReplicationRulesSpectraS3Request *GetDs3DataReplicationRulesSpectraS3Request) WithPageLength(pageLength int) *GetDs3DataReplicationRulesSpectraS3Request {
-    getDs3DataReplicationRulesSpectraS3Request.PageLength = &pageLength
-    return getDs3DataReplicationRulesSpectraS3Request
+	getDs3DataReplicationRulesSpectraS3Request.PageLength = &pageLength
+	return getDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDs3DataReplicationRulesSpectraS3Request *GetDs3DataReplicationRulesSpectraS3Request) WithPageOffset(pageOffset int) *GetDs3DataReplicationRulesSpectraS3Request {
-    getDs3DataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
-    return getDs3DataReplicationRulesSpectraS3Request
+	getDs3DataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
+	return getDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDs3DataReplicationRulesSpectraS3Request *GetDs3DataReplicationRulesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDs3DataReplicationRulesSpectraS3Request {
-    getDs3DataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDs3DataReplicationRulesSpectraS3Request
+	getDs3DataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDs3DataReplicationRulesSpectraS3Request *GetDs3DataReplicationRulesSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *GetDs3DataReplicationRulesSpectraS3Request {
-    getDs3DataReplicationRulesSpectraS3Request.ReplicateDeletes = &replicateDeletes
-    return getDs3DataReplicationRulesSpectraS3Request
+	getDs3DataReplicationRulesSpectraS3Request.ReplicateDeletes = &replicateDeletes
+	return getDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDs3DataReplicationRulesSpectraS3Request *GetDs3DataReplicationRulesSpectraS3Request) WithState(state DataPlacementRuleState) *GetDs3DataReplicationRulesSpectraS3Request {
-    getDs3DataReplicationRulesSpectraS3Request.State = state
-    return getDs3DataReplicationRulesSpectraS3Request
+	getDs3DataReplicationRulesSpectraS3Request.State = state
+	return getDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDs3DataReplicationRulesSpectraS3Request *GetDs3DataReplicationRulesSpectraS3Request) WithTargetId(targetId string) *GetDs3DataReplicationRulesSpectraS3Request {
-    getDs3DataReplicationRulesSpectraS3Request.TargetId = &targetId
-    return getDs3DataReplicationRulesSpectraS3Request
+	getDs3DataReplicationRulesSpectraS3Request.TargetId = &targetId
+	return getDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDs3DataReplicationRulesSpectraS3Request *GetDs3DataReplicationRulesSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *GetDs3DataReplicationRulesSpectraS3Request {
-    getDs3DataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
-    return getDs3DataReplicationRulesSpectraS3Request
+	getDs3DataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
+	return getDs3DataReplicationRulesSpectraS3Request
 }
 
 type GetS3DataReplicationRuleSpectraS3Request struct {
-    S3DataReplicationRule string
+	S3DataReplicationRule string
 }
 
 func NewGetS3DataReplicationRuleSpectraS3Request(s3DataReplicationRule string) *GetS3DataReplicationRuleSpectraS3Request {
-    return &GetS3DataReplicationRuleSpectraS3Request{
-        S3DataReplicationRule: s3DataReplicationRule,
-    }
+	return &GetS3DataReplicationRuleSpectraS3Request{
+		S3DataReplicationRule: s3DataReplicationRule,
+	}
 }
 
 type GetS3DataReplicationRulesSpectraS3Request struct {
-    DataPolicyId *string
-    DataReplicationRuleType DataReplicationRuleType
-    InitialDataPlacement S3InitialDataPlacementPolicy
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    ReplicateDeletes *bool
-    State DataPlacementRuleState
-    TargetId *string
+	DataPolicyId            *string
+	DataReplicationRuleType DataReplicationRuleType
+	InitialDataPlacement    S3InitialDataPlacementPolicy
+	LastPage                bool
+	PageLength              *int
+	PageOffset              *int
+	PageStartMarker         *string
+	ReplicateDeletes        *bool
+	State                   DataPlacementRuleState
+	TargetId                *string
 }
 
 func NewGetS3DataReplicationRulesSpectraS3Request() *GetS3DataReplicationRulesSpectraS3Request {
-    return &GetS3DataReplicationRulesSpectraS3Request{
-    }
+	return &GetS3DataReplicationRulesSpectraS3Request{}
 }
 
 func (getS3DataReplicationRulesSpectraS3Request *GetS3DataReplicationRulesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetS3DataReplicationRulesSpectraS3Request {
-    getS3DataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getS3DataReplicationRulesSpectraS3Request
+	getS3DataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getS3DataReplicationRulesSpectraS3Request
 }
 
 func (getS3DataReplicationRulesSpectraS3Request *GetS3DataReplicationRulesSpectraS3Request) WithInitialDataPlacement(initialDataPlacement S3InitialDataPlacementPolicy) *GetS3DataReplicationRulesSpectraS3Request {
-    getS3DataReplicationRulesSpectraS3Request.InitialDataPlacement = initialDataPlacement
-    return getS3DataReplicationRulesSpectraS3Request
+	getS3DataReplicationRulesSpectraS3Request.InitialDataPlacement = initialDataPlacement
+	return getS3DataReplicationRulesSpectraS3Request
 }
 
 func (getS3DataReplicationRulesSpectraS3Request *GetS3DataReplicationRulesSpectraS3Request) WithLastPage() *GetS3DataReplicationRulesSpectraS3Request {
-    getS3DataReplicationRulesSpectraS3Request.LastPage = true
-    return getS3DataReplicationRulesSpectraS3Request
+	getS3DataReplicationRulesSpectraS3Request.LastPage = true
+	return getS3DataReplicationRulesSpectraS3Request
 }
 
 func (getS3DataReplicationRulesSpectraS3Request *GetS3DataReplicationRulesSpectraS3Request) WithPageLength(pageLength int) *GetS3DataReplicationRulesSpectraS3Request {
-    getS3DataReplicationRulesSpectraS3Request.PageLength = &pageLength
-    return getS3DataReplicationRulesSpectraS3Request
+	getS3DataReplicationRulesSpectraS3Request.PageLength = &pageLength
+	return getS3DataReplicationRulesSpectraS3Request
 }
 
 func (getS3DataReplicationRulesSpectraS3Request *GetS3DataReplicationRulesSpectraS3Request) WithPageOffset(pageOffset int) *GetS3DataReplicationRulesSpectraS3Request {
-    getS3DataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
-    return getS3DataReplicationRulesSpectraS3Request
+	getS3DataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
+	return getS3DataReplicationRulesSpectraS3Request
 }
 
 func (getS3DataReplicationRulesSpectraS3Request *GetS3DataReplicationRulesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetS3DataReplicationRulesSpectraS3Request {
-    getS3DataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getS3DataReplicationRulesSpectraS3Request
+	getS3DataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getS3DataReplicationRulesSpectraS3Request
 }
 
 func (getS3DataReplicationRulesSpectraS3Request *GetS3DataReplicationRulesSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *GetS3DataReplicationRulesSpectraS3Request {
-    getS3DataReplicationRulesSpectraS3Request.ReplicateDeletes = &replicateDeletes
-    return getS3DataReplicationRulesSpectraS3Request
+	getS3DataReplicationRulesSpectraS3Request.ReplicateDeletes = &replicateDeletes
+	return getS3DataReplicationRulesSpectraS3Request
 }
 
 func (getS3DataReplicationRulesSpectraS3Request *GetS3DataReplicationRulesSpectraS3Request) WithState(state DataPlacementRuleState) *GetS3DataReplicationRulesSpectraS3Request {
-    getS3DataReplicationRulesSpectraS3Request.State = state
-    return getS3DataReplicationRulesSpectraS3Request
+	getS3DataReplicationRulesSpectraS3Request.State = state
+	return getS3DataReplicationRulesSpectraS3Request
 }
 
 func (getS3DataReplicationRulesSpectraS3Request *GetS3DataReplicationRulesSpectraS3Request) WithTargetId(targetId string) *GetS3DataReplicationRulesSpectraS3Request {
-    getS3DataReplicationRulesSpectraS3Request.TargetId = &targetId
-    return getS3DataReplicationRulesSpectraS3Request
+	getS3DataReplicationRulesSpectraS3Request.TargetId = &targetId
+	return getS3DataReplicationRulesSpectraS3Request
 }
 
 func (getS3DataReplicationRulesSpectraS3Request *GetS3DataReplicationRulesSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *GetS3DataReplicationRulesSpectraS3Request {
-    getS3DataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
-    return getS3DataReplicationRulesSpectraS3Request
+	getS3DataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
+	return getS3DataReplicationRulesSpectraS3Request
 }
 
 type ModifyAzureDataReplicationRuleSpectraS3Request struct {
-    AzureDataReplicationRule string
-    DataReplicationRuleType DataReplicationRuleType
-    MaxBlobPartSizeInBytes *int64
-    ReplicateDeletes *bool
+	AzureDataReplicationRule string
+	DataReplicationRuleType  DataReplicationRuleType
+	MaxBlobPartSizeInBytes   *int64
+	ReplicateDeletes         *bool
 }
 
 func NewModifyAzureDataReplicationRuleSpectraS3Request(azureDataReplicationRule string) *ModifyAzureDataReplicationRuleSpectraS3Request {
-    return &ModifyAzureDataReplicationRuleSpectraS3Request{
-        AzureDataReplicationRule: azureDataReplicationRule,
-    }
+	return &ModifyAzureDataReplicationRuleSpectraS3Request{
+		AzureDataReplicationRule: azureDataReplicationRule,
+	}
 }
 
 func (modifyAzureDataReplicationRuleSpectraS3Request *ModifyAzureDataReplicationRuleSpectraS3Request) WithMaxBlobPartSizeInBytes(maxBlobPartSizeInBytes int64) *ModifyAzureDataReplicationRuleSpectraS3Request {
-    modifyAzureDataReplicationRuleSpectraS3Request.MaxBlobPartSizeInBytes = &maxBlobPartSizeInBytes
-    return modifyAzureDataReplicationRuleSpectraS3Request
+	modifyAzureDataReplicationRuleSpectraS3Request.MaxBlobPartSizeInBytes = &maxBlobPartSizeInBytes
+	return modifyAzureDataReplicationRuleSpectraS3Request
 }
 
 func (modifyAzureDataReplicationRuleSpectraS3Request *ModifyAzureDataReplicationRuleSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *ModifyAzureDataReplicationRuleSpectraS3Request {
-    modifyAzureDataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
-    return modifyAzureDataReplicationRuleSpectraS3Request
+	modifyAzureDataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
+	return modifyAzureDataReplicationRuleSpectraS3Request
 }
 
 func (modifyAzureDataReplicationRuleSpectraS3Request *ModifyAzureDataReplicationRuleSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *ModifyAzureDataReplicationRuleSpectraS3Request {
-    modifyAzureDataReplicationRuleSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
-    return modifyAzureDataReplicationRuleSpectraS3Request
+	modifyAzureDataReplicationRuleSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
+	return modifyAzureDataReplicationRuleSpectraS3Request
 }
 
 type ModifyDataPersistenceRuleSpectraS3Request struct {
-    DataPersistenceRuleId string
-    DataPersistenceRuleType DataPersistenceRuleType
-    IsolationLevel DataIsolationLevel
-    MinimumDaysToRetain *int
+	DataPersistenceRuleId   string
+	DataPersistenceRuleType DataPersistenceRuleType
+	IsolationLevel          DataIsolationLevel
+	MinimumDaysToRetain     *int
 }
 
 func NewModifyDataPersistenceRuleSpectraS3Request(dataPersistenceRuleId string) *ModifyDataPersistenceRuleSpectraS3Request {
-    return &ModifyDataPersistenceRuleSpectraS3Request{
-        DataPersistenceRuleId: dataPersistenceRuleId,
-    }
+	return &ModifyDataPersistenceRuleSpectraS3Request{
+		DataPersistenceRuleId: dataPersistenceRuleId,
+	}
 }
 
 func (modifyDataPersistenceRuleSpectraS3Request *ModifyDataPersistenceRuleSpectraS3Request) WithIsolationLevel(isolationLevel DataIsolationLevel) *ModifyDataPersistenceRuleSpectraS3Request {
-    modifyDataPersistenceRuleSpectraS3Request.IsolationLevel = isolationLevel
-    return modifyDataPersistenceRuleSpectraS3Request
+	modifyDataPersistenceRuleSpectraS3Request.IsolationLevel = isolationLevel
+	return modifyDataPersistenceRuleSpectraS3Request
 }
 
 func (modifyDataPersistenceRuleSpectraS3Request *ModifyDataPersistenceRuleSpectraS3Request) WithMinimumDaysToRetain(minimumDaysToRetain int) *ModifyDataPersistenceRuleSpectraS3Request {
-    modifyDataPersistenceRuleSpectraS3Request.MinimumDaysToRetain = &minimumDaysToRetain
-    return modifyDataPersistenceRuleSpectraS3Request
+	modifyDataPersistenceRuleSpectraS3Request.MinimumDaysToRetain = &minimumDaysToRetain
+	return modifyDataPersistenceRuleSpectraS3Request
 }
 
 func (modifyDataPersistenceRuleSpectraS3Request *ModifyDataPersistenceRuleSpectraS3Request) WithDataPersistenceRuleType(dataPersistenceRuleType DataPersistenceRuleType) *ModifyDataPersistenceRuleSpectraS3Request {
-    modifyDataPersistenceRuleSpectraS3Request.DataPersistenceRuleType = dataPersistenceRuleType
-    return modifyDataPersistenceRuleSpectraS3Request
+	modifyDataPersistenceRuleSpectraS3Request.DataPersistenceRuleType = dataPersistenceRuleType
+	return modifyDataPersistenceRuleSpectraS3Request
 }
 
 type ModifyDataPolicySpectraS3Request struct {
-    AlwaysForcePutJobCreation *bool
-    AlwaysMinimizeSpanningAcrossMedia *bool
-    BlobbingEnabled *bool
-    ChecksumType ChecksumType
-    DataPolicyId string
-    DefaultBlobSize *int64
-    DefaultGetJobPriority Priority
-    DefaultPutJobPriority Priority
-    DefaultVerifyAfterWrite *bool
-    DefaultVerifyJobPriority Priority
-    EndToEndCrcRequired *bool
-    MaxVersionsToKeep *int
-    Name *string
-    RebuildPriority Priority
-    Versioning VersioningLevel
+	AlwaysForcePutJobCreation         *bool
+	AlwaysMinimizeSpanningAcrossMedia *bool
+	BlobbingEnabled                   *bool
+	ChecksumType                      ChecksumType
+	DataPolicyId                      string
+	DefaultBlobSize                   *int64
+	DefaultGetJobPriority             Priority
+	DefaultPutJobPriority             Priority
+	DefaultVerifyAfterWrite           *bool
+	DefaultVerifyJobPriority          Priority
+	EndToEndCrcRequired               *bool
+	MaxVersionsToKeep                 *int
+	Name                              *string
+	RebuildPriority                   Priority
+	Versioning                        VersioningLevel
 }
 
 func NewModifyDataPolicySpectraS3Request(dataPolicyId string) *ModifyDataPolicySpectraS3Request {
-    return &ModifyDataPolicySpectraS3Request{
-        DataPolicyId: dataPolicyId,
-    }
+	return &ModifyDataPolicySpectraS3Request{
+		DataPolicyId: dataPolicyId,
+	}
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithAlwaysForcePutJobCreation(alwaysForcePutJobCreation bool) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.AlwaysForcePutJobCreation = &alwaysForcePutJobCreation
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.AlwaysForcePutJobCreation = &alwaysForcePutJobCreation
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithAlwaysMinimizeSpanningAcrossMedia(alwaysMinimizeSpanningAcrossMedia bool) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.AlwaysMinimizeSpanningAcrossMedia = &alwaysMinimizeSpanningAcrossMedia
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.AlwaysMinimizeSpanningAcrossMedia = &alwaysMinimizeSpanningAcrossMedia
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithBlobbingEnabled(blobbingEnabled bool) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.BlobbingEnabled = &blobbingEnabled
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.BlobbingEnabled = &blobbingEnabled
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithChecksumType(checksumType ChecksumType) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.ChecksumType = checksumType
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.ChecksumType = checksumType
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithDefaultBlobSize(defaultBlobSize int64) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.DefaultBlobSize = &defaultBlobSize
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.DefaultBlobSize = &defaultBlobSize
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithDefaultGetJobPriority(defaultGetJobPriority Priority) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.DefaultGetJobPriority = defaultGetJobPriority
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.DefaultGetJobPriority = defaultGetJobPriority
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithDefaultPutJobPriority(defaultPutJobPriority Priority) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.DefaultPutJobPriority = defaultPutJobPriority
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.DefaultPutJobPriority = defaultPutJobPriority
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithDefaultVerifyAfterWrite(defaultVerifyAfterWrite bool) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.DefaultVerifyAfterWrite = &defaultVerifyAfterWrite
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.DefaultVerifyAfterWrite = &defaultVerifyAfterWrite
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithDefaultVerifyJobPriority(defaultVerifyJobPriority Priority) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.DefaultVerifyJobPriority = defaultVerifyJobPriority
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.DefaultVerifyJobPriority = defaultVerifyJobPriority
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithEndToEndCrcRequired(endToEndCrcRequired bool) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.EndToEndCrcRequired = &endToEndCrcRequired
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.EndToEndCrcRequired = &endToEndCrcRequired
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithMaxVersionsToKeep(maxVersionsToKeep int) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.MaxVersionsToKeep = &maxVersionsToKeep
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.MaxVersionsToKeep = &maxVersionsToKeep
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithName(name string) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.Name = &name
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.Name = &name
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithRebuildPriority(rebuildPriority Priority) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.RebuildPriority = rebuildPriority
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.RebuildPriority = rebuildPriority
+	return modifyDataPolicySpectraS3Request
 }
 
 func (modifyDataPolicySpectraS3Request *ModifyDataPolicySpectraS3Request) WithVersioning(versioning VersioningLevel) *ModifyDataPolicySpectraS3Request {
-    modifyDataPolicySpectraS3Request.Versioning = versioning
-    return modifyDataPolicySpectraS3Request
+	modifyDataPolicySpectraS3Request.Versioning = versioning
+	return modifyDataPolicySpectraS3Request
 }
 
 type ModifyDs3DataReplicationRuleSpectraS3Request struct {
-    DataReplicationRuleType DataReplicationRuleType
-    Ds3DataReplicationRule string
-    ReplicateDeletes *bool
-    TargetDataPolicy *string
+	DataReplicationRuleType DataReplicationRuleType
+	Ds3DataReplicationRule  string
+	ReplicateDeletes        *bool
+	TargetDataPolicy        *string
 }
 
 func NewModifyDs3DataReplicationRuleSpectraS3Request(ds3DataReplicationRule string) *ModifyDs3DataReplicationRuleSpectraS3Request {
-    return &ModifyDs3DataReplicationRuleSpectraS3Request{
-        Ds3DataReplicationRule: ds3DataReplicationRule,
-    }
+	return &ModifyDs3DataReplicationRuleSpectraS3Request{
+		Ds3DataReplicationRule: ds3DataReplicationRule,
+	}
 }
 
 func (modifyDs3DataReplicationRuleSpectraS3Request *ModifyDs3DataReplicationRuleSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *ModifyDs3DataReplicationRuleSpectraS3Request {
-    modifyDs3DataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
-    return modifyDs3DataReplicationRuleSpectraS3Request
+	modifyDs3DataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
+	return modifyDs3DataReplicationRuleSpectraS3Request
 }
 
 func (modifyDs3DataReplicationRuleSpectraS3Request *ModifyDs3DataReplicationRuleSpectraS3Request) WithTargetDataPolicy(targetDataPolicy string) *ModifyDs3DataReplicationRuleSpectraS3Request {
-    modifyDs3DataReplicationRuleSpectraS3Request.TargetDataPolicy = &targetDataPolicy
-    return modifyDs3DataReplicationRuleSpectraS3Request
+	modifyDs3DataReplicationRuleSpectraS3Request.TargetDataPolicy = &targetDataPolicy
+	return modifyDs3DataReplicationRuleSpectraS3Request
 }
 
 func (modifyDs3DataReplicationRuleSpectraS3Request *ModifyDs3DataReplicationRuleSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *ModifyDs3DataReplicationRuleSpectraS3Request {
-    modifyDs3DataReplicationRuleSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
-    return modifyDs3DataReplicationRuleSpectraS3Request
+	modifyDs3DataReplicationRuleSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
+	return modifyDs3DataReplicationRuleSpectraS3Request
 }
 
 type ModifyS3DataReplicationRuleSpectraS3Request struct {
-    DataReplicationRuleType DataReplicationRuleType
-    InitialDataPlacement S3InitialDataPlacementPolicy
-    MaxBlobPartSizeInBytes *int64
-    ReplicateDeletes *bool
-    S3DataReplicationRule string
+	DataReplicationRuleType DataReplicationRuleType
+	InitialDataPlacement    S3InitialDataPlacementPolicy
+	MaxBlobPartSizeInBytes  *int64
+	ReplicateDeletes        *bool
+	S3DataReplicationRule   string
 }
 
 func NewModifyS3DataReplicationRuleSpectraS3Request(s3DataReplicationRule string) *ModifyS3DataReplicationRuleSpectraS3Request {
-    return &ModifyS3DataReplicationRuleSpectraS3Request{
-        S3DataReplicationRule: s3DataReplicationRule,
-    }
+	return &ModifyS3DataReplicationRuleSpectraS3Request{
+		S3DataReplicationRule: s3DataReplicationRule,
+	}
 }
 
 func (modifyS3DataReplicationRuleSpectraS3Request *ModifyS3DataReplicationRuleSpectraS3Request) WithInitialDataPlacement(initialDataPlacement S3InitialDataPlacementPolicy) *ModifyS3DataReplicationRuleSpectraS3Request {
-    modifyS3DataReplicationRuleSpectraS3Request.InitialDataPlacement = initialDataPlacement
-    return modifyS3DataReplicationRuleSpectraS3Request
+	modifyS3DataReplicationRuleSpectraS3Request.InitialDataPlacement = initialDataPlacement
+	return modifyS3DataReplicationRuleSpectraS3Request
 }
 
 func (modifyS3DataReplicationRuleSpectraS3Request *ModifyS3DataReplicationRuleSpectraS3Request) WithMaxBlobPartSizeInBytes(maxBlobPartSizeInBytes int64) *ModifyS3DataReplicationRuleSpectraS3Request {
-    modifyS3DataReplicationRuleSpectraS3Request.MaxBlobPartSizeInBytes = &maxBlobPartSizeInBytes
-    return modifyS3DataReplicationRuleSpectraS3Request
+	modifyS3DataReplicationRuleSpectraS3Request.MaxBlobPartSizeInBytes = &maxBlobPartSizeInBytes
+	return modifyS3DataReplicationRuleSpectraS3Request
 }
 
 func (modifyS3DataReplicationRuleSpectraS3Request *ModifyS3DataReplicationRuleSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *ModifyS3DataReplicationRuleSpectraS3Request {
-    modifyS3DataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
-    return modifyS3DataReplicationRuleSpectraS3Request
+	modifyS3DataReplicationRuleSpectraS3Request.ReplicateDeletes = &replicateDeletes
+	return modifyS3DataReplicationRuleSpectraS3Request
 }
 
 func (modifyS3DataReplicationRuleSpectraS3Request *ModifyS3DataReplicationRuleSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *ModifyS3DataReplicationRuleSpectraS3Request {
-    modifyS3DataReplicationRuleSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
-    return modifyS3DataReplicationRuleSpectraS3Request
+	modifyS3DataReplicationRuleSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
+	return modifyS3DataReplicationRuleSpectraS3Request
 }
 
 type ClearSuspectBlobAzureTargetsSpectraS3Request struct {
-    Force bool
-    Ids []string
+	Force bool
+	Ids   []string
 }
 
 func NewClearSuspectBlobAzureTargetsSpectraS3Request(ids []string) *ClearSuspectBlobAzureTargetsSpectraS3Request {
-    return &ClearSuspectBlobAzureTargetsSpectraS3Request{
-        Ids: ids,
-    }
+	return &ClearSuspectBlobAzureTargetsSpectraS3Request{
+		Ids: ids,
+	}
 }
 
 func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) WithForce() *ClearSuspectBlobAzureTargetsSpectraS3Request {
-    clearSuspectBlobAzureTargetsSpectraS3Request.Force = true
-    return clearSuspectBlobAzureTargetsSpectraS3Request
+	clearSuspectBlobAzureTargetsSpectraS3Request.Force = true
+	return clearSuspectBlobAzureTargetsSpectraS3Request
 }
 
 type ClearSuspectBlobDs3TargetsSpectraS3Request struct {
-    Force bool
-    Ids []string
+	Force bool
+	Ids   []string
 }
 
 func NewClearSuspectBlobDs3TargetsSpectraS3Request(ids []string) *ClearSuspectBlobDs3TargetsSpectraS3Request {
-    return &ClearSuspectBlobDs3TargetsSpectraS3Request{
-        Ids: ids,
-    }
+	return &ClearSuspectBlobDs3TargetsSpectraS3Request{
+		Ids: ids,
+	}
 }
 
 func (clearSuspectBlobDs3TargetsSpectraS3Request *ClearSuspectBlobDs3TargetsSpectraS3Request) WithForce() *ClearSuspectBlobDs3TargetsSpectraS3Request {
-    clearSuspectBlobDs3TargetsSpectraS3Request.Force = true
-    return clearSuspectBlobDs3TargetsSpectraS3Request
+	clearSuspectBlobDs3TargetsSpectraS3Request.Force = true
+	return clearSuspectBlobDs3TargetsSpectraS3Request
 }
 
 type ClearSuspectBlobPoolsSpectraS3Request struct {
-    Force bool
-    Ids []string
+	Force bool
+	Ids   []string
 }
 
 func NewClearSuspectBlobPoolsSpectraS3Request(ids []string) *ClearSuspectBlobPoolsSpectraS3Request {
-    return &ClearSuspectBlobPoolsSpectraS3Request{
-        Ids: ids,
-    }
+	return &ClearSuspectBlobPoolsSpectraS3Request{
+		Ids: ids,
+	}
 }
 
 func (clearSuspectBlobPoolsSpectraS3Request *ClearSuspectBlobPoolsSpectraS3Request) WithForce() *ClearSuspectBlobPoolsSpectraS3Request {
-    clearSuspectBlobPoolsSpectraS3Request.Force = true
-    return clearSuspectBlobPoolsSpectraS3Request
+	clearSuspectBlobPoolsSpectraS3Request.Force = true
+	return clearSuspectBlobPoolsSpectraS3Request
 }
 
 type ClearSuspectBlobS3TargetsSpectraS3Request struct {
-    Force bool
-    Ids []string
+	Force bool
+	Ids   []string
 }
 
 func NewClearSuspectBlobS3TargetsSpectraS3Request(ids []string) *ClearSuspectBlobS3TargetsSpectraS3Request {
-    return &ClearSuspectBlobS3TargetsSpectraS3Request{
-        Ids: ids,
-    }
+	return &ClearSuspectBlobS3TargetsSpectraS3Request{
+		Ids: ids,
+	}
 }
 
 func (clearSuspectBlobS3TargetsSpectraS3Request *ClearSuspectBlobS3TargetsSpectraS3Request) WithForce() *ClearSuspectBlobS3TargetsSpectraS3Request {
-    clearSuspectBlobS3TargetsSpectraS3Request.Force = true
-    return clearSuspectBlobS3TargetsSpectraS3Request
+	clearSuspectBlobS3TargetsSpectraS3Request.Force = true
+	return clearSuspectBlobS3TargetsSpectraS3Request
 }
 
 type ClearSuspectBlobTapesSpectraS3Request struct {
-    Force bool
-    Ids []string
+	Force bool
+	Ids   []string
 }
 
 func NewClearSuspectBlobTapesSpectraS3Request(ids []string) *ClearSuspectBlobTapesSpectraS3Request {
-    return &ClearSuspectBlobTapesSpectraS3Request{
-        Ids: ids,
-    }
+	return &ClearSuspectBlobTapesSpectraS3Request{
+		Ids: ids,
+	}
 }
 
 func (clearSuspectBlobTapesSpectraS3Request *ClearSuspectBlobTapesSpectraS3Request) WithForce() *ClearSuspectBlobTapesSpectraS3Request {
-    clearSuspectBlobTapesSpectraS3Request.Force = true
-    return clearSuspectBlobTapesSpectraS3Request
+	clearSuspectBlobTapesSpectraS3Request.Force = true
+	return clearSuspectBlobTapesSpectraS3Request
 }
 
 type GetDegradedAzureDataReplicationRulesSpectraS3Request struct {
-    DataPolicyId *string
-    DataReplicationRuleType DataReplicationRuleType
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    State DataPlacementRuleState
-    TargetId *string
+	DataPolicyId            *string
+	DataReplicationRuleType DataReplicationRuleType
+	LastPage                bool
+	PageLength              *int
+	PageOffset              *int
+	PageStartMarker         *string
+	State                   DataPlacementRuleState
+	TargetId                *string
 }
 
 func NewGetDegradedAzureDataReplicationRulesSpectraS3Request() *GetDegradedAzureDataReplicationRulesSpectraS3Request {
-    return &GetDegradedAzureDataReplicationRulesSpectraS3Request{
-    }
+	return &GetDegradedAzureDataReplicationRulesSpectraS3Request{}
 }
 
 func (getDegradedAzureDataReplicationRulesSpectraS3Request *GetDegradedAzureDataReplicationRulesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetDegradedAzureDataReplicationRulesSpectraS3Request {
-    getDegradedAzureDataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getDegradedAzureDataReplicationRulesSpectraS3Request
+	getDegradedAzureDataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getDegradedAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedAzureDataReplicationRulesSpectraS3Request *GetDegradedAzureDataReplicationRulesSpectraS3Request) WithLastPage() *GetDegradedAzureDataReplicationRulesSpectraS3Request {
-    getDegradedAzureDataReplicationRulesSpectraS3Request.LastPage = true
-    return getDegradedAzureDataReplicationRulesSpectraS3Request
+	getDegradedAzureDataReplicationRulesSpectraS3Request.LastPage = true
+	return getDegradedAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedAzureDataReplicationRulesSpectraS3Request *GetDegradedAzureDataReplicationRulesSpectraS3Request) WithPageLength(pageLength int) *GetDegradedAzureDataReplicationRulesSpectraS3Request {
-    getDegradedAzureDataReplicationRulesSpectraS3Request.PageLength = &pageLength
-    return getDegradedAzureDataReplicationRulesSpectraS3Request
+	getDegradedAzureDataReplicationRulesSpectraS3Request.PageLength = &pageLength
+	return getDegradedAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedAzureDataReplicationRulesSpectraS3Request *GetDegradedAzureDataReplicationRulesSpectraS3Request) WithPageOffset(pageOffset int) *GetDegradedAzureDataReplicationRulesSpectraS3Request {
-    getDegradedAzureDataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
-    return getDegradedAzureDataReplicationRulesSpectraS3Request
+	getDegradedAzureDataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
+	return getDegradedAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedAzureDataReplicationRulesSpectraS3Request *GetDegradedAzureDataReplicationRulesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDegradedAzureDataReplicationRulesSpectraS3Request {
-    getDegradedAzureDataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDegradedAzureDataReplicationRulesSpectraS3Request
+	getDegradedAzureDataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDegradedAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedAzureDataReplicationRulesSpectraS3Request *GetDegradedAzureDataReplicationRulesSpectraS3Request) WithState(state DataPlacementRuleState) *GetDegradedAzureDataReplicationRulesSpectraS3Request {
-    getDegradedAzureDataReplicationRulesSpectraS3Request.State = state
-    return getDegradedAzureDataReplicationRulesSpectraS3Request
+	getDegradedAzureDataReplicationRulesSpectraS3Request.State = state
+	return getDegradedAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedAzureDataReplicationRulesSpectraS3Request *GetDegradedAzureDataReplicationRulesSpectraS3Request) WithTargetId(targetId string) *GetDegradedAzureDataReplicationRulesSpectraS3Request {
-    getDegradedAzureDataReplicationRulesSpectraS3Request.TargetId = &targetId
-    return getDegradedAzureDataReplicationRulesSpectraS3Request
+	getDegradedAzureDataReplicationRulesSpectraS3Request.TargetId = &targetId
+	return getDegradedAzureDataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedAzureDataReplicationRulesSpectraS3Request *GetDegradedAzureDataReplicationRulesSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *GetDegradedAzureDataReplicationRulesSpectraS3Request {
-    getDegradedAzureDataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
-    return getDegradedAzureDataReplicationRulesSpectraS3Request
+	getDegradedAzureDataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
+	return getDegradedAzureDataReplicationRulesSpectraS3Request
 }
 
 type GetDegradedBlobsSpectraS3Request struct {
-    BlobId *string
-    BucketId *string
-    Ds3ReplicationRuleId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PersistenceRuleId *string
+	BlobId               *string
+	BucketId             *string
+	Ds3ReplicationRuleId *string
+	LastPage             bool
+	PageLength           *int
+	PageOffset           *int
+	PageStartMarker      *string
+	PersistenceRuleId    *string
 }
 
 func NewGetDegradedBlobsSpectraS3Request() *GetDegradedBlobsSpectraS3Request {
-    return &GetDegradedBlobsSpectraS3Request{
-    }
+	return &GetDegradedBlobsSpectraS3Request{}
 }
 
 func (getDegradedBlobsSpectraS3Request *GetDegradedBlobsSpectraS3Request) WithBlobId(blobId string) *GetDegradedBlobsSpectraS3Request {
-    getDegradedBlobsSpectraS3Request.BlobId = &blobId
-    return getDegradedBlobsSpectraS3Request
+	getDegradedBlobsSpectraS3Request.BlobId = &blobId
+	return getDegradedBlobsSpectraS3Request
 }
 
 func (getDegradedBlobsSpectraS3Request *GetDegradedBlobsSpectraS3Request) WithBucketId(bucketId string) *GetDegradedBlobsSpectraS3Request {
-    getDegradedBlobsSpectraS3Request.BucketId = &bucketId
-    return getDegradedBlobsSpectraS3Request
+	getDegradedBlobsSpectraS3Request.BucketId = &bucketId
+	return getDegradedBlobsSpectraS3Request
 }
 
 func (getDegradedBlobsSpectraS3Request *GetDegradedBlobsSpectraS3Request) WithDs3ReplicationRuleId(ds3ReplicationRuleId string) *GetDegradedBlobsSpectraS3Request {
-    getDegradedBlobsSpectraS3Request.Ds3ReplicationRuleId = &ds3ReplicationRuleId
-    return getDegradedBlobsSpectraS3Request
+	getDegradedBlobsSpectraS3Request.Ds3ReplicationRuleId = &ds3ReplicationRuleId
+	return getDegradedBlobsSpectraS3Request
 }
 
 func (getDegradedBlobsSpectraS3Request *GetDegradedBlobsSpectraS3Request) WithLastPage() *GetDegradedBlobsSpectraS3Request {
-    getDegradedBlobsSpectraS3Request.LastPage = true
-    return getDegradedBlobsSpectraS3Request
+	getDegradedBlobsSpectraS3Request.LastPage = true
+	return getDegradedBlobsSpectraS3Request
 }
 
 func (getDegradedBlobsSpectraS3Request *GetDegradedBlobsSpectraS3Request) WithPageLength(pageLength int) *GetDegradedBlobsSpectraS3Request {
-    getDegradedBlobsSpectraS3Request.PageLength = &pageLength
-    return getDegradedBlobsSpectraS3Request
+	getDegradedBlobsSpectraS3Request.PageLength = &pageLength
+	return getDegradedBlobsSpectraS3Request
 }
 
 func (getDegradedBlobsSpectraS3Request *GetDegradedBlobsSpectraS3Request) WithPageOffset(pageOffset int) *GetDegradedBlobsSpectraS3Request {
-    getDegradedBlobsSpectraS3Request.PageOffset = &pageOffset
-    return getDegradedBlobsSpectraS3Request
+	getDegradedBlobsSpectraS3Request.PageOffset = &pageOffset
+	return getDegradedBlobsSpectraS3Request
 }
 
 func (getDegradedBlobsSpectraS3Request *GetDegradedBlobsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDegradedBlobsSpectraS3Request {
-    getDegradedBlobsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDegradedBlobsSpectraS3Request
+	getDegradedBlobsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDegradedBlobsSpectraS3Request
 }
 
 func (getDegradedBlobsSpectraS3Request *GetDegradedBlobsSpectraS3Request) WithPersistenceRuleId(persistenceRuleId string) *GetDegradedBlobsSpectraS3Request {
-    getDegradedBlobsSpectraS3Request.PersistenceRuleId = &persistenceRuleId
-    return getDegradedBlobsSpectraS3Request
+	getDegradedBlobsSpectraS3Request.PersistenceRuleId = &persistenceRuleId
+	return getDegradedBlobsSpectraS3Request
 }
 
 type GetDegradedBucketsSpectraS3Request struct {
-    DataPolicyId *string
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	DataPolicyId    *string
+	LastPage        bool
+	Name            *string
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetDegradedBucketsSpectraS3Request() *GetDegradedBucketsSpectraS3Request {
-    return &GetDegradedBucketsSpectraS3Request{
-    }
+	return &GetDegradedBucketsSpectraS3Request{}
 }
 
 func (getDegradedBucketsSpectraS3Request *GetDegradedBucketsSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetDegradedBucketsSpectraS3Request {
-    getDegradedBucketsSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getDegradedBucketsSpectraS3Request
+	getDegradedBucketsSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getDegradedBucketsSpectraS3Request
 }
 
 func (getDegradedBucketsSpectraS3Request *GetDegradedBucketsSpectraS3Request) WithLastPage() *GetDegradedBucketsSpectraS3Request {
-    getDegradedBucketsSpectraS3Request.LastPage = true
-    return getDegradedBucketsSpectraS3Request
+	getDegradedBucketsSpectraS3Request.LastPage = true
+	return getDegradedBucketsSpectraS3Request
 }
 
 func (getDegradedBucketsSpectraS3Request *GetDegradedBucketsSpectraS3Request) WithName(name string) *GetDegradedBucketsSpectraS3Request {
-    getDegradedBucketsSpectraS3Request.Name = &name
-    return getDegradedBucketsSpectraS3Request
+	getDegradedBucketsSpectraS3Request.Name = &name
+	return getDegradedBucketsSpectraS3Request
 }
 
 func (getDegradedBucketsSpectraS3Request *GetDegradedBucketsSpectraS3Request) WithPageLength(pageLength int) *GetDegradedBucketsSpectraS3Request {
-    getDegradedBucketsSpectraS3Request.PageLength = &pageLength
-    return getDegradedBucketsSpectraS3Request
+	getDegradedBucketsSpectraS3Request.PageLength = &pageLength
+	return getDegradedBucketsSpectraS3Request
 }
 
 func (getDegradedBucketsSpectraS3Request *GetDegradedBucketsSpectraS3Request) WithPageOffset(pageOffset int) *GetDegradedBucketsSpectraS3Request {
-    getDegradedBucketsSpectraS3Request.PageOffset = &pageOffset
-    return getDegradedBucketsSpectraS3Request
+	getDegradedBucketsSpectraS3Request.PageOffset = &pageOffset
+	return getDegradedBucketsSpectraS3Request
 }
 
 func (getDegradedBucketsSpectraS3Request *GetDegradedBucketsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDegradedBucketsSpectraS3Request {
-    getDegradedBucketsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDegradedBucketsSpectraS3Request
+	getDegradedBucketsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDegradedBucketsSpectraS3Request
 }
 
 func (getDegradedBucketsSpectraS3Request *GetDegradedBucketsSpectraS3Request) WithUserId(userId string) *GetDegradedBucketsSpectraS3Request {
-    getDegradedBucketsSpectraS3Request.UserId = &userId
-    return getDegradedBucketsSpectraS3Request
+	getDegradedBucketsSpectraS3Request.UserId = &userId
+	return getDegradedBucketsSpectraS3Request
 }
 
 type GetDegradedDataPersistenceRulesSpectraS3Request struct {
-    DataPersistenceRuleType DataPersistenceRuleType
-    DataPolicyId *string
-    IsolationLevel DataIsolationLevel
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    State DataPlacementRuleState
-    StorageDomainId *string
+	DataPersistenceRuleType DataPersistenceRuleType
+	DataPolicyId            *string
+	IsolationLevel          DataIsolationLevel
+	LastPage                bool
+	PageLength              *int
+	PageOffset              *int
+	PageStartMarker         *string
+	State                   DataPlacementRuleState
+	StorageDomainId         *string
 }
 
 func NewGetDegradedDataPersistenceRulesSpectraS3Request() *GetDegradedDataPersistenceRulesSpectraS3Request {
-    return &GetDegradedDataPersistenceRulesSpectraS3Request{
-    }
+	return &GetDegradedDataPersistenceRulesSpectraS3Request{}
 }
 
 func (getDegradedDataPersistenceRulesSpectraS3Request *GetDegradedDataPersistenceRulesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetDegradedDataPersistenceRulesSpectraS3Request {
-    getDegradedDataPersistenceRulesSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getDegradedDataPersistenceRulesSpectraS3Request
+	getDegradedDataPersistenceRulesSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getDegradedDataPersistenceRulesSpectraS3Request
 }
 
 func (getDegradedDataPersistenceRulesSpectraS3Request *GetDegradedDataPersistenceRulesSpectraS3Request) WithIsolationLevel(isolationLevel DataIsolationLevel) *GetDegradedDataPersistenceRulesSpectraS3Request {
-    getDegradedDataPersistenceRulesSpectraS3Request.IsolationLevel = isolationLevel
-    return getDegradedDataPersistenceRulesSpectraS3Request
+	getDegradedDataPersistenceRulesSpectraS3Request.IsolationLevel = isolationLevel
+	return getDegradedDataPersistenceRulesSpectraS3Request
 }
 
 func (getDegradedDataPersistenceRulesSpectraS3Request *GetDegradedDataPersistenceRulesSpectraS3Request) WithLastPage() *GetDegradedDataPersistenceRulesSpectraS3Request {
-    getDegradedDataPersistenceRulesSpectraS3Request.LastPage = true
-    return getDegradedDataPersistenceRulesSpectraS3Request
+	getDegradedDataPersistenceRulesSpectraS3Request.LastPage = true
+	return getDegradedDataPersistenceRulesSpectraS3Request
 }
 
 func (getDegradedDataPersistenceRulesSpectraS3Request *GetDegradedDataPersistenceRulesSpectraS3Request) WithPageLength(pageLength int) *GetDegradedDataPersistenceRulesSpectraS3Request {
-    getDegradedDataPersistenceRulesSpectraS3Request.PageLength = &pageLength
-    return getDegradedDataPersistenceRulesSpectraS3Request
+	getDegradedDataPersistenceRulesSpectraS3Request.PageLength = &pageLength
+	return getDegradedDataPersistenceRulesSpectraS3Request
 }
 
 func (getDegradedDataPersistenceRulesSpectraS3Request *GetDegradedDataPersistenceRulesSpectraS3Request) WithPageOffset(pageOffset int) *GetDegradedDataPersistenceRulesSpectraS3Request {
-    getDegradedDataPersistenceRulesSpectraS3Request.PageOffset = &pageOffset
-    return getDegradedDataPersistenceRulesSpectraS3Request
+	getDegradedDataPersistenceRulesSpectraS3Request.PageOffset = &pageOffset
+	return getDegradedDataPersistenceRulesSpectraS3Request
 }
 
 func (getDegradedDataPersistenceRulesSpectraS3Request *GetDegradedDataPersistenceRulesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDegradedDataPersistenceRulesSpectraS3Request {
-    getDegradedDataPersistenceRulesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDegradedDataPersistenceRulesSpectraS3Request
+	getDegradedDataPersistenceRulesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDegradedDataPersistenceRulesSpectraS3Request
 }
 
 func (getDegradedDataPersistenceRulesSpectraS3Request *GetDegradedDataPersistenceRulesSpectraS3Request) WithState(state DataPlacementRuleState) *GetDegradedDataPersistenceRulesSpectraS3Request {
-    getDegradedDataPersistenceRulesSpectraS3Request.State = state
-    return getDegradedDataPersistenceRulesSpectraS3Request
+	getDegradedDataPersistenceRulesSpectraS3Request.State = state
+	return getDegradedDataPersistenceRulesSpectraS3Request
 }
 
 func (getDegradedDataPersistenceRulesSpectraS3Request *GetDegradedDataPersistenceRulesSpectraS3Request) WithStorageDomainId(storageDomainId string) *GetDegradedDataPersistenceRulesSpectraS3Request {
-    getDegradedDataPersistenceRulesSpectraS3Request.StorageDomainId = &storageDomainId
-    return getDegradedDataPersistenceRulesSpectraS3Request
+	getDegradedDataPersistenceRulesSpectraS3Request.StorageDomainId = &storageDomainId
+	return getDegradedDataPersistenceRulesSpectraS3Request
 }
 
 func (getDegradedDataPersistenceRulesSpectraS3Request *GetDegradedDataPersistenceRulesSpectraS3Request) WithDataPersistenceRuleType(dataPersistenceRuleType DataPersistenceRuleType) *GetDegradedDataPersistenceRulesSpectraS3Request {
-    getDegradedDataPersistenceRulesSpectraS3Request.DataPersistenceRuleType = dataPersistenceRuleType
-    return getDegradedDataPersistenceRulesSpectraS3Request
+	getDegradedDataPersistenceRulesSpectraS3Request.DataPersistenceRuleType = dataPersistenceRuleType
+	return getDegradedDataPersistenceRulesSpectraS3Request
 }
 
 type GetDegradedDs3DataReplicationRulesSpectraS3Request struct {
-    DataPolicyId *string
-    DataReplicationRuleType DataReplicationRuleType
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    State DataPlacementRuleState
-    TargetId *string
+	DataPolicyId            *string
+	DataReplicationRuleType DataReplicationRuleType
+	LastPage                bool
+	PageLength              *int
+	PageOffset              *int
+	PageStartMarker         *string
+	State                   DataPlacementRuleState
+	TargetId                *string
 }
 
 func NewGetDegradedDs3DataReplicationRulesSpectraS3Request() *GetDegradedDs3DataReplicationRulesSpectraS3Request {
-    return &GetDegradedDs3DataReplicationRulesSpectraS3Request{
-    }
+	return &GetDegradedDs3DataReplicationRulesSpectraS3Request{}
 }
 
 func (getDegradedDs3DataReplicationRulesSpectraS3Request *GetDegradedDs3DataReplicationRulesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetDegradedDs3DataReplicationRulesSpectraS3Request {
-    getDegradedDs3DataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getDegradedDs3DataReplicationRulesSpectraS3Request
+	getDegradedDs3DataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getDegradedDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedDs3DataReplicationRulesSpectraS3Request *GetDegradedDs3DataReplicationRulesSpectraS3Request) WithLastPage() *GetDegradedDs3DataReplicationRulesSpectraS3Request {
-    getDegradedDs3DataReplicationRulesSpectraS3Request.LastPage = true
-    return getDegradedDs3DataReplicationRulesSpectraS3Request
+	getDegradedDs3DataReplicationRulesSpectraS3Request.LastPage = true
+	return getDegradedDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedDs3DataReplicationRulesSpectraS3Request *GetDegradedDs3DataReplicationRulesSpectraS3Request) WithPageLength(pageLength int) *GetDegradedDs3DataReplicationRulesSpectraS3Request {
-    getDegradedDs3DataReplicationRulesSpectraS3Request.PageLength = &pageLength
-    return getDegradedDs3DataReplicationRulesSpectraS3Request
+	getDegradedDs3DataReplicationRulesSpectraS3Request.PageLength = &pageLength
+	return getDegradedDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedDs3DataReplicationRulesSpectraS3Request *GetDegradedDs3DataReplicationRulesSpectraS3Request) WithPageOffset(pageOffset int) *GetDegradedDs3DataReplicationRulesSpectraS3Request {
-    getDegradedDs3DataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
-    return getDegradedDs3DataReplicationRulesSpectraS3Request
+	getDegradedDs3DataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
+	return getDegradedDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedDs3DataReplicationRulesSpectraS3Request *GetDegradedDs3DataReplicationRulesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDegradedDs3DataReplicationRulesSpectraS3Request {
-    getDegradedDs3DataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDegradedDs3DataReplicationRulesSpectraS3Request
+	getDegradedDs3DataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDegradedDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedDs3DataReplicationRulesSpectraS3Request *GetDegradedDs3DataReplicationRulesSpectraS3Request) WithState(state DataPlacementRuleState) *GetDegradedDs3DataReplicationRulesSpectraS3Request {
-    getDegradedDs3DataReplicationRulesSpectraS3Request.State = state
-    return getDegradedDs3DataReplicationRulesSpectraS3Request
+	getDegradedDs3DataReplicationRulesSpectraS3Request.State = state
+	return getDegradedDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedDs3DataReplicationRulesSpectraS3Request *GetDegradedDs3DataReplicationRulesSpectraS3Request) WithTargetId(targetId string) *GetDegradedDs3DataReplicationRulesSpectraS3Request {
-    getDegradedDs3DataReplicationRulesSpectraS3Request.TargetId = &targetId
-    return getDegradedDs3DataReplicationRulesSpectraS3Request
+	getDegradedDs3DataReplicationRulesSpectraS3Request.TargetId = &targetId
+	return getDegradedDs3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedDs3DataReplicationRulesSpectraS3Request *GetDegradedDs3DataReplicationRulesSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *GetDegradedDs3DataReplicationRulesSpectraS3Request {
-    getDegradedDs3DataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
-    return getDegradedDs3DataReplicationRulesSpectraS3Request
+	getDegradedDs3DataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
+	return getDegradedDs3DataReplicationRulesSpectraS3Request
 }
 
 type GetDegradedS3DataReplicationRulesSpectraS3Request struct {
-    DataPolicyId *string
-    DataReplicationRuleType DataReplicationRuleType
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    State DataPlacementRuleState
-    TargetId *string
+	DataPolicyId            *string
+	DataReplicationRuleType DataReplicationRuleType
+	LastPage                bool
+	PageLength              *int
+	PageOffset              *int
+	PageStartMarker         *string
+	State                   DataPlacementRuleState
+	TargetId                *string
 }
 
 func NewGetDegradedS3DataReplicationRulesSpectraS3Request() *GetDegradedS3DataReplicationRulesSpectraS3Request {
-    return &GetDegradedS3DataReplicationRulesSpectraS3Request{
-    }
+	return &GetDegradedS3DataReplicationRulesSpectraS3Request{}
 }
 
 func (getDegradedS3DataReplicationRulesSpectraS3Request *GetDegradedS3DataReplicationRulesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetDegradedS3DataReplicationRulesSpectraS3Request {
-    getDegradedS3DataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getDegradedS3DataReplicationRulesSpectraS3Request
+	getDegradedS3DataReplicationRulesSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getDegradedS3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedS3DataReplicationRulesSpectraS3Request *GetDegradedS3DataReplicationRulesSpectraS3Request) WithLastPage() *GetDegradedS3DataReplicationRulesSpectraS3Request {
-    getDegradedS3DataReplicationRulesSpectraS3Request.LastPage = true
-    return getDegradedS3DataReplicationRulesSpectraS3Request
+	getDegradedS3DataReplicationRulesSpectraS3Request.LastPage = true
+	return getDegradedS3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedS3DataReplicationRulesSpectraS3Request *GetDegradedS3DataReplicationRulesSpectraS3Request) WithPageLength(pageLength int) *GetDegradedS3DataReplicationRulesSpectraS3Request {
-    getDegradedS3DataReplicationRulesSpectraS3Request.PageLength = &pageLength
-    return getDegradedS3DataReplicationRulesSpectraS3Request
+	getDegradedS3DataReplicationRulesSpectraS3Request.PageLength = &pageLength
+	return getDegradedS3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedS3DataReplicationRulesSpectraS3Request *GetDegradedS3DataReplicationRulesSpectraS3Request) WithPageOffset(pageOffset int) *GetDegradedS3DataReplicationRulesSpectraS3Request {
-    getDegradedS3DataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
-    return getDegradedS3DataReplicationRulesSpectraS3Request
+	getDegradedS3DataReplicationRulesSpectraS3Request.PageOffset = &pageOffset
+	return getDegradedS3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedS3DataReplicationRulesSpectraS3Request *GetDegradedS3DataReplicationRulesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDegradedS3DataReplicationRulesSpectraS3Request {
-    getDegradedS3DataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDegradedS3DataReplicationRulesSpectraS3Request
+	getDegradedS3DataReplicationRulesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDegradedS3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedS3DataReplicationRulesSpectraS3Request *GetDegradedS3DataReplicationRulesSpectraS3Request) WithState(state DataPlacementRuleState) *GetDegradedS3DataReplicationRulesSpectraS3Request {
-    getDegradedS3DataReplicationRulesSpectraS3Request.State = state
-    return getDegradedS3DataReplicationRulesSpectraS3Request
+	getDegradedS3DataReplicationRulesSpectraS3Request.State = state
+	return getDegradedS3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedS3DataReplicationRulesSpectraS3Request *GetDegradedS3DataReplicationRulesSpectraS3Request) WithTargetId(targetId string) *GetDegradedS3DataReplicationRulesSpectraS3Request {
-    getDegradedS3DataReplicationRulesSpectraS3Request.TargetId = &targetId
-    return getDegradedS3DataReplicationRulesSpectraS3Request
+	getDegradedS3DataReplicationRulesSpectraS3Request.TargetId = &targetId
+	return getDegradedS3DataReplicationRulesSpectraS3Request
 }
 
 func (getDegradedS3DataReplicationRulesSpectraS3Request *GetDegradedS3DataReplicationRulesSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *GetDegradedS3DataReplicationRulesSpectraS3Request {
-    getDegradedS3DataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
-    return getDegradedS3DataReplicationRulesSpectraS3Request
+	getDegradedS3DataReplicationRulesSpectraS3Request.DataReplicationRuleType = dataReplicationRuleType
+	return getDegradedS3DataReplicationRulesSpectraS3Request
 }
 
 type GetSuspectBlobAzureTargetsSpectraS3Request struct {
-    BlobId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    TargetId *string
+	BlobId          *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	TargetId        *string
 }
 
 func NewGetSuspectBlobAzureTargetsSpectraS3Request() *GetSuspectBlobAzureTargetsSpectraS3Request {
-    return &GetSuspectBlobAzureTargetsSpectraS3Request{
-    }
+	return &GetSuspectBlobAzureTargetsSpectraS3Request{}
 }
 
 func (getSuspectBlobAzureTargetsSpectraS3Request *GetSuspectBlobAzureTargetsSpectraS3Request) WithBlobId(blobId string) *GetSuspectBlobAzureTargetsSpectraS3Request {
-    getSuspectBlobAzureTargetsSpectraS3Request.BlobId = &blobId
-    return getSuspectBlobAzureTargetsSpectraS3Request
+	getSuspectBlobAzureTargetsSpectraS3Request.BlobId = &blobId
+	return getSuspectBlobAzureTargetsSpectraS3Request
 }
 
 func (getSuspectBlobAzureTargetsSpectraS3Request *GetSuspectBlobAzureTargetsSpectraS3Request) WithLastPage() *GetSuspectBlobAzureTargetsSpectraS3Request {
-    getSuspectBlobAzureTargetsSpectraS3Request.LastPage = true
-    return getSuspectBlobAzureTargetsSpectraS3Request
+	getSuspectBlobAzureTargetsSpectraS3Request.LastPage = true
+	return getSuspectBlobAzureTargetsSpectraS3Request
 }
 
 func (getSuspectBlobAzureTargetsSpectraS3Request *GetSuspectBlobAzureTargetsSpectraS3Request) WithPageLength(pageLength int) *GetSuspectBlobAzureTargetsSpectraS3Request {
-    getSuspectBlobAzureTargetsSpectraS3Request.PageLength = &pageLength
-    return getSuspectBlobAzureTargetsSpectraS3Request
+	getSuspectBlobAzureTargetsSpectraS3Request.PageLength = &pageLength
+	return getSuspectBlobAzureTargetsSpectraS3Request
 }
 
 func (getSuspectBlobAzureTargetsSpectraS3Request *GetSuspectBlobAzureTargetsSpectraS3Request) WithPageOffset(pageOffset int) *GetSuspectBlobAzureTargetsSpectraS3Request {
-    getSuspectBlobAzureTargetsSpectraS3Request.PageOffset = &pageOffset
-    return getSuspectBlobAzureTargetsSpectraS3Request
+	getSuspectBlobAzureTargetsSpectraS3Request.PageOffset = &pageOffset
+	return getSuspectBlobAzureTargetsSpectraS3Request
 }
 
 func (getSuspectBlobAzureTargetsSpectraS3Request *GetSuspectBlobAzureTargetsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetSuspectBlobAzureTargetsSpectraS3Request {
-    getSuspectBlobAzureTargetsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getSuspectBlobAzureTargetsSpectraS3Request
+	getSuspectBlobAzureTargetsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getSuspectBlobAzureTargetsSpectraS3Request
 }
 
 func (getSuspectBlobAzureTargetsSpectraS3Request *GetSuspectBlobAzureTargetsSpectraS3Request) WithTargetId(targetId string) *GetSuspectBlobAzureTargetsSpectraS3Request {
-    getSuspectBlobAzureTargetsSpectraS3Request.TargetId = &targetId
-    return getSuspectBlobAzureTargetsSpectraS3Request
+	getSuspectBlobAzureTargetsSpectraS3Request.TargetId = &targetId
+	return getSuspectBlobAzureTargetsSpectraS3Request
 }
 
 type GetSuspectBlobDs3TargetsSpectraS3Request struct {
-    BlobId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    TargetId *string
+	BlobId          *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	TargetId        *string
 }
 
 func NewGetSuspectBlobDs3TargetsSpectraS3Request() *GetSuspectBlobDs3TargetsSpectraS3Request {
-    return &GetSuspectBlobDs3TargetsSpectraS3Request{
-    }
+	return &GetSuspectBlobDs3TargetsSpectraS3Request{}
 }
 
 func (getSuspectBlobDs3TargetsSpectraS3Request *GetSuspectBlobDs3TargetsSpectraS3Request) WithBlobId(blobId string) *GetSuspectBlobDs3TargetsSpectraS3Request {
-    getSuspectBlobDs3TargetsSpectraS3Request.BlobId = &blobId
-    return getSuspectBlobDs3TargetsSpectraS3Request
+	getSuspectBlobDs3TargetsSpectraS3Request.BlobId = &blobId
+	return getSuspectBlobDs3TargetsSpectraS3Request
 }
 
 func (getSuspectBlobDs3TargetsSpectraS3Request *GetSuspectBlobDs3TargetsSpectraS3Request) WithLastPage() *GetSuspectBlobDs3TargetsSpectraS3Request {
-    getSuspectBlobDs3TargetsSpectraS3Request.LastPage = true
-    return getSuspectBlobDs3TargetsSpectraS3Request
+	getSuspectBlobDs3TargetsSpectraS3Request.LastPage = true
+	return getSuspectBlobDs3TargetsSpectraS3Request
 }
 
 func (getSuspectBlobDs3TargetsSpectraS3Request *GetSuspectBlobDs3TargetsSpectraS3Request) WithPageLength(pageLength int) *GetSuspectBlobDs3TargetsSpectraS3Request {
-    getSuspectBlobDs3TargetsSpectraS3Request.PageLength = &pageLength
-    return getSuspectBlobDs3TargetsSpectraS3Request
+	getSuspectBlobDs3TargetsSpectraS3Request.PageLength = &pageLength
+	return getSuspectBlobDs3TargetsSpectraS3Request
 }
 
 func (getSuspectBlobDs3TargetsSpectraS3Request *GetSuspectBlobDs3TargetsSpectraS3Request) WithPageOffset(pageOffset int) *GetSuspectBlobDs3TargetsSpectraS3Request {
-    getSuspectBlobDs3TargetsSpectraS3Request.PageOffset = &pageOffset
-    return getSuspectBlobDs3TargetsSpectraS3Request
+	getSuspectBlobDs3TargetsSpectraS3Request.PageOffset = &pageOffset
+	return getSuspectBlobDs3TargetsSpectraS3Request
 }
 
 func (getSuspectBlobDs3TargetsSpectraS3Request *GetSuspectBlobDs3TargetsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetSuspectBlobDs3TargetsSpectraS3Request {
-    getSuspectBlobDs3TargetsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getSuspectBlobDs3TargetsSpectraS3Request
+	getSuspectBlobDs3TargetsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getSuspectBlobDs3TargetsSpectraS3Request
 }
 
 func (getSuspectBlobDs3TargetsSpectraS3Request *GetSuspectBlobDs3TargetsSpectraS3Request) WithTargetId(targetId string) *GetSuspectBlobDs3TargetsSpectraS3Request {
-    getSuspectBlobDs3TargetsSpectraS3Request.TargetId = &targetId
-    return getSuspectBlobDs3TargetsSpectraS3Request
+	getSuspectBlobDs3TargetsSpectraS3Request.TargetId = &targetId
+	return getSuspectBlobDs3TargetsSpectraS3Request
 }
 
 type GetSuspectBlobPoolsSpectraS3Request struct {
-    BlobId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PoolId *string
+	BlobId          *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	PoolId          *string
 }
 
 func NewGetSuspectBlobPoolsSpectraS3Request() *GetSuspectBlobPoolsSpectraS3Request {
-    return &GetSuspectBlobPoolsSpectraS3Request{
-    }
+	return &GetSuspectBlobPoolsSpectraS3Request{}
 }
 
 func (getSuspectBlobPoolsSpectraS3Request *GetSuspectBlobPoolsSpectraS3Request) WithBlobId(blobId string) *GetSuspectBlobPoolsSpectraS3Request {
-    getSuspectBlobPoolsSpectraS3Request.BlobId = &blobId
-    return getSuspectBlobPoolsSpectraS3Request
+	getSuspectBlobPoolsSpectraS3Request.BlobId = &blobId
+	return getSuspectBlobPoolsSpectraS3Request
 }
 
 func (getSuspectBlobPoolsSpectraS3Request *GetSuspectBlobPoolsSpectraS3Request) WithLastPage() *GetSuspectBlobPoolsSpectraS3Request {
-    getSuspectBlobPoolsSpectraS3Request.LastPage = true
-    return getSuspectBlobPoolsSpectraS3Request
+	getSuspectBlobPoolsSpectraS3Request.LastPage = true
+	return getSuspectBlobPoolsSpectraS3Request
 }
 
 func (getSuspectBlobPoolsSpectraS3Request *GetSuspectBlobPoolsSpectraS3Request) WithPageLength(pageLength int) *GetSuspectBlobPoolsSpectraS3Request {
-    getSuspectBlobPoolsSpectraS3Request.PageLength = &pageLength
-    return getSuspectBlobPoolsSpectraS3Request
+	getSuspectBlobPoolsSpectraS3Request.PageLength = &pageLength
+	return getSuspectBlobPoolsSpectraS3Request
 }
 
 func (getSuspectBlobPoolsSpectraS3Request *GetSuspectBlobPoolsSpectraS3Request) WithPageOffset(pageOffset int) *GetSuspectBlobPoolsSpectraS3Request {
-    getSuspectBlobPoolsSpectraS3Request.PageOffset = &pageOffset
-    return getSuspectBlobPoolsSpectraS3Request
+	getSuspectBlobPoolsSpectraS3Request.PageOffset = &pageOffset
+	return getSuspectBlobPoolsSpectraS3Request
 }
 
 func (getSuspectBlobPoolsSpectraS3Request *GetSuspectBlobPoolsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetSuspectBlobPoolsSpectraS3Request {
-    getSuspectBlobPoolsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getSuspectBlobPoolsSpectraS3Request
+	getSuspectBlobPoolsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getSuspectBlobPoolsSpectraS3Request
 }
 
 func (getSuspectBlobPoolsSpectraS3Request *GetSuspectBlobPoolsSpectraS3Request) WithPoolId(poolId string) *GetSuspectBlobPoolsSpectraS3Request {
-    getSuspectBlobPoolsSpectraS3Request.PoolId = &poolId
-    return getSuspectBlobPoolsSpectraS3Request
+	getSuspectBlobPoolsSpectraS3Request.PoolId = &poolId
+	return getSuspectBlobPoolsSpectraS3Request
 }
 
 type GetSuspectBlobS3TargetsSpectraS3Request struct {
-    BlobId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    TargetId *string
+	BlobId          *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	TargetId        *string
 }
 
 func NewGetSuspectBlobS3TargetsSpectraS3Request() *GetSuspectBlobS3TargetsSpectraS3Request {
-    return &GetSuspectBlobS3TargetsSpectraS3Request{
-    }
+	return &GetSuspectBlobS3TargetsSpectraS3Request{}
 }
 
 func (getSuspectBlobS3TargetsSpectraS3Request *GetSuspectBlobS3TargetsSpectraS3Request) WithBlobId(blobId string) *GetSuspectBlobS3TargetsSpectraS3Request {
-    getSuspectBlobS3TargetsSpectraS3Request.BlobId = &blobId
-    return getSuspectBlobS3TargetsSpectraS3Request
+	getSuspectBlobS3TargetsSpectraS3Request.BlobId = &blobId
+	return getSuspectBlobS3TargetsSpectraS3Request
 }
 
 func (getSuspectBlobS3TargetsSpectraS3Request *GetSuspectBlobS3TargetsSpectraS3Request) WithLastPage() *GetSuspectBlobS3TargetsSpectraS3Request {
-    getSuspectBlobS3TargetsSpectraS3Request.LastPage = true
-    return getSuspectBlobS3TargetsSpectraS3Request
+	getSuspectBlobS3TargetsSpectraS3Request.LastPage = true
+	return getSuspectBlobS3TargetsSpectraS3Request
 }
 
 func (getSuspectBlobS3TargetsSpectraS3Request *GetSuspectBlobS3TargetsSpectraS3Request) WithPageLength(pageLength int) *GetSuspectBlobS3TargetsSpectraS3Request {
-    getSuspectBlobS3TargetsSpectraS3Request.PageLength = &pageLength
-    return getSuspectBlobS3TargetsSpectraS3Request
+	getSuspectBlobS3TargetsSpectraS3Request.PageLength = &pageLength
+	return getSuspectBlobS3TargetsSpectraS3Request
 }
 
 func (getSuspectBlobS3TargetsSpectraS3Request *GetSuspectBlobS3TargetsSpectraS3Request) WithPageOffset(pageOffset int) *GetSuspectBlobS3TargetsSpectraS3Request {
-    getSuspectBlobS3TargetsSpectraS3Request.PageOffset = &pageOffset
-    return getSuspectBlobS3TargetsSpectraS3Request
+	getSuspectBlobS3TargetsSpectraS3Request.PageOffset = &pageOffset
+	return getSuspectBlobS3TargetsSpectraS3Request
 }
 
 func (getSuspectBlobS3TargetsSpectraS3Request *GetSuspectBlobS3TargetsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetSuspectBlobS3TargetsSpectraS3Request {
-    getSuspectBlobS3TargetsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getSuspectBlobS3TargetsSpectraS3Request
+	getSuspectBlobS3TargetsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getSuspectBlobS3TargetsSpectraS3Request
 }
 
 func (getSuspectBlobS3TargetsSpectraS3Request *GetSuspectBlobS3TargetsSpectraS3Request) WithTargetId(targetId string) *GetSuspectBlobS3TargetsSpectraS3Request {
-    getSuspectBlobS3TargetsSpectraS3Request.TargetId = &targetId
-    return getSuspectBlobS3TargetsSpectraS3Request
+	getSuspectBlobS3TargetsSpectraS3Request.TargetId = &targetId
+	return getSuspectBlobS3TargetsSpectraS3Request
 }
 
 type GetSuspectBlobTapesSpectraS3Request struct {
-    BlobId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    TapeId *string
+	BlobId          *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	TapeId          *string
 }
 
 func NewGetSuspectBlobTapesSpectraS3Request() *GetSuspectBlobTapesSpectraS3Request {
-    return &GetSuspectBlobTapesSpectraS3Request{
-    }
+	return &GetSuspectBlobTapesSpectraS3Request{}
 }
 
 func (getSuspectBlobTapesSpectraS3Request *GetSuspectBlobTapesSpectraS3Request) WithBlobId(blobId string) *GetSuspectBlobTapesSpectraS3Request {
-    getSuspectBlobTapesSpectraS3Request.BlobId = &blobId
-    return getSuspectBlobTapesSpectraS3Request
+	getSuspectBlobTapesSpectraS3Request.BlobId = &blobId
+	return getSuspectBlobTapesSpectraS3Request
 }
 
 func (getSuspectBlobTapesSpectraS3Request *GetSuspectBlobTapesSpectraS3Request) WithLastPage() *GetSuspectBlobTapesSpectraS3Request {
-    getSuspectBlobTapesSpectraS3Request.LastPage = true
-    return getSuspectBlobTapesSpectraS3Request
+	getSuspectBlobTapesSpectraS3Request.LastPage = true
+	return getSuspectBlobTapesSpectraS3Request
 }
 
 func (getSuspectBlobTapesSpectraS3Request *GetSuspectBlobTapesSpectraS3Request) WithPageLength(pageLength int) *GetSuspectBlobTapesSpectraS3Request {
-    getSuspectBlobTapesSpectraS3Request.PageLength = &pageLength
-    return getSuspectBlobTapesSpectraS3Request
+	getSuspectBlobTapesSpectraS3Request.PageLength = &pageLength
+	return getSuspectBlobTapesSpectraS3Request
 }
 
 func (getSuspectBlobTapesSpectraS3Request *GetSuspectBlobTapesSpectraS3Request) WithPageOffset(pageOffset int) *GetSuspectBlobTapesSpectraS3Request {
-    getSuspectBlobTapesSpectraS3Request.PageOffset = &pageOffset
-    return getSuspectBlobTapesSpectraS3Request
+	getSuspectBlobTapesSpectraS3Request.PageOffset = &pageOffset
+	return getSuspectBlobTapesSpectraS3Request
 }
 
 func (getSuspectBlobTapesSpectraS3Request *GetSuspectBlobTapesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetSuspectBlobTapesSpectraS3Request {
-    getSuspectBlobTapesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getSuspectBlobTapesSpectraS3Request
+	getSuspectBlobTapesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getSuspectBlobTapesSpectraS3Request
 }
 
 func (getSuspectBlobTapesSpectraS3Request *GetSuspectBlobTapesSpectraS3Request) WithTapeId(tapeId string) *GetSuspectBlobTapesSpectraS3Request {
-    getSuspectBlobTapesSpectraS3Request.TapeId = &tapeId
-    return getSuspectBlobTapesSpectraS3Request
+	getSuspectBlobTapesSpectraS3Request.TapeId = &tapeId
+	return getSuspectBlobTapesSpectraS3Request
 }
 
 type GetSuspectBucketsSpectraS3Request struct {
-    DataPolicyId *string
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	DataPolicyId    *string
+	LastPage        bool
+	Name            *string
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetSuspectBucketsSpectraS3Request() *GetSuspectBucketsSpectraS3Request {
-    return &GetSuspectBucketsSpectraS3Request{
-    }
+	return &GetSuspectBucketsSpectraS3Request{}
 }
 
 func (getSuspectBucketsSpectraS3Request *GetSuspectBucketsSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetSuspectBucketsSpectraS3Request {
-    getSuspectBucketsSpectraS3Request.DataPolicyId = &dataPolicyId
-    return getSuspectBucketsSpectraS3Request
+	getSuspectBucketsSpectraS3Request.DataPolicyId = &dataPolicyId
+	return getSuspectBucketsSpectraS3Request
 }
 
 func (getSuspectBucketsSpectraS3Request *GetSuspectBucketsSpectraS3Request) WithLastPage() *GetSuspectBucketsSpectraS3Request {
-    getSuspectBucketsSpectraS3Request.LastPage = true
-    return getSuspectBucketsSpectraS3Request
+	getSuspectBucketsSpectraS3Request.LastPage = true
+	return getSuspectBucketsSpectraS3Request
 }
 
 func (getSuspectBucketsSpectraS3Request *GetSuspectBucketsSpectraS3Request) WithName(name string) *GetSuspectBucketsSpectraS3Request {
-    getSuspectBucketsSpectraS3Request.Name = &name
-    return getSuspectBucketsSpectraS3Request
+	getSuspectBucketsSpectraS3Request.Name = &name
+	return getSuspectBucketsSpectraS3Request
 }
 
 func (getSuspectBucketsSpectraS3Request *GetSuspectBucketsSpectraS3Request) WithPageLength(pageLength int) *GetSuspectBucketsSpectraS3Request {
-    getSuspectBucketsSpectraS3Request.PageLength = &pageLength
-    return getSuspectBucketsSpectraS3Request
+	getSuspectBucketsSpectraS3Request.PageLength = &pageLength
+	return getSuspectBucketsSpectraS3Request
 }
 
 func (getSuspectBucketsSpectraS3Request *GetSuspectBucketsSpectraS3Request) WithPageOffset(pageOffset int) *GetSuspectBucketsSpectraS3Request {
-    getSuspectBucketsSpectraS3Request.PageOffset = &pageOffset
-    return getSuspectBucketsSpectraS3Request
+	getSuspectBucketsSpectraS3Request.PageOffset = &pageOffset
+	return getSuspectBucketsSpectraS3Request
 }
 
 func (getSuspectBucketsSpectraS3Request *GetSuspectBucketsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetSuspectBucketsSpectraS3Request {
-    getSuspectBucketsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getSuspectBucketsSpectraS3Request
+	getSuspectBucketsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getSuspectBucketsSpectraS3Request
 }
 
 func (getSuspectBucketsSpectraS3Request *GetSuspectBucketsSpectraS3Request) WithUserId(userId string) *GetSuspectBucketsSpectraS3Request {
-    getSuspectBucketsSpectraS3Request.UserId = &userId
-    return getSuspectBucketsSpectraS3Request
+	getSuspectBucketsSpectraS3Request.UserId = &userId
+	return getSuspectBucketsSpectraS3Request
 }
 
 type GetSuspectObjectsSpectraS3Request struct {
-    BucketId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
+	BucketId        *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
 }
 
 func NewGetSuspectObjectsSpectraS3Request() *GetSuspectObjectsSpectraS3Request {
-    return &GetSuspectObjectsSpectraS3Request{
-    }
+	return &GetSuspectObjectsSpectraS3Request{}
 }
 
 func (getSuspectObjectsSpectraS3Request *GetSuspectObjectsSpectraS3Request) WithBucketId(bucketId string) *GetSuspectObjectsSpectraS3Request {
-    getSuspectObjectsSpectraS3Request.BucketId = &bucketId
-    return getSuspectObjectsSpectraS3Request
+	getSuspectObjectsSpectraS3Request.BucketId = &bucketId
+	return getSuspectObjectsSpectraS3Request
 }
 
 func (getSuspectObjectsSpectraS3Request *GetSuspectObjectsSpectraS3Request) WithLastPage() *GetSuspectObjectsSpectraS3Request {
-    getSuspectObjectsSpectraS3Request.LastPage = true
-    return getSuspectObjectsSpectraS3Request
+	getSuspectObjectsSpectraS3Request.LastPage = true
+	return getSuspectObjectsSpectraS3Request
 }
 
 func (getSuspectObjectsSpectraS3Request *GetSuspectObjectsSpectraS3Request) WithPageLength(pageLength int) *GetSuspectObjectsSpectraS3Request {
-    getSuspectObjectsSpectraS3Request.PageLength = &pageLength
-    return getSuspectObjectsSpectraS3Request
+	getSuspectObjectsSpectraS3Request.PageLength = &pageLength
+	return getSuspectObjectsSpectraS3Request
 }
 
 func (getSuspectObjectsSpectraS3Request *GetSuspectObjectsSpectraS3Request) WithPageOffset(pageOffset int) *GetSuspectObjectsSpectraS3Request {
-    getSuspectObjectsSpectraS3Request.PageOffset = &pageOffset
-    return getSuspectObjectsSpectraS3Request
+	getSuspectObjectsSpectraS3Request.PageOffset = &pageOffset
+	return getSuspectObjectsSpectraS3Request
 }
 
 func (getSuspectObjectsSpectraS3Request *GetSuspectObjectsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetSuspectObjectsSpectraS3Request {
-    getSuspectObjectsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getSuspectObjectsSpectraS3Request
+	getSuspectObjectsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getSuspectObjectsSpectraS3Request
 }
 
 type GetSuspectObjectsWithFullDetailsSpectraS3Request struct {
-    BucketId *string
-    StorageDomain *string
+	BucketId      *string
+	StorageDomain *string
 }
 
 func NewGetSuspectObjectsWithFullDetailsSpectraS3Request() *GetSuspectObjectsWithFullDetailsSpectraS3Request {
-    return &GetSuspectObjectsWithFullDetailsSpectraS3Request{
-    }
+	return &GetSuspectObjectsWithFullDetailsSpectraS3Request{}
 }
 
 func (getSuspectObjectsWithFullDetailsSpectraS3Request *GetSuspectObjectsWithFullDetailsSpectraS3Request) WithBucketId(bucketId string) *GetSuspectObjectsWithFullDetailsSpectraS3Request {
-    getSuspectObjectsWithFullDetailsSpectraS3Request.BucketId = &bucketId
-    return getSuspectObjectsWithFullDetailsSpectraS3Request
+	getSuspectObjectsWithFullDetailsSpectraS3Request.BucketId = &bucketId
+	return getSuspectObjectsWithFullDetailsSpectraS3Request
 }
 
 func (getSuspectObjectsWithFullDetailsSpectraS3Request *GetSuspectObjectsWithFullDetailsSpectraS3Request) WithStorageDomain(storageDomain string) *GetSuspectObjectsWithFullDetailsSpectraS3Request {
-    getSuspectObjectsWithFullDetailsSpectraS3Request.StorageDomain = &storageDomain
-    return getSuspectObjectsWithFullDetailsSpectraS3Request
+	getSuspectObjectsWithFullDetailsSpectraS3Request.StorageDomain = &storageDomain
+	return getSuspectObjectsWithFullDetailsSpectraS3Request
 }
 
 type MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request struct {
-    Force bool
-    Ids []string
+	Force bool
+	Ids   []string
 }
 
 func NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(ids []string) *MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request {
-    return &MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request{
-        Ids: ids,
-    }
+	return &MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request{
+		Ids: ids,
+	}
 }
 
 func (markSuspectBlobAzureTargetsAsDegradedSpectraS3Request *MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request) WithForce() *MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request {
-    markSuspectBlobAzureTargetsAsDegradedSpectraS3Request.Force = true
-    return markSuspectBlobAzureTargetsAsDegradedSpectraS3Request
+	markSuspectBlobAzureTargetsAsDegradedSpectraS3Request.Force = true
+	return markSuspectBlobAzureTargetsAsDegradedSpectraS3Request
 }
 
 type MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request struct {
-    Force bool
-    Ids []string
+	Force bool
+	Ids   []string
 }
 
 func NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(ids []string) *MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request {
-    return &MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request{
-        Ids: ids,
-    }
+	return &MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request{
+		Ids: ids,
+	}
 }
 
 func (markSuspectBlobDs3TargetsAsDegradedSpectraS3Request *MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request) WithForce() *MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request {
-    markSuspectBlobDs3TargetsAsDegradedSpectraS3Request.Force = true
-    return markSuspectBlobDs3TargetsAsDegradedSpectraS3Request
+	markSuspectBlobDs3TargetsAsDegradedSpectraS3Request.Force = true
+	return markSuspectBlobDs3TargetsAsDegradedSpectraS3Request
 }
 
 type MarkSuspectBlobPoolsAsDegradedSpectraS3Request struct {
-    Force bool
-    Ids []string
+	Force bool
+	Ids   []string
 }
 
 func NewMarkSuspectBlobPoolsAsDegradedSpectraS3Request(ids []string) *MarkSuspectBlobPoolsAsDegradedSpectraS3Request {
-    return &MarkSuspectBlobPoolsAsDegradedSpectraS3Request{
-        Ids: ids,
-    }
+	return &MarkSuspectBlobPoolsAsDegradedSpectraS3Request{
+		Ids: ids,
+	}
 }
 
 func (markSuspectBlobPoolsAsDegradedSpectraS3Request *MarkSuspectBlobPoolsAsDegradedSpectraS3Request) WithForce() *MarkSuspectBlobPoolsAsDegradedSpectraS3Request {
-    markSuspectBlobPoolsAsDegradedSpectraS3Request.Force = true
-    return markSuspectBlobPoolsAsDegradedSpectraS3Request
+	markSuspectBlobPoolsAsDegradedSpectraS3Request.Force = true
+	return markSuspectBlobPoolsAsDegradedSpectraS3Request
 }
 
 type MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request struct {
-    Force bool
-    Ids []string
+	Force bool
+	Ids   []string
 }
 
 func NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(ids []string) *MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request {
-    return &MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request{
-        Ids: ids,
-    }
+	return &MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request{
+		Ids: ids,
+	}
 }
 
 func (markSuspectBlobS3TargetsAsDegradedSpectraS3Request *MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request) WithForce() *MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request {
-    markSuspectBlobS3TargetsAsDegradedSpectraS3Request.Force = true
-    return markSuspectBlobS3TargetsAsDegradedSpectraS3Request
+	markSuspectBlobS3TargetsAsDegradedSpectraS3Request.Force = true
+	return markSuspectBlobS3TargetsAsDegradedSpectraS3Request
 }
 
 type MarkSuspectBlobTapesAsDegradedSpectraS3Request struct {
-    Force bool
-    Ids []string
+	Force bool
+	Ids   []string
 }
 
 func NewMarkSuspectBlobTapesAsDegradedSpectraS3Request(ids []string) *MarkSuspectBlobTapesAsDegradedSpectraS3Request {
-    return &MarkSuspectBlobTapesAsDegradedSpectraS3Request{
-        Ids: ids,
-    }
+	return &MarkSuspectBlobTapesAsDegradedSpectraS3Request{
+		Ids: ids,
+	}
 }
 
 func (markSuspectBlobTapesAsDegradedSpectraS3Request *MarkSuspectBlobTapesAsDegradedSpectraS3Request) WithForce() *MarkSuspectBlobTapesAsDegradedSpectraS3Request {
-    markSuspectBlobTapesAsDegradedSpectraS3Request.Force = true
-    return markSuspectBlobTapesAsDegradedSpectraS3Request
+	markSuspectBlobTapesAsDegradedSpectraS3Request.Force = true
+	return markSuspectBlobTapesAsDegradedSpectraS3Request
 }
 
 type PutGroupGroupMemberSpectraS3Request struct {
-    GroupId string
-    MemberGroupId string
+	GroupId       string
+	MemberGroupId string
 }
 
 func NewPutGroupGroupMemberSpectraS3Request(groupId string, memberGroupId string) *PutGroupGroupMemberSpectraS3Request {
-    return &PutGroupGroupMemberSpectraS3Request{
-        GroupId: groupId,
-        MemberGroupId: memberGroupId,
-    }
+	return &PutGroupGroupMemberSpectraS3Request{
+		GroupId:       groupId,
+		MemberGroupId: memberGroupId,
+	}
 }
 
 type PutGroupSpectraS3Request struct {
-    Name string
+	Name string
 }
 
 func NewPutGroupSpectraS3Request(name string) *PutGroupSpectraS3Request {
-    return &PutGroupSpectraS3Request{
-        Name: name,
-    }
+	return &PutGroupSpectraS3Request{
+		Name: name,
+	}
 }
 
 type PutUserGroupMemberSpectraS3Request struct {
-    GroupId string
-    MemberUserId string
+	GroupId      string
+	MemberUserId string
 }
 
 func NewPutUserGroupMemberSpectraS3Request(groupId string, memberUserId string) *PutUserGroupMemberSpectraS3Request {
-    return &PutUserGroupMemberSpectraS3Request{
-        GroupId: groupId,
-        MemberUserId: memberUserId,
-    }
+	return &PutUserGroupMemberSpectraS3Request{
+		GroupId:      groupId,
+		MemberUserId: memberUserId,
+	}
 }
 
 type DeleteGroupMemberSpectraS3Request struct {
-    GroupMember string
+	GroupMember string
 }
 
 func NewDeleteGroupMemberSpectraS3Request(groupMember string) *DeleteGroupMemberSpectraS3Request {
-    return &DeleteGroupMemberSpectraS3Request{
-        GroupMember: groupMember,
-    }
+	return &DeleteGroupMemberSpectraS3Request{
+		GroupMember: groupMember,
+	}
 }
 
 type DeleteGroupSpectraS3Request struct {
-    Group string
+	Group string
 }
 
 func NewDeleteGroupSpectraS3Request(group string) *DeleteGroupSpectraS3Request {
-    return &DeleteGroupSpectraS3Request{
-        Group: group,
-    }
+	return &DeleteGroupSpectraS3Request{
+		Group: group,
+	}
 }
 
 type GetGroupMemberSpectraS3Request struct {
-    GroupMember string
+	GroupMember string
 }
 
 func NewGetGroupMemberSpectraS3Request(groupMember string) *GetGroupMemberSpectraS3Request {
-    return &GetGroupMemberSpectraS3Request{
-        GroupMember: groupMember,
-    }
+	return &GetGroupMemberSpectraS3Request{
+		GroupMember: groupMember,
+	}
 }
 
 type GetGroupMembersSpectraS3Request struct {
-    GroupId *string
-    LastPage bool
-    MemberGroupId *string
-    MemberUserId *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
+	GroupId         *string
+	LastPage        bool
+	MemberGroupId   *string
+	MemberUserId    *string
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
 }
 
 func NewGetGroupMembersSpectraS3Request() *GetGroupMembersSpectraS3Request {
-    return &GetGroupMembersSpectraS3Request{
-    }
+	return &GetGroupMembersSpectraS3Request{}
 }
 
 func (getGroupMembersSpectraS3Request *GetGroupMembersSpectraS3Request) WithGroupId(groupId string) *GetGroupMembersSpectraS3Request {
-    getGroupMembersSpectraS3Request.GroupId = &groupId
-    return getGroupMembersSpectraS3Request
+	getGroupMembersSpectraS3Request.GroupId = &groupId
+	return getGroupMembersSpectraS3Request
 }
 
 func (getGroupMembersSpectraS3Request *GetGroupMembersSpectraS3Request) WithLastPage() *GetGroupMembersSpectraS3Request {
-    getGroupMembersSpectraS3Request.LastPage = true
-    return getGroupMembersSpectraS3Request
+	getGroupMembersSpectraS3Request.LastPage = true
+	return getGroupMembersSpectraS3Request
 }
 
 func (getGroupMembersSpectraS3Request *GetGroupMembersSpectraS3Request) WithMemberGroupId(memberGroupId string) *GetGroupMembersSpectraS3Request {
-    getGroupMembersSpectraS3Request.MemberGroupId = &memberGroupId
-    return getGroupMembersSpectraS3Request
+	getGroupMembersSpectraS3Request.MemberGroupId = &memberGroupId
+	return getGroupMembersSpectraS3Request
 }
 
 func (getGroupMembersSpectraS3Request *GetGroupMembersSpectraS3Request) WithMemberUserId(memberUserId string) *GetGroupMembersSpectraS3Request {
-    getGroupMembersSpectraS3Request.MemberUserId = &memberUserId
-    return getGroupMembersSpectraS3Request
+	getGroupMembersSpectraS3Request.MemberUserId = &memberUserId
+	return getGroupMembersSpectraS3Request
 }
 
 func (getGroupMembersSpectraS3Request *GetGroupMembersSpectraS3Request) WithPageLength(pageLength int) *GetGroupMembersSpectraS3Request {
-    getGroupMembersSpectraS3Request.PageLength = &pageLength
-    return getGroupMembersSpectraS3Request
+	getGroupMembersSpectraS3Request.PageLength = &pageLength
+	return getGroupMembersSpectraS3Request
 }
 
 func (getGroupMembersSpectraS3Request *GetGroupMembersSpectraS3Request) WithPageOffset(pageOffset int) *GetGroupMembersSpectraS3Request {
-    getGroupMembersSpectraS3Request.PageOffset = &pageOffset
-    return getGroupMembersSpectraS3Request
+	getGroupMembersSpectraS3Request.PageOffset = &pageOffset
+	return getGroupMembersSpectraS3Request
 }
 
 func (getGroupMembersSpectraS3Request *GetGroupMembersSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetGroupMembersSpectraS3Request {
-    getGroupMembersSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getGroupMembersSpectraS3Request
+	getGroupMembersSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getGroupMembersSpectraS3Request
 }
 
 type GetGroupSpectraS3Request struct {
-    Group string
+	Group string
 }
 
 func NewGetGroupSpectraS3Request(group string) *GetGroupSpectraS3Request {
-    return &GetGroupSpectraS3Request{
-        Group: group,
-    }
+	return &GetGroupSpectraS3Request{
+		Group: group,
+	}
 }
 
 type GetGroupsSpectraS3Request struct {
-    BuiltIn *bool
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
+	BuiltIn         *bool
+	LastPage        bool
+	Name            *string
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
 }
 
 func NewGetGroupsSpectraS3Request() *GetGroupsSpectraS3Request {
-    return &GetGroupsSpectraS3Request{
-    }
+	return &GetGroupsSpectraS3Request{}
 }
 
 func (getGroupsSpectraS3Request *GetGroupsSpectraS3Request) WithBuiltIn(builtIn bool) *GetGroupsSpectraS3Request {
-    getGroupsSpectraS3Request.BuiltIn = &builtIn
-    return getGroupsSpectraS3Request
+	getGroupsSpectraS3Request.BuiltIn = &builtIn
+	return getGroupsSpectraS3Request
 }
 
 func (getGroupsSpectraS3Request *GetGroupsSpectraS3Request) WithLastPage() *GetGroupsSpectraS3Request {
-    getGroupsSpectraS3Request.LastPage = true
-    return getGroupsSpectraS3Request
+	getGroupsSpectraS3Request.LastPage = true
+	return getGroupsSpectraS3Request
 }
 
 func (getGroupsSpectraS3Request *GetGroupsSpectraS3Request) WithName(name string) *GetGroupsSpectraS3Request {
-    getGroupsSpectraS3Request.Name = &name
-    return getGroupsSpectraS3Request
+	getGroupsSpectraS3Request.Name = &name
+	return getGroupsSpectraS3Request
 }
 
 func (getGroupsSpectraS3Request *GetGroupsSpectraS3Request) WithPageLength(pageLength int) *GetGroupsSpectraS3Request {
-    getGroupsSpectraS3Request.PageLength = &pageLength
-    return getGroupsSpectraS3Request
+	getGroupsSpectraS3Request.PageLength = &pageLength
+	return getGroupsSpectraS3Request
 }
 
 func (getGroupsSpectraS3Request *GetGroupsSpectraS3Request) WithPageOffset(pageOffset int) *GetGroupsSpectraS3Request {
-    getGroupsSpectraS3Request.PageOffset = &pageOffset
-    return getGroupsSpectraS3Request
+	getGroupsSpectraS3Request.PageOffset = &pageOffset
+	return getGroupsSpectraS3Request
 }
 
 func (getGroupsSpectraS3Request *GetGroupsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetGroupsSpectraS3Request {
-    getGroupsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getGroupsSpectraS3Request
+	getGroupsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getGroupsSpectraS3Request
 }
 
 type ModifyGroupSpectraS3Request struct {
-    Group string
-    Name *string
+	Group string
+	Name  *string
 }
 
 func NewModifyGroupSpectraS3Request(group string) *ModifyGroupSpectraS3Request {
-    return &ModifyGroupSpectraS3Request{
-        Group: group,
-    }
+	return &ModifyGroupSpectraS3Request{
+		Group: group,
+	}
 }
 
 func (modifyGroupSpectraS3Request *ModifyGroupSpectraS3Request) WithName(name string) *ModifyGroupSpectraS3Request {
-    modifyGroupSpectraS3Request.Name = &name
-    return modifyGroupSpectraS3Request
+	modifyGroupSpectraS3Request.Name = &name
+	return modifyGroupSpectraS3Request
 }
 
 type VerifyUserIsMemberOfGroupSpectraS3Request struct {
-    Group string
-    UserId *string
+	Group  string
+	UserId *string
 }
 
 func NewVerifyUserIsMemberOfGroupSpectraS3Request(group string) *VerifyUserIsMemberOfGroupSpectraS3Request {
-    return &VerifyUserIsMemberOfGroupSpectraS3Request{
-        Group: group,
-    }
+	return &VerifyUserIsMemberOfGroupSpectraS3Request{
+		Group: group,
+	}
 }
 
 func (verifyUserIsMemberOfGroupSpectraS3Request *VerifyUserIsMemberOfGroupSpectraS3Request) WithUserId(userId string) *VerifyUserIsMemberOfGroupSpectraS3Request {
-    verifyUserIsMemberOfGroupSpectraS3Request.UserId = &userId
-    return verifyUserIsMemberOfGroupSpectraS3Request
+	verifyUserIsMemberOfGroupSpectraS3Request.UserId = &userId
+	return verifyUserIsMemberOfGroupSpectraS3Request
 }
 
 type AllocateJobChunkSpectraS3Request struct {
-    JobChunkId string
+	JobChunkId string
 }
 
 func NewAllocateJobChunkSpectraS3Request(jobChunkId string) *AllocateJobChunkSpectraS3Request {
-    return &AllocateJobChunkSpectraS3Request{
-        JobChunkId: jobChunkId,
-    }
+	return &AllocateJobChunkSpectraS3Request{
+		JobChunkId: jobChunkId,
+	}
 }
 
 type CancelActiveJobSpectraS3Request struct {
-    ActiveJobId string
+	ActiveJobId string
 }
 
 func NewCancelActiveJobSpectraS3Request(activeJobId string) *CancelActiveJobSpectraS3Request {
-    return &CancelActiveJobSpectraS3Request{
-        ActiveJobId: activeJobId,
-    }
+	return &CancelActiveJobSpectraS3Request{
+		ActiveJobId: activeJobId,
+	}
 }
 
 type CancelAllActiveJobsSpectraS3Request struct {
-    BucketId *string
-    RequestType JobRequestType
+	BucketId    *string
+	RequestType JobRequestType
 }
 
 func NewCancelAllActiveJobsSpectraS3Request() *CancelAllActiveJobsSpectraS3Request {
-    return &CancelAllActiveJobsSpectraS3Request{
-    }
+	return &CancelAllActiveJobsSpectraS3Request{}
 }
 
 func (cancelAllActiveJobsSpectraS3Request *CancelAllActiveJobsSpectraS3Request) WithBucketId(bucketId string) *CancelAllActiveJobsSpectraS3Request {
-    cancelAllActiveJobsSpectraS3Request.BucketId = &bucketId
-    return cancelAllActiveJobsSpectraS3Request
+	cancelAllActiveJobsSpectraS3Request.BucketId = &bucketId
+	return cancelAllActiveJobsSpectraS3Request
 }
 
 func (cancelAllActiveJobsSpectraS3Request *CancelAllActiveJobsSpectraS3Request) WithRequestType(requestType JobRequestType) *CancelAllActiveJobsSpectraS3Request {
-    cancelAllActiveJobsSpectraS3Request.RequestType = requestType
-    return cancelAllActiveJobsSpectraS3Request
+	cancelAllActiveJobsSpectraS3Request.RequestType = requestType
+	return cancelAllActiveJobsSpectraS3Request
 }
 
 type CancelAllJobsSpectraS3Request struct {
-    BucketId *string
-    RequestType JobRequestType
+	BucketId    *string
+	RequestType JobRequestType
 }
 
 func NewCancelAllJobsSpectraS3Request() *CancelAllJobsSpectraS3Request {
-    return &CancelAllJobsSpectraS3Request{
-    }
+	return &CancelAllJobsSpectraS3Request{}
 }
 
 func (cancelAllJobsSpectraS3Request *CancelAllJobsSpectraS3Request) WithBucketId(bucketId string) *CancelAllJobsSpectraS3Request {
-    cancelAllJobsSpectraS3Request.BucketId = &bucketId
-    return cancelAllJobsSpectraS3Request
+	cancelAllJobsSpectraS3Request.BucketId = &bucketId
+	return cancelAllJobsSpectraS3Request
 }
 
 func (cancelAllJobsSpectraS3Request *CancelAllJobsSpectraS3Request) WithRequestType(requestType JobRequestType) *CancelAllJobsSpectraS3Request {
-    cancelAllJobsSpectraS3Request.RequestType = requestType
-    return cancelAllJobsSpectraS3Request
+	cancelAllJobsSpectraS3Request.RequestType = requestType
+	return cancelAllJobsSpectraS3Request
 }
 
 type CancelJobSpectraS3Request struct {
-    JobId string
+	JobId string
 }
 
 func NewCancelJobSpectraS3Request(jobId string) *CancelJobSpectraS3Request {
-    return &CancelJobSpectraS3Request{
-        JobId: jobId,
-    }
+	return &CancelJobSpectraS3Request{
+		JobId: jobId,
+	}
 }
 
 type ClearAllCanceledJobsSpectraS3Request struct {
 }
 
 func NewClearAllCanceledJobsSpectraS3Request() *ClearAllCanceledJobsSpectraS3Request {
-    return &ClearAllCanceledJobsSpectraS3Request{
-    }
+	return &ClearAllCanceledJobsSpectraS3Request{}
 }
 
 type ClearAllCompletedJobsSpectraS3Request struct {
 }
 
 func NewClearAllCompletedJobsSpectraS3Request() *ClearAllCompletedJobsSpectraS3Request {
-    return &ClearAllCompletedJobsSpectraS3Request{
-    }
+	return &ClearAllCompletedJobsSpectraS3Request{}
 }
 
 type CloseAggregatingJobSpectraS3Request struct {
-    JobId string
+	JobId string
 }
 
 func NewCloseAggregatingJobSpectraS3Request(jobId string) *CloseAggregatingJobSpectraS3Request {
-    return &CloseAggregatingJobSpectraS3Request{
-        JobId: jobId,
-    }
+	return &CloseAggregatingJobSpectraS3Request{
+		JobId: jobId,
+	}
 }
 
 type GetBulkJobSpectraS3Request struct {
-    BucketName string
-    Aggregating *bool
-    ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
-    DeadJobCleanupAllowed *bool
-    ImplicitJobIdResolution *bool
-    Name *string
-    Objects []Ds3GetObject
-    Priority Priority
-    Protected *bool
+	BucketName                          string
+	Aggregating                         *bool
+	ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
+	DeadJobCleanupAllowed               *bool
+	ImplicitJobIdResolution             *bool
+	Name                                *string
+	Objects                             []Ds3GetObject
+	Priority                            Priority
+	Protected                           *bool
 }
 
 func NewGetBulkJobSpectraS3Request(bucketName string, objectNames []string) *GetBulkJobSpectraS3Request {
 
-    return &GetBulkJobSpectraS3Request{
-        BucketName: bucketName,
-        Objects: buildDs3GetObjectSliceFromNames(objectNames),
-    }
+	return &GetBulkJobSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
+	}
 }
 
 func NewGetBulkJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *GetBulkJobSpectraS3Request {
 
-    return &GetBulkJobSpectraS3Request{
-        BucketName: bucketName,
-        Objects: objects,
-    }
+	return &GetBulkJobSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    objects,
+	}
 }
 
 func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithAggregating(aggregating bool) *GetBulkJobSpectraS3Request {
-    getBulkJobSpectraS3Request.Aggregating = &aggregating
-    return getBulkJobSpectraS3Request
+	getBulkJobSpectraS3Request.Aggregating = &aggregating
+	return getBulkJobSpectraS3Request
 }
 
 func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithChunkClientProcessingOrderGuarantee(chunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee) *GetBulkJobSpectraS3Request {
-    getBulkJobSpectraS3Request.ChunkClientProcessingOrderGuarantee = chunkClientProcessingOrderGuarantee
-    return getBulkJobSpectraS3Request
+	getBulkJobSpectraS3Request.ChunkClientProcessingOrderGuarantee = chunkClientProcessingOrderGuarantee
+	return getBulkJobSpectraS3Request
 }
 
 func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithDeadJobCleanupAllowed(deadJobCleanupAllowed bool) *GetBulkJobSpectraS3Request {
-    getBulkJobSpectraS3Request.DeadJobCleanupAllowed = &deadJobCleanupAllowed
-    return getBulkJobSpectraS3Request
+	getBulkJobSpectraS3Request.DeadJobCleanupAllowed = &deadJobCleanupAllowed
+	return getBulkJobSpectraS3Request
 }
 
 func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithImplicitJobIdResolution(implicitJobIdResolution bool) *GetBulkJobSpectraS3Request {
-    getBulkJobSpectraS3Request.ImplicitJobIdResolution = &implicitJobIdResolution
-    return getBulkJobSpectraS3Request
+	getBulkJobSpectraS3Request.ImplicitJobIdResolution = &implicitJobIdResolution
+	return getBulkJobSpectraS3Request
 }
 
 func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithName(name string) *GetBulkJobSpectraS3Request {
-    getBulkJobSpectraS3Request.Name = &name
-    return getBulkJobSpectraS3Request
+	getBulkJobSpectraS3Request.Name = &name
+	return getBulkJobSpectraS3Request
 }
 
 func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithPriority(priority Priority) *GetBulkJobSpectraS3Request {
-    getBulkJobSpectraS3Request.Priority = priority
-    return getBulkJobSpectraS3Request
+	getBulkJobSpectraS3Request.Priority = priority
+	return getBulkJobSpectraS3Request
 }
 
 func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithProtected(protected bool) *GetBulkJobSpectraS3Request {
-    getBulkJobSpectraS3Request.Protected = &protected
-    return getBulkJobSpectraS3Request
+	getBulkJobSpectraS3Request.Protected = &protected
+	return getBulkJobSpectraS3Request
 }
 
 type PutBulkJobSpectraS3Request struct {
-    BucketName string
-    Aggregating *bool
-    DeadJobCleanupAllowed *bool
-    Force bool
-    IgnoreNamingConflicts bool
-    ImplicitJobIdResolution *bool
-    MaxUploadSize *int64
-    MinimizeSpanningAcrossMedia *bool
-    Name *string
-    Objects []Ds3PutObject
-    PreAllocateJobSpace bool
-    Priority Priority
-    Protected *bool
-    VerifyAfterWrite *bool
+	BucketName                  string
+	Aggregating                 *bool
+	DeadJobCleanupAllowed       *bool
+	Force                       bool
+	IgnoreNamingConflicts       bool
+	ImplicitJobIdResolution     *bool
+	MaxUploadSize               *int64
+	MinimizeSpanningAcrossMedia *bool
+	Name                        *string
+	Objects                     []Ds3PutObject
+	PreAllocateJobSpace         bool
+	Priority                    Priority
+	Protected                   *bool
+	VerifyAfterWrite            *bool
 }
 
 func NewPutBulkJobSpectraS3Request(bucketName string, objects []Ds3PutObject) *PutBulkJobSpectraS3Request {
-    return &PutBulkJobSpectraS3Request{
-        BucketName: bucketName,
-        Objects: objects,
-    }
+	return &PutBulkJobSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    objects,
+	}
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithAggregating(aggregating bool) *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.Aggregating = &aggregating
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.Aggregating = &aggregating
+	return putBulkJobSpectraS3Request
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithDeadJobCleanupAllowed(deadJobCleanupAllowed bool) *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.DeadJobCleanupAllowed = &deadJobCleanupAllowed
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.DeadJobCleanupAllowed = &deadJobCleanupAllowed
+	return putBulkJobSpectraS3Request
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithForce() *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.Force = true
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.Force = true
+	return putBulkJobSpectraS3Request
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithIgnoreNamingConflicts() *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.IgnoreNamingConflicts = true
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.IgnoreNamingConflicts = true
+	return putBulkJobSpectraS3Request
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithImplicitJobIdResolution(implicitJobIdResolution bool) *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.ImplicitJobIdResolution = &implicitJobIdResolution
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.ImplicitJobIdResolution = &implicitJobIdResolution
+	return putBulkJobSpectraS3Request
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithMaxUploadSize(maxUploadSize int64) *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.MaxUploadSize = &maxUploadSize
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.MaxUploadSize = &maxUploadSize
+	return putBulkJobSpectraS3Request
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithMinimizeSpanningAcrossMedia(minimizeSpanningAcrossMedia bool) *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.MinimizeSpanningAcrossMedia = &minimizeSpanningAcrossMedia
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.MinimizeSpanningAcrossMedia = &minimizeSpanningAcrossMedia
+	return putBulkJobSpectraS3Request
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithName(name string) *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.Name = &name
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.Name = &name
+	return putBulkJobSpectraS3Request
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithPreAllocateJobSpace() *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.PreAllocateJobSpace = true
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.PreAllocateJobSpace = true
+	return putBulkJobSpectraS3Request
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithPriority(priority Priority) *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.Priority = priority
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.Priority = priority
+	return putBulkJobSpectraS3Request
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithProtected(protected bool) *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.Protected = &protected
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.Protected = &protected
+	return putBulkJobSpectraS3Request
 }
 
 func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithVerifyAfterWrite(verifyAfterWrite bool) *PutBulkJobSpectraS3Request {
-    putBulkJobSpectraS3Request.VerifyAfterWrite = &verifyAfterWrite
-    return putBulkJobSpectraS3Request
+	putBulkJobSpectraS3Request.VerifyAfterWrite = &verifyAfterWrite
+	return putBulkJobSpectraS3Request
 }
 
 type VerifyBulkJobSpectraS3Request struct {
-    BucketName string
-    Aggregating *bool
-    Name *string
-    Objects []Ds3GetObject
-    Priority Priority
+	BucketName  string
+	Aggregating *bool
+	Name        *string
+	Objects     []Ds3GetObject
+	Priority    Priority
 }
 
 func NewVerifyBulkJobSpectraS3Request(bucketName string, objectNames []string) *VerifyBulkJobSpectraS3Request {
 
-    return &VerifyBulkJobSpectraS3Request{
-        BucketName: bucketName,
-        Objects: buildDs3GetObjectSliceFromNames(objectNames),
-    }
+	return &VerifyBulkJobSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
+	}
 }
 
 func NewVerifyBulkJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *VerifyBulkJobSpectraS3Request {
 
-    return &VerifyBulkJobSpectraS3Request{
-        BucketName: bucketName,
-        Objects: objects,
-    }
+	return &VerifyBulkJobSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    objects,
+	}
 }
 
 func (verifyBulkJobSpectraS3Request *VerifyBulkJobSpectraS3Request) WithAggregating(aggregating bool) *VerifyBulkJobSpectraS3Request {
-    verifyBulkJobSpectraS3Request.Aggregating = &aggregating
-    return verifyBulkJobSpectraS3Request
+	verifyBulkJobSpectraS3Request.Aggregating = &aggregating
+	return verifyBulkJobSpectraS3Request
 }
 
 func (verifyBulkJobSpectraS3Request *VerifyBulkJobSpectraS3Request) WithName(name string) *VerifyBulkJobSpectraS3Request {
-    verifyBulkJobSpectraS3Request.Name = &name
-    return verifyBulkJobSpectraS3Request
+	verifyBulkJobSpectraS3Request.Name = &name
+	return verifyBulkJobSpectraS3Request
 }
 
 func (verifyBulkJobSpectraS3Request *VerifyBulkJobSpectraS3Request) WithPriority(priority Priority) *VerifyBulkJobSpectraS3Request {
-    verifyBulkJobSpectraS3Request.Priority = priority
-    return verifyBulkJobSpectraS3Request
+	verifyBulkJobSpectraS3Request.Priority = priority
+	return verifyBulkJobSpectraS3Request
 }
 
 type DeleteJobCreationFailureSpectraS3Request struct {
-    JobCreationFailed string
+	JobCreationFailed string
 }
 
 func NewDeleteJobCreationFailureSpectraS3Request(jobCreationFailed string) *DeleteJobCreationFailureSpectraS3Request {
-    return &DeleteJobCreationFailureSpectraS3Request{
-        JobCreationFailed: jobCreationFailed,
-    }
+	return &DeleteJobCreationFailureSpectraS3Request{
+		JobCreationFailed: jobCreationFailed,
+	}
 }
 
 type GetActiveJobSpectraS3Request struct {
-    ActiveJobId string
+	ActiveJobId string
 }
 
 func NewGetActiveJobSpectraS3Request(activeJobId string) *GetActiveJobSpectraS3Request {
-    return &GetActiveJobSpectraS3Request{
-        ActiveJobId: activeJobId,
-    }
+	return &GetActiveJobSpectraS3Request{
+		ActiveJobId: activeJobId,
+	}
 }
 
 type GetActiveJobsSpectraS3Request struct {
-    Aggregating *bool
-    BucketId *string
-    ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    Priority Priority
-    Rechunked *string
-    RequestType JobRequestType
-    Truncated *bool
-    UserId *string
+	Aggregating                         *bool
+	BucketId                            *string
+	ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
+	LastPage                            bool
+	Name                                *string
+	PageLength                          *int
+	PageOffset                          *int
+	PageStartMarker                     *string
+	Priority                            Priority
+	Rechunked                           *string
+	RequestType                         JobRequestType
+	Truncated                           *bool
+	UserId                              *string
 }
 
 func NewGetActiveJobsSpectraS3Request() *GetActiveJobsSpectraS3Request {
-    return &GetActiveJobsSpectraS3Request{
-    }
+	return &GetActiveJobsSpectraS3Request{}
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithAggregating(aggregating bool) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.Aggregating = &aggregating
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.Aggregating = &aggregating
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithBucketId(bucketId string) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.BucketId = &bucketId
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.BucketId = &bucketId
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithChunkClientProcessingOrderGuarantee(chunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.ChunkClientProcessingOrderGuarantee = chunkClientProcessingOrderGuarantee
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.ChunkClientProcessingOrderGuarantee = chunkClientProcessingOrderGuarantee
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithLastPage() *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.LastPage = true
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.LastPage = true
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithName(name string) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.Name = &name
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.Name = &name
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithPageLength(pageLength int) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.PageLength = &pageLength
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.PageLength = &pageLength
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithPageOffset(pageOffset int) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.PageOffset = &pageOffset
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.PageOffset = &pageOffset
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithPriority(priority Priority) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.Priority = priority
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.Priority = priority
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithRechunked(rechunked string) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.Rechunked = &rechunked
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.Rechunked = &rechunked
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithRequestType(requestType JobRequestType) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.RequestType = requestType
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.RequestType = requestType
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithTruncated(truncated bool) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.Truncated = &truncated
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.Truncated = &truncated
+	return getActiveJobsSpectraS3Request
 }
 
 func (getActiveJobsSpectraS3Request *GetActiveJobsSpectraS3Request) WithUserId(userId string) *GetActiveJobsSpectraS3Request {
-    getActiveJobsSpectraS3Request.UserId = &userId
-    return getActiveJobsSpectraS3Request
+	getActiveJobsSpectraS3Request.UserId = &userId
+	return getActiveJobsSpectraS3Request
 }
 
 type GetCanceledJobSpectraS3Request struct {
-    CanceledJob string
+	CanceledJob string
 }
 
 func NewGetCanceledJobSpectraS3Request(canceledJob string) *GetCanceledJobSpectraS3Request {
-    return &GetCanceledJobSpectraS3Request{
-        CanceledJob: canceledJob,
-    }
+	return &GetCanceledJobSpectraS3Request{
+		CanceledJob: canceledJob,
+	}
 }
 
 type GetCanceledJobsSpectraS3Request struct {
-    BucketId *string
-    CanceledDueToTimeout *bool
-    ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    Priority Priority
-    Rechunked *string
-    RequestType JobRequestType
-    Truncated *bool
-    UserId *string
+	BucketId                            *string
+	CanceledDueToTimeout                *bool
+	ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
+	LastPage                            bool
+	Name                                *string
+	PageLength                          *int
+	PageOffset                          *int
+	PageStartMarker                     *string
+	Priority                            Priority
+	Rechunked                           *string
+	RequestType                         JobRequestType
+	Truncated                           *bool
+	UserId                              *string
 }
 
 func NewGetCanceledJobsSpectraS3Request() *GetCanceledJobsSpectraS3Request {
-    return &GetCanceledJobsSpectraS3Request{
-    }
+	return &GetCanceledJobsSpectraS3Request{}
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithBucketId(bucketId string) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.BucketId = &bucketId
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.BucketId = &bucketId
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithCanceledDueToTimeout(canceledDueToTimeout bool) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.CanceledDueToTimeout = &canceledDueToTimeout
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.CanceledDueToTimeout = &canceledDueToTimeout
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithChunkClientProcessingOrderGuarantee(chunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.ChunkClientProcessingOrderGuarantee = chunkClientProcessingOrderGuarantee
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.ChunkClientProcessingOrderGuarantee = chunkClientProcessingOrderGuarantee
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithLastPage() *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.LastPage = true
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.LastPage = true
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithName(name string) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.Name = &name
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.Name = &name
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithPageLength(pageLength int) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.PageLength = &pageLength
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.PageLength = &pageLength
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithPageOffset(pageOffset int) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.PageOffset = &pageOffset
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.PageOffset = &pageOffset
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithPriority(priority Priority) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.Priority = priority
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.Priority = priority
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithRechunked(rechunked string) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.Rechunked = &rechunked
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.Rechunked = &rechunked
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithRequestType(requestType JobRequestType) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.RequestType = requestType
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.RequestType = requestType
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithTruncated(truncated bool) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.Truncated = &truncated
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.Truncated = &truncated
+	return getCanceledJobsSpectraS3Request
 }
 
 func (getCanceledJobsSpectraS3Request *GetCanceledJobsSpectraS3Request) WithUserId(userId string) *GetCanceledJobsSpectraS3Request {
-    getCanceledJobsSpectraS3Request.UserId = &userId
-    return getCanceledJobsSpectraS3Request
+	getCanceledJobsSpectraS3Request.UserId = &userId
+	return getCanceledJobsSpectraS3Request
 }
 
 type GetCompletedJobSpectraS3Request struct {
-    CompletedJob string
+	CompletedJob string
 }
 
 func NewGetCompletedJobSpectraS3Request(completedJob string) *GetCompletedJobSpectraS3Request {
-    return &GetCompletedJobSpectraS3Request{
-        CompletedJob: completedJob,
-    }
+	return &GetCompletedJobSpectraS3Request{
+		CompletedJob: completedJob,
+	}
 }
 
 type GetCompletedJobsSpectraS3Request struct {
-    BucketId *string
-    ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    Priority Priority
-    Rechunked *string
-    RequestType JobRequestType
-    Truncated *bool
-    UserId *string
+	BucketId                            *string
+	ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
+	LastPage                            bool
+	Name                                *string
+	PageLength                          *int
+	PageOffset                          *int
+	PageStartMarker                     *string
+	Priority                            Priority
+	Rechunked                           *string
+	RequestType                         JobRequestType
+	Truncated                           *bool
+	UserId                              *string
 }
 
 func NewGetCompletedJobsSpectraS3Request() *GetCompletedJobsSpectraS3Request {
-    return &GetCompletedJobsSpectraS3Request{
-    }
+	return &GetCompletedJobsSpectraS3Request{}
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithBucketId(bucketId string) *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.BucketId = &bucketId
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.BucketId = &bucketId
+	return getCompletedJobsSpectraS3Request
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithChunkClientProcessingOrderGuarantee(chunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee) *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.ChunkClientProcessingOrderGuarantee = chunkClientProcessingOrderGuarantee
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.ChunkClientProcessingOrderGuarantee = chunkClientProcessingOrderGuarantee
+	return getCompletedJobsSpectraS3Request
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithLastPage() *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.LastPage = true
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.LastPage = true
+	return getCompletedJobsSpectraS3Request
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithName(name string) *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.Name = &name
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.Name = &name
+	return getCompletedJobsSpectraS3Request
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithPageLength(pageLength int) *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.PageLength = &pageLength
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.PageLength = &pageLength
+	return getCompletedJobsSpectraS3Request
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithPageOffset(pageOffset int) *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.PageOffset = &pageOffset
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.PageOffset = &pageOffset
+	return getCompletedJobsSpectraS3Request
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getCompletedJobsSpectraS3Request
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithPriority(priority Priority) *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.Priority = priority
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.Priority = priority
+	return getCompletedJobsSpectraS3Request
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithRechunked(rechunked string) *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.Rechunked = &rechunked
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.Rechunked = &rechunked
+	return getCompletedJobsSpectraS3Request
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithRequestType(requestType JobRequestType) *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.RequestType = requestType
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.RequestType = requestType
+	return getCompletedJobsSpectraS3Request
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithTruncated(truncated bool) *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.Truncated = &truncated
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.Truncated = &truncated
+	return getCompletedJobsSpectraS3Request
 }
 
 func (getCompletedJobsSpectraS3Request *GetCompletedJobsSpectraS3Request) WithUserId(userId string) *GetCompletedJobsSpectraS3Request {
-    getCompletedJobsSpectraS3Request.UserId = &userId
-    return getCompletedJobsSpectraS3Request
+	getCompletedJobsSpectraS3Request.UserId = &userId
+	return getCompletedJobsSpectraS3Request
 }
 
 type GetJobChunkDaoSpectraS3Request struct {
-    JobChunkDao string
+	JobChunkDao string
 }
 
 func NewGetJobChunkDaoSpectraS3Request(jobChunkDao string) *GetJobChunkDaoSpectraS3Request {
-    return &GetJobChunkDaoSpectraS3Request{
-        JobChunkDao: jobChunkDao,
-    }
+	return &GetJobChunkDaoSpectraS3Request{
+		JobChunkDao: jobChunkDao,
+	}
 }
 
 type GetJobChunkSpectraS3Request struct {
-    JobChunkId string
+	JobChunkId string
 }
 
 func NewGetJobChunkSpectraS3Request(jobChunkId string) *GetJobChunkSpectraS3Request {
-    return &GetJobChunkSpectraS3Request{
-        JobChunkId: jobChunkId,
-    }
+	return &GetJobChunkSpectraS3Request{
+		JobChunkId: jobChunkId,
+	}
 }
 
 type GetJobChunksReadyForClientProcessingSpectraS3Request struct {
-    Job string
-    JobChunk *string
-    PreferredNumberOfChunks *int
+	Job                     string
+	JobChunk                *string
+	PreferredNumberOfChunks *int
 }
 
 func NewGetJobChunksReadyForClientProcessingSpectraS3Request(job string) *GetJobChunksReadyForClientProcessingSpectraS3Request {
-    return &GetJobChunksReadyForClientProcessingSpectraS3Request{
-        Job: job,
-    }
+	return &GetJobChunksReadyForClientProcessingSpectraS3Request{
+		Job: job,
+	}
 }
 
 func (getJobChunksReadyForClientProcessingSpectraS3Request *GetJobChunksReadyForClientProcessingSpectraS3Request) WithJobChunk(jobChunk string) *GetJobChunksReadyForClientProcessingSpectraS3Request {
-    getJobChunksReadyForClientProcessingSpectraS3Request.JobChunk = &jobChunk
-    return getJobChunksReadyForClientProcessingSpectraS3Request
+	getJobChunksReadyForClientProcessingSpectraS3Request.JobChunk = &jobChunk
+	return getJobChunksReadyForClientProcessingSpectraS3Request
 }
 
 func (getJobChunksReadyForClientProcessingSpectraS3Request *GetJobChunksReadyForClientProcessingSpectraS3Request) WithPreferredNumberOfChunks(preferredNumberOfChunks int) *GetJobChunksReadyForClientProcessingSpectraS3Request {
-    getJobChunksReadyForClientProcessingSpectraS3Request.PreferredNumberOfChunks = &preferredNumberOfChunks
-    return getJobChunksReadyForClientProcessingSpectraS3Request
+	getJobChunksReadyForClientProcessingSpectraS3Request.PreferredNumberOfChunks = &preferredNumberOfChunks
+	return getJobChunksReadyForClientProcessingSpectraS3Request
 }
 
 type GetJobCreationFailuresSpectraS3Request struct {
-    Date *string
-    ErrorMessage *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserName *string
+	Date            *string
+	ErrorMessage    *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserName        *string
 }
 
 func NewGetJobCreationFailuresSpectraS3Request() *GetJobCreationFailuresSpectraS3Request {
-    return &GetJobCreationFailuresSpectraS3Request{
-    }
+	return &GetJobCreationFailuresSpectraS3Request{}
 }
 
 func (getJobCreationFailuresSpectraS3Request *GetJobCreationFailuresSpectraS3Request) WithDate(date string) *GetJobCreationFailuresSpectraS3Request {
-    getJobCreationFailuresSpectraS3Request.Date = &date
-    return getJobCreationFailuresSpectraS3Request
+	getJobCreationFailuresSpectraS3Request.Date = &date
+	return getJobCreationFailuresSpectraS3Request
 }
 
 func (getJobCreationFailuresSpectraS3Request *GetJobCreationFailuresSpectraS3Request) WithErrorMessage(errorMessage string) *GetJobCreationFailuresSpectraS3Request {
-    getJobCreationFailuresSpectraS3Request.ErrorMessage = &errorMessage
-    return getJobCreationFailuresSpectraS3Request
+	getJobCreationFailuresSpectraS3Request.ErrorMessage = &errorMessage
+	return getJobCreationFailuresSpectraS3Request
 }
 
 func (getJobCreationFailuresSpectraS3Request *GetJobCreationFailuresSpectraS3Request) WithLastPage() *GetJobCreationFailuresSpectraS3Request {
-    getJobCreationFailuresSpectraS3Request.LastPage = true
-    return getJobCreationFailuresSpectraS3Request
+	getJobCreationFailuresSpectraS3Request.LastPage = true
+	return getJobCreationFailuresSpectraS3Request
 }
 
 func (getJobCreationFailuresSpectraS3Request *GetJobCreationFailuresSpectraS3Request) WithPageLength(pageLength int) *GetJobCreationFailuresSpectraS3Request {
-    getJobCreationFailuresSpectraS3Request.PageLength = &pageLength
-    return getJobCreationFailuresSpectraS3Request
+	getJobCreationFailuresSpectraS3Request.PageLength = &pageLength
+	return getJobCreationFailuresSpectraS3Request
 }
 
 func (getJobCreationFailuresSpectraS3Request *GetJobCreationFailuresSpectraS3Request) WithPageOffset(pageOffset int) *GetJobCreationFailuresSpectraS3Request {
-    getJobCreationFailuresSpectraS3Request.PageOffset = &pageOffset
-    return getJobCreationFailuresSpectraS3Request
+	getJobCreationFailuresSpectraS3Request.PageOffset = &pageOffset
+	return getJobCreationFailuresSpectraS3Request
 }
 
 func (getJobCreationFailuresSpectraS3Request *GetJobCreationFailuresSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetJobCreationFailuresSpectraS3Request {
-    getJobCreationFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getJobCreationFailuresSpectraS3Request
+	getJobCreationFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getJobCreationFailuresSpectraS3Request
 }
 
 func (getJobCreationFailuresSpectraS3Request *GetJobCreationFailuresSpectraS3Request) WithUserName(userName string) *GetJobCreationFailuresSpectraS3Request {
-    getJobCreationFailuresSpectraS3Request.UserName = &userName
-    return getJobCreationFailuresSpectraS3Request
+	getJobCreationFailuresSpectraS3Request.UserName = &userName
+	return getJobCreationFailuresSpectraS3Request
 }
 
 type GetJobSpectraS3Request struct {
-    JobId string
+	JobId string
 }
 
 func NewGetJobSpectraS3Request(jobId string) *GetJobSpectraS3Request {
-    return &GetJobSpectraS3Request{
-        JobId: jobId,
-    }
+	return &GetJobSpectraS3Request{
+		JobId: jobId,
+	}
 }
 
 type GetJobToReplicateSpectraS3Request struct {
-    JobId string
+	JobId string
 }
 
 func NewGetJobToReplicateSpectraS3Request(jobId string) *GetJobToReplicateSpectraS3Request {
-    return &GetJobToReplicateSpectraS3Request{
-        JobId: jobId,
-    }
+	return &GetJobToReplicateSpectraS3Request{
+		JobId: jobId,
+	}
 }
 
 type GetJobsSpectraS3Request struct {
-    BucketId *string
-    FullDetails bool
+	BucketId    *string
+	FullDetails bool
 }
 
 func NewGetJobsSpectraS3Request() *GetJobsSpectraS3Request {
-    return &GetJobsSpectraS3Request{
-    }
+	return &GetJobsSpectraS3Request{}
 }
 
 func (getJobsSpectraS3Request *GetJobsSpectraS3Request) WithBucketId(bucketId string) *GetJobsSpectraS3Request {
-    getJobsSpectraS3Request.BucketId = &bucketId
-    return getJobsSpectraS3Request
+	getJobsSpectraS3Request.BucketId = &bucketId
+	return getJobsSpectraS3Request
 }
 
 func (getJobsSpectraS3Request *GetJobsSpectraS3Request) WithFullDetails() *GetJobsSpectraS3Request {
-    getJobsSpectraS3Request.FullDetails = true
-    return getJobsSpectraS3Request
+	getJobsSpectraS3Request.FullDetails = true
+	return getJobsSpectraS3Request
 }
 
 type ModifyActiveJobSpectraS3Request struct {
-    ActiveJobId string
-    CreatedAt *string
-    DeadJobCleanupAllowed *bool
-    Name *string
-    Priority Priority
-    Protected *bool
+	ActiveJobId           string
+	CreatedAt             *string
+	DeadJobCleanupAllowed *bool
+	Name                  *string
+	Priority              Priority
+	Protected             *bool
 }
 
 func NewModifyActiveJobSpectraS3Request(activeJobId string) *ModifyActiveJobSpectraS3Request {
-    return &ModifyActiveJobSpectraS3Request{
-        ActiveJobId: activeJobId,
-    }
+	return &ModifyActiveJobSpectraS3Request{
+		ActiveJobId: activeJobId,
+	}
 }
 
 func (modifyActiveJobSpectraS3Request *ModifyActiveJobSpectraS3Request) WithCreatedAt(createdAt string) *ModifyActiveJobSpectraS3Request {
-    modifyActiveJobSpectraS3Request.CreatedAt = &createdAt
-    return modifyActiveJobSpectraS3Request
+	modifyActiveJobSpectraS3Request.CreatedAt = &createdAt
+	return modifyActiveJobSpectraS3Request
 }
 
 func (modifyActiveJobSpectraS3Request *ModifyActiveJobSpectraS3Request) WithDeadJobCleanupAllowed(deadJobCleanupAllowed bool) *ModifyActiveJobSpectraS3Request {
-    modifyActiveJobSpectraS3Request.DeadJobCleanupAllowed = &deadJobCleanupAllowed
-    return modifyActiveJobSpectraS3Request
+	modifyActiveJobSpectraS3Request.DeadJobCleanupAllowed = &deadJobCleanupAllowed
+	return modifyActiveJobSpectraS3Request
 }
 
 func (modifyActiveJobSpectraS3Request *ModifyActiveJobSpectraS3Request) WithName(name string) *ModifyActiveJobSpectraS3Request {
-    modifyActiveJobSpectraS3Request.Name = &name
-    return modifyActiveJobSpectraS3Request
+	modifyActiveJobSpectraS3Request.Name = &name
+	return modifyActiveJobSpectraS3Request
 }
 
 func (modifyActiveJobSpectraS3Request *ModifyActiveJobSpectraS3Request) WithPriority(priority Priority) *ModifyActiveJobSpectraS3Request {
-    modifyActiveJobSpectraS3Request.Priority = priority
-    return modifyActiveJobSpectraS3Request
+	modifyActiveJobSpectraS3Request.Priority = priority
+	return modifyActiveJobSpectraS3Request
 }
 
 func (modifyActiveJobSpectraS3Request *ModifyActiveJobSpectraS3Request) WithProtected(protected bool) *ModifyActiveJobSpectraS3Request {
-    modifyActiveJobSpectraS3Request.Protected = &protected
-    return modifyActiveJobSpectraS3Request
+	modifyActiveJobSpectraS3Request.Protected = &protected
+	return modifyActiveJobSpectraS3Request
 }
 
 type ModifyJobSpectraS3Request struct {
-    CreatedAt *string
-    DeadJobCleanupAllowed *bool
-    JobId string
-    Name *string
-    Priority Priority
-    Protected *bool
+	CreatedAt             *string
+	DeadJobCleanupAllowed *bool
+	JobId                 string
+	Name                  *string
+	Priority              Priority
+	Protected             *bool
 }
 
 func NewModifyJobSpectraS3Request(jobId string) *ModifyJobSpectraS3Request {
-    return &ModifyJobSpectraS3Request{
-        JobId: jobId,
-    }
+	return &ModifyJobSpectraS3Request{
+		JobId: jobId,
+	}
 }
 
 func (modifyJobSpectraS3Request *ModifyJobSpectraS3Request) WithCreatedAt(createdAt string) *ModifyJobSpectraS3Request {
-    modifyJobSpectraS3Request.CreatedAt = &createdAt
-    return modifyJobSpectraS3Request
+	modifyJobSpectraS3Request.CreatedAt = &createdAt
+	return modifyJobSpectraS3Request
 }
 
 func (modifyJobSpectraS3Request *ModifyJobSpectraS3Request) WithDeadJobCleanupAllowed(deadJobCleanupAllowed bool) *ModifyJobSpectraS3Request {
-    modifyJobSpectraS3Request.DeadJobCleanupAllowed = &deadJobCleanupAllowed
-    return modifyJobSpectraS3Request
+	modifyJobSpectraS3Request.DeadJobCleanupAllowed = &deadJobCleanupAllowed
+	return modifyJobSpectraS3Request
 }
 
 func (modifyJobSpectraS3Request *ModifyJobSpectraS3Request) WithName(name string) *ModifyJobSpectraS3Request {
-    modifyJobSpectraS3Request.Name = &name
-    return modifyJobSpectraS3Request
+	modifyJobSpectraS3Request.Name = &name
+	return modifyJobSpectraS3Request
 }
 
 func (modifyJobSpectraS3Request *ModifyJobSpectraS3Request) WithPriority(priority Priority) *ModifyJobSpectraS3Request {
-    modifyJobSpectraS3Request.Priority = priority
-    return modifyJobSpectraS3Request
+	modifyJobSpectraS3Request.Priority = priority
+	return modifyJobSpectraS3Request
 }
 
 func (modifyJobSpectraS3Request *ModifyJobSpectraS3Request) WithProtected(protected bool) *ModifyJobSpectraS3Request {
-    modifyJobSpectraS3Request.Protected = &protected
-    return modifyJobSpectraS3Request
+	modifyJobSpectraS3Request.Protected = &protected
+	return modifyJobSpectraS3Request
 }
 
 type ReplicatePutJobSpectraS3Request struct {
-    BucketName string
-    Priority Priority
-    RequestPayload string
+	BucketName     string
+	Priority       Priority
+	RequestPayload string
 }
 
 func NewReplicatePutJobSpectraS3Request(bucketName string, requestPayload string) *ReplicatePutJobSpectraS3Request {
-    return &ReplicatePutJobSpectraS3Request{
-        BucketName: bucketName,
-        RequestPayload: requestPayload,
-    }
+	return &ReplicatePutJobSpectraS3Request{
+		BucketName:     bucketName,
+		RequestPayload: requestPayload,
+	}
 }
 
 func (replicatePutJobSpectraS3Request *ReplicatePutJobSpectraS3Request) WithPriority(priority Priority) *ReplicatePutJobSpectraS3Request {
-    replicatePutJobSpectraS3Request.Priority = priority
-    return replicatePutJobSpectraS3Request
+	replicatePutJobSpectraS3Request.Priority = priority
+	return replicatePutJobSpectraS3Request
 }
 
 type StageObjectsJobSpectraS3Request struct {
-    BucketName string
-    Name *string
-    Objects []Ds3GetObject
-    Priority Priority
+	BucketName string
+	Name       *string
+	Objects    []Ds3GetObject
+	Priority   Priority
 }
 
 func NewStageObjectsJobSpectraS3Request(bucketName string, objectNames []string) *StageObjectsJobSpectraS3Request {
 
-    return &StageObjectsJobSpectraS3Request{
-        BucketName: bucketName,
-        Objects: buildDs3GetObjectSliceFromNames(objectNames),
-    }
+	return &StageObjectsJobSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
+	}
 }
 
 func NewStageObjectsJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *StageObjectsJobSpectraS3Request {
 
-    return &StageObjectsJobSpectraS3Request{
-        BucketName: bucketName,
-        Objects: objects,
-    }
+	return &StageObjectsJobSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    objects,
+	}
 }
 
 func (stageObjectsJobSpectraS3Request *StageObjectsJobSpectraS3Request) WithName(name string) *StageObjectsJobSpectraS3Request {
-    stageObjectsJobSpectraS3Request.Name = &name
-    return stageObjectsJobSpectraS3Request
+	stageObjectsJobSpectraS3Request.Name = &name
+	return stageObjectsJobSpectraS3Request
 }
 
 func (stageObjectsJobSpectraS3Request *StageObjectsJobSpectraS3Request) WithPriority(priority Priority) *StageObjectsJobSpectraS3Request {
-    stageObjectsJobSpectraS3Request.Priority = priority
-    return stageObjectsJobSpectraS3Request
+	stageObjectsJobSpectraS3Request.Priority = priority
+	return stageObjectsJobSpectraS3Request
 }
 
 type TruncateActiveJobSpectraS3Request struct {
-    ActiveJobId string
+	ActiveJobId string
 }
 
 func NewTruncateActiveJobSpectraS3Request(activeJobId string) *TruncateActiveJobSpectraS3Request {
-    return &TruncateActiveJobSpectraS3Request{
-        ActiveJobId: activeJobId,
-    }
+	return &TruncateActiveJobSpectraS3Request{
+		ActiveJobId: activeJobId,
+	}
 }
 
 type TruncateAllActiveJobsSpectraS3Request struct {
-    BucketId *string
-    RequestType JobRequestType
+	BucketId    *string
+	RequestType JobRequestType
 }
 
 func NewTruncateAllActiveJobsSpectraS3Request() *TruncateAllActiveJobsSpectraS3Request {
-    return &TruncateAllActiveJobsSpectraS3Request{
-    }
+	return &TruncateAllActiveJobsSpectraS3Request{}
 }
 
 func (truncateAllActiveJobsSpectraS3Request *TruncateAllActiveJobsSpectraS3Request) WithBucketId(bucketId string) *TruncateAllActiveJobsSpectraS3Request {
-    truncateAllActiveJobsSpectraS3Request.BucketId = &bucketId
-    return truncateAllActiveJobsSpectraS3Request
+	truncateAllActiveJobsSpectraS3Request.BucketId = &bucketId
+	return truncateAllActiveJobsSpectraS3Request
 }
 
 func (truncateAllActiveJobsSpectraS3Request *TruncateAllActiveJobsSpectraS3Request) WithRequestType(requestType JobRequestType) *TruncateAllActiveJobsSpectraS3Request {
-    truncateAllActiveJobsSpectraS3Request.RequestType = requestType
-    return truncateAllActiveJobsSpectraS3Request
+	truncateAllActiveJobsSpectraS3Request.RequestType = requestType
+	return truncateAllActiveJobsSpectraS3Request
 }
 
 type TruncateAllJobsSpectraS3Request struct {
-    BucketId *string
-    RequestType JobRequestType
+	BucketId    *string
+	RequestType JobRequestType
 }
 
 func NewTruncateAllJobsSpectraS3Request() *TruncateAllJobsSpectraS3Request {
-    return &TruncateAllJobsSpectraS3Request{
-    }
+	return &TruncateAllJobsSpectraS3Request{}
 }
 
 func (truncateAllJobsSpectraS3Request *TruncateAllJobsSpectraS3Request) WithBucketId(bucketId string) *TruncateAllJobsSpectraS3Request {
-    truncateAllJobsSpectraS3Request.BucketId = &bucketId
-    return truncateAllJobsSpectraS3Request
+	truncateAllJobsSpectraS3Request.BucketId = &bucketId
+	return truncateAllJobsSpectraS3Request
 }
 
 func (truncateAllJobsSpectraS3Request *TruncateAllJobsSpectraS3Request) WithRequestType(requestType JobRequestType) *TruncateAllJobsSpectraS3Request {
-    truncateAllJobsSpectraS3Request.RequestType = requestType
-    return truncateAllJobsSpectraS3Request
+	truncateAllJobsSpectraS3Request.RequestType = requestType
+	return truncateAllJobsSpectraS3Request
 }
 
 type TruncateJobSpectraS3Request struct {
-    JobId string
+	JobId string
 }
 
 func NewTruncateJobSpectraS3Request(jobId string) *TruncateJobSpectraS3Request {
-    return &TruncateJobSpectraS3Request{
-        JobId: jobId,
-    }
+	return &TruncateJobSpectraS3Request{
+		JobId: jobId,
+	}
 }
 
 type VerifySafeToCreatePutJobSpectraS3Request struct {
-    BucketName string
+	BucketName string
 }
 
 func NewVerifySafeToCreatePutJobSpectraS3Request(bucketName string) *VerifySafeToCreatePutJobSpectraS3Request {
-    return &VerifySafeToCreatePutJobSpectraS3Request{
-        BucketName: bucketName,
-    }
+	return &VerifySafeToCreatePutJobSpectraS3Request{
+		BucketName: bucketName,
+	}
 }
 
 type GetNodeSpectraS3Request struct {
-    Node string
+	Node string
 }
 
 func NewGetNodeSpectraS3Request(node string) *GetNodeSpectraS3Request {
-    return &GetNodeSpectraS3Request{
-        Node: node,
-    }
+	return &GetNodeSpectraS3Request{
+		Node: node,
+	}
 }
 
 type GetNodesSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
 }
 
 func NewGetNodesSpectraS3Request() *GetNodesSpectraS3Request {
-    return &GetNodesSpectraS3Request{
-    }
+	return &GetNodesSpectraS3Request{}
 }
 
 func (getNodesSpectraS3Request *GetNodesSpectraS3Request) WithLastPage() *GetNodesSpectraS3Request {
-    getNodesSpectraS3Request.LastPage = true
-    return getNodesSpectraS3Request
+	getNodesSpectraS3Request.LastPage = true
+	return getNodesSpectraS3Request
 }
 
 func (getNodesSpectraS3Request *GetNodesSpectraS3Request) WithPageLength(pageLength int) *GetNodesSpectraS3Request {
-    getNodesSpectraS3Request.PageLength = &pageLength
-    return getNodesSpectraS3Request
+	getNodesSpectraS3Request.PageLength = &pageLength
+	return getNodesSpectraS3Request
 }
 
 func (getNodesSpectraS3Request *GetNodesSpectraS3Request) WithPageOffset(pageOffset int) *GetNodesSpectraS3Request {
-    getNodesSpectraS3Request.PageOffset = &pageOffset
-    return getNodesSpectraS3Request
+	getNodesSpectraS3Request.PageOffset = &pageOffset
+	return getNodesSpectraS3Request
 }
 
 func (getNodesSpectraS3Request *GetNodesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetNodesSpectraS3Request {
-    getNodesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getNodesSpectraS3Request
+	getNodesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getNodesSpectraS3Request
 }
 
 type ModifyNodeSpectraS3Request struct {
-    DnsName *string
-    Name *string
-    Node string
+	DnsName *string
+	Name    *string
+	Node    string
 }
 
 func NewModifyNodeSpectraS3Request(node string) *ModifyNodeSpectraS3Request {
-    return &ModifyNodeSpectraS3Request{
-        Node: node,
-    }
+	return &ModifyNodeSpectraS3Request{
+		Node: node,
+	}
 }
 
 func (modifyNodeSpectraS3Request *ModifyNodeSpectraS3Request) WithDnsName(dnsName string) *ModifyNodeSpectraS3Request {
-    modifyNodeSpectraS3Request.DnsName = &dnsName
-    return modifyNodeSpectraS3Request
+	modifyNodeSpectraS3Request.DnsName = &dnsName
+	return modifyNodeSpectraS3Request
 }
 
 func (modifyNodeSpectraS3Request *ModifyNodeSpectraS3Request) WithName(name string) *ModifyNodeSpectraS3Request {
-    modifyNodeSpectraS3Request.Name = &name
-    return modifyNodeSpectraS3Request
+	modifyNodeSpectraS3Request.Name = &name
+	return modifyNodeSpectraS3Request
 }
 
 type PutAzureTargetFailureNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutAzureTargetFailureNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutAzureTargetFailureNotificationRegistrationSpectraS3Request {
-    return &PutAzureTargetFailureNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutAzureTargetFailureNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putAzureTargetFailureNotificationRegistrationSpectraS3Request *PutAzureTargetFailureNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutAzureTargetFailureNotificationRegistrationSpectraS3Request {
-    putAzureTargetFailureNotificationRegistrationSpectraS3Request.Format = format
-    return putAzureTargetFailureNotificationRegistrationSpectraS3Request
+	putAzureTargetFailureNotificationRegistrationSpectraS3Request.Format = format
+	return putAzureTargetFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putAzureTargetFailureNotificationRegistrationSpectraS3Request *PutAzureTargetFailureNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutAzureTargetFailureNotificationRegistrationSpectraS3Request {
-    putAzureTargetFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putAzureTargetFailureNotificationRegistrationSpectraS3Request
+	putAzureTargetFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putAzureTargetFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putAzureTargetFailureNotificationRegistrationSpectraS3Request *PutAzureTargetFailureNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutAzureTargetFailureNotificationRegistrationSpectraS3Request {
-    putAzureTargetFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putAzureTargetFailureNotificationRegistrationSpectraS3Request
+	putAzureTargetFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putAzureTargetFailureNotificationRegistrationSpectraS3Request
 }
 
 type PutBucketChangesNotificationRegistrationSpectraS3Request struct {
-    BucketId *string
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	BucketId               *string
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutBucketChangesNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutBucketChangesNotificationRegistrationSpectraS3Request {
-    return &PutBucketChangesNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutBucketChangesNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putBucketChangesNotificationRegistrationSpectraS3Request *PutBucketChangesNotificationRegistrationSpectraS3Request) WithBucketId(bucketId string) *PutBucketChangesNotificationRegistrationSpectraS3Request {
-    putBucketChangesNotificationRegistrationSpectraS3Request.BucketId = &bucketId
-    return putBucketChangesNotificationRegistrationSpectraS3Request
+	putBucketChangesNotificationRegistrationSpectraS3Request.BucketId = &bucketId
+	return putBucketChangesNotificationRegistrationSpectraS3Request
 }
 
 func (putBucketChangesNotificationRegistrationSpectraS3Request *PutBucketChangesNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutBucketChangesNotificationRegistrationSpectraS3Request {
-    putBucketChangesNotificationRegistrationSpectraS3Request.Format = format
-    return putBucketChangesNotificationRegistrationSpectraS3Request
+	putBucketChangesNotificationRegistrationSpectraS3Request.Format = format
+	return putBucketChangesNotificationRegistrationSpectraS3Request
 }
 
 func (putBucketChangesNotificationRegistrationSpectraS3Request *PutBucketChangesNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutBucketChangesNotificationRegistrationSpectraS3Request {
-    putBucketChangesNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putBucketChangesNotificationRegistrationSpectraS3Request
+	putBucketChangesNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putBucketChangesNotificationRegistrationSpectraS3Request
 }
 
 func (putBucketChangesNotificationRegistrationSpectraS3Request *PutBucketChangesNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutBucketChangesNotificationRegistrationSpectraS3Request {
-    putBucketChangesNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putBucketChangesNotificationRegistrationSpectraS3Request
+	putBucketChangesNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putBucketChangesNotificationRegistrationSpectraS3Request
 }
 
 type PutDs3TargetFailureNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutDs3TargetFailureNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutDs3TargetFailureNotificationRegistrationSpectraS3Request {
-    return &PutDs3TargetFailureNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutDs3TargetFailureNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putDs3TargetFailureNotificationRegistrationSpectraS3Request *PutDs3TargetFailureNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutDs3TargetFailureNotificationRegistrationSpectraS3Request {
-    putDs3TargetFailureNotificationRegistrationSpectraS3Request.Format = format
-    return putDs3TargetFailureNotificationRegistrationSpectraS3Request
+	putDs3TargetFailureNotificationRegistrationSpectraS3Request.Format = format
+	return putDs3TargetFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putDs3TargetFailureNotificationRegistrationSpectraS3Request *PutDs3TargetFailureNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutDs3TargetFailureNotificationRegistrationSpectraS3Request {
-    putDs3TargetFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putDs3TargetFailureNotificationRegistrationSpectraS3Request
+	putDs3TargetFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putDs3TargetFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putDs3TargetFailureNotificationRegistrationSpectraS3Request *PutDs3TargetFailureNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutDs3TargetFailureNotificationRegistrationSpectraS3Request {
-    putDs3TargetFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putDs3TargetFailureNotificationRegistrationSpectraS3Request
+	putDs3TargetFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putDs3TargetFailureNotificationRegistrationSpectraS3Request
 }
 
 type PutJobCompletedNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    JobId *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	JobId                  *string
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutJobCompletedNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutJobCompletedNotificationRegistrationSpectraS3Request {
-    return &PutJobCompletedNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutJobCompletedNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putJobCompletedNotificationRegistrationSpectraS3Request *PutJobCompletedNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutJobCompletedNotificationRegistrationSpectraS3Request {
-    putJobCompletedNotificationRegistrationSpectraS3Request.Format = format
-    return putJobCompletedNotificationRegistrationSpectraS3Request
+	putJobCompletedNotificationRegistrationSpectraS3Request.Format = format
+	return putJobCompletedNotificationRegistrationSpectraS3Request
 }
 
 func (putJobCompletedNotificationRegistrationSpectraS3Request *PutJobCompletedNotificationRegistrationSpectraS3Request) WithJobId(jobId string) *PutJobCompletedNotificationRegistrationSpectraS3Request {
-    putJobCompletedNotificationRegistrationSpectraS3Request.JobId = &jobId
-    return putJobCompletedNotificationRegistrationSpectraS3Request
+	putJobCompletedNotificationRegistrationSpectraS3Request.JobId = &jobId
+	return putJobCompletedNotificationRegistrationSpectraS3Request
 }
 
 func (putJobCompletedNotificationRegistrationSpectraS3Request *PutJobCompletedNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutJobCompletedNotificationRegistrationSpectraS3Request {
-    putJobCompletedNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putJobCompletedNotificationRegistrationSpectraS3Request
+	putJobCompletedNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putJobCompletedNotificationRegistrationSpectraS3Request
 }
 
 func (putJobCompletedNotificationRegistrationSpectraS3Request *PutJobCompletedNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutJobCompletedNotificationRegistrationSpectraS3Request {
-    putJobCompletedNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putJobCompletedNotificationRegistrationSpectraS3Request
+	putJobCompletedNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putJobCompletedNotificationRegistrationSpectraS3Request
 }
 
 type PutJobCreatedNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutJobCreatedNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutJobCreatedNotificationRegistrationSpectraS3Request {
-    return &PutJobCreatedNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutJobCreatedNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putJobCreatedNotificationRegistrationSpectraS3Request *PutJobCreatedNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutJobCreatedNotificationRegistrationSpectraS3Request {
-    putJobCreatedNotificationRegistrationSpectraS3Request.Format = format
-    return putJobCreatedNotificationRegistrationSpectraS3Request
+	putJobCreatedNotificationRegistrationSpectraS3Request.Format = format
+	return putJobCreatedNotificationRegistrationSpectraS3Request
 }
 
 func (putJobCreatedNotificationRegistrationSpectraS3Request *PutJobCreatedNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutJobCreatedNotificationRegistrationSpectraS3Request {
-    putJobCreatedNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putJobCreatedNotificationRegistrationSpectraS3Request
+	putJobCreatedNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putJobCreatedNotificationRegistrationSpectraS3Request
 }
 
 func (putJobCreatedNotificationRegistrationSpectraS3Request *PutJobCreatedNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutJobCreatedNotificationRegistrationSpectraS3Request {
-    putJobCreatedNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putJobCreatedNotificationRegistrationSpectraS3Request
+	putJobCreatedNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putJobCreatedNotificationRegistrationSpectraS3Request
 }
 
 type PutJobCreationFailedNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutJobCreationFailedNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutJobCreationFailedNotificationRegistrationSpectraS3Request {
-    return &PutJobCreationFailedNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutJobCreationFailedNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putJobCreationFailedNotificationRegistrationSpectraS3Request *PutJobCreationFailedNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutJobCreationFailedNotificationRegistrationSpectraS3Request {
-    putJobCreationFailedNotificationRegistrationSpectraS3Request.Format = format
-    return putJobCreationFailedNotificationRegistrationSpectraS3Request
+	putJobCreationFailedNotificationRegistrationSpectraS3Request.Format = format
+	return putJobCreationFailedNotificationRegistrationSpectraS3Request
 }
 
 func (putJobCreationFailedNotificationRegistrationSpectraS3Request *PutJobCreationFailedNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutJobCreationFailedNotificationRegistrationSpectraS3Request {
-    putJobCreationFailedNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putJobCreationFailedNotificationRegistrationSpectraS3Request
+	putJobCreationFailedNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putJobCreationFailedNotificationRegistrationSpectraS3Request
 }
 
 func (putJobCreationFailedNotificationRegistrationSpectraS3Request *PutJobCreationFailedNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutJobCreationFailedNotificationRegistrationSpectraS3Request {
-    putJobCreationFailedNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putJobCreationFailedNotificationRegistrationSpectraS3Request
+	putJobCreationFailedNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putJobCreationFailedNotificationRegistrationSpectraS3Request
 }
 
 type PutObjectCachedNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    JobId *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	JobId                  *string
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutObjectCachedNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutObjectCachedNotificationRegistrationSpectraS3Request {
-    return &PutObjectCachedNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutObjectCachedNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putObjectCachedNotificationRegistrationSpectraS3Request *PutObjectCachedNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutObjectCachedNotificationRegistrationSpectraS3Request {
-    putObjectCachedNotificationRegistrationSpectraS3Request.Format = format
-    return putObjectCachedNotificationRegistrationSpectraS3Request
+	putObjectCachedNotificationRegistrationSpectraS3Request.Format = format
+	return putObjectCachedNotificationRegistrationSpectraS3Request
 }
 
 func (putObjectCachedNotificationRegistrationSpectraS3Request *PutObjectCachedNotificationRegistrationSpectraS3Request) WithJobId(jobId string) *PutObjectCachedNotificationRegistrationSpectraS3Request {
-    putObjectCachedNotificationRegistrationSpectraS3Request.JobId = &jobId
-    return putObjectCachedNotificationRegistrationSpectraS3Request
+	putObjectCachedNotificationRegistrationSpectraS3Request.JobId = &jobId
+	return putObjectCachedNotificationRegistrationSpectraS3Request
 }
 
 func (putObjectCachedNotificationRegistrationSpectraS3Request *PutObjectCachedNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutObjectCachedNotificationRegistrationSpectraS3Request {
-    putObjectCachedNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putObjectCachedNotificationRegistrationSpectraS3Request
+	putObjectCachedNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putObjectCachedNotificationRegistrationSpectraS3Request
 }
 
 func (putObjectCachedNotificationRegistrationSpectraS3Request *PutObjectCachedNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutObjectCachedNotificationRegistrationSpectraS3Request {
-    putObjectCachedNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putObjectCachedNotificationRegistrationSpectraS3Request
+	putObjectCachedNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putObjectCachedNotificationRegistrationSpectraS3Request
 }
 
 type PutObjectLostNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutObjectLostNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutObjectLostNotificationRegistrationSpectraS3Request {
-    return &PutObjectLostNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutObjectLostNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putObjectLostNotificationRegistrationSpectraS3Request *PutObjectLostNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutObjectLostNotificationRegistrationSpectraS3Request {
-    putObjectLostNotificationRegistrationSpectraS3Request.Format = format
-    return putObjectLostNotificationRegistrationSpectraS3Request
+	putObjectLostNotificationRegistrationSpectraS3Request.Format = format
+	return putObjectLostNotificationRegistrationSpectraS3Request
 }
 
 func (putObjectLostNotificationRegistrationSpectraS3Request *PutObjectLostNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutObjectLostNotificationRegistrationSpectraS3Request {
-    putObjectLostNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putObjectLostNotificationRegistrationSpectraS3Request
+	putObjectLostNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putObjectLostNotificationRegistrationSpectraS3Request
 }
 
 func (putObjectLostNotificationRegistrationSpectraS3Request *PutObjectLostNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutObjectLostNotificationRegistrationSpectraS3Request {
-    putObjectLostNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putObjectLostNotificationRegistrationSpectraS3Request
+	putObjectLostNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putObjectLostNotificationRegistrationSpectraS3Request
 }
 
 type PutObjectPersistedNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    JobId *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	JobId                  *string
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutObjectPersistedNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutObjectPersistedNotificationRegistrationSpectraS3Request {
-    return &PutObjectPersistedNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutObjectPersistedNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putObjectPersistedNotificationRegistrationSpectraS3Request *PutObjectPersistedNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutObjectPersistedNotificationRegistrationSpectraS3Request {
-    putObjectPersistedNotificationRegistrationSpectraS3Request.Format = format
-    return putObjectPersistedNotificationRegistrationSpectraS3Request
+	putObjectPersistedNotificationRegistrationSpectraS3Request.Format = format
+	return putObjectPersistedNotificationRegistrationSpectraS3Request
 }
 
 func (putObjectPersistedNotificationRegistrationSpectraS3Request *PutObjectPersistedNotificationRegistrationSpectraS3Request) WithJobId(jobId string) *PutObjectPersistedNotificationRegistrationSpectraS3Request {
-    putObjectPersistedNotificationRegistrationSpectraS3Request.JobId = &jobId
-    return putObjectPersistedNotificationRegistrationSpectraS3Request
+	putObjectPersistedNotificationRegistrationSpectraS3Request.JobId = &jobId
+	return putObjectPersistedNotificationRegistrationSpectraS3Request
 }
 
 func (putObjectPersistedNotificationRegistrationSpectraS3Request *PutObjectPersistedNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutObjectPersistedNotificationRegistrationSpectraS3Request {
-    putObjectPersistedNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putObjectPersistedNotificationRegistrationSpectraS3Request
+	putObjectPersistedNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putObjectPersistedNotificationRegistrationSpectraS3Request
 }
 
 func (putObjectPersistedNotificationRegistrationSpectraS3Request *PutObjectPersistedNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutObjectPersistedNotificationRegistrationSpectraS3Request {
-    putObjectPersistedNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putObjectPersistedNotificationRegistrationSpectraS3Request
+	putObjectPersistedNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putObjectPersistedNotificationRegistrationSpectraS3Request
 }
 
 type PutPoolFailureNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutPoolFailureNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutPoolFailureNotificationRegistrationSpectraS3Request {
-    return &PutPoolFailureNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutPoolFailureNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putPoolFailureNotificationRegistrationSpectraS3Request *PutPoolFailureNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutPoolFailureNotificationRegistrationSpectraS3Request {
-    putPoolFailureNotificationRegistrationSpectraS3Request.Format = format
-    return putPoolFailureNotificationRegistrationSpectraS3Request
+	putPoolFailureNotificationRegistrationSpectraS3Request.Format = format
+	return putPoolFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putPoolFailureNotificationRegistrationSpectraS3Request *PutPoolFailureNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutPoolFailureNotificationRegistrationSpectraS3Request {
-    putPoolFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putPoolFailureNotificationRegistrationSpectraS3Request
+	putPoolFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putPoolFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putPoolFailureNotificationRegistrationSpectraS3Request *PutPoolFailureNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutPoolFailureNotificationRegistrationSpectraS3Request {
-    putPoolFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putPoolFailureNotificationRegistrationSpectraS3Request
+	putPoolFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putPoolFailureNotificationRegistrationSpectraS3Request
 }
 
 type PutS3TargetFailureNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutS3TargetFailureNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutS3TargetFailureNotificationRegistrationSpectraS3Request {
-    return &PutS3TargetFailureNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutS3TargetFailureNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putS3TargetFailureNotificationRegistrationSpectraS3Request *PutS3TargetFailureNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutS3TargetFailureNotificationRegistrationSpectraS3Request {
-    putS3TargetFailureNotificationRegistrationSpectraS3Request.Format = format
-    return putS3TargetFailureNotificationRegistrationSpectraS3Request
+	putS3TargetFailureNotificationRegistrationSpectraS3Request.Format = format
+	return putS3TargetFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putS3TargetFailureNotificationRegistrationSpectraS3Request *PutS3TargetFailureNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutS3TargetFailureNotificationRegistrationSpectraS3Request {
-    putS3TargetFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putS3TargetFailureNotificationRegistrationSpectraS3Request
+	putS3TargetFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putS3TargetFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putS3TargetFailureNotificationRegistrationSpectraS3Request *PutS3TargetFailureNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutS3TargetFailureNotificationRegistrationSpectraS3Request {
-    putS3TargetFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putS3TargetFailureNotificationRegistrationSpectraS3Request
+	putS3TargetFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putS3TargetFailureNotificationRegistrationSpectraS3Request
 }
 
 type PutStorageDomainFailureNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutStorageDomainFailureNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutStorageDomainFailureNotificationRegistrationSpectraS3Request {
-    return &PutStorageDomainFailureNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutStorageDomainFailureNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putStorageDomainFailureNotificationRegistrationSpectraS3Request *PutStorageDomainFailureNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutStorageDomainFailureNotificationRegistrationSpectraS3Request {
-    putStorageDomainFailureNotificationRegistrationSpectraS3Request.Format = format
-    return putStorageDomainFailureNotificationRegistrationSpectraS3Request
+	putStorageDomainFailureNotificationRegistrationSpectraS3Request.Format = format
+	return putStorageDomainFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putStorageDomainFailureNotificationRegistrationSpectraS3Request *PutStorageDomainFailureNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutStorageDomainFailureNotificationRegistrationSpectraS3Request {
-    putStorageDomainFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putStorageDomainFailureNotificationRegistrationSpectraS3Request
+	putStorageDomainFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putStorageDomainFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putStorageDomainFailureNotificationRegistrationSpectraS3Request *PutStorageDomainFailureNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutStorageDomainFailureNotificationRegistrationSpectraS3Request {
-    putStorageDomainFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putStorageDomainFailureNotificationRegistrationSpectraS3Request
+	putStorageDomainFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putStorageDomainFailureNotificationRegistrationSpectraS3Request
 }
 
 type PutSystemFailureNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutSystemFailureNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutSystemFailureNotificationRegistrationSpectraS3Request {
-    return &PutSystemFailureNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutSystemFailureNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putSystemFailureNotificationRegistrationSpectraS3Request *PutSystemFailureNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutSystemFailureNotificationRegistrationSpectraS3Request {
-    putSystemFailureNotificationRegistrationSpectraS3Request.Format = format
-    return putSystemFailureNotificationRegistrationSpectraS3Request
+	putSystemFailureNotificationRegistrationSpectraS3Request.Format = format
+	return putSystemFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putSystemFailureNotificationRegistrationSpectraS3Request *PutSystemFailureNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutSystemFailureNotificationRegistrationSpectraS3Request {
-    putSystemFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putSystemFailureNotificationRegistrationSpectraS3Request
+	putSystemFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putSystemFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putSystemFailureNotificationRegistrationSpectraS3Request *PutSystemFailureNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutSystemFailureNotificationRegistrationSpectraS3Request {
-    putSystemFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putSystemFailureNotificationRegistrationSpectraS3Request
+	putSystemFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putSystemFailureNotificationRegistrationSpectraS3Request
 }
 
 type PutTapeFailureNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutTapeFailureNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutTapeFailureNotificationRegistrationSpectraS3Request {
-    return &PutTapeFailureNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutTapeFailureNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putTapeFailureNotificationRegistrationSpectraS3Request *PutTapeFailureNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutTapeFailureNotificationRegistrationSpectraS3Request {
-    putTapeFailureNotificationRegistrationSpectraS3Request.Format = format
-    return putTapeFailureNotificationRegistrationSpectraS3Request
+	putTapeFailureNotificationRegistrationSpectraS3Request.Format = format
+	return putTapeFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putTapeFailureNotificationRegistrationSpectraS3Request *PutTapeFailureNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutTapeFailureNotificationRegistrationSpectraS3Request {
-    putTapeFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putTapeFailureNotificationRegistrationSpectraS3Request
+	putTapeFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putTapeFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putTapeFailureNotificationRegistrationSpectraS3Request *PutTapeFailureNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutTapeFailureNotificationRegistrationSpectraS3Request {
-    putTapeFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putTapeFailureNotificationRegistrationSpectraS3Request
+	putTapeFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putTapeFailureNotificationRegistrationSpectraS3Request
 }
 
 type PutTapePartitionFailureNotificationRegistrationSpectraS3Request struct {
-    Format HttpResponseFormatType
-    NamingConvention NamingConventionType
-    NotificationEndPoint string
-    NotificationHttpMethod RequestType
+	Format                 HttpResponseFormatType
+	NamingConvention       NamingConventionType
+	NotificationEndPoint   string
+	NotificationHttpMethod RequestType
 }
 
 func NewPutTapePartitionFailureNotificationRegistrationSpectraS3Request(notificationEndPoint string) *PutTapePartitionFailureNotificationRegistrationSpectraS3Request {
-    return &PutTapePartitionFailureNotificationRegistrationSpectraS3Request{
-        NotificationEndPoint: notificationEndPoint,
-    }
+	return &PutTapePartitionFailureNotificationRegistrationSpectraS3Request{
+		NotificationEndPoint: notificationEndPoint,
+	}
 }
 
 func (putTapePartitionFailureNotificationRegistrationSpectraS3Request *PutTapePartitionFailureNotificationRegistrationSpectraS3Request) WithFormat(format HttpResponseFormatType) *PutTapePartitionFailureNotificationRegistrationSpectraS3Request {
-    putTapePartitionFailureNotificationRegistrationSpectraS3Request.Format = format
-    return putTapePartitionFailureNotificationRegistrationSpectraS3Request
+	putTapePartitionFailureNotificationRegistrationSpectraS3Request.Format = format
+	return putTapePartitionFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putTapePartitionFailureNotificationRegistrationSpectraS3Request *PutTapePartitionFailureNotificationRegistrationSpectraS3Request) WithNamingConvention(namingConvention NamingConventionType) *PutTapePartitionFailureNotificationRegistrationSpectraS3Request {
-    putTapePartitionFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
-    return putTapePartitionFailureNotificationRegistrationSpectraS3Request
+	putTapePartitionFailureNotificationRegistrationSpectraS3Request.NamingConvention = namingConvention
+	return putTapePartitionFailureNotificationRegistrationSpectraS3Request
 }
 
 func (putTapePartitionFailureNotificationRegistrationSpectraS3Request *PutTapePartitionFailureNotificationRegistrationSpectraS3Request) WithNotificationHttpMethod(notificationHttpMethod RequestType) *PutTapePartitionFailureNotificationRegistrationSpectraS3Request {
-    putTapePartitionFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
-    return putTapePartitionFailureNotificationRegistrationSpectraS3Request
+	putTapePartitionFailureNotificationRegistrationSpectraS3Request.NotificationHttpMethod = notificationHttpMethod
+	return putTapePartitionFailureNotificationRegistrationSpectraS3Request
 }
 
 type DeleteAzureTargetFailureNotificationRegistrationSpectraS3Request struct {
-    AzureTargetFailureNotificationRegistration string
+	AzureTargetFailureNotificationRegistration string
 }
 
 func NewDeleteAzureTargetFailureNotificationRegistrationSpectraS3Request(azureTargetFailureNotificationRegistration string) *DeleteAzureTargetFailureNotificationRegistrationSpectraS3Request {
-    return &DeleteAzureTargetFailureNotificationRegistrationSpectraS3Request{
-        AzureTargetFailureNotificationRegistration: azureTargetFailureNotificationRegistration,
-    }
+	return &DeleteAzureTargetFailureNotificationRegistrationSpectraS3Request{
+		AzureTargetFailureNotificationRegistration: azureTargetFailureNotificationRegistration,
+	}
 }
 
 type DeleteBucketChangesNotificationRegistrationSpectraS3Request struct {
-    BucketChangesNotificationRegistration string
+	BucketChangesNotificationRegistration string
 }
 
 func NewDeleteBucketChangesNotificationRegistrationSpectraS3Request(bucketChangesNotificationRegistration string) *DeleteBucketChangesNotificationRegistrationSpectraS3Request {
-    return &DeleteBucketChangesNotificationRegistrationSpectraS3Request{
-        BucketChangesNotificationRegistration: bucketChangesNotificationRegistration,
-    }
+	return &DeleteBucketChangesNotificationRegistrationSpectraS3Request{
+		BucketChangesNotificationRegistration: bucketChangesNotificationRegistration,
+	}
 }
 
 type DeleteDs3TargetFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeleteDs3TargetFailureNotificationRegistrationSpectraS3Request(notificationId string) *DeleteDs3TargetFailureNotificationRegistrationSpectraS3Request {
-    return &DeleteDs3TargetFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeleteDs3TargetFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type DeleteJobCompletedNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeleteJobCompletedNotificationRegistrationSpectraS3Request(notificationId string) *DeleteJobCompletedNotificationRegistrationSpectraS3Request {
-    return &DeleteJobCompletedNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeleteJobCompletedNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type DeleteJobCreatedNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeleteJobCreatedNotificationRegistrationSpectraS3Request(notificationId string) *DeleteJobCreatedNotificationRegistrationSpectraS3Request {
-    return &DeleteJobCreatedNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeleteJobCreatedNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type DeleteJobCreationFailedNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeleteJobCreationFailedNotificationRegistrationSpectraS3Request(notificationId string) *DeleteJobCreationFailedNotificationRegistrationSpectraS3Request {
-    return &DeleteJobCreationFailedNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeleteJobCreationFailedNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type DeleteObjectCachedNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeleteObjectCachedNotificationRegistrationSpectraS3Request(notificationId string) *DeleteObjectCachedNotificationRegistrationSpectraS3Request {
-    return &DeleteObjectCachedNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeleteObjectCachedNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type DeleteObjectLostNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeleteObjectLostNotificationRegistrationSpectraS3Request(notificationId string) *DeleteObjectLostNotificationRegistrationSpectraS3Request {
-    return &DeleteObjectLostNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeleteObjectLostNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type DeleteObjectPersistedNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeleteObjectPersistedNotificationRegistrationSpectraS3Request(notificationId string) *DeleteObjectPersistedNotificationRegistrationSpectraS3Request {
-    return &DeleteObjectPersistedNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeleteObjectPersistedNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type DeletePoolFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeletePoolFailureNotificationRegistrationSpectraS3Request(notificationId string) *DeletePoolFailureNotificationRegistrationSpectraS3Request {
-    return &DeletePoolFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeletePoolFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type DeleteS3TargetFailureNotificationRegistrationSpectraS3Request struct {
-    S3TargetFailureNotificationRegistration string
+	S3TargetFailureNotificationRegistration string
 }
 
 func NewDeleteS3TargetFailureNotificationRegistrationSpectraS3Request(s3TargetFailureNotificationRegistration string) *DeleteS3TargetFailureNotificationRegistrationSpectraS3Request {
-    return &DeleteS3TargetFailureNotificationRegistrationSpectraS3Request{
-        S3TargetFailureNotificationRegistration: s3TargetFailureNotificationRegistration,
-    }
+	return &DeleteS3TargetFailureNotificationRegistrationSpectraS3Request{
+		S3TargetFailureNotificationRegistration: s3TargetFailureNotificationRegistration,
+	}
 }
 
 type DeleteStorageDomainFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeleteStorageDomainFailureNotificationRegistrationSpectraS3Request(notificationId string) *DeleteStorageDomainFailureNotificationRegistrationSpectraS3Request {
-    return &DeleteStorageDomainFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeleteStorageDomainFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type DeleteSystemFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeleteSystemFailureNotificationRegistrationSpectraS3Request(notificationId string) *DeleteSystemFailureNotificationRegistrationSpectraS3Request {
-    return &DeleteSystemFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeleteSystemFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type DeleteTapeFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeleteTapeFailureNotificationRegistrationSpectraS3Request(notificationId string) *DeleteTapeFailureNotificationRegistrationSpectraS3Request {
-    return &DeleteTapeFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeleteTapeFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type DeleteTapePartitionFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewDeleteTapePartitionFailureNotificationRegistrationSpectraS3Request(notificationId string) *DeleteTapePartitionFailureNotificationRegistrationSpectraS3Request {
-    return &DeleteTapePartitionFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &DeleteTapePartitionFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetAzureTargetFailureNotificationRegistrationSpectraS3Request struct {
-    AzureTargetFailureNotificationRegistration string
+	AzureTargetFailureNotificationRegistration string
 }
 
 func NewGetAzureTargetFailureNotificationRegistrationSpectraS3Request(azureTargetFailureNotificationRegistration string) *GetAzureTargetFailureNotificationRegistrationSpectraS3Request {
-    return &GetAzureTargetFailureNotificationRegistrationSpectraS3Request{
-        AzureTargetFailureNotificationRegistration: azureTargetFailureNotificationRegistration,
-    }
+	return &GetAzureTargetFailureNotificationRegistrationSpectraS3Request{
+		AzureTargetFailureNotificationRegistration: azureTargetFailureNotificationRegistration,
+	}
 }
 
 type GetAzureTargetFailureNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetAzureTargetFailureNotificationRegistrationsSpectraS3Request() *GetAzureTargetFailureNotificationRegistrationsSpectraS3Request {
-    return &GetAzureTargetFailureNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetAzureTargetFailureNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getAzureTargetFailureNotificationRegistrationsSpectraS3Request *GetAzureTargetFailureNotificationRegistrationsSpectraS3Request) WithLastPage() *GetAzureTargetFailureNotificationRegistrationsSpectraS3Request {
-    getAzureTargetFailureNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getAzureTargetFailureNotificationRegistrationsSpectraS3Request
+	getAzureTargetFailureNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getAzureTargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getAzureTargetFailureNotificationRegistrationsSpectraS3Request *GetAzureTargetFailureNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetAzureTargetFailureNotificationRegistrationsSpectraS3Request {
-    getAzureTargetFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getAzureTargetFailureNotificationRegistrationsSpectraS3Request
+	getAzureTargetFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getAzureTargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getAzureTargetFailureNotificationRegistrationsSpectraS3Request *GetAzureTargetFailureNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetAzureTargetFailureNotificationRegistrationsSpectraS3Request {
-    getAzureTargetFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getAzureTargetFailureNotificationRegistrationsSpectraS3Request
+	getAzureTargetFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getAzureTargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getAzureTargetFailureNotificationRegistrationsSpectraS3Request *GetAzureTargetFailureNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetAzureTargetFailureNotificationRegistrationsSpectraS3Request {
-    getAzureTargetFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getAzureTargetFailureNotificationRegistrationsSpectraS3Request
+	getAzureTargetFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getAzureTargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getAzureTargetFailureNotificationRegistrationsSpectraS3Request *GetAzureTargetFailureNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetAzureTargetFailureNotificationRegistrationsSpectraS3Request {
-    getAzureTargetFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getAzureTargetFailureNotificationRegistrationsSpectraS3Request
+	getAzureTargetFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getAzureTargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 type GetBucketChangesNotificationRegistrationSpectraS3Request struct {
-    BucketChangesNotificationRegistration string
+	BucketChangesNotificationRegistration string
 }
 
 func NewGetBucketChangesNotificationRegistrationSpectraS3Request(bucketChangesNotificationRegistration string) *GetBucketChangesNotificationRegistrationSpectraS3Request {
-    return &GetBucketChangesNotificationRegistrationSpectraS3Request{
-        BucketChangesNotificationRegistration: bucketChangesNotificationRegistration,
-    }
+	return &GetBucketChangesNotificationRegistrationSpectraS3Request{
+		BucketChangesNotificationRegistration: bucketChangesNotificationRegistration,
+	}
 }
 
 type GetBucketChangesNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetBucketChangesNotificationRegistrationsSpectraS3Request() *GetBucketChangesNotificationRegistrationsSpectraS3Request {
-    return &GetBucketChangesNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetBucketChangesNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getBucketChangesNotificationRegistrationsSpectraS3Request *GetBucketChangesNotificationRegistrationsSpectraS3Request) WithLastPage() *GetBucketChangesNotificationRegistrationsSpectraS3Request {
-    getBucketChangesNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getBucketChangesNotificationRegistrationsSpectraS3Request
+	getBucketChangesNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getBucketChangesNotificationRegistrationsSpectraS3Request
 }
 
 func (getBucketChangesNotificationRegistrationsSpectraS3Request *GetBucketChangesNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetBucketChangesNotificationRegistrationsSpectraS3Request {
-    getBucketChangesNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getBucketChangesNotificationRegistrationsSpectraS3Request
+	getBucketChangesNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getBucketChangesNotificationRegistrationsSpectraS3Request
 }
 
 func (getBucketChangesNotificationRegistrationsSpectraS3Request *GetBucketChangesNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetBucketChangesNotificationRegistrationsSpectraS3Request {
-    getBucketChangesNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getBucketChangesNotificationRegistrationsSpectraS3Request
+	getBucketChangesNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getBucketChangesNotificationRegistrationsSpectraS3Request
 }
 
 func (getBucketChangesNotificationRegistrationsSpectraS3Request *GetBucketChangesNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetBucketChangesNotificationRegistrationsSpectraS3Request {
-    getBucketChangesNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getBucketChangesNotificationRegistrationsSpectraS3Request
+	getBucketChangesNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getBucketChangesNotificationRegistrationsSpectraS3Request
 }
 
 func (getBucketChangesNotificationRegistrationsSpectraS3Request *GetBucketChangesNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetBucketChangesNotificationRegistrationsSpectraS3Request {
-    getBucketChangesNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getBucketChangesNotificationRegistrationsSpectraS3Request
+	getBucketChangesNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getBucketChangesNotificationRegistrationsSpectraS3Request
 }
 
 type GetBucketHistorySpectraS3Request struct {
-    BucketId *string
-    LastPage bool
-    MinSequenceNumber *int64
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
+	BucketId          *string
+	LastPage          bool
+	MinSequenceNumber *int64
+	PageLength        *int
+	PageOffset        *int
+	PageStartMarker   *string
 }
 
 func NewGetBucketHistorySpectraS3Request() *GetBucketHistorySpectraS3Request {
-    return &GetBucketHistorySpectraS3Request{
-    }
+	return &GetBucketHistorySpectraS3Request{}
 }
 
 func (getBucketHistorySpectraS3Request *GetBucketHistorySpectraS3Request) WithBucketId(bucketId string) *GetBucketHistorySpectraS3Request {
-    getBucketHistorySpectraS3Request.BucketId = &bucketId
-    return getBucketHistorySpectraS3Request
+	getBucketHistorySpectraS3Request.BucketId = &bucketId
+	return getBucketHistorySpectraS3Request
 }
 
 func (getBucketHistorySpectraS3Request *GetBucketHistorySpectraS3Request) WithLastPage() *GetBucketHistorySpectraS3Request {
-    getBucketHistorySpectraS3Request.LastPage = true
-    return getBucketHistorySpectraS3Request
+	getBucketHistorySpectraS3Request.LastPage = true
+	return getBucketHistorySpectraS3Request
 }
 
 func (getBucketHistorySpectraS3Request *GetBucketHistorySpectraS3Request) WithMinSequenceNumber(minSequenceNumber int64) *GetBucketHistorySpectraS3Request {
-    getBucketHistorySpectraS3Request.MinSequenceNumber = &minSequenceNumber
-    return getBucketHistorySpectraS3Request
+	getBucketHistorySpectraS3Request.MinSequenceNumber = &minSequenceNumber
+	return getBucketHistorySpectraS3Request
 }
 
 func (getBucketHistorySpectraS3Request *GetBucketHistorySpectraS3Request) WithPageLength(pageLength int) *GetBucketHistorySpectraS3Request {
-    getBucketHistorySpectraS3Request.PageLength = &pageLength
-    return getBucketHistorySpectraS3Request
+	getBucketHistorySpectraS3Request.PageLength = &pageLength
+	return getBucketHistorySpectraS3Request
 }
 
 func (getBucketHistorySpectraS3Request *GetBucketHistorySpectraS3Request) WithPageOffset(pageOffset int) *GetBucketHistorySpectraS3Request {
-    getBucketHistorySpectraS3Request.PageOffset = &pageOffset
-    return getBucketHistorySpectraS3Request
+	getBucketHistorySpectraS3Request.PageOffset = &pageOffset
+	return getBucketHistorySpectraS3Request
 }
 
 func (getBucketHistorySpectraS3Request *GetBucketHistorySpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetBucketHistorySpectraS3Request {
-    getBucketHistorySpectraS3Request.PageStartMarker = &pageStartMarker
-    return getBucketHistorySpectraS3Request
+	getBucketHistorySpectraS3Request.PageStartMarker = &pageStartMarker
+	return getBucketHistorySpectraS3Request
 }
 
 type GetDs3TargetFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetDs3TargetFailureNotificationRegistrationSpectraS3Request(notificationId string) *GetDs3TargetFailureNotificationRegistrationSpectraS3Request {
-    return &GetDs3TargetFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetDs3TargetFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetDs3TargetFailureNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetDs3TargetFailureNotificationRegistrationsSpectraS3Request() *GetDs3TargetFailureNotificationRegistrationsSpectraS3Request {
-    return &GetDs3TargetFailureNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetDs3TargetFailureNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getDs3TargetFailureNotificationRegistrationsSpectraS3Request *GetDs3TargetFailureNotificationRegistrationsSpectraS3Request) WithLastPage() *GetDs3TargetFailureNotificationRegistrationsSpectraS3Request {
-    getDs3TargetFailureNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getDs3TargetFailureNotificationRegistrationsSpectraS3Request
+	getDs3TargetFailureNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getDs3TargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getDs3TargetFailureNotificationRegistrationsSpectraS3Request *GetDs3TargetFailureNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetDs3TargetFailureNotificationRegistrationsSpectraS3Request {
-    getDs3TargetFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getDs3TargetFailureNotificationRegistrationsSpectraS3Request
+	getDs3TargetFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getDs3TargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getDs3TargetFailureNotificationRegistrationsSpectraS3Request *GetDs3TargetFailureNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetDs3TargetFailureNotificationRegistrationsSpectraS3Request {
-    getDs3TargetFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getDs3TargetFailureNotificationRegistrationsSpectraS3Request
+	getDs3TargetFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getDs3TargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getDs3TargetFailureNotificationRegistrationsSpectraS3Request *GetDs3TargetFailureNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDs3TargetFailureNotificationRegistrationsSpectraS3Request {
-    getDs3TargetFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDs3TargetFailureNotificationRegistrationsSpectraS3Request
+	getDs3TargetFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDs3TargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getDs3TargetFailureNotificationRegistrationsSpectraS3Request *GetDs3TargetFailureNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetDs3TargetFailureNotificationRegistrationsSpectraS3Request {
-    getDs3TargetFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getDs3TargetFailureNotificationRegistrationsSpectraS3Request
+	getDs3TargetFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getDs3TargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 type GetJobCompletedNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetJobCompletedNotificationRegistrationSpectraS3Request(notificationId string) *GetJobCompletedNotificationRegistrationSpectraS3Request {
-    return &GetJobCompletedNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetJobCompletedNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetJobCompletedNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetJobCompletedNotificationRegistrationsSpectraS3Request() *GetJobCompletedNotificationRegistrationsSpectraS3Request {
-    return &GetJobCompletedNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetJobCompletedNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getJobCompletedNotificationRegistrationsSpectraS3Request *GetJobCompletedNotificationRegistrationsSpectraS3Request) WithLastPage() *GetJobCompletedNotificationRegistrationsSpectraS3Request {
-    getJobCompletedNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getJobCompletedNotificationRegistrationsSpectraS3Request
+	getJobCompletedNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getJobCompletedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCompletedNotificationRegistrationsSpectraS3Request *GetJobCompletedNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetJobCompletedNotificationRegistrationsSpectraS3Request {
-    getJobCompletedNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getJobCompletedNotificationRegistrationsSpectraS3Request
+	getJobCompletedNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getJobCompletedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCompletedNotificationRegistrationsSpectraS3Request *GetJobCompletedNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetJobCompletedNotificationRegistrationsSpectraS3Request {
-    getJobCompletedNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getJobCompletedNotificationRegistrationsSpectraS3Request
+	getJobCompletedNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getJobCompletedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCompletedNotificationRegistrationsSpectraS3Request *GetJobCompletedNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetJobCompletedNotificationRegistrationsSpectraS3Request {
-    getJobCompletedNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getJobCompletedNotificationRegistrationsSpectraS3Request
+	getJobCompletedNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getJobCompletedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCompletedNotificationRegistrationsSpectraS3Request *GetJobCompletedNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetJobCompletedNotificationRegistrationsSpectraS3Request {
-    getJobCompletedNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getJobCompletedNotificationRegistrationsSpectraS3Request
+	getJobCompletedNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getJobCompletedNotificationRegistrationsSpectraS3Request
 }
 
 type GetJobCreatedNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetJobCreatedNotificationRegistrationSpectraS3Request(notificationId string) *GetJobCreatedNotificationRegistrationSpectraS3Request {
-    return &GetJobCreatedNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetJobCreatedNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetJobCreatedNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetJobCreatedNotificationRegistrationsSpectraS3Request() *GetJobCreatedNotificationRegistrationsSpectraS3Request {
-    return &GetJobCreatedNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetJobCreatedNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getJobCreatedNotificationRegistrationsSpectraS3Request *GetJobCreatedNotificationRegistrationsSpectraS3Request) WithLastPage() *GetJobCreatedNotificationRegistrationsSpectraS3Request {
-    getJobCreatedNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getJobCreatedNotificationRegistrationsSpectraS3Request
+	getJobCreatedNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getJobCreatedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCreatedNotificationRegistrationsSpectraS3Request *GetJobCreatedNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetJobCreatedNotificationRegistrationsSpectraS3Request {
-    getJobCreatedNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getJobCreatedNotificationRegistrationsSpectraS3Request
+	getJobCreatedNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getJobCreatedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCreatedNotificationRegistrationsSpectraS3Request *GetJobCreatedNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetJobCreatedNotificationRegistrationsSpectraS3Request {
-    getJobCreatedNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getJobCreatedNotificationRegistrationsSpectraS3Request
+	getJobCreatedNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getJobCreatedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCreatedNotificationRegistrationsSpectraS3Request *GetJobCreatedNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetJobCreatedNotificationRegistrationsSpectraS3Request {
-    getJobCreatedNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getJobCreatedNotificationRegistrationsSpectraS3Request
+	getJobCreatedNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getJobCreatedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCreatedNotificationRegistrationsSpectraS3Request *GetJobCreatedNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetJobCreatedNotificationRegistrationsSpectraS3Request {
-    getJobCreatedNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getJobCreatedNotificationRegistrationsSpectraS3Request
+	getJobCreatedNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getJobCreatedNotificationRegistrationsSpectraS3Request
 }
 
 type GetJobCreationFailedNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetJobCreationFailedNotificationRegistrationSpectraS3Request(notificationId string) *GetJobCreationFailedNotificationRegistrationSpectraS3Request {
-    return &GetJobCreationFailedNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetJobCreationFailedNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetJobCreationFailedNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetJobCreationFailedNotificationRegistrationsSpectraS3Request() *GetJobCreationFailedNotificationRegistrationsSpectraS3Request {
-    return &GetJobCreationFailedNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetJobCreationFailedNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getJobCreationFailedNotificationRegistrationsSpectraS3Request *GetJobCreationFailedNotificationRegistrationsSpectraS3Request) WithLastPage() *GetJobCreationFailedNotificationRegistrationsSpectraS3Request {
-    getJobCreationFailedNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getJobCreationFailedNotificationRegistrationsSpectraS3Request
+	getJobCreationFailedNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getJobCreationFailedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCreationFailedNotificationRegistrationsSpectraS3Request *GetJobCreationFailedNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetJobCreationFailedNotificationRegistrationsSpectraS3Request {
-    getJobCreationFailedNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getJobCreationFailedNotificationRegistrationsSpectraS3Request
+	getJobCreationFailedNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getJobCreationFailedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCreationFailedNotificationRegistrationsSpectraS3Request *GetJobCreationFailedNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetJobCreationFailedNotificationRegistrationsSpectraS3Request {
-    getJobCreationFailedNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getJobCreationFailedNotificationRegistrationsSpectraS3Request
+	getJobCreationFailedNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getJobCreationFailedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCreationFailedNotificationRegistrationsSpectraS3Request *GetJobCreationFailedNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetJobCreationFailedNotificationRegistrationsSpectraS3Request {
-    getJobCreationFailedNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getJobCreationFailedNotificationRegistrationsSpectraS3Request
+	getJobCreationFailedNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getJobCreationFailedNotificationRegistrationsSpectraS3Request
 }
 
 func (getJobCreationFailedNotificationRegistrationsSpectraS3Request *GetJobCreationFailedNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetJobCreationFailedNotificationRegistrationsSpectraS3Request {
-    getJobCreationFailedNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getJobCreationFailedNotificationRegistrationsSpectraS3Request
+	getJobCreationFailedNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getJobCreationFailedNotificationRegistrationsSpectraS3Request
 }
 
 type GetObjectCachedNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetObjectCachedNotificationRegistrationSpectraS3Request(notificationId string) *GetObjectCachedNotificationRegistrationSpectraS3Request {
-    return &GetObjectCachedNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetObjectCachedNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetObjectCachedNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetObjectCachedNotificationRegistrationsSpectraS3Request() *GetObjectCachedNotificationRegistrationsSpectraS3Request {
-    return &GetObjectCachedNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetObjectCachedNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getObjectCachedNotificationRegistrationsSpectraS3Request *GetObjectCachedNotificationRegistrationsSpectraS3Request) WithLastPage() *GetObjectCachedNotificationRegistrationsSpectraS3Request {
-    getObjectCachedNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getObjectCachedNotificationRegistrationsSpectraS3Request
+	getObjectCachedNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getObjectCachedNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectCachedNotificationRegistrationsSpectraS3Request *GetObjectCachedNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetObjectCachedNotificationRegistrationsSpectraS3Request {
-    getObjectCachedNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getObjectCachedNotificationRegistrationsSpectraS3Request
+	getObjectCachedNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getObjectCachedNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectCachedNotificationRegistrationsSpectraS3Request *GetObjectCachedNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetObjectCachedNotificationRegistrationsSpectraS3Request {
-    getObjectCachedNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getObjectCachedNotificationRegistrationsSpectraS3Request
+	getObjectCachedNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getObjectCachedNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectCachedNotificationRegistrationsSpectraS3Request *GetObjectCachedNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetObjectCachedNotificationRegistrationsSpectraS3Request {
-    getObjectCachedNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getObjectCachedNotificationRegistrationsSpectraS3Request
+	getObjectCachedNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getObjectCachedNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectCachedNotificationRegistrationsSpectraS3Request *GetObjectCachedNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetObjectCachedNotificationRegistrationsSpectraS3Request {
-    getObjectCachedNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getObjectCachedNotificationRegistrationsSpectraS3Request
+	getObjectCachedNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getObjectCachedNotificationRegistrationsSpectraS3Request
 }
 
 type GetObjectLostNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetObjectLostNotificationRegistrationSpectraS3Request(notificationId string) *GetObjectLostNotificationRegistrationSpectraS3Request {
-    return &GetObjectLostNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetObjectLostNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetObjectLostNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetObjectLostNotificationRegistrationsSpectraS3Request() *GetObjectLostNotificationRegistrationsSpectraS3Request {
-    return &GetObjectLostNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetObjectLostNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getObjectLostNotificationRegistrationsSpectraS3Request *GetObjectLostNotificationRegistrationsSpectraS3Request) WithLastPage() *GetObjectLostNotificationRegistrationsSpectraS3Request {
-    getObjectLostNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getObjectLostNotificationRegistrationsSpectraS3Request
+	getObjectLostNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getObjectLostNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectLostNotificationRegistrationsSpectraS3Request *GetObjectLostNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetObjectLostNotificationRegistrationsSpectraS3Request {
-    getObjectLostNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getObjectLostNotificationRegistrationsSpectraS3Request
+	getObjectLostNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getObjectLostNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectLostNotificationRegistrationsSpectraS3Request *GetObjectLostNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetObjectLostNotificationRegistrationsSpectraS3Request {
-    getObjectLostNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getObjectLostNotificationRegistrationsSpectraS3Request
+	getObjectLostNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getObjectLostNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectLostNotificationRegistrationsSpectraS3Request *GetObjectLostNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetObjectLostNotificationRegistrationsSpectraS3Request {
-    getObjectLostNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getObjectLostNotificationRegistrationsSpectraS3Request
+	getObjectLostNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getObjectLostNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectLostNotificationRegistrationsSpectraS3Request *GetObjectLostNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetObjectLostNotificationRegistrationsSpectraS3Request {
-    getObjectLostNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getObjectLostNotificationRegistrationsSpectraS3Request
+	getObjectLostNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getObjectLostNotificationRegistrationsSpectraS3Request
 }
 
 type GetObjectPersistedNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetObjectPersistedNotificationRegistrationSpectraS3Request(notificationId string) *GetObjectPersistedNotificationRegistrationSpectraS3Request {
-    return &GetObjectPersistedNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetObjectPersistedNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetObjectPersistedNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetObjectPersistedNotificationRegistrationsSpectraS3Request() *GetObjectPersistedNotificationRegistrationsSpectraS3Request {
-    return &GetObjectPersistedNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetObjectPersistedNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getObjectPersistedNotificationRegistrationsSpectraS3Request *GetObjectPersistedNotificationRegistrationsSpectraS3Request) WithLastPage() *GetObjectPersistedNotificationRegistrationsSpectraS3Request {
-    getObjectPersistedNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getObjectPersistedNotificationRegistrationsSpectraS3Request
+	getObjectPersistedNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getObjectPersistedNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectPersistedNotificationRegistrationsSpectraS3Request *GetObjectPersistedNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetObjectPersistedNotificationRegistrationsSpectraS3Request {
-    getObjectPersistedNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getObjectPersistedNotificationRegistrationsSpectraS3Request
+	getObjectPersistedNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getObjectPersistedNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectPersistedNotificationRegistrationsSpectraS3Request *GetObjectPersistedNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetObjectPersistedNotificationRegistrationsSpectraS3Request {
-    getObjectPersistedNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getObjectPersistedNotificationRegistrationsSpectraS3Request
+	getObjectPersistedNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getObjectPersistedNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectPersistedNotificationRegistrationsSpectraS3Request *GetObjectPersistedNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetObjectPersistedNotificationRegistrationsSpectraS3Request {
-    getObjectPersistedNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getObjectPersistedNotificationRegistrationsSpectraS3Request
+	getObjectPersistedNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getObjectPersistedNotificationRegistrationsSpectraS3Request
 }
 
 func (getObjectPersistedNotificationRegistrationsSpectraS3Request *GetObjectPersistedNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetObjectPersistedNotificationRegistrationsSpectraS3Request {
-    getObjectPersistedNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getObjectPersistedNotificationRegistrationsSpectraS3Request
+	getObjectPersistedNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getObjectPersistedNotificationRegistrationsSpectraS3Request
 }
 
 type GetPoolFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetPoolFailureNotificationRegistrationSpectraS3Request(notificationId string) *GetPoolFailureNotificationRegistrationSpectraS3Request {
-    return &GetPoolFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetPoolFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetPoolFailureNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetPoolFailureNotificationRegistrationsSpectraS3Request() *GetPoolFailureNotificationRegistrationsSpectraS3Request {
-    return &GetPoolFailureNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetPoolFailureNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getPoolFailureNotificationRegistrationsSpectraS3Request *GetPoolFailureNotificationRegistrationsSpectraS3Request) WithLastPage() *GetPoolFailureNotificationRegistrationsSpectraS3Request {
-    getPoolFailureNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getPoolFailureNotificationRegistrationsSpectraS3Request
+	getPoolFailureNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getPoolFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getPoolFailureNotificationRegistrationsSpectraS3Request *GetPoolFailureNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetPoolFailureNotificationRegistrationsSpectraS3Request {
-    getPoolFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getPoolFailureNotificationRegistrationsSpectraS3Request
+	getPoolFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getPoolFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getPoolFailureNotificationRegistrationsSpectraS3Request *GetPoolFailureNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetPoolFailureNotificationRegistrationsSpectraS3Request {
-    getPoolFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getPoolFailureNotificationRegistrationsSpectraS3Request
+	getPoolFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getPoolFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getPoolFailureNotificationRegistrationsSpectraS3Request *GetPoolFailureNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetPoolFailureNotificationRegistrationsSpectraS3Request {
-    getPoolFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getPoolFailureNotificationRegistrationsSpectraS3Request
+	getPoolFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getPoolFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getPoolFailureNotificationRegistrationsSpectraS3Request *GetPoolFailureNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetPoolFailureNotificationRegistrationsSpectraS3Request {
-    getPoolFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getPoolFailureNotificationRegistrationsSpectraS3Request
+	getPoolFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getPoolFailureNotificationRegistrationsSpectraS3Request
 }
 
 type GetS3TargetFailureNotificationRegistrationSpectraS3Request struct {
-    S3TargetFailureNotificationRegistration string
+	S3TargetFailureNotificationRegistration string
 }
 
 func NewGetS3TargetFailureNotificationRegistrationSpectraS3Request(s3TargetFailureNotificationRegistration string) *GetS3TargetFailureNotificationRegistrationSpectraS3Request {
-    return &GetS3TargetFailureNotificationRegistrationSpectraS3Request{
-        S3TargetFailureNotificationRegistration: s3TargetFailureNotificationRegistration,
-    }
+	return &GetS3TargetFailureNotificationRegistrationSpectraS3Request{
+		S3TargetFailureNotificationRegistration: s3TargetFailureNotificationRegistration,
+	}
 }
 
 type GetS3TargetFailureNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetS3TargetFailureNotificationRegistrationsSpectraS3Request() *GetS3TargetFailureNotificationRegistrationsSpectraS3Request {
-    return &GetS3TargetFailureNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetS3TargetFailureNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getS3TargetFailureNotificationRegistrationsSpectraS3Request *GetS3TargetFailureNotificationRegistrationsSpectraS3Request) WithLastPage() *GetS3TargetFailureNotificationRegistrationsSpectraS3Request {
-    getS3TargetFailureNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getS3TargetFailureNotificationRegistrationsSpectraS3Request
+	getS3TargetFailureNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getS3TargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getS3TargetFailureNotificationRegistrationsSpectraS3Request *GetS3TargetFailureNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetS3TargetFailureNotificationRegistrationsSpectraS3Request {
-    getS3TargetFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getS3TargetFailureNotificationRegistrationsSpectraS3Request
+	getS3TargetFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getS3TargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getS3TargetFailureNotificationRegistrationsSpectraS3Request *GetS3TargetFailureNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetS3TargetFailureNotificationRegistrationsSpectraS3Request {
-    getS3TargetFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getS3TargetFailureNotificationRegistrationsSpectraS3Request
+	getS3TargetFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getS3TargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getS3TargetFailureNotificationRegistrationsSpectraS3Request *GetS3TargetFailureNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetS3TargetFailureNotificationRegistrationsSpectraS3Request {
-    getS3TargetFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getS3TargetFailureNotificationRegistrationsSpectraS3Request
+	getS3TargetFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getS3TargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getS3TargetFailureNotificationRegistrationsSpectraS3Request *GetS3TargetFailureNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetS3TargetFailureNotificationRegistrationsSpectraS3Request {
-    getS3TargetFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getS3TargetFailureNotificationRegistrationsSpectraS3Request
+	getS3TargetFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getS3TargetFailureNotificationRegistrationsSpectraS3Request
 }
 
 type GetStorageDomainFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetStorageDomainFailureNotificationRegistrationSpectraS3Request(notificationId string) *GetStorageDomainFailureNotificationRegistrationSpectraS3Request {
-    return &GetStorageDomainFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetStorageDomainFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetStorageDomainFailureNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetStorageDomainFailureNotificationRegistrationsSpectraS3Request() *GetStorageDomainFailureNotificationRegistrationsSpectraS3Request {
-    return &GetStorageDomainFailureNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetStorageDomainFailureNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getStorageDomainFailureNotificationRegistrationsSpectraS3Request *GetStorageDomainFailureNotificationRegistrationsSpectraS3Request) WithLastPage() *GetStorageDomainFailureNotificationRegistrationsSpectraS3Request {
-    getStorageDomainFailureNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getStorageDomainFailureNotificationRegistrationsSpectraS3Request
+	getStorageDomainFailureNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getStorageDomainFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getStorageDomainFailureNotificationRegistrationsSpectraS3Request *GetStorageDomainFailureNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetStorageDomainFailureNotificationRegistrationsSpectraS3Request {
-    getStorageDomainFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getStorageDomainFailureNotificationRegistrationsSpectraS3Request
+	getStorageDomainFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getStorageDomainFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getStorageDomainFailureNotificationRegistrationsSpectraS3Request *GetStorageDomainFailureNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetStorageDomainFailureNotificationRegistrationsSpectraS3Request {
-    getStorageDomainFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getStorageDomainFailureNotificationRegistrationsSpectraS3Request
+	getStorageDomainFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getStorageDomainFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getStorageDomainFailureNotificationRegistrationsSpectraS3Request *GetStorageDomainFailureNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetStorageDomainFailureNotificationRegistrationsSpectraS3Request {
-    getStorageDomainFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getStorageDomainFailureNotificationRegistrationsSpectraS3Request
+	getStorageDomainFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getStorageDomainFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getStorageDomainFailureNotificationRegistrationsSpectraS3Request *GetStorageDomainFailureNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetStorageDomainFailureNotificationRegistrationsSpectraS3Request {
-    getStorageDomainFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getStorageDomainFailureNotificationRegistrationsSpectraS3Request
+	getStorageDomainFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getStorageDomainFailureNotificationRegistrationsSpectraS3Request
 }
 
 type GetSystemFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetSystemFailureNotificationRegistrationSpectraS3Request(notificationId string) *GetSystemFailureNotificationRegistrationSpectraS3Request {
-    return &GetSystemFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetSystemFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetSystemFailureNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetSystemFailureNotificationRegistrationsSpectraS3Request() *GetSystemFailureNotificationRegistrationsSpectraS3Request {
-    return &GetSystemFailureNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetSystemFailureNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getSystemFailureNotificationRegistrationsSpectraS3Request *GetSystemFailureNotificationRegistrationsSpectraS3Request) WithLastPage() *GetSystemFailureNotificationRegistrationsSpectraS3Request {
-    getSystemFailureNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getSystemFailureNotificationRegistrationsSpectraS3Request
+	getSystemFailureNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getSystemFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getSystemFailureNotificationRegistrationsSpectraS3Request *GetSystemFailureNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetSystemFailureNotificationRegistrationsSpectraS3Request {
-    getSystemFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getSystemFailureNotificationRegistrationsSpectraS3Request
+	getSystemFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getSystemFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getSystemFailureNotificationRegistrationsSpectraS3Request *GetSystemFailureNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetSystemFailureNotificationRegistrationsSpectraS3Request {
-    getSystemFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getSystemFailureNotificationRegistrationsSpectraS3Request
+	getSystemFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getSystemFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getSystemFailureNotificationRegistrationsSpectraS3Request *GetSystemFailureNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetSystemFailureNotificationRegistrationsSpectraS3Request {
-    getSystemFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getSystemFailureNotificationRegistrationsSpectraS3Request
+	getSystemFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getSystemFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getSystemFailureNotificationRegistrationsSpectraS3Request *GetSystemFailureNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetSystemFailureNotificationRegistrationsSpectraS3Request {
-    getSystemFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getSystemFailureNotificationRegistrationsSpectraS3Request
+	getSystemFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getSystemFailureNotificationRegistrationsSpectraS3Request
 }
 
 type GetTapeFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetTapeFailureNotificationRegistrationSpectraS3Request(notificationId string) *GetTapeFailureNotificationRegistrationSpectraS3Request {
-    return &GetTapeFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetTapeFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetTapeFailureNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetTapeFailureNotificationRegistrationsSpectraS3Request() *GetTapeFailureNotificationRegistrationsSpectraS3Request {
-    return &GetTapeFailureNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetTapeFailureNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getTapeFailureNotificationRegistrationsSpectraS3Request *GetTapeFailureNotificationRegistrationsSpectraS3Request) WithLastPage() *GetTapeFailureNotificationRegistrationsSpectraS3Request {
-    getTapeFailureNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getTapeFailureNotificationRegistrationsSpectraS3Request
+	getTapeFailureNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getTapeFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getTapeFailureNotificationRegistrationsSpectraS3Request *GetTapeFailureNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetTapeFailureNotificationRegistrationsSpectraS3Request {
-    getTapeFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getTapeFailureNotificationRegistrationsSpectraS3Request
+	getTapeFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getTapeFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getTapeFailureNotificationRegistrationsSpectraS3Request *GetTapeFailureNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetTapeFailureNotificationRegistrationsSpectraS3Request {
-    getTapeFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getTapeFailureNotificationRegistrationsSpectraS3Request
+	getTapeFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getTapeFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getTapeFailureNotificationRegistrationsSpectraS3Request *GetTapeFailureNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetTapeFailureNotificationRegistrationsSpectraS3Request {
-    getTapeFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getTapeFailureNotificationRegistrationsSpectraS3Request
+	getTapeFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getTapeFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getTapeFailureNotificationRegistrationsSpectraS3Request *GetTapeFailureNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetTapeFailureNotificationRegistrationsSpectraS3Request {
-    getTapeFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getTapeFailureNotificationRegistrationsSpectraS3Request
+	getTapeFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getTapeFailureNotificationRegistrationsSpectraS3Request
 }
 
 type GetTapePartitionFailureNotificationRegistrationSpectraS3Request struct {
-    NotificationId string
+	NotificationId string
 }
 
 func NewGetTapePartitionFailureNotificationRegistrationSpectraS3Request(notificationId string) *GetTapePartitionFailureNotificationRegistrationSpectraS3Request {
-    return &GetTapePartitionFailureNotificationRegistrationSpectraS3Request{
-        NotificationId: notificationId,
-    }
+	return &GetTapePartitionFailureNotificationRegistrationSpectraS3Request{
+		NotificationId: notificationId,
+	}
 }
 
 type GetTapePartitionFailureNotificationRegistrationsSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    UserId *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	UserId          *string
 }
 
 func NewGetTapePartitionFailureNotificationRegistrationsSpectraS3Request() *GetTapePartitionFailureNotificationRegistrationsSpectraS3Request {
-    return &GetTapePartitionFailureNotificationRegistrationsSpectraS3Request{
-    }
+	return &GetTapePartitionFailureNotificationRegistrationsSpectraS3Request{}
 }
 
 func (getTapePartitionFailureNotificationRegistrationsSpectraS3Request *GetTapePartitionFailureNotificationRegistrationsSpectraS3Request) WithLastPage() *GetTapePartitionFailureNotificationRegistrationsSpectraS3Request {
-    getTapePartitionFailureNotificationRegistrationsSpectraS3Request.LastPage = true
-    return getTapePartitionFailureNotificationRegistrationsSpectraS3Request
+	getTapePartitionFailureNotificationRegistrationsSpectraS3Request.LastPage = true
+	return getTapePartitionFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getTapePartitionFailureNotificationRegistrationsSpectraS3Request *GetTapePartitionFailureNotificationRegistrationsSpectraS3Request) WithPageLength(pageLength int) *GetTapePartitionFailureNotificationRegistrationsSpectraS3Request {
-    getTapePartitionFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
-    return getTapePartitionFailureNotificationRegistrationsSpectraS3Request
+	getTapePartitionFailureNotificationRegistrationsSpectraS3Request.PageLength = &pageLength
+	return getTapePartitionFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getTapePartitionFailureNotificationRegistrationsSpectraS3Request *GetTapePartitionFailureNotificationRegistrationsSpectraS3Request) WithPageOffset(pageOffset int) *GetTapePartitionFailureNotificationRegistrationsSpectraS3Request {
-    getTapePartitionFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
-    return getTapePartitionFailureNotificationRegistrationsSpectraS3Request
+	getTapePartitionFailureNotificationRegistrationsSpectraS3Request.PageOffset = &pageOffset
+	return getTapePartitionFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getTapePartitionFailureNotificationRegistrationsSpectraS3Request *GetTapePartitionFailureNotificationRegistrationsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetTapePartitionFailureNotificationRegistrationsSpectraS3Request {
-    getTapePartitionFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getTapePartitionFailureNotificationRegistrationsSpectraS3Request
+	getTapePartitionFailureNotificationRegistrationsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getTapePartitionFailureNotificationRegistrationsSpectraS3Request
 }
 
 func (getTapePartitionFailureNotificationRegistrationsSpectraS3Request *GetTapePartitionFailureNotificationRegistrationsSpectraS3Request) WithUserId(userId string) *GetTapePartitionFailureNotificationRegistrationsSpectraS3Request {
-    getTapePartitionFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
-    return getTapePartitionFailureNotificationRegistrationsSpectraS3Request
+	getTapePartitionFailureNotificationRegistrationsSpectraS3Request.UserId = &userId
+	return getTapePartitionFailureNotificationRegistrationsSpectraS3Request
 }
 
 type DeleteFolderRecursivelySpectraS3Request struct {
-    BucketId string
-    Folder string
+	BucketId string
+	Folder   string
 }
 
 func NewDeleteFolderRecursivelySpectraS3Request(bucketId string, folder string) *DeleteFolderRecursivelySpectraS3Request {
-    return &DeleteFolderRecursivelySpectraS3Request{
-        Folder: folder,
-        BucketId: bucketId,
-    }
+	return &DeleteFolderRecursivelySpectraS3Request{
+		Folder:   folder,
+		BucketId: bucketId,
+	}
 }
 
 type GetBlobPersistenceSpectraS3Request struct {
-    RequestPayload string
+	RequestPayload string
 }
 
 func NewGetBlobPersistenceSpectraS3Request(requestPayload string) *GetBlobPersistenceSpectraS3Request {
-    return &GetBlobPersistenceSpectraS3Request{
-        RequestPayload: requestPayload,
-    }
+	return &GetBlobPersistenceSpectraS3Request{
+		RequestPayload: requestPayload,
+	}
 }
 
 type GetObjectDetailsSpectraS3Request struct {
-    ObjectName string
-    BucketId string
+	ObjectName string
+	BucketId   string
 }
 
 func NewGetObjectDetailsSpectraS3Request(objectName string, bucketId string) *GetObjectDetailsSpectraS3Request {
-    return &GetObjectDetailsSpectraS3Request{
-        ObjectName: objectName,
-        BucketId: bucketId,
-    }
+	return &GetObjectDetailsSpectraS3Request{
+		ObjectName: objectName,
+		BucketId:   bucketId,
+	}
 }
 
 type GetObjectsDetailsSpectraS3Request struct {
-    BucketId *string
-    EndDate *int64
-    LastPage bool
-    Latest *bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    S3ObjectType S3ObjectType
-    StartDate *int64
+	BucketId        *string
+	EndDate         *int64
+	LastPage        bool
+	Latest          *bool
+	Name            *string
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	S3ObjectType    S3ObjectType
+	StartDate       *int64
 }
 
 func NewGetObjectsDetailsSpectraS3Request() *GetObjectsDetailsSpectraS3Request {
-    return &GetObjectsDetailsSpectraS3Request{
-    }
+	return &GetObjectsDetailsSpectraS3Request{}
 }
 
 func (getObjectsDetailsSpectraS3Request *GetObjectsDetailsSpectraS3Request) WithBucketId(bucketId string) *GetObjectsDetailsSpectraS3Request {
-    getObjectsDetailsSpectraS3Request.BucketId = &bucketId
-    return getObjectsDetailsSpectraS3Request
+	getObjectsDetailsSpectraS3Request.BucketId = &bucketId
+	return getObjectsDetailsSpectraS3Request
 }
 
 func (getObjectsDetailsSpectraS3Request *GetObjectsDetailsSpectraS3Request) WithEndDate(endDate int64) *GetObjectsDetailsSpectraS3Request {
-    getObjectsDetailsSpectraS3Request.EndDate = &endDate
-    return getObjectsDetailsSpectraS3Request
+	getObjectsDetailsSpectraS3Request.EndDate = &endDate
+	return getObjectsDetailsSpectraS3Request
 }
 
 func (getObjectsDetailsSpectraS3Request *GetObjectsDetailsSpectraS3Request) WithLastPage() *GetObjectsDetailsSpectraS3Request {
-    getObjectsDetailsSpectraS3Request.LastPage = true
-    return getObjectsDetailsSpectraS3Request
+	getObjectsDetailsSpectraS3Request.LastPage = true
+	return getObjectsDetailsSpectraS3Request
 }
 
 func (getObjectsDetailsSpectraS3Request *GetObjectsDetailsSpectraS3Request) WithLatest(latest bool) *GetObjectsDetailsSpectraS3Request {
-    getObjectsDetailsSpectraS3Request.Latest = &latest
-    return getObjectsDetailsSpectraS3Request
+	getObjectsDetailsSpectraS3Request.Latest = &latest
+	return getObjectsDetailsSpectraS3Request
 }
 
 func (getObjectsDetailsSpectraS3Request *GetObjectsDetailsSpectraS3Request) WithName(name string) *GetObjectsDetailsSpectraS3Request {
-    getObjectsDetailsSpectraS3Request.Name = &name
-    return getObjectsDetailsSpectraS3Request
+	getObjectsDetailsSpectraS3Request.Name = &name
+	return getObjectsDetailsSpectraS3Request
 }
 
 func (getObjectsDetailsSpectraS3Request *GetObjectsDetailsSpectraS3Request) WithPageLength(pageLength int) *GetObjectsDetailsSpectraS3Request {
-    getObjectsDetailsSpectraS3Request.PageLength = &pageLength
-    return getObjectsDetailsSpectraS3Request
+	getObjectsDetailsSpectraS3Request.PageLength = &pageLength
+	return getObjectsDetailsSpectraS3Request
 }
 
 func (getObjectsDetailsSpectraS3Request *GetObjectsDetailsSpectraS3Request) WithPageOffset(pageOffset int) *GetObjectsDetailsSpectraS3Request {
-    getObjectsDetailsSpectraS3Request.PageOffset = &pageOffset
-    return getObjectsDetailsSpectraS3Request
+	getObjectsDetailsSpectraS3Request.PageOffset = &pageOffset
+	return getObjectsDetailsSpectraS3Request
 }
 
 func (getObjectsDetailsSpectraS3Request *GetObjectsDetailsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetObjectsDetailsSpectraS3Request {
-    getObjectsDetailsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getObjectsDetailsSpectraS3Request
+	getObjectsDetailsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getObjectsDetailsSpectraS3Request
 }
 
 func (getObjectsDetailsSpectraS3Request *GetObjectsDetailsSpectraS3Request) WithStartDate(startDate int64) *GetObjectsDetailsSpectraS3Request {
-    getObjectsDetailsSpectraS3Request.StartDate = &startDate
-    return getObjectsDetailsSpectraS3Request
+	getObjectsDetailsSpectraS3Request.StartDate = &startDate
+	return getObjectsDetailsSpectraS3Request
 }
 
 func (getObjectsDetailsSpectraS3Request *GetObjectsDetailsSpectraS3Request) WithS3ObjectType(s3ObjectType S3ObjectType) *GetObjectsDetailsSpectraS3Request {
-    getObjectsDetailsSpectraS3Request.S3ObjectType = s3ObjectType
-    return getObjectsDetailsSpectraS3Request
+	getObjectsDetailsSpectraS3Request.S3ObjectType = s3ObjectType
+	return getObjectsDetailsSpectraS3Request
 }
 
 type GetObjectsWithFullDetailsSpectraS3Request struct {
-    BucketId *string
-    EndDate *int64
-    IncludePhysicalPlacement bool
-    LastPage bool
-    Latest *bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    S3ObjectType S3ObjectType
-    StartDate *int64
+	BucketId                 *string
+	EndDate                  *int64
+	IncludePhysicalPlacement bool
+	LastPage                 bool
+	Latest                   *bool
+	Name                     *string
+	PageLength               *int
+	PageOffset               *int
+	PageStartMarker          *string
+	S3ObjectType             S3ObjectType
+	StartDate                *int64
 }
 
 func NewGetObjectsWithFullDetailsSpectraS3Request() *GetObjectsWithFullDetailsSpectraS3Request {
-    return &GetObjectsWithFullDetailsSpectraS3Request{
-    }
+	return &GetObjectsWithFullDetailsSpectraS3Request{}
 }
 
 func (getObjectsWithFullDetailsSpectraS3Request *GetObjectsWithFullDetailsSpectraS3Request) WithBucketId(bucketId string) *GetObjectsWithFullDetailsSpectraS3Request {
-    getObjectsWithFullDetailsSpectraS3Request.BucketId = &bucketId
-    return getObjectsWithFullDetailsSpectraS3Request
+	getObjectsWithFullDetailsSpectraS3Request.BucketId = &bucketId
+	return getObjectsWithFullDetailsSpectraS3Request
 }
 
 func (getObjectsWithFullDetailsSpectraS3Request *GetObjectsWithFullDetailsSpectraS3Request) WithEndDate(endDate int64) *GetObjectsWithFullDetailsSpectraS3Request {
-    getObjectsWithFullDetailsSpectraS3Request.EndDate = &endDate
-    return getObjectsWithFullDetailsSpectraS3Request
+	getObjectsWithFullDetailsSpectraS3Request.EndDate = &endDate
+	return getObjectsWithFullDetailsSpectraS3Request
 }
 
 func (getObjectsWithFullDetailsSpectraS3Request *GetObjectsWithFullDetailsSpectraS3Request) WithIncludePhysicalPlacement() *GetObjectsWithFullDetailsSpectraS3Request {
-    getObjectsWithFullDetailsSpectraS3Request.IncludePhysicalPlacement = true
-    return getObjectsWithFullDetailsSpectraS3Request
+	getObjectsWithFullDetailsSpectraS3Request.IncludePhysicalPlacement = true
+	return getObjectsWithFullDetailsSpectraS3Request
 }
 
 func (getObjectsWithFullDetailsSpectraS3Request *GetObjectsWithFullDetailsSpectraS3Request) WithLastPage() *GetObjectsWithFullDetailsSpectraS3Request {
-    getObjectsWithFullDetailsSpectraS3Request.LastPage = true
-    return getObjectsWithFullDetailsSpectraS3Request
+	getObjectsWithFullDetailsSpectraS3Request.LastPage = true
+	return getObjectsWithFullDetailsSpectraS3Request
 }
 
 func (getObjectsWithFullDetailsSpectraS3Request *GetObjectsWithFullDetailsSpectraS3Request) WithLatest(latest bool) *GetObjectsWithFullDetailsSpectraS3Request {
-    getObjectsWithFullDetailsSpectraS3Request.Latest = &latest
-    return getObjectsWithFullDetailsSpectraS3Request
+	getObjectsWithFullDetailsSpectraS3Request.Latest = &latest
+	return getObjectsWithFullDetailsSpectraS3Request
 }
 
 func (getObjectsWithFullDetailsSpectraS3Request *GetObjectsWithFullDetailsSpectraS3Request) WithName(name string) *GetObjectsWithFullDetailsSpectraS3Request {
-    getObjectsWithFullDetailsSpectraS3Request.Name = &name
-    return getObjectsWithFullDetailsSpectraS3Request
+	getObjectsWithFullDetailsSpectraS3Request.Name = &name
+	return getObjectsWithFullDetailsSpectraS3Request
 }
 
 func (getObjectsWithFullDetailsSpectraS3Request *GetObjectsWithFullDetailsSpectraS3Request) WithPageLength(pageLength int) *GetObjectsWithFullDetailsSpectraS3Request {
-    getObjectsWithFullDetailsSpectraS3Request.PageLength = &pageLength
-    return getObjectsWithFullDetailsSpectraS3Request
+	getObjectsWithFullDetailsSpectraS3Request.PageLength = &pageLength
+	return getObjectsWithFullDetailsSpectraS3Request
 }
 
 func (getObjectsWithFullDetailsSpectraS3Request *GetObjectsWithFullDetailsSpectraS3Request) WithPageOffset(pageOffset int) *GetObjectsWithFullDetailsSpectraS3Request {
-    getObjectsWithFullDetailsSpectraS3Request.PageOffset = &pageOffset
-    return getObjectsWithFullDetailsSpectraS3Request
+	getObjectsWithFullDetailsSpectraS3Request.PageOffset = &pageOffset
+	return getObjectsWithFullDetailsSpectraS3Request
 }
 
 func (getObjectsWithFullDetailsSpectraS3Request *GetObjectsWithFullDetailsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetObjectsWithFullDetailsSpectraS3Request {
-    getObjectsWithFullDetailsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getObjectsWithFullDetailsSpectraS3Request
+	getObjectsWithFullDetailsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getObjectsWithFullDetailsSpectraS3Request
 }
 
 func (getObjectsWithFullDetailsSpectraS3Request *GetObjectsWithFullDetailsSpectraS3Request) WithStartDate(startDate int64) *GetObjectsWithFullDetailsSpectraS3Request {
-    getObjectsWithFullDetailsSpectraS3Request.StartDate = &startDate
-    return getObjectsWithFullDetailsSpectraS3Request
+	getObjectsWithFullDetailsSpectraS3Request.StartDate = &startDate
+	return getObjectsWithFullDetailsSpectraS3Request
 }
 
 func (getObjectsWithFullDetailsSpectraS3Request *GetObjectsWithFullDetailsSpectraS3Request) WithS3ObjectType(s3ObjectType S3ObjectType) *GetObjectsWithFullDetailsSpectraS3Request {
-    getObjectsWithFullDetailsSpectraS3Request.S3ObjectType = s3ObjectType
-    return getObjectsWithFullDetailsSpectraS3Request
+	getObjectsWithFullDetailsSpectraS3Request.S3ObjectType = s3ObjectType
+	return getObjectsWithFullDetailsSpectraS3Request
 }
 
 type GetPhysicalPlacementForObjectsSpectraS3Request struct {
-    BucketName string
-    Objects []Ds3GetObject
-    StorageDomain *string
+	BucketName    string
+	Objects       []Ds3GetObject
+	StorageDomain *string
 }
 
 func NewGetPhysicalPlacementForObjectsSpectraS3Request(bucketName string, objectNames []string) *GetPhysicalPlacementForObjectsSpectraS3Request {
 
-    return &GetPhysicalPlacementForObjectsSpectraS3Request{
-        BucketName: bucketName,
-        Objects: buildDs3GetObjectSliceFromNames(objectNames),
-    }
+	return &GetPhysicalPlacementForObjectsSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
+	}
 }
 
 func NewGetPhysicalPlacementForObjectsSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *GetPhysicalPlacementForObjectsSpectraS3Request {
 
-    return &GetPhysicalPlacementForObjectsSpectraS3Request{
-        BucketName: bucketName,
-        Objects: objects,
-    }
+	return &GetPhysicalPlacementForObjectsSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    objects,
+	}
 }
 
 func (getPhysicalPlacementForObjectsSpectraS3Request *GetPhysicalPlacementForObjectsSpectraS3Request) WithStorageDomain(storageDomain string) *GetPhysicalPlacementForObjectsSpectraS3Request {
-    getPhysicalPlacementForObjectsSpectraS3Request.StorageDomain = &storageDomain
-    return getPhysicalPlacementForObjectsSpectraS3Request
+	getPhysicalPlacementForObjectsSpectraS3Request.StorageDomain = &storageDomain
+	return getPhysicalPlacementForObjectsSpectraS3Request
 }
 
 type GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request struct {
-    BucketName string
-    Objects []Ds3GetObject
-    StorageDomain *string
+	BucketName    string
+	Objects       []Ds3GetObject
+	StorageDomain *string
 }
 
 func NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName string, objectNames []string) *GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
 
-    return &GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
-        BucketName: bucketName,
-        Objects: buildDs3GetObjectSliceFromNames(objectNames),
-    }
+	return &GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
+	}
 }
 
 func NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
 
-    return &GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
-        BucketName: bucketName,
-        Objects: objects,
-    }
+	return &GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    objects,
+	}
 }
 
 func (getPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request *GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request) WithStorageDomain(storageDomain string) *GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
-    getPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request.StorageDomain = &storageDomain
-    return getPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request
+	getPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request.StorageDomain = &storageDomain
+	return getPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request
 }
 
 type UndeleteObjectSpectraS3Request struct {
-    BucketId string
-    Name string
-    VersionId *string
+	BucketId  string
+	Name      string
+	VersionId *string
 }
 
 func NewUndeleteObjectSpectraS3Request(bucketId string, name string) *UndeleteObjectSpectraS3Request {
-    return &UndeleteObjectSpectraS3Request{
-        BucketId: bucketId,
-        Name: name,
-    }
+	return &UndeleteObjectSpectraS3Request{
+		BucketId: bucketId,
+		Name:     name,
+	}
 }
 
 func (undeleteObjectSpectraS3Request *UndeleteObjectSpectraS3Request) WithVersionId(versionId string) *UndeleteObjectSpectraS3Request {
-    undeleteObjectSpectraS3Request.VersionId = &versionId
-    return undeleteObjectSpectraS3Request
+	undeleteObjectSpectraS3Request.VersionId = &versionId
+	return undeleteObjectSpectraS3Request
 }
 
 type VerifyPhysicalPlacementForObjectsSpectraS3Request struct {
-    BucketName string
-    Objects []Ds3GetObject
-    StorageDomain *string
+	BucketName    string
+	Objects       []Ds3GetObject
+	StorageDomain *string
 }
 
 func NewVerifyPhysicalPlacementForObjectsSpectraS3Request(bucketName string, objectNames []string) *VerifyPhysicalPlacementForObjectsSpectraS3Request {
 
-    return &VerifyPhysicalPlacementForObjectsSpectraS3Request{
-        BucketName: bucketName,
-        Objects: buildDs3GetObjectSliceFromNames(objectNames),
-    }
+	return &VerifyPhysicalPlacementForObjectsSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
+	}
 }
 
 func NewVerifyPhysicalPlacementForObjectsSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *VerifyPhysicalPlacementForObjectsSpectraS3Request {
 
-    return &VerifyPhysicalPlacementForObjectsSpectraS3Request{
-        BucketName: bucketName,
-        Objects: objects,
-    }
+	return &VerifyPhysicalPlacementForObjectsSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    objects,
+	}
 }
 
 func (verifyPhysicalPlacementForObjectsSpectraS3Request *VerifyPhysicalPlacementForObjectsSpectraS3Request) WithStorageDomain(storageDomain string) *VerifyPhysicalPlacementForObjectsSpectraS3Request {
-    verifyPhysicalPlacementForObjectsSpectraS3Request.StorageDomain = &storageDomain
-    return verifyPhysicalPlacementForObjectsSpectraS3Request
+	verifyPhysicalPlacementForObjectsSpectraS3Request.StorageDomain = &storageDomain
+	return verifyPhysicalPlacementForObjectsSpectraS3Request
 }
 
 type VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request struct {
-    BucketName string
-    Objects []Ds3GetObject
-    StorageDomain *string
+	BucketName    string
+	Objects       []Ds3GetObject
+	StorageDomain *string
 }
 
 func NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName string, objectNames []string) *VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
 
-    return &VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
-        BucketName: bucketName,
-        Objects: buildDs3GetObjectSliceFromNames(objectNames),
-    }
+	return &VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
+	}
 }
 
 func NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
 
-    return &VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
-        BucketName: bucketName,
-        Objects: objects,
-    }
+	return &VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
+		BucketName: bucketName,
+		Objects:    objects,
+	}
 }
 
 func (verifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request *VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request) WithStorageDomain(storageDomain string) *VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
-    verifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request.StorageDomain = &storageDomain
-    return verifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request
+	verifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request.StorageDomain = &storageDomain
+	return verifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request
 }
 
 type CancelImportOnAllPoolsSpectraS3Request struct {
 }
 
 func NewCancelImportOnAllPoolsSpectraS3Request() *CancelImportOnAllPoolsSpectraS3Request {
-    return &CancelImportOnAllPoolsSpectraS3Request{
-    }
+	return &CancelImportOnAllPoolsSpectraS3Request{}
 }
 
 type CancelImportPoolSpectraS3Request struct {
-    Pool string
+	Pool string
 }
 
 func NewCancelImportPoolSpectraS3Request(pool string) *CancelImportPoolSpectraS3Request {
-    return &CancelImportPoolSpectraS3Request{
-        Pool: pool,
-    }
+	return &CancelImportPoolSpectraS3Request{
+		Pool: pool,
+	}
 }
 
 type CancelVerifyOnAllPoolsSpectraS3Request struct {
 }
 
 func NewCancelVerifyOnAllPoolsSpectraS3Request() *CancelVerifyOnAllPoolsSpectraS3Request {
-    return &CancelVerifyOnAllPoolsSpectraS3Request{
-    }
+	return &CancelVerifyOnAllPoolsSpectraS3Request{}
 }
 
 type CancelVerifyPoolSpectraS3Request struct {
-    Pool string
+	Pool string
 }
 
 func NewCancelVerifyPoolSpectraS3Request(pool string) *CancelVerifyPoolSpectraS3Request {
-    return &CancelVerifyPoolSpectraS3Request{
-        Pool: pool,
-    }
+	return &CancelVerifyPoolSpectraS3Request{
+		Pool: pool,
+	}
 }
 
 type CompactAllPoolsSpectraS3Request struct {
-    Priority Priority
+	Priority Priority
 }
 
 func NewCompactAllPoolsSpectraS3Request() *CompactAllPoolsSpectraS3Request {
-    return &CompactAllPoolsSpectraS3Request{
-    }
+	return &CompactAllPoolsSpectraS3Request{}
 }
 
 func (compactAllPoolsSpectraS3Request *CompactAllPoolsSpectraS3Request) WithPriority(priority Priority) *CompactAllPoolsSpectraS3Request {
-    compactAllPoolsSpectraS3Request.Priority = priority
-    return compactAllPoolsSpectraS3Request
+	compactAllPoolsSpectraS3Request.Priority = priority
+	return compactAllPoolsSpectraS3Request
 }
 
 type CompactPoolSpectraS3Request struct {
-    Pool string
-    Priority Priority
+	Pool     string
+	Priority Priority
 }
 
 func NewCompactPoolSpectraS3Request(pool string) *CompactPoolSpectraS3Request {
-    return &CompactPoolSpectraS3Request{
-        Pool: pool,
-    }
+	return &CompactPoolSpectraS3Request{
+		Pool: pool,
+	}
 }
 
 func (compactPoolSpectraS3Request *CompactPoolSpectraS3Request) WithPriority(priority Priority) *CompactPoolSpectraS3Request {
-    compactPoolSpectraS3Request.Priority = priority
-    return compactPoolSpectraS3Request
+	compactPoolSpectraS3Request.Priority = priority
+	return compactPoolSpectraS3Request
 }
 
 type PutPoolPartitionSpectraS3Request struct {
-    Name string
-    PoolType PoolType
+	Name     string
+	PoolType PoolType
 }
 
 func NewPutPoolPartitionSpectraS3Request(name string, poolType PoolType) *PutPoolPartitionSpectraS3Request {
-    return &PutPoolPartitionSpectraS3Request{
-        Name: name,
-        PoolType: poolType,
-    }
+	return &PutPoolPartitionSpectraS3Request{
+		Name:     name,
+		PoolType: poolType,
+	}
 }
 
 type DeallocatePoolSpectraS3Request struct {
-    Pool string
+	Pool string
 }
 
 func NewDeallocatePoolSpectraS3Request(pool string) *DeallocatePoolSpectraS3Request {
-    return &DeallocatePoolSpectraS3Request{
-        Pool: pool,
-    }
+	return &DeallocatePoolSpectraS3Request{
+		Pool: pool,
+	}
 }
 
 type DeletePermanentlyLostPoolSpectraS3Request struct {
-    Pool string
+	Pool string
 }
 
 func NewDeletePermanentlyLostPoolSpectraS3Request(pool string) *DeletePermanentlyLostPoolSpectraS3Request {
-    return &DeletePermanentlyLostPoolSpectraS3Request{
-        Pool: pool,
-    }
+	return &DeletePermanentlyLostPoolSpectraS3Request{
+		Pool: pool,
+	}
 }
 
 type DeletePoolFailureSpectraS3Request struct {
-    PoolFailure string
+	PoolFailure string
 }
 
 func NewDeletePoolFailureSpectraS3Request(poolFailure string) *DeletePoolFailureSpectraS3Request {
-    return &DeletePoolFailureSpectraS3Request{
-        PoolFailure: poolFailure,
-    }
+	return &DeletePoolFailureSpectraS3Request{
+		PoolFailure: poolFailure,
+	}
 }
 
 type DeletePoolPartitionSpectraS3Request struct {
-    PoolPartition string
+	PoolPartition string
 }
 
 func NewDeletePoolPartitionSpectraS3Request(poolPartition string) *DeletePoolPartitionSpectraS3Request {
-    return &DeletePoolPartitionSpectraS3Request{
-        PoolPartition: poolPartition,
-    }
+	return &DeletePoolPartitionSpectraS3Request{
+		PoolPartition: poolPartition,
+	}
 }
 
 type ForcePoolEnvironmentRefreshSpectraS3Request struct {
 }
 
 func NewForcePoolEnvironmentRefreshSpectraS3Request() *ForcePoolEnvironmentRefreshSpectraS3Request {
-    return &ForcePoolEnvironmentRefreshSpectraS3Request{
-    }
+	return &ForcePoolEnvironmentRefreshSpectraS3Request{}
 }
 
 type FormatAllForeignPoolsSpectraS3Request struct {
 }
 
 func NewFormatAllForeignPoolsSpectraS3Request() *FormatAllForeignPoolsSpectraS3Request {
-    return &FormatAllForeignPoolsSpectraS3Request{
-    }
+	return &FormatAllForeignPoolsSpectraS3Request{}
 }
 
 type FormatForeignPoolSpectraS3Request struct {
-    Pool string
+	Pool string
 }
 
 func NewFormatForeignPoolSpectraS3Request(pool string) *FormatForeignPoolSpectraS3Request {
-    return &FormatForeignPoolSpectraS3Request{
-        Pool: pool,
-    }
+	return &FormatForeignPoolSpectraS3Request{
+		Pool: pool,
+	}
 }
 
 type GetBlobsOnPoolSpectraS3Request struct {
-    Pool string
+	Pool string
 }
 
 func NewGetBlobsOnPoolSpectraS3Request(pool string) *GetBlobsOnPoolSpectraS3Request {
-    return &GetBlobsOnPoolSpectraS3Request{
-        Pool: pool,
-    }
+	return &GetBlobsOnPoolSpectraS3Request{
+		Pool: pool,
+	}
 }
 
 type GetPoolFailuresSpectraS3Request struct {
-    ErrorMessage *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PoolFailureType PoolFailureType
-    PoolId *string
+	ErrorMessage    *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	PoolFailureType PoolFailureType
+	PoolId          *string
 }
 
 func NewGetPoolFailuresSpectraS3Request() *GetPoolFailuresSpectraS3Request {
-    return &GetPoolFailuresSpectraS3Request{
-    }
+	return &GetPoolFailuresSpectraS3Request{}
 }
 
 func (getPoolFailuresSpectraS3Request *GetPoolFailuresSpectraS3Request) WithErrorMessage(errorMessage string) *GetPoolFailuresSpectraS3Request {
-    getPoolFailuresSpectraS3Request.ErrorMessage = &errorMessage
-    return getPoolFailuresSpectraS3Request
+	getPoolFailuresSpectraS3Request.ErrorMessage = &errorMessage
+	return getPoolFailuresSpectraS3Request
 }
 
 func (getPoolFailuresSpectraS3Request *GetPoolFailuresSpectraS3Request) WithLastPage() *GetPoolFailuresSpectraS3Request {
-    getPoolFailuresSpectraS3Request.LastPage = true
-    return getPoolFailuresSpectraS3Request
+	getPoolFailuresSpectraS3Request.LastPage = true
+	return getPoolFailuresSpectraS3Request
 }
 
 func (getPoolFailuresSpectraS3Request *GetPoolFailuresSpectraS3Request) WithPageLength(pageLength int) *GetPoolFailuresSpectraS3Request {
-    getPoolFailuresSpectraS3Request.PageLength = &pageLength
-    return getPoolFailuresSpectraS3Request
+	getPoolFailuresSpectraS3Request.PageLength = &pageLength
+	return getPoolFailuresSpectraS3Request
 }
 
 func (getPoolFailuresSpectraS3Request *GetPoolFailuresSpectraS3Request) WithPageOffset(pageOffset int) *GetPoolFailuresSpectraS3Request {
-    getPoolFailuresSpectraS3Request.PageOffset = &pageOffset
-    return getPoolFailuresSpectraS3Request
+	getPoolFailuresSpectraS3Request.PageOffset = &pageOffset
+	return getPoolFailuresSpectraS3Request
 }
 
 func (getPoolFailuresSpectraS3Request *GetPoolFailuresSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetPoolFailuresSpectraS3Request {
-    getPoolFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getPoolFailuresSpectraS3Request
+	getPoolFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getPoolFailuresSpectraS3Request
 }
 
 func (getPoolFailuresSpectraS3Request *GetPoolFailuresSpectraS3Request) WithPoolId(poolId string) *GetPoolFailuresSpectraS3Request {
-    getPoolFailuresSpectraS3Request.PoolId = &poolId
-    return getPoolFailuresSpectraS3Request
+	getPoolFailuresSpectraS3Request.PoolId = &poolId
+	return getPoolFailuresSpectraS3Request
 }
 
 func (getPoolFailuresSpectraS3Request *GetPoolFailuresSpectraS3Request) WithPoolFailureType(poolFailureType PoolFailureType) *GetPoolFailuresSpectraS3Request {
-    getPoolFailuresSpectraS3Request.PoolFailureType = poolFailureType
-    return getPoolFailuresSpectraS3Request
+	getPoolFailuresSpectraS3Request.PoolFailureType = poolFailureType
+	return getPoolFailuresSpectraS3Request
 }
 
 type GetPoolPartitionSpectraS3Request struct {
-    PoolPartition string
+	PoolPartition string
 }
 
 func NewGetPoolPartitionSpectraS3Request(poolPartition string) *GetPoolPartitionSpectraS3Request {
-    return &GetPoolPartitionSpectraS3Request{
-        PoolPartition: poolPartition,
-    }
+	return &GetPoolPartitionSpectraS3Request{
+		PoolPartition: poolPartition,
+	}
 }
 
 type GetPoolPartitionsSpectraS3Request struct {
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PoolType PoolType
+	LastPage        bool
+	Name            *string
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	PoolType        PoolType
 }
 
 func NewGetPoolPartitionsSpectraS3Request() *GetPoolPartitionsSpectraS3Request {
-    return &GetPoolPartitionsSpectraS3Request{
-    }
+	return &GetPoolPartitionsSpectraS3Request{}
 }
 
 func (getPoolPartitionsSpectraS3Request *GetPoolPartitionsSpectraS3Request) WithLastPage() *GetPoolPartitionsSpectraS3Request {
-    getPoolPartitionsSpectraS3Request.LastPage = true
-    return getPoolPartitionsSpectraS3Request
+	getPoolPartitionsSpectraS3Request.LastPage = true
+	return getPoolPartitionsSpectraS3Request
 }
 
 func (getPoolPartitionsSpectraS3Request *GetPoolPartitionsSpectraS3Request) WithName(name string) *GetPoolPartitionsSpectraS3Request {
-    getPoolPartitionsSpectraS3Request.Name = &name
-    return getPoolPartitionsSpectraS3Request
+	getPoolPartitionsSpectraS3Request.Name = &name
+	return getPoolPartitionsSpectraS3Request
 }
 
 func (getPoolPartitionsSpectraS3Request *GetPoolPartitionsSpectraS3Request) WithPageLength(pageLength int) *GetPoolPartitionsSpectraS3Request {
-    getPoolPartitionsSpectraS3Request.PageLength = &pageLength
-    return getPoolPartitionsSpectraS3Request
+	getPoolPartitionsSpectraS3Request.PageLength = &pageLength
+	return getPoolPartitionsSpectraS3Request
 }
 
 func (getPoolPartitionsSpectraS3Request *GetPoolPartitionsSpectraS3Request) WithPageOffset(pageOffset int) *GetPoolPartitionsSpectraS3Request {
-    getPoolPartitionsSpectraS3Request.PageOffset = &pageOffset
-    return getPoolPartitionsSpectraS3Request
+	getPoolPartitionsSpectraS3Request.PageOffset = &pageOffset
+	return getPoolPartitionsSpectraS3Request
 }
 
 func (getPoolPartitionsSpectraS3Request *GetPoolPartitionsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetPoolPartitionsSpectraS3Request {
-    getPoolPartitionsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getPoolPartitionsSpectraS3Request
+	getPoolPartitionsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getPoolPartitionsSpectraS3Request
 }
 
 func (getPoolPartitionsSpectraS3Request *GetPoolPartitionsSpectraS3Request) WithPoolType(poolType PoolType) *GetPoolPartitionsSpectraS3Request {
-    getPoolPartitionsSpectraS3Request.PoolType = poolType
-    return getPoolPartitionsSpectraS3Request
+	getPoolPartitionsSpectraS3Request.PoolType = poolType
+	return getPoolPartitionsSpectraS3Request
 }
 
 type GetPoolSpectraS3Request struct {
-    Pool string
+	Pool string
 }
 
 func NewGetPoolSpectraS3Request(pool string) *GetPoolSpectraS3Request {
-    return &GetPoolSpectraS3Request{
-        Pool: pool,
-    }
+	return &GetPoolSpectraS3Request{
+		Pool: pool,
+	}
 }
 
 type GetPoolsSpectraS3Request struct {
-    AssignedToStorageDomain *bool
-    BucketId *string
-    Guid *string
-    Health PoolHealth
-    LastPage bool
-    LastVerified *string
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PartitionId *string
-    PoolType PoolType
-    PoweredOn *bool
-    State PoolState
-    StorageDomainMemberId *string
+	AssignedToStorageDomain *bool
+	BucketId                *string
+	Guid                    *string
+	Health                  PoolHealth
+	LastPage                bool
+	LastVerified            *string
+	Name                    *string
+	PageLength              *int
+	PageOffset              *int
+	PageStartMarker         *string
+	PartitionId             *string
+	PoolType                PoolType
+	PoweredOn               *bool
+	State                   PoolState
+	StorageDomainMemberId   *string
 }
 
 func NewGetPoolsSpectraS3Request() *GetPoolsSpectraS3Request {
-    return &GetPoolsSpectraS3Request{
-    }
+	return &GetPoolsSpectraS3Request{}
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithAssignedToStorageDomain(assignedToStorageDomain bool) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.AssignedToStorageDomain = &assignedToStorageDomain
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.AssignedToStorageDomain = &assignedToStorageDomain
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithBucketId(bucketId string) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.BucketId = &bucketId
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.BucketId = &bucketId
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithGuid(guid string) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.Guid = &guid
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.Guid = &guid
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithHealth(health PoolHealth) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.Health = health
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.Health = health
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithLastPage() *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.LastPage = true
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.LastPage = true
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithLastVerified(lastVerified string) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.LastVerified = &lastVerified
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.LastVerified = &lastVerified
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithName(name string) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.Name = &name
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.Name = &name
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithPageLength(pageLength int) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.PageLength = &pageLength
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.PageLength = &pageLength
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithPageOffset(pageOffset int) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.PageOffset = &pageOffset
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.PageOffset = &pageOffset
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithPartitionId(partitionId string) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.PartitionId = &partitionId
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.PartitionId = &partitionId
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithPoweredOn(poweredOn bool) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.PoweredOn = &poweredOn
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.PoweredOn = &poweredOn
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithState(state PoolState) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.State = state
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.State = state
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithStorageDomainMemberId(storageDomainMemberId string) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.StorageDomainMemberId = &storageDomainMemberId
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.StorageDomainMemberId = &storageDomainMemberId
+	return getPoolsSpectraS3Request
 }
 
 func (getPoolsSpectraS3Request *GetPoolsSpectraS3Request) WithPoolType(poolType PoolType) *GetPoolsSpectraS3Request {
-    getPoolsSpectraS3Request.PoolType = poolType
-    return getPoolsSpectraS3Request
+	getPoolsSpectraS3Request.PoolType = poolType
+	return getPoolsSpectraS3Request
 }
 
 type ImportAllPoolsSpectraS3Request struct {
-    DataPolicyId *string
-    Priority Priority
-    StorageDomainId *string
-    UserId *string
-    VerifyDataAfterImport Priority
-    VerifyDataPriorToImport *bool
+	DataPolicyId            *string
+	Priority                Priority
+	StorageDomainId         *string
+	UserId                  *string
+	VerifyDataAfterImport   Priority
+	VerifyDataPriorToImport *bool
 }
 
 func NewImportAllPoolsSpectraS3Request() *ImportAllPoolsSpectraS3Request {
-    return &ImportAllPoolsSpectraS3Request{
-    }
+	return &ImportAllPoolsSpectraS3Request{}
 }
 
 func (importAllPoolsSpectraS3Request *ImportAllPoolsSpectraS3Request) WithDataPolicyId(dataPolicyId string) *ImportAllPoolsSpectraS3Request {
-    importAllPoolsSpectraS3Request.DataPolicyId = &dataPolicyId
-    return importAllPoolsSpectraS3Request
+	importAllPoolsSpectraS3Request.DataPolicyId = &dataPolicyId
+	return importAllPoolsSpectraS3Request
 }
 
 func (importAllPoolsSpectraS3Request *ImportAllPoolsSpectraS3Request) WithPriority(priority Priority) *ImportAllPoolsSpectraS3Request {
-    importAllPoolsSpectraS3Request.Priority = priority
-    return importAllPoolsSpectraS3Request
+	importAllPoolsSpectraS3Request.Priority = priority
+	return importAllPoolsSpectraS3Request
 }
 
 func (importAllPoolsSpectraS3Request *ImportAllPoolsSpectraS3Request) WithStorageDomainId(storageDomainId string) *ImportAllPoolsSpectraS3Request {
-    importAllPoolsSpectraS3Request.StorageDomainId = &storageDomainId
-    return importAllPoolsSpectraS3Request
+	importAllPoolsSpectraS3Request.StorageDomainId = &storageDomainId
+	return importAllPoolsSpectraS3Request
 }
 
 func (importAllPoolsSpectraS3Request *ImportAllPoolsSpectraS3Request) WithUserId(userId string) *ImportAllPoolsSpectraS3Request {
-    importAllPoolsSpectraS3Request.UserId = &userId
-    return importAllPoolsSpectraS3Request
+	importAllPoolsSpectraS3Request.UserId = &userId
+	return importAllPoolsSpectraS3Request
 }
 
 func (importAllPoolsSpectraS3Request *ImportAllPoolsSpectraS3Request) WithVerifyDataAfterImport(verifyDataAfterImport Priority) *ImportAllPoolsSpectraS3Request {
-    importAllPoolsSpectraS3Request.VerifyDataAfterImport = verifyDataAfterImport
-    return importAllPoolsSpectraS3Request
+	importAllPoolsSpectraS3Request.VerifyDataAfterImport = verifyDataAfterImport
+	return importAllPoolsSpectraS3Request
 }
 
 func (importAllPoolsSpectraS3Request *ImportAllPoolsSpectraS3Request) WithVerifyDataPriorToImport(verifyDataPriorToImport bool) *ImportAllPoolsSpectraS3Request {
-    importAllPoolsSpectraS3Request.VerifyDataPriorToImport = &verifyDataPriorToImport
-    return importAllPoolsSpectraS3Request
+	importAllPoolsSpectraS3Request.VerifyDataPriorToImport = &verifyDataPriorToImport
+	return importAllPoolsSpectraS3Request
 }
 
 type ImportPoolSpectraS3Request struct {
-    DataPolicyId *string
-    Pool string
-    Priority Priority
-    StorageDomainId *string
-    UserId *string
-    VerifyDataAfterImport Priority
-    VerifyDataPriorToImport *bool
+	DataPolicyId            *string
+	Pool                    string
+	Priority                Priority
+	StorageDomainId         *string
+	UserId                  *string
+	VerifyDataAfterImport   Priority
+	VerifyDataPriorToImport *bool
 }
 
 func NewImportPoolSpectraS3Request(pool string) *ImportPoolSpectraS3Request {
-    return &ImportPoolSpectraS3Request{
-        Pool: pool,
-    }
+	return &ImportPoolSpectraS3Request{
+		Pool: pool,
+	}
 }
 
 func (importPoolSpectraS3Request *ImportPoolSpectraS3Request) WithDataPolicyId(dataPolicyId string) *ImportPoolSpectraS3Request {
-    importPoolSpectraS3Request.DataPolicyId = &dataPolicyId
-    return importPoolSpectraS3Request
+	importPoolSpectraS3Request.DataPolicyId = &dataPolicyId
+	return importPoolSpectraS3Request
 }
 
 func (importPoolSpectraS3Request *ImportPoolSpectraS3Request) WithPriority(priority Priority) *ImportPoolSpectraS3Request {
-    importPoolSpectraS3Request.Priority = priority
-    return importPoolSpectraS3Request
+	importPoolSpectraS3Request.Priority = priority
+	return importPoolSpectraS3Request
 }
 
 func (importPoolSpectraS3Request *ImportPoolSpectraS3Request) WithStorageDomainId(storageDomainId string) *ImportPoolSpectraS3Request {
-    importPoolSpectraS3Request.StorageDomainId = &storageDomainId
-    return importPoolSpectraS3Request
+	importPoolSpectraS3Request.StorageDomainId = &storageDomainId
+	return importPoolSpectraS3Request
 }
 
 func (importPoolSpectraS3Request *ImportPoolSpectraS3Request) WithUserId(userId string) *ImportPoolSpectraS3Request {
-    importPoolSpectraS3Request.UserId = &userId
-    return importPoolSpectraS3Request
+	importPoolSpectraS3Request.UserId = &userId
+	return importPoolSpectraS3Request
 }
 
 func (importPoolSpectraS3Request *ImportPoolSpectraS3Request) WithVerifyDataAfterImport(verifyDataAfterImport Priority) *ImportPoolSpectraS3Request {
-    importPoolSpectraS3Request.VerifyDataAfterImport = verifyDataAfterImport
-    return importPoolSpectraS3Request
+	importPoolSpectraS3Request.VerifyDataAfterImport = verifyDataAfterImport
+	return importPoolSpectraS3Request
 }
 
 func (importPoolSpectraS3Request *ImportPoolSpectraS3Request) WithVerifyDataPriorToImport(verifyDataPriorToImport bool) *ImportPoolSpectraS3Request {
-    importPoolSpectraS3Request.VerifyDataPriorToImport = &verifyDataPriorToImport
-    return importPoolSpectraS3Request
+	importPoolSpectraS3Request.VerifyDataPriorToImport = &verifyDataPriorToImport
+	return importPoolSpectraS3Request
 }
 
 type ModifyAllPoolsSpectraS3Request struct {
-    Quiesced Quiesced
+	Quiesced Quiesced
 }
 
 func NewModifyAllPoolsSpectraS3Request(quiesced Quiesced) *ModifyAllPoolsSpectraS3Request {
-    return &ModifyAllPoolsSpectraS3Request{
-        Quiesced: quiesced,
-    }
+	return &ModifyAllPoolsSpectraS3Request{
+		Quiesced: quiesced,
+	}
 }
 
 type ModifyPoolPartitionSpectraS3Request struct {
-    Name *string
-    PoolPartition string
+	Name          *string
+	PoolPartition string
 }
 
 func NewModifyPoolPartitionSpectraS3Request(poolPartition string) *ModifyPoolPartitionSpectraS3Request {
-    return &ModifyPoolPartitionSpectraS3Request{
-        PoolPartition: poolPartition,
-    }
+	return &ModifyPoolPartitionSpectraS3Request{
+		PoolPartition: poolPartition,
+	}
 }
 
 func (modifyPoolPartitionSpectraS3Request *ModifyPoolPartitionSpectraS3Request) WithName(name string) *ModifyPoolPartitionSpectraS3Request {
-    modifyPoolPartitionSpectraS3Request.Name = &name
-    return modifyPoolPartitionSpectraS3Request
+	modifyPoolPartitionSpectraS3Request.Name = &name
+	return modifyPoolPartitionSpectraS3Request
 }
 
 type ModifyPoolSpectraS3Request struct {
-    PartitionId *string
-    Pool string
-    Quiesced Quiesced
+	PartitionId *string
+	Pool        string
+	Quiesced    Quiesced
 }
 
 func NewModifyPoolSpectraS3Request(pool string) *ModifyPoolSpectraS3Request {
-    return &ModifyPoolSpectraS3Request{
-        Pool: pool,
-    }
+	return &ModifyPoolSpectraS3Request{
+		Pool: pool,
+	}
 }
 
 func (modifyPoolSpectraS3Request *ModifyPoolSpectraS3Request) WithPartitionId(partitionId string) *ModifyPoolSpectraS3Request {
-    modifyPoolSpectraS3Request.PartitionId = &partitionId
-    return modifyPoolSpectraS3Request
+	modifyPoolSpectraS3Request.PartitionId = &partitionId
+	return modifyPoolSpectraS3Request
 }
 
 func (modifyPoolSpectraS3Request *ModifyPoolSpectraS3Request) WithQuiesced(quiesced Quiesced) *ModifyPoolSpectraS3Request {
-    modifyPoolSpectraS3Request.Quiesced = quiesced
-    return modifyPoolSpectraS3Request
+	modifyPoolSpectraS3Request.Quiesced = quiesced
+	return modifyPoolSpectraS3Request
 }
 
 type VerifyAllPoolsSpectraS3Request struct {
-    Priority Priority
+	Priority Priority
 }
 
 func NewVerifyAllPoolsSpectraS3Request() *VerifyAllPoolsSpectraS3Request {
-    return &VerifyAllPoolsSpectraS3Request{
-    }
+	return &VerifyAllPoolsSpectraS3Request{}
 }
 
 func (verifyAllPoolsSpectraS3Request *VerifyAllPoolsSpectraS3Request) WithPriority(priority Priority) *VerifyAllPoolsSpectraS3Request {
-    verifyAllPoolsSpectraS3Request.Priority = priority
-    return verifyAllPoolsSpectraS3Request
+	verifyAllPoolsSpectraS3Request.Priority = priority
+	return verifyAllPoolsSpectraS3Request
 }
 
 type VerifyPoolSpectraS3Request struct {
-    Pool string
-    Priority Priority
+	Pool     string
+	Priority Priority
 }
 
 func NewVerifyPoolSpectraS3Request(pool string) *VerifyPoolSpectraS3Request {
-    return &VerifyPoolSpectraS3Request{
-        Pool: pool,
-    }
+	return &VerifyPoolSpectraS3Request{
+		Pool: pool,
+	}
 }
 
 func (verifyPoolSpectraS3Request *VerifyPoolSpectraS3Request) WithPriority(priority Priority) *VerifyPoolSpectraS3Request {
-    verifyPoolSpectraS3Request.Priority = priority
-    return verifyPoolSpectraS3Request
+	verifyPoolSpectraS3Request.Priority = priority
+	return verifyPoolSpectraS3Request
 }
 
 type ConvertStorageDomainToDs3TargetSpectraS3Request struct {
-    ConvertToDs3Target string
-    StorageDomain string
+	ConvertToDs3Target string
+	StorageDomain      string
 }
 
 func NewConvertStorageDomainToDs3TargetSpectraS3Request(convertToDs3Target string, storageDomain string) *ConvertStorageDomainToDs3TargetSpectraS3Request {
-    return &ConvertStorageDomainToDs3TargetSpectraS3Request{
-        StorageDomain: storageDomain,
-        ConvertToDs3Target: convertToDs3Target,
-    }
+	return &ConvertStorageDomainToDs3TargetSpectraS3Request{
+		StorageDomain:      storageDomain,
+		ConvertToDs3Target: convertToDs3Target,
+	}
 }
 
 type PutPoolStorageDomainMemberSpectraS3Request struct {
-    PoolPartitionId string
-    StorageDomainId string
-    WritePreference WritePreferenceLevel
+	PoolPartitionId string
+	StorageDomainId string
+	WritePreference WritePreferenceLevel
 }
 
 func NewPutPoolStorageDomainMemberSpectraS3Request(poolPartitionId string, storageDomainId string) *PutPoolStorageDomainMemberSpectraS3Request {
-    return &PutPoolStorageDomainMemberSpectraS3Request{
-        PoolPartitionId: poolPartitionId,
-        StorageDomainId: storageDomainId,
-    }
+	return &PutPoolStorageDomainMemberSpectraS3Request{
+		PoolPartitionId: poolPartitionId,
+		StorageDomainId: storageDomainId,
+	}
 }
 
 func (putPoolStorageDomainMemberSpectraS3Request *PutPoolStorageDomainMemberSpectraS3Request) WithWritePreference(writePreference WritePreferenceLevel) *PutPoolStorageDomainMemberSpectraS3Request {
-    putPoolStorageDomainMemberSpectraS3Request.WritePreference = writePreference
-    return putPoolStorageDomainMemberSpectraS3Request
+	putPoolStorageDomainMemberSpectraS3Request.WritePreference = writePreference
+	return putPoolStorageDomainMemberSpectraS3Request
 }
 
 type PutStorageDomainSpectraS3Request struct {
-    AutoEjectMediaFullThreshold *int64
-    AutoEjectUponCron *string
-    AutoEjectUponJobCancellation *bool
-    AutoEjectUponJobCompletion *bool
-    AutoEjectUponMediaFull *bool
-    LtfsFileNaming LtfsFileNamingMode
-    MaximumAutoVerificationFrequencyInDays *int
-    MaxTapeFragmentationPercent *int
-    MediaEjectionAllowed *bool
-    Name string
-    SecureMediaAllocation *bool
-    VerifyPriorToAutoEject Priority
-    WriteOptimization WriteOptimization
+	AutoEjectMediaFullThreshold            *int64
+	AutoEjectUponCron                      *string
+	AutoEjectUponJobCancellation           *bool
+	AutoEjectUponJobCompletion             *bool
+	AutoEjectUponMediaFull                 *bool
+	LtfsFileNaming                         LtfsFileNamingMode
+	MaximumAutoVerificationFrequencyInDays *int
+	MaxTapeFragmentationPercent            *int
+	MediaEjectionAllowed                   *bool
+	Name                                   string
+	SecureMediaAllocation                  *bool
+	VerifyPriorToAutoEject                 Priority
+	WriteOptimization                      WriteOptimization
 }
 
 func NewPutStorageDomainSpectraS3Request(name string) *PutStorageDomainSpectraS3Request {
-    return &PutStorageDomainSpectraS3Request{
-        Name: name,
-    }
+	return &PutStorageDomainSpectraS3Request{
+		Name: name,
+	}
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithAutoEjectMediaFullThreshold(autoEjectMediaFullThreshold int64) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.AutoEjectMediaFullThreshold = &autoEjectMediaFullThreshold
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.AutoEjectMediaFullThreshold = &autoEjectMediaFullThreshold
+	return putStorageDomainSpectraS3Request
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithAutoEjectUponCron(autoEjectUponCron string) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.AutoEjectUponCron = &autoEjectUponCron
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.AutoEjectUponCron = &autoEjectUponCron
+	return putStorageDomainSpectraS3Request
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithAutoEjectUponJobCancellation(autoEjectUponJobCancellation bool) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.AutoEjectUponJobCancellation = &autoEjectUponJobCancellation
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.AutoEjectUponJobCancellation = &autoEjectUponJobCancellation
+	return putStorageDomainSpectraS3Request
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithAutoEjectUponJobCompletion(autoEjectUponJobCompletion bool) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.AutoEjectUponJobCompletion = &autoEjectUponJobCompletion
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.AutoEjectUponJobCompletion = &autoEjectUponJobCompletion
+	return putStorageDomainSpectraS3Request
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithAutoEjectUponMediaFull(autoEjectUponMediaFull bool) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.AutoEjectUponMediaFull = &autoEjectUponMediaFull
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.AutoEjectUponMediaFull = &autoEjectUponMediaFull
+	return putStorageDomainSpectraS3Request
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithLtfsFileNaming(ltfsFileNaming LtfsFileNamingMode) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.LtfsFileNaming = ltfsFileNaming
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.LtfsFileNaming = ltfsFileNaming
+	return putStorageDomainSpectraS3Request
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithMaxTapeFragmentationPercent(maxTapeFragmentationPercent int) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.MaxTapeFragmentationPercent = &maxTapeFragmentationPercent
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.MaxTapeFragmentationPercent = &maxTapeFragmentationPercent
+	return putStorageDomainSpectraS3Request
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithMaximumAutoVerificationFrequencyInDays(maximumAutoVerificationFrequencyInDays int) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.MaximumAutoVerificationFrequencyInDays = &maximumAutoVerificationFrequencyInDays
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.MaximumAutoVerificationFrequencyInDays = &maximumAutoVerificationFrequencyInDays
+	return putStorageDomainSpectraS3Request
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithMediaEjectionAllowed(mediaEjectionAllowed bool) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.MediaEjectionAllowed = &mediaEjectionAllowed
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.MediaEjectionAllowed = &mediaEjectionAllowed
+	return putStorageDomainSpectraS3Request
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithSecureMediaAllocation(secureMediaAllocation bool) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.SecureMediaAllocation = &secureMediaAllocation
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.SecureMediaAllocation = &secureMediaAllocation
+	return putStorageDomainSpectraS3Request
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithVerifyPriorToAutoEject(verifyPriorToAutoEject Priority) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.VerifyPriorToAutoEject = verifyPriorToAutoEject
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.VerifyPriorToAutoEject = verifyPriorToAutoEject
+	return putStorageDomainSpectraS3Request
 }
 
 func (putStorageDomainSpectraS3Request *PutStorageDomainSpectraS3Request) WithWriteOptimization(writeOptimization WriteOptimization) *PutStorageDomainSpectraS3Request {
-    putStorageDomainSpectraS3Request.WriteOptimization = writeOptimization
-    return putStorageDomainSpectraS3Request
+	putStorageDomainSpectraS3Request.WriteOptimization = writeOptimization
+	return putStorageDomainSpectraS3Request
 }
 
 type PutTapeStorageDomainMemberSpectraS3Request struct {
-    AutoCompactionThreshold *int
-    StorageDomainId string
-    TapePartitionId string
-    TapeType string
-    WritePreference WritePreferenceLevel
+	AutoCompactionThreshold *int
+	StorageDomainId         string
+	TapePartitionId         string
+	TapeType                string
+	WritePreference         WritePreferenceLevel
 }
 
 func NewPutTapeStorageDomainMemberSpectraS3Request(storageDomainId string, tapePartitionId string, tapeType string) *PutTapeStorageDomainMemberSpectraS3Request {
-    return &PutTapeStorageDomainMemberSpectraS3Request{
-        StorageDomainId: storageDomainId,
-        TapePartitionId: tapePartitionId,
-        TapeType: tapeType,
-    }
+	return &PutTapeStorageDomainMemberSpectraS3Request{
+		StorageDomainId: storageDomainId,
+		TapePartitionId: tapePartitionId,
+		TapeType:        tapeType,
+	}
 }
 
 func (putTapeStorageDomainMemberSpectraS3Request *PutTapeStorageDomainMemberSpectraS3Request) WithAutoCompactionThreshold(autoCompactionThreshold int) *PutTapeStorageDomainMemberSpectraS3Request {
-    putTapeStorageDomainMemberSpectraS3Request.AutoCompactionThreshold = &autoCompactionThreshold
-    return putTapeStorageDomainMemberSpectraS3Request
+	putTapeStorageDomainMemberSpectraS3Request.AutoCompactionThreshold = &autoCompactionThreshold
+	return putTapeStorageDomainMemberSpectraS3Request
 }
 
 func (putTapeStorageDomainMemberSpectraS3Request *PutTapeStorageDomainMemberSpectraS3Request) WithWritePreference(writePreference WritePreferenceLevel) *PutTapeStorageDomainMemberSpectraS3Request {
-    putTapeStorageDomainMemberSpectraS3Request.WritePreference = writePreference
-    return putTapeStorageDomainMemberSpectraS3Request
+	putTapeStorageDomainMemberSpectraS3Request.WritePreference = writePreference
+	return putTapeStorageDomainMemberSpectraS3Request
 }
 
 type DeleteStorageDomainFailureSpectraS3Request struct {
-    StorageDomainFailure string
+	StorageDomainFailure string
 }
 
 func NewDeleteStorageDomainFailureSpectraS3Request(storageDomainFailure string) *DeleteStorageDomainFailureSpectraS3Request {
-    return &DeleteStorageDomainFailureSpectraS3Request{
-        StorageDomainFailure: storageDomainFailure,
-    }
+	return &DeleteStorageDomainFailureSpectraS3Request{
+		StorageDomainFailure: storageDomainFailure,
+	}
 }
 
 type DeleteStorageDomainMemberSpectraS3Request struct {
-    StorageDomainMember string
+	StorageDomainMember string
 }
 
 func NewDeleteStorageDomainMemberSpectraS3Request(storageDomainMember string) *DeleteStorageDomainMemberSpectraS3Request {
-    return &DeleteStorageDomainMemberSpectraS3Request{
-        StorageDomainMember: storageDomainMember,
-    }
+	return &DeleteStorageDomainMemberSpectraS3Request{
+		StorageDomainMember: storageDomainMember,
+	}
 }
 
 type DeleteStorageDomainSpectraS3Request struct {
-    StorageDomain string
+	StorageDomain string
 }
 
 func NewDeleteStorageDomainSpectraS3Request(storageDomain string) *DeleteStorageDomainSpectraS3Request {
-    return &DeleteStorageDomainSpectraS3Request{
-        StorageDomain: storageDomain,
-    }
+	return &DeleteStorageDomainSpectraS3Request{
+		StorageDomain: storageDomain,
+	}
 }
 
 type GetStorageDomainFailuresSpectraS3Request struct {
-    ErrorMessage *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    StorageDomainFailureType StorageDomainFailureType
-    StorageDomainId *string
+	ErrorMessage             *string
+	LastPage                 bool
+	PageLength               *int
+	PageOffset               *int
+	PageStartMarker          *string
+	StorageDomainFailureType StorageDomainFailureType
+	StorageDomainId          *string
 }
 
 func NewGetStorageDomainFailuresSpectraS3Request() *GetStorageDomainFailuresSpectraS3Request {
-    return &GetStorageDomainFailuresSpectraS3Request{
-    }
+	return &GetStorageDomainFailuresSpectraS3Request{}
 }
 
 func (getStorageDomainFailuresSpectraS3Request *GetStorageDomainFailuresSpectraS3Request) WithErrorMessage(errorMessage string) *GetStorageDomainFailuresSpectraS3Request {
-    getStorageDomainFailuresSpectraS3Request.ErrorMessage = &errorMessage
-    return getStorageDomainFailuresSpectraS3Request
+	getStorageDomainFailuresSpectraS3Request.ErrorMessage = &errorMessage
+	return getStorageDomainFailuresSpectraS3Request
 }
 
 func (getStorageDomainFailuresSpectraS3Request *GetStorageDomainFailuresSpectraS3Request) WithLastPage() *GetStorageDomainFailuresSpectraS3Request {
-    getStorageDomainFailuresSpectraS3Request.LastPage = true
-    return getStorageDomainFailuresSpectraS3Request
+	getStorageDomainFailuresSpectraS3Request.LastPage = true
+	return getStorageDomainFailuresSpectraS3Request
 }
 
 func (getStorageDomainFailuresSpectraS3Request *GetStorageDomainFailuresSpectraS3Request) WithPageLength(pageLength int) *GetStorageDomainFailuresSpectraS3Request {
-    getStorageDomainFailuresSpectraS3Request.PageLength = &pageLength
-    return getStorageDomainFailuresSpectraS3Request
+	getStorageDomainFailuresSpectraS3Request.PageLength = &pageLength
+	return getStorageDomainFailuresSpectraS3Request
 }
 
 func (getStorageDomainFailuresSpectraS3Request *GetStorageDomainFailuresSpectraS3Request) WithPageOffset(pageOffset int) *GetStorageDomainFailuresSpectraS3Request {
-    getStorageDomainFailuresSpectraS3Request.PageOffset = &pageOffset
-    return getStorageDomainFailuresSpectraS3Request
+	getStorageDomainFailuresSpectraS3Request.PageOffset = &pageOffset
+	return getStorageDomainFailuresSpectraS3Request
 }
 
 func (getStorageDomainFailuresSpectraS3Request *GetStorageDomainFailuresSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetStorageDomainFailuresSpectraS3Request {
-    getStorageDomainFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getStorageDomainFailuresSpectraS3Request
+	getStorageDomainFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getStorageDomainFailuresSpectraS3Request
 }
 
 func (getStorageDomainFailuresSpectraS3Request *GetStorageDomainFailuresSpectraS3Request) WithStorageDomainId(storageDomainId string) *GetStorageDomainFailuresSpectraS3Request {
-    getStorageDomainFailuresSpectraS3Request.StorageDomainId = &storageDomainId
-    return getStorageDomainFailuresSpectraS3Request
+	getStorageDomainFailuresSpectraS3Request.StorageDomainId = &storageDomainId
+	return getStorageDomainFailuresSpectraS3Request
 }
 
 func (getStorageDomainFailuresSpectraS3Request *GetStorageDomainFailuresSpectraS3Request) WithStorageDomainFailureType(storageDomainFailureType StorageDomainFailureType) *GetStorageDomainFailuresSpectraS3Request {
-    getStorageDomainFailuresSpectraS3Request.StorageDomainFailureType = storageDomainFailureType
-    return getStorageDomainFailuresSpectraS3Request
+	getStorageDomainFailuresSpectraS3Request.StorageDomainFailureType = storageDomainFailureType
+	return getStorageDomainFailuresSpectraS3Request
 }
 
 type GetStorageDomainMemberSpectraS3Request struct {
-    StorageDomainMember string
+	StorageDomainMember string
 }
 
 func NewGetStorageDomainMemberSpectraS3Request(storageDomainMember string) *GetStorageDomainMemberSpectraS3Request {
-    return &GetStorageDomainMemberSpectraS3Request{
-        StorageDomainMember: storageDomainMember,
-    }
+	return &GetStorageDomainMemberSpectraS3Request{
+		StorageDomainMember: storageDomainMember,
+	}
 }
 
 type GetStorageDomainMembersSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PoolPartitionId *string
-    State StorageDomainMemberState
-    StorageDomainId *string
-    TapePartitionId *string
-    TapeType *string
-    WritePreference WritePreferenceLevel
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	PoolPartitionId *string
+	State           StorageDomainMemberState
+	StorageDomainId *string
+	TapePartitionId *string
+	TapeType        *string
+	WritePreference WritePreferenceLevel
 }
 
 func NewGetStorageDomainMembersSpectraS3Request() *GetStorageDomainMembersSpectraS3Request {
-    return &GetStorageDomainMembersSpectraS3Request{
-    }
+	return &GetStorageDomainMembersSpectraS3Request{}
 }
 
 func (getStorageDomainMembersSpectraS3Request *GetStorageDomainMembersSpectraS3Request) WithLastPage() *GetStorageDomainMembersSpectraS3Request {
-    getStorageDomainMembersSpectraS3Request.LastPage = true
-    return getStorageDomainMembersSpectraS3Request
+	getStorageDomainMembersSpectraS3Request.LastPage = true
+	return getStorageDomainMembersSpectraS3Request
 }
 
 func (getStorageDomainMembersSpectraS3Request *GetStorageDomainMembersSpectraS3Request) WithPageLength(pageLength int) *GetStorageDomainMembersSpectraS3Request {
-    getStorageDomainMembersSpectraS3Request.PageLength = &pageLength
-    return getStorageDomainMembersSpectraS3Request
+	getStorageDomainMembersSpectraS3Request.PageLength = &pageLength
+	return getStorageDomainMembersSpectraS3Request
 }
 
 func (getStorageDomainMembersSpectraS3Request *GetStorageDomainMembersSpectraS3Request) WithPageOffset(pageOffset int) *GetStorageDomainMembersSpectraS3Request {
-    getStorageDomainMembersSpectraS3Request.PageOffset = &pageOffset
-    return getStorageDomainMembersSpectraS3Request
+	getStorageDomainMembersSpectraS3Request.PageOffset = &pageOffset
+	return getStorageDomainMembersSpectraS3Request
 }
 
 func (getStorageDomainMembersSpectraS3Request *GetStorageDomainMembersSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetStorageDomainMembersSpectraS3Request {
-    getStorageDomainMembersSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getStorageDomainMembersSpectraS3Request
+	getStorageDomainMembersSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getStorageDomainMembersSpectraS3Request
 }
 
 func (getStorageDomainMembersSpectraS3Request *GetStorageDomainMembersSpectraS3Request) WithPoolPartitionId(poolPartitionId string) *GetStorageDomainMembersSpectraS3Request {
-    getStorageDomainMembersSpectraS3Request.PoolPartitionId = &poolPartitionId
-    return getStorageDomainMembersSpectraS3Request
+	getStorageDomainMembersSpectraS3Request.PoolPartitionId = &poolPartitionId
+	return getStorageDomainMembersSpectraS3Request
 }
 
 func (getStorageDomainMembersSpectraS3Request *GetStorageDomainMembersSpectraS3Request) WithState(state StorageDomainMemberState) *GetStorageDomainMembersSpectraS3Request {
-    getStorageDomainMembersSpectraS3Request.State = state
-    return getStorageDomainMembersSpectraS3Request
+	getStorageDomainMembersSpectraS3Request.State = state
+	return getStorageDomainMembersSpectraS3Request
 }
 
 func (getStorageDomainMembersSpectraS3Request *GetStorageDomainMembersSpectraS3Request) WithStorageDomainId(storageDomainId string) *GetStorageDomainMembersSpectraS3Request {
-    getStorageDomainMembersSpectraS3Request.StorageDomainId = &storageDomainId
-    return getStorageDomainMembersSpectraS3Request
+	getStorageDomainMembersSpectraS3Request.StorageDomainId = &storageDomainId
+	return getStorageDomainMembersSpectraS3Request
 }
 
 func (getStorageDomainMembersSpectraS3Request *GetStorageDomainMembersSpectraS3Request) WithTapePartitionId(tapePartitionId string) *GetStorageDomainMembersSpectraS3Request {
-    getStorageDomainMembersSpectraS3Request.TapePartitionId = &tapePartitionId
-    return getStorageDomainMembersSpectraS3Request
+	getStorageDomainMembersSpectraS3Request.TapePartitionId = &tapePartitionId
+	return getStorageDomainMembersSpectraS3Request
 }
 
 func (getStorageDomainMembersSpectraS3Request *GetStorageDomainMembersSpectraS3Request) WithTapeType(tapeType string) *GetStorageDomainMembersSpectraS3Request {
-    getStorageDomainMembersSpectraS3Request.TapeType = &tapeType
-    return getStorageDomainMembersSpectraS3Request
+	getStorageDomainMembersSpectraS3Request.TapeType = &tapeType
+	return getStorageDomainMembersSpectraS3Request
 }
 
 func (getStorageDomainMembersSpectraS3Request *GetStorageDomainMembersSpectraS3Request) WithWritePreference(writePreference WritePreferenceLevel) *GetStorageDomainMembersSpectraS3Request {
-    getStorageDomainMembersSpectraS3Request.WritePreference = writePreference
-    return getStorageDomainMembersSpectraS3Request
+	getStorageDomainMembersSpectraS3Request.WritePreference = writePreference
+	return getStorageDomainMembersSpectraS3Request
 }
 
 type GetStorageDomainSpectraS3Request struct {
-    StorageDomain string
+	StorageDomain string
 }
 
 func NewGetStorageDomainSpectraS3Request(storageDomain string) *GetStorageDomainSpectraS3Request {
-    return &GetStorageDomainSpectraS3Request{
-        StorageDomain: storageDomain,
-    }
+	return &GetStorageDomainSpectraS3Request{
+		StorageDomain: storageDomain,
+	}
 }
 
 type GetStorageDomainsSpectraS3Request struct {
-    AutoEjectUponCron *string
-    AutoEjectUponJobCancellation *bool
-    AutoEjectUponJobCompletion *bool
-    AutoEjectUponMediaFull *bool
-    LastPage bool
-    MediaEjectionAllowed *bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    SecureMediaAllocation *bool
-    WriteOptimization WriteOptimization
+	AutoEjectUponCron            *string
+	AutoEjectUponJobCancellation *bool
+	AutoEjectUponJobCompletion   *bool
+	AutoEjectUponMediaFull       *bool
+	LastPage                     bool
+	MediaEjectionAllowed         *bool
+	Name                         *string
+	PageLength                   *int
+	PageOffset                   *int
+	PageStartMarker              *string
+	SecureMediaAllocation        *bool
+	WriteOptimization            WriteOptimization
 }
 
 func NewGetStorageDomainsSpectraS3Request() *GetStorageDomainsSpectraS3Request {
-    return &GetStorageDomainsSpectraS3Request{
-    }
+	return &GetStorageDomainsSpectraS3Request{}
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithAutoEjectUponCron(autoEjectUponCron string) *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.AutoEjectUponCron = &autoEjectUponCron
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.AutoEjectUponCron = &autoEjectUponCron
+	return getStorageDomainsSpectraS3Request
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithAutoEjectUponJobCancellation(autoEjectUponJobCancellation bool) *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.AutoEjectUponJobCancellation = &autoEjectUponJobCancellation
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.AutoEjectUponJobCancellation = &autoEjectUponJobCancellation
+	return getStorageDomainsSpectraS3Request
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithAutoEjectUponJobCompletion(autoEjectUponJobCompletion bool) *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.AutoEjectUponJobCompletion = &autoEjectUponJobCompletion
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.AutoEjectUponJobCompletion = &autoEjectUponJobCompletion
+	return getStorageDomainsSpectraS3Request
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithAutoEjectUponMediaFull(autoEjectUponMediaFull bool) *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.AutoEjectUponMediaFull = &autoEjectUponMediaFull
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.AutoEjectUponMediaFull = &autoEjectUponMediaFull
+	return getStorageDomainsSpectraS3Request
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithLastPage() *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.LastPage = true
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.LastPage = true
+	return getStorageDomainsSpectraS3Request
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithMediaEjectionAllowed(mediaEjectionAllowed bool) *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.MediaEjectionAllowed = &mediaEjectionAllowed
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.MediaEjectionAllowed = &mediaEjectionAllowed
+	return getStorageDomainsSpectraS3Request
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithName(name string) *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.Name = &name
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.Name = &name
+	return getStorageDomainsSpectraS3Request
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithPageLength(pageLength int) *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.PageLength = &pageLength
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.PageLength = &pageLength
+	return getStorageDomainsSpectraS3Request
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithPageOffset(pageOffset int) *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.PageOffset = &pageOffset
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.PageOffset = &pageOffset
+	return getStorageDomainsSpectraS3Request
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getStorageDomainsSpectraS3Request
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithSecureMediaAllocation(secureMediaAllocation bool) *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.SecureMediaAllocation = &secureMediaAllocation
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.SecureMediaAllocation = &secureMediaAllocation
+	return getStorageDomainsSpectraS3Request
 }
 
 func (getStorageDomainsSpectraS3Request *GetStorageDomainsSpectraS3Request) WithWriteOptimization(writeOptimization WriteOptimization) *GetStorageDomainsSpectraS3Request {
-    getStorageDomainsSpectraS3Request.WriteOptimization = writeOptimization
-    return getStorageDomainsSpectraS3Request
+	getStorageDomainsSpectraS3Request.WriteOptimization = writeOptimization
+	return getStorageDomainsSpectraS3Request
 }
 
 type ModifyStorageDomainMemberSpectraS3Request struct {
-    AutoCompactionThreshold *int
-    State StorageDomainMemberState
-    StorageDomainMember string
-    WritePreference WritePreferenceLevel
+	AutoCompactionThreshold *int
+	State                   StorageDomainMemberState
+	StorageDomainMember     string
+	WritePreference         WritePreferenceLevel
 }
 
 func NewModifyStorageDomainMemberSpectraS3Request(storageDomainMember string) *ModifyStorageDomainMemberSpectraS3Request {
-    return &ModifyStorageDomainMemberSpectraS3Request{
-        StorageDomainMember: storageDomainMember,
-    }
+	return &ModifyStorageDomainMemberSpectraS3Request{
+		StorageDomainMember: storageDomainMember,
+	}
 }
 
 func (modifyStorageDomainMemberSpectraS3Request *ModifyStorageDomainMemberSpectraS3Request) WithAutoCompactionThreshold(autoCompactionThreshold int) *ModifyStorageDomainMemberSpectraS3Request {
-    modifyStorageDomainMemberSpectraS3Request.AutoCompactionThreshold = &autoCompactionThreshold
-    return modifyStorageDomainMemberSpectraS3Request
+	modifyStorageDomainMemberSpectraS3Request.AutoCompactionThreshold = &autoCompactionThreshold
+	return modifyStorageDomainMemberSpectraS3Request
 }
 
 func (modifyStorageDomainMemberSpectraS3Request *ModifyStorageDomainMemberSpectraS3Request) WithState(state StorageDomainMemberState) *ModifyStorageDomainMemberSpectraS3Request {
-    modifyStorageDomainMemberSpectraS3Request.State = state
-    return modifyStorageDomainMemberSpectraS3Request
+	modifyStorageDomainMemberSpectraS3Request.State = state
+	return modifyStorageDomainMemberSpectraS3Request
 }
 
 func (modifyStorageDomainMemberSpectraS3Request *ModifyStorageDomainMemberSpectraS3Request) WithWritePreference(writePreference WritePreferenceLevel) *ModifyStorageDomainMemberSpectraS3Request {
-    modifyStorageDomainMemberSpectraS3Request.WritePreference = writePreference
-    return modifyStorageDomainMemberSpectraS3Request
+	modifyStorageDomainMemberSpectraS3Request.WritePreference = writePreference
+	return modifyStorageDomainMemberSpectraS3Request
 }
 
 type ModifyStorageDomainSpectraS3Request struct {
-    AutoEjectMediaFullThreshold *int64
-    AutoEjectUponCron *string
-    AutoEjectUponJobCancellation *bool
-    AutoEjectUponJobCompletion *bool
-    AutoEjectUponMediaFull *bool
-    LtfsFileNaming LtfsFileNamingMode
-    MaximumAutoVerificationFrequencyInDays *int
-    MaxTapeFragmentationPercent *int
-    MediaEjectionAllowed *bool
-    Name *string
-    SecureMediaAllocation *bool
-    StorageDomain string
-    VerifyPriorToAutoEject Priority
-    WriteOptimization WriteOptimization
+	AutoEjectMediaFullThreshold            *int64
+	AutoEjectUponCron                      *string
+	AutoEjectUponJobCancellation           *bool
+	AutoEjectUponJobCompletion             *bool
+	AutoEjectUponMediaFull                 *bool
+	LtfsFileNaming                         LtfsFileNamingMode
+	MaximumAutoVerificationFrequencyInDays *int
+	MaxTapeFragmentationPercent            *int
+	MediaEjectionAllowed                   *bool
+	Name                                   *string
+	SecureMediaAllocation                  *bool
+	StorageDomain                          string
+	VerifyPriorToAutoEject                 Priority
+	WriteOptimization                      WriteOptimization
 }
 
 func NewModifyStorageDomainSpectraS3Request(storageDomain string) *ModifyStorageDomainSpectraS3Request {
-    return &ModifyStorageDomainSpectraS3Request{
-        StorageDomain: storageDomain,
-    }
+	return &ModifyStorageDomainSpectraS3Request{
+		StorageDomain: storageDomain,
+	}
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithAutoEjectMediaFullThreshold(autoEjectMediaFullThreshold int64) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.AutoEjectMediaFullThreshold = &autoEjectMediaFullThreshold
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.AutoEjectMediaFullThreshold = &autoEjectMediaFullThreshold
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithAutoEjectUponCron(autoEjectUponCron string) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.AutoEjectUponCron = &autoEjectUponCron
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.AutoEjectUponCron = &autoEjectUponCron
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithAutoEjectUponJobCancellation(autoEjectUponJobCancellation bool) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.AutoEjectUponJobCancellation = &autoEjectUponJobCancellation
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.AutoEjectUponJobCancellation = &autoEjectUponJobCancellation
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithAutoEjectUponJobCompletion(autoEjectUponJobCompletion bool) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.AutoEjectUponJobCompletion = &autoEjectUponJobCompletion
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.AutoEjectUponJobCompletion = &autoEjectUponJobCompletion
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithAutoEjectUponMediaFull(autoEjectUponMediaFull bool) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.AutoEjectUponMediaFull = &autoEjectUponMediaFull
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.AutoEjectUponMediaFull = &autoEjectUponMediaFull
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithLtfsFileNaming(ltfsFileNaming LtfsFileNamingMode) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.LtfsFileNaming = ltfsFileNaming
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.LtfsFileNaming = ltfsFileNaming
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithMaxTapeFragmentationPercent(maxTapeFragmentationPercent int) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.MaxTapeFragmentationPercent = &maxTapeFragmentationPercent
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.MaxTapeFragmentationPercent = &maxTapeFragmentationPercent
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithMaximumAutoVerificationFrequencyInDays(maximumAutoVerificationFrequencyInDays int) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.MaximumAutoVerificationFrequencyInDays = &maximumAutoVerificationFrequencyInDays
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.MaximumAutoVerificationFrequencyInDays = &maximumAutoVerificationFrequencyInDays
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithMediaEjectionAllowed(mediaEjectionAllowed bool) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.MediaEjectionAllowed = &mediaEjectionAllowed
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.MediaEjectionAllowed = &mediaEjectionAllowed
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithName(name string) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.Name = &name
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.Name = &name
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithSecureMediaAllocation(secureMediaAllocation bool) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.SecureMediaAllocation = &secureMediaAllocation
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.SecureMediaAllocation = &secureMediaAllocation
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithVerifyPriorToAutoEject(verifyPriorToAutoEject Priority) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.VerifyPriorToAutoEject = verifyPriorToAutoEject
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.VerifyPriorToAutoEject = verifyPriorToAutoEject
+	return modifyStorageDomainSpectraS3Request
 }
 
 func (modifyStorageDomainSpectraS3Request *ModifyStorageDomainSpectraS3Request) WithWriteOptimization(writeOptimization WriteOptimization) *ModifyStorageDomainSpectraS3Request {
-    modifyStorageDomainSpectraS3Request.WriteOptimization = writeOptimization
-    return modifyStorageDomainSpectraS3Request
+	modifyStorageDomainSpectraS3Request.WriteOptimization = writeOptimization
+	return modifyStorageDomainSpectraS3Request
 }
 
 type ForceFeatureKeyValidationSpectraS3Request struct {
 }
 
 func NewForceFeatureKeyValidationSpectraS3Request() *ForceFeatureKeyValidationSpectraS3Request {
-    return &ForceFeatureKeyValidationSpectraS3Request{
-    }
+	return &ForceFeatureKeyValidationSpectraS3Request{}
 }
 
 type GetFeatureKeysSpectraS3Request struct {
-    ErrorMessage *string
-    ExpirationDate *string
-    Key FeatureKeyType
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
+	ErrorMessage    *string
+	ExpirationDate  *string
+	Key             FeatureKeyType
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
 }
 
 func NewGetFeatureKeysSpectraS3Request() *GetFeatureKeysSpectraS3Request {
-    return &GetFeatureKeysSpectraS3Request{
-    }
+	return &GetFeatureKeysSpectraS3Request{}
 }
 
 func (getFeatureKeysSpectraS3Request *GetFeatureKeysSpectraS3Request) WithErrorMessage(errorMessage string) *GetFeatureKeysSpectraS3Request {
-    getFeatureKeysSpectraS3Request.ErrorMessage = &errorMessage
-    return getFeatureKeysSpectraS3Request
+	getFeatureKeysSpectraS3Request.ErrorMessage = &errorMessage
+	return getFeatureKeysSpectraS3Request
 }
 
 func (getFeatureKeysSpectraS3Request *GetFeatureKeysSpectraS3Request) WithExpirationDate(expirationDate string) *GetFeatureKeysSpectraS3Request {
-    getFeatureKeysSpectraS3Request.ExpirationDate = &expirationDate
-    return getFeatureKeysSpectraS3Request
+	getFeatureKeysSpectraS3Request.ExpirationDate = &expirationDate
+	return getFeatureKeysSpectraS3Request
 }
 
 func (getFeatureKeysSpectraS3Request *GetFeatureKeysSpectraS3Request) WithKey(key FeatureKeyType) *GetFeatureKeysSpectraS3Request {
-    getFeatureKeysSpectraS3Request.Key = key
-    return getFeatureKeysSpectraS3Request
+	getFeatureKeysSpectraS3Request.Key = key
+	return getFeatureKeysSpectraS3Request
 }
 
 func (getFeatureKeysSpectraS3Request *GetFeatureKeysSpectraS3Request) WithLastPage() *GetFeatureKeysSpectraS3Request {
-    getFeatureKeysSpectraS3Request.LastPage = true
-    return getFeatureKeysSpectraS3Request
+	getFeatureKeysSpectraS3Request.LastPage = true
+	return getFeatureKeysSpectraS3Request
 }
 
 func (getFeatureKeysSpectraS3Request *GetFeatureKeysSpectraS3Request) WithPageLength(pageLength int) *GetFeatureKeysSpectraS3Request {
-    getFeatureKeysSpectraS3Request.PageLength = &pageLength
-    return getFeatureKeysSpectraS3Request
+	getFeatureKeysSpectraS3Request.PageLength = &pageLength
+	return getFeatureKeysSpectraS3Request
 }
 
 func (getFeatureKeysSpectraS3Request *GetFeatureKeysSpectraS3Request) WithPageOffset(pageOffset int) *GetFeatureKeysSpectraS3Request {
-    getFeatureKeysSpectraS3Request.PageOffset = &pageOffset
-    return getFeatureKeysSpectraS3Request
+	getFeatureKeysSpectraS3Request.PageOffset = &pageOffset
+	return getFeatureKeysSpectraS3Request
 }
 
 func (getFeatureKeysSpectraS3Request *GetFeatureKeysSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetFeatureKeysSpectraS3Request {
-    getFeatureKeysSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getFeatureKeysSpectraS3Request
+	getFeatureKeysSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getFeatureKeysSpectraS3Request
 }
 
 type GetSystemFailuresSpectraS3Request struct {
-    ErrorMessage *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    SystemFailureType SystemFailureType
+	ErrorMessage      *string
+	LastPage          bool
+	PageLength        *int
+	PageOffset        *int
+	PageStartMarker   *string
+	SystemFailureType SystemFailureType
 }
 
 func NewGetSystemFailuresSpectraS3Request() *GetSystemFailuresSpectraS3Request {
-    return &GetSystemFailuresSpectraS3Request{
-    }
+	return &GetSystemFailuresSpectraS3Request{}
 }
 
 func (getSystemFailuresSpectraS3Request *GetSystemFailuresSpectraS3Request) WithErrorMessage(errorMessage string) *GetSystemFailuresSpectraS3Request {
-    getSystemFailuresSpectraS3Request.ErrorMessage = &errorMessage
-    return getSystemFailuresSpectraS3Request
+	getSystemFailuresSpectraS3Request.ErrorMessage = &errorMessage
+	return getSystemFailuresSpectraS3Request
 }
 
 func (getSystemFailuresSpectraS3Request *GetSystemFailuresSpectraS3Request) WithLastPage() *GetSystemFailuresSpectraS3Request {
-    getSystemFailuresSpectraS3Request.LastPage = true
-    return getSystemFailuresSpectraS3Request
+	getSystemFailuresSpectraS3Request.LastPage = true
+	return getSystemFailuresSpectraS3Request
 }
 
 func (getSystemFailuresSpectraS3Request *GetSystemFailuresSpectraS3Request) WithPageLength(pageLength int) *GetSystemFailuresSpectraS3Request {
-    getSystemFailuresSpectraS3Request.PageLength = &pageLength
-    return getSystemFailuresSpectraS3Request
+	getSystemFailuresSpectraS3Request.PageLength = &pageLength
+	return getSystemFailuresSpectraS3Request
 }
 
 func (getSystemFailuresSpectraS3Request *GetSystemFailuresSpectraS3Request) WithPageOffset(pageOffset int) *GetSystemFailuresSpectraS3Request {
-    getSystemFailuresSpectraS3Request.PageOffset = &pageOffset
-    return getSystemFailuresSpectraS3Request
+	getSystemFailuresSpectraS3Request.PageOffset = &pageOffset
+	return getSystemFailuresSpectraS3Request
 }
 
 func (getSystemFailuresSpectraS3Request *GetSystemFailuresSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetSystemFailuresSpectraS3Request {
-    getSystemFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getSystemFailuresSpectraS3Request
+	getSystemFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getSystemFailuresSpectraS3Request
 }
 
 func (getSystemFailuresSpectraS3Request *GetSystemFailuresSpectraS3Request) WithSystemFailureType(systemFailureType SystemFailureType) *GetSystemFailuresSpectraS3Request {
-    getSystemFailuresSpectraS3Request.SystemFailureType = systemFailureType
-    return getSystemFailuresSpectraS3Request
+	getSystemFailuresSpectraS3Request.SystemFailureType = systemFailureType
+	return getSystemFailuresSpectraS3Request
 }
 
 type GetSystemInformationSpectraS3Request struct {
 }
 
 func NewGetSystemInformationSpectraS3Request() *GetSystemInformationSpectraS3Request {
-    return &GetSystemInformationSpectraS3Request{
-    }
+	return &GetSystemInformationSpectraS3Request{}
 }
 
 type ResetInstanceIdentifierSpectraS3Request struct {
 }
 
 func NewResetInstanceIdentifierSpectraS3Request() *ResetInstanceIdentifierSpectraS3Request {
-    return &ResetInstanceIdentifierSpectraS3Request{
-    }
+	return &ResetInstanceIdentifierSpectraS3Request{}
 }
 
 type VerifySystemHealthSpectraS3Request struct {
 }
 
 func NewVerifySystemHealthSpectraS3Request() *VerifySystemHealthSpectraS3Request {
-    return &VerifySystemHealthSpectraS3Request{
-    }
+	return &VerifySystemHealthSpectraS3Request{}
 }
 
 type CancelEjectOnAllTapesSpectraS3Request struct {
 }
 
 func NewCancelEjectOnAllTapesSpectraS3Request() *CancelEjectOnAllTapesSpectraS3Request {
-    return &CancelEjectOnAllTapesSpectraS3Request{
-    }
+	return &CancelEjectOnAllTapesSpectraS3Request{}
 }
 
 type CancelEjectTapeSpectraS3Request struct {
-    TapeId string
+	TapeId string
 }
 
 func NewCancelEjectTapeSpectraS3Request(tapeId string) *CancelEjectTapeSpectraS3Request {
-    return &CancelEjectTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &CancelEjectTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 type CancelFormatOnAllTapesSpectraS3Request struct {
 }
 
 func NewCancelFormatOnAllTapesSpectraS3Request() *CancelFormatOnAllTapesSpectraS3Request {
-    return &CancelFormatOnAllTapesSpectraS3Request{
-    }
+	return &CancelFormatOnAllTapesSpectraS3Request{}
 }
 
 type CancelFormatTapeSpectraS3Request struct {
-    TapeId string
+	TapeId string
 }
 
 func NewCancelFormatTapeSpectraS3Request(tapeId string) *CancelFormatTapeSpectraS3Request {
-    return &CancelFormatTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &CancelFormatTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 type CancelImportOnAllTapesSpectraS3Request struct {
 }
 
 func NewCancelImportOnAllTapesSpectraS3Request() *CancelImportOnAllTapesSpectraS3Request {
-    return &CancelImportOnAllTapesSpectraS3Request{
-    }
+	return &CancelImportOnAllTapesSpectraS3Request{}
 }
 
 type CancelImportTapeSpectraS3Request struct {
-    TapeId string
+	TapeId string
 }
 
 func NewCancelImportTapeSpectraS3Request(tapeId string) *CancelImportTapeSpectraS3Request {
-    return &CancelImportTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &CancelImportTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 type CancelOnlineOnAllTapesSpectraS3Request struct {
 }
 
 func NewCancelOnlineOnAllTapesSpectraS3Request() *CancelOnlineOnAllTapesSpectraS3Request {
-    return &CancelOnlineOnAllTapesSpectraS3Request{
-    }
+	return &CancelOnlineOnAllTapesSpectraS3Request{}
 }
 
 type CancelOnlineTapeSpectraS3Request struct {
-    TapeId string
+	TapeId string
 }
 
 func NewCancelOnlineTapeSpectraS3Request(tapeId string) *CancelOnlineTapeSpectraS3Request {
-    return &CancelOnlineTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &CancelOnlineTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 type CancelTestTapeDriveSpectraS3Request struct {
-    TapeDriveId string
+	TapeDriveId string
 }
 
 func NewCancelTestTapeDriveSpectraS3Request(tapeDriveId string) *CancelTestTapeDriveSpectraS3Request {
-    return &CancelTestTapeDriveSpectraS3Request{
-        TapeDriveId: tapeDriveId,
-    }
+	return &CancelTestTapeDriveSpectraS3Request{
+		TapeDriveId: tapeDriveId,
+	}
 }
 
 type CancelVerifyOnAllTapesSpectraS3Request struct {
 }
 
 func NewCancelVerifyOnAllTapesSpectraS3Request() *CancelVerifyOnAllTapesSpectraS3Request {
-    return &CancelVerifyOnAllTapesSpectraS3Request{
-    }
+	return &CancelVerifyOnAllTapesSpectraS3Request{}
 }
 
 type CancelVerifyTapeSpectraS3Request struct {
-    TapeId string
+	TapeId string
 }
 
 func NewCancelVerifyTapeSpectraS3Request(tapeId string) *CancelVerifyTapeSpectraS3Request {
-    return &CancelVerifyTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &CancelVerifyTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 type CleanTapeDriveSpectraS3Request struct {
-    TapeDriveId string
+	TapeDriveId string
 }
 
 func NewCleanTapeDriveSpectraS3Request(tapeDriveId string) *CleanTapeDriveSpectraS3Request {
-    return &CleanTapeDriveSpectraS3Request{
-        TapeDriveId: tapeDriveId,
-    }
+	return &CleanTapeDriveSpectraS3Request{
+		TapeDriveId: tapeDriveId,
+	}
 }
 
 type PutDriveDumpSpectraS3Request struct {
-    TapeDriveId string
+	TapeDriveId string
 }
 
 func NewPutDriveDumpSpectraS3Request(tapeDriveId string) *PutDriveDumpSpectraS3Request {
-    return &PutDriveDumpSpectraS3Request{
-        TapeDriveId: tapeDriveId,
-    }
+	return &PutDriveDumpSpectraS3Request{
+		TapeDriveId: tapeDriveId,
+	}
 }
 
 type PutTapeDensityDirectiveSpectraS3Request struct {
-    Density TapeDriveType
-    PartitionId string
-    TapeType string
+	Density     TapeDriveType
+	PartitionId string
+	TapeType    string
 }
 
 func NewPutTapeDensityDirectiveSpectraS3Request(density TapeDriveType, partitionId string, tapeType string) *PutTapeDensityDirectiveSpectraS3Request {
-    return &PutTapeDensityDirectiveSpectraS3Request{
-        Density: density,
-        PartitionId: partitionId,
-        TapeType: tapeType,
-    }
+	return &PutTapeDensityDirectiveSpectraS3Request{
+		Density:     density,
+		PartitionId: partitionId,
+		TapeType:    tapeType,
+	}
 }
 
 type DeletePermanentlyLostTapeSpectraS3Request struct {
-    TapeId string
+	TapeId string
 }
 
 func NewDeletePermanentlyLostTapeSpectraS3Request(tapeId string) *DeletePermanentlyLostTapeSpectraS3Request {
-    return &DeletePermanentlyLostTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &DeletePermanentlyLostTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 type DeleteTapeDensityDirectiveSpectraS3Request struct {
-    TapeDensityDirective string
+	TapeDensityDirective string
 }
 
 func NewDeleteTapeDensityDirectiveSpectraS3Request(tapeDensityDirective string) *DeleteTapeDensityDirectiveSpectraS3Request {
-    return &DeleteTapeDensityDirectiveSpectraS3Request{
-        TapeDensityDirective: tapeDensityDirective,
-    }
+	return &DeleteTapeDensityDirectiveSpectraS3Request{
+		TapeDensityDirective: tapeDensityDirective,
+	}
 }
 
 type DeleteTapeDriveSpectraS3Request struct {
-    TapeDriveId string
+	TapeDriveId string
 }
 
 func NewDeleteTapeDriveSpectraS3Request(tapeDriveId string) *DeleteTapeDriveSpectraS3Request {
-    return &DeleteTapeDriveSpectraS3Request{
-        TapeDriveId: tapeDriveId,
-    }
+	return &DeleteTapeDriveSpectraS3Request{
+		TapeDriveId: tapeDriveId,
+	}
 }
 
 type DeleteTapeFailureSpectraS3Request struct {
-    TapeFailure string
+	TapeFailure string
 }
 
 func NewDeleteTapeFailureSpectraS3Request(tapeFailure string) *DeleteTapeFailureSpectraS3Request {
-    return &DeleteTapeFailureSpectraS3Request{
-        TapeFailure: tapeFailure,
-    }
+	return &DeleteTapeFailureSpectraS3Request{
+		TapeFailure: tapeFailure,
+	}
 }
 
 type DeleteTapePartitionFailureSpectraS3Request struct {
-    TapePartitionFailure string
+	TapePartitionFailure string
 }
 
 func NewDeleteTapePartitionFailureSpectraS3Request(tapePartitionFailure string) *DeleteTapePartitionFailureSpectraS3Request {
-    return &DeleteTapePartitionFailureSpectraS3Request{
-        TapePartitionFailure: tapePartitionFailure,
-    }
+	return &DeleteTapePartitionFailureSpectraS3Request{
+		TapePartitionFailure: tapePartitionFailure,
+	}
 }
 
 type DeleteTapePartitionSpectraS3Request struct {
-    TapePartition string
+	TapePartition string
 }
 
 func NewDeleteTapePartitionSpectraS3Request(tapePartition string) *DeleteTapePartitionSpectraS3Request {
-    return &DeleteTapePartitionSpectraS3Request{
-        TapePartition: tapePartition,
-    }
+	return &DeleteTapePartitionSpectraS3Request{
+		TapePartition: tapePartition,
+	}
 }
 
 type EjectAllTapesSpectraS3Request struct {
-    EjectLabel *string
-    EjectLocation *string
+	EjectLabel    *string
+	EjectLocation *string
 }
 
 func NewEjectAllTapesSpectraS3Request() *EjectAllTapesSpectraS3Request {
-    return &EjectAllTapesSpectraS3Request{
-    }
+	return &EjectAllTapesSpectraS3Request{}
 }
 
 func (ejectAllTapesSpectraS3Request *EjectAllTapesSpectraS3Request) WithEjectLabel(ejectLabel string) *EjectAllTapesSpectraS3Request {
-    ejectAllTapesSpectraS3Request.EjectLabel = &ejectLabel
-    return ejectAllTapesSpectraS3Request
+	ejectAllTapesSpectraS3Request.EjectLabel = &ejectLabel
+	return ejectAllTapesSpectraS3Request
 }
 
 func (ejectAllTapesSpectraS3Request *EjectAllTapesSpectraS3Request) WithEjectLocation(ejectLocation string) *EjectAllTapesSpectraS3Request {
-    ejectAllTapesSpectraS3Request.EjectLocation = &ejectLocation
-    return ejectAllTapesSpectraS3Request
+	ejectAllTapesSpectraS3Request.EjectLocation = &ejectLocation
+	return ejectAllTapesSpectraS3Request
 }
 
 type EjectStorageDomainBlobsSpectraS3Request struct {
-    BucketId string
-    EjectLabel *string
-    EjectLocation *string
-    Objects []Ds3GetObject
-    StorageDomain string
+	BucketId      string
+	EjectLabel    *string
+	EjectLocation *string
+	Objects       []Ds3GetObject
+	StorageDomain string
 }
 
 func NewEjectStorageDomainBlobsSpectraS3Request(bucketId string, storageDomain string, objectNames []string) *EjectStorageDomainBlobsSpectraS3Request {
 
-    return &EjectStorageDomainBlobsSpectraS3Request{
-        BucketId: bucketId,
-        StorageDomain: storageDomain,
-        Objects: buildDs3GetObjectSliceFromNames(objectNames),
-    }
+	return &EjectStorageDomainBlobsSpectraS3Request{
+		BucketId:      bucketId,
+		StorageDomain: storageDomain,
+		Objects:       buildDs3GetObjectSliceFromNames(objectNames),
+	}
 }
 
 func NewEjectStorageDomainBlobsSpectraS3RequestWithPartialObjects(bucketId string, storageDomain string, objects []Ds3GetObject) *EjectStorageDomainBlobsSpectraS3Request {
 
-    return &EjectStorageDomainBlobsSpectraS3Request{
-        BucketId: bucketId,
-        StorageDomain: storageDomain,
-        Objects: objects,
-    }
+	return &EjectStorageDomainBlobsSpectraS3Request{
+		BucketId:      bucketId,
+		StorageDomain: storageDomain,
+		Objects:       objects,
+	}
 }
 
 func (ejectStorageDomainBlobsSpectraS3Request *EjectStorageDomainBlobsSpectraS3Request) WithEjectLabel(ejectLabel string) *EjectStorageDomainBlobsSpectraS3Request {
-    ejectStorageDomainBlobsSpectraS3Request.EjectLabel = &ejectLabel
-    return ejectStorageDomainBlobsSpectraS3Request
+	ejectStorageDomainBlobsSpectraS3Request.EjectLabel = &ejectLabel
+	return ejectStorageDomainBlobsSpectraS3Request
 }
 
 func (ejectStorageDomainBlobsSpectraS3Request *EjectStorageDomainBlobsSpectraS3Request) WithEjectLocation(ejectLocation string) *EjectStorageDomainBlobsSpectraS3Request {
-    ejectStorageDomainBlobsSpectraS3Request.EjectLocation = &ejectLocation
-    return ejectStorageDomainBlobsSpectraS3Request
+	ejectStorageDomainBlobsSpectraS3Request.EjectLocation = &ejectLocation
+	return ejectStorageDomainBlobsSpectraS3Request
 }
 
 type EjectStorageDomainSpectraS3Request struct {
-    BucketId *string
-    EjectLabel *string
-    EjectLocation *string
-    StorageDomain string
+	BucketId      *string
+	EjectLabel    *string
+	EjectLocation *string
+	StorageDomain string
 }
 
 func NewEjectStorageDomainSpectraS3Request(storageDomain string) *EjectStorageDomainSpectraS3Request {
-    return &EjectStorageDomainSpectraS3Request{
-        StorageDomain: storageDomain,
-    }
+	return &EjectStorageDomainSpectraS3Request{
+		StorageDomain: storageDomain,
+	}
 }
 
 func (ejectStorageDomainSpectraS3Request *EjectStorageDomainSpectraS3Request) WithBucketId(bucketId string) *EjectStorageDomainSpectraS3Request {
-    ejectStorageDomainSpectraS3Request.BucketId = &bucketId
-    return ejectStorageDomainSpectraS3Request
+	ejectStorageDomainSpectraS3Request.BucketId = &bucketId
+	return ejectStorageDomainSpectraS3Request
 }
 
 func (ejectStorageDomainSpectraS3Request *EjectStorageDomainSpectraS3Request) WithEjectLabel(ejectLabel string) *EjectStorageDomainSpectraS3Request {
-    ejectStorageDomainSpectraS3Request.EjectLabel = &ejectLabel
-    return ejectStorageDomainSpectraS3Request
+	ejectStorageDomainSpectraS3Request.EjectLabel = &ejectLabel
+	return ejectStorageDomainSpectraS3Request
 }
 
 func (ejectStorageDomainSpectraS3Request *EjectStorageDomainSpectraS3Request) WithEjectLocation(ejectLocation string) *EjectStorageDomainSpectraS3Request {
-    ejectStorageDomainSpectraS3Request.EjectLocation = &ejectLocation
-    return ejectStorageDomainSpectraS3Request
+	ejectStorageDomainSpectraS3Request.EjectLocation = &ejectLocation
+	return ejectStorageDomainSpectraS3Request
 }
 
 type EjectTapeSpectraS3Request struct {
-    EjectLabel *string
-    EjectLocation *string
-    TapeId string
+	EjectLabel    *string
+	EjectLocation *string
+	TapeId        string
 }
 
 func NewEjectTapeSpectraS3Request(tapeId string) *EjectTapeSpectraS3Request {
-    return &EjectTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &EjectTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 func (ejectTapeSpectraS3Request *EjectTapeSpectraS3Request) WithEjectLabel(ejectLabel string) *EjectTapeSpectraS3Request {
-    ejectTapeSpectraS3Request.EjectLabel = &ejectLabel
-    return ejectTapeSpectraS3Request
+	ejectTapeSpectraS3Request.EjectLabel = &ejectLabel
+	return ejectTapeSpectraS3Request
 }
 
 func (ejectTapeSpectraS3Request *EjectTapeSpectraS3Request) WithEjectLocation(ejectLocation string) *EjectTapeSpectraS3Request {
-    ejectTapeSpectraS3Request.EjectLocation = &ejectLocation
-    return ejectTapeSpectraS3Request
+	ejectTapeSpectraS3Request.EjectLocation = &ejectLocation
+	return ejectTapeSpectraS3Request
 }
 
 type ForceTapeEnvironmentRefreshSpectraS3Request struct {
 }
 
 func NewForceTapeEnvironmentRefreshSpectraS3Request() *ForceTapeEnvironmentRefreshSpectraS3Request {
-    return &ForceTapeEnvironmentRefreshSpectraS3Request{
-    }
+	return &ForceTapeEnvironmentRefreshSpectraS3Request{}
 }
 
 type FormatAllTapesSpectraS3Request struct {
-    Force bool
+	Force bool
 }
 
 func NewFormatAllTapesSpectraS3Request() *FormatAllTapesSpectraS3Request {
-    return &FormatAllTapesSpectraS3Request{
-    }
+	return &FormatAllTapesSpectraS3Request{}
 }
 
 func (formatAllTapesSpectraS3Request *FormatAllTapesSpectraS3Request) WithForce() *FormatAllTapesSpectraS3Request {
-    formatAllTapesSpectraS3Request.Force = true
-    return formatAllTapesSpectraS3Request
+	formatAllTapesSpectraS3Request.Force = true
+	return formatAllTapesSpectraS3Request
 }
 
 type FormatTapeSpectraS3Request struct {
-    Force bool
-    TapeId string
+	Force  bool
+	TapeId string
 }
 
 func NewFormatTapeSpectraS3Request(tapeId string) *FormatTapeSpectraS3Request {
-    return &FormatTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &FormatTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 func (formatTapeSpectraS3Request *FormatTapeSpectraS3Request) WithForce() *FormatTapeSpectraS3Request {
-    formatTapeSpectraS3Request.Force = true
-    return formatTapeSpectraS3Request
+	formatTapeSpectraS3Request.Force = true
+	return formatTapeSpectraS3Request
 }
 
 type GetBlobsOnTapeSpectraS3Request struct {
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    TapeId string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	TapeId          string
 }
 
 func NewGetBlobsOnTapeSpectraS3Request(tapeId string) *GetBlobsOnTapeSpectraS3Request {
-    return &GetBlobsOnTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &GetBlobsOnTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 func (getBlobsOnTapeSpectraS3Request *GetBlobsOnTapeSpectraS3Request) WithLastPage() *GetBlobsOnTapeSpectraS3Request {
-    getBlobsOnTapeSpectraS3Request.LastPage = true
-    return getBlobsOnTapeSpectraS3Request
+	getBlobsOnTapeSpectraS3Request.LastPage = true
+	return getBlobsOnTapeSpectraS3Request
 }
 
 func (getBlobsOnTapeSpectraS3Request *GetBlobsOnTapeSpectraS3Request) WithPageLength(pageLength int) *GetBlobsOnTapeSpectraS3Request {
-    getBlobsOnTapeSpectraS3Request.PageLength = &pageLength
-    return getBlobsOnTapeSpectraS3Request
+	getBlobsOnTapeSpectraS3Request.PageLength = &pageLength
+	return getBlobsOnTapeSpectraS3Request
 }
 
 func (getBlobsOnTapeSpectraS3Request *GetBlobsOnTapeSpectraS3Request) WithPageOffset(pageOffset int) *GetBlobsOnTapeSpectraS3Request {
-    getBlobsOnTapeSpectraS3Request.PageOffset = &pageOffset
-    return getBlobsOnTapeSpectraS3Request
+	getBlobsOnTapeSpectraS3Request.PageOffset = &pageOffset
+	return getBlobsOnTapeSpectraS3Request
 }
 
 func (getBlobsOnTapeSpectraS3Request *GetBlobsOnTapeSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetBlobsOnTapeSpectraS3Request {
-    getBlobsOnTapeSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getBlobsOnTapeSpectraS3Request
+	getBlobsOnTapeSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getBlobsOnTapeSpectraS3Request
 }
 
 type GetTapeDensityDirectiveSpectraS3Request struct {
-    TapeDensityDirective string
+	TapeDensityDirective string
 }
 
 func NewGetTapeDensityDirectiveSpectraS3Request(tapeDensityDirective string) *GetTapeDensityDirectiveSpectraS3Request {
-    return &GetTapeDensityDirectiveSpectraS3Request{
-        TapeDensityDirective: tapeDensityDirective,
-    }
+	return &GetTapeDensityDirectiveSpectraS3Request{
+		TapeDensityDirective: tapeDensityDirective,
+	}
 }
 
 type GetTapeDensityDirectivesSpectraS3Request struct {
-    Density TapeDriveType
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PartitionId *string
-    TapeType *string
+	Density         TapeDriveType
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	PartitionId     *string
+	TapeType        *string
 }
 
 func NewGetTapeDensityDirectivesSpectraS3Request() *GetTapeDensityDirectivesSpectraS3Request {
-    return &GetTapeDensityDirectivesSpectraS3Request{
-    }
+	return &GetTapeDensityDirectivesSpectraS3Request{}
 }
 
 func (getTapeDensityDirectivesSpectraS3Request *GetTapeDensityDirectivesSpectraS3Request) WithDensity(density TapeDriveType) *GetTapeDensityDirectivesSpectraS3Request {
-    getTapeDensityDirectivesSpectraS3Request.Density = density
-    return getTapeDensityDirectivesSpectraS3Request
+	getTapeDensityDirectivesSpectraS3Request.Density = density
+	return getTapeDensityDirectivesSpectraS3Request
 }
 
 func (getTapeDensityDirectivesSpectraS3Request *GetTapeDensityDirectivesSpectraS3Request) WithLastPage() *GetTapeDensityDirectivesSpectraS3Request {
-    getTapeDensityDirectivesSpectraS3Request.LastPage = true
-    return getTapeDensityDirectivesSpectraS3Request
+	getTapeDensityDirectivesSpectraS3Request.LastPage = true
+	return getTapeDensityDirectivesSpectraS3Request
 }
 
 func (getTapeDensityDirectivesSpectraS3Request *GetTapeDensityDirectivesSpectraS3Request) WithPageLength(pageLength int) *GetTapeDensityDirectivesSpectraS3Request {
-    getTapeDensityDirectivesSpectraS3Request.PageLength = &pageLength
-    return getTapeDensityDirectivesSpectraS3Request
+	getTapeDensityDirectivesSpectraS3Request.PageLength = &pageLength
+	return getTapeDensityDirectivesSpectraS3Request
 }
 
 func (getTapeDensityDirectivesSpectraS3Request *GetTapeDensityDirectivesSpectraS3Request) WithPageOffset(pageOffset int) *GetTapeDensityDirectivesSpectraS3Request {
-    getTapeDensityDirectivesSpectraS3Request.PageOffset = &pageOffset
-    return getTapeDensityDirectivesSpectraS3Request
+	getTapeDensityDirectivesSpectraS3Request.PageOffset = &pageOffset
+	return getTapeDensityDirectivesSpectraS3Request
 }
 
 func (getTapeDensityDirectivesSpectraS3Request *GetTapeDensityDirectivesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetTapeDensityDirectivesSpectraS3Request {
-    getTapeDensityDirectivesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getTapeDensityDirectivesSpectraS3Request
+	getTapeDensityDirectivesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getTapeDensityDirectivesSpectraS3Request
 }
 
 func (getTapeDensityDirectivesSpectraS3Request *GetTapeDensityDirectivesSpectraS3Request) WithPartitionId(partitionId string) *GetTapeDensityDirectivesSpectraS3Request {
-    getTapeDensityDirectivesSpectraS3Request.PartitionId = &partitionId
-    return getTapeDensityDirectivesSpectraS3Request
+	getTapeDensityDirectivesSpectraS3Request.PartitionId = &partitionId
+	return getTapeDensityDirectivesSpectraS3Request
 }
 
 func (getTapeDensityDirectivesSpectraS3Request *GetTapeDensityDirectivesSpectraS3Request) WithTapeType(tapeType string) *GetTapeDensityDirectivesSpectraS3Request {
-    getTapeDensityDirectivesSpectraS3Request.TapeType = &tapeType
-    return getTapeDensityDirectivesSpectraS3Request
+	getTapeDensityDirectivesSpectraS3Request.TapeType = &tapeType
+	return getTapeDensityDirectivesSpectraS3Request
 }
 
 type GetTapeDriveSpectraS3Request struct {
-    TapeDriveId string
+	TapeDriveId string
 }
 
 func NewGetTapeDriveSpectraS3Request(tapeDriveId string) *GetTapeDriveSpectraS3Request {
-    return &GetTapeDriveSpectraS3Request{
-        TapeDriveId: tapeDriveId,
-    }
+	return &GetTapeDriveSpectraS3Request{
+		TapeDriveId: tapeDriveId,
+	}
 }
 
 type GetTapeDrivesSpectraS3Request struct {
-    LastPage bool
-    MinimumTaskPriority Priority
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PartitionId *string
-    ReservedTaskType ReservedTaskType
-    SerialNumber *string
-    State TapeDriveState
-    TapeDriveType TapeDriveType
+	LastPage            bool
+	MinimumTaskPriority Priority
+	PageLength          *int
+	PageOffset          *int
+	PageStartMarker     *string
+	PartitionId         *string
+	ReservedTaskType    ReservedTaskType
+	SerialNumber        *string
+	State               TapeDriveState
+	TapeDriveType       TapeDriveType
 }
 
 func NewGetTapeDrivesSpectraS3Request() *GetTapeDrivesSpectraS3Request {
-    return &GetTapeDrivesSpectraS3Request{
-    }
+	return &GetTapeDrivesSpectraS3Request{}
 }
 
 func (getTapeDrivesSpectraS3Request *GetTapeDrivesSpectraS3Request) WithLastPage() *GetTapeDrivesSpectraS3Request {
-    getTapeDrivesSpectraS3Request.LastPage = true
-    return getTapeDrivesSpectraS3Request
+	getTapeDrivesSpectraS3Request.LastPage = true
+	return getTapeDrivesSpectraS3Request
 }
 
 func (getTapeDrivesSpectraS3Request *GetTapeDrivesSpectraS3Request) WithMinimumTaskPriority(minimumTaskPriority Priority) *GetTapeDrivesSpectraS3Request {
-    getTapeDrivesSpectraS3Request.MinimumTaskPriority = minimumTaskPriority
-    return getTapeDrivesSpectraS3Request
+	getTapeDrivesSpectraS3Request.MinimumTaskPriority = minimumTaskPriority
+	return getTapeDrivesSpectraS3Request
 }
 
 func (getTapeDrivesSpectraS3Request *GetTapeDrivesSpectraS3Request) WithPageLength(pageLength int) *GetTapeDrivesSpectraS3Request {
-    getTapeDrivesSpectraS3Request.PageLength = &pageLength
-    return getTapeDrivesSpectraS3Request
+	getTapeDrivesSpectraS3Request.PageLength = &pageLength
+	return getTapeDrivesSpectraS3Request
 }
 
 func (getTapeDrivesSpectraS3Request *GetTapeDrivesSpectraS3Request) WithPageOffset(pageOffset int) *GetTapeDrivesSpectraS3Request {
-    getTapeDrivesSpectraS3Request.PageOffset = &pageOffset
-    return getTapeDrivesSpectraS3Request
+	getTapeDrivesSpectraS3Request.PageOffset = &pageOffset
+	return getTapeDrivesSpectraS3Request
 }
 
 func (getTapeDrivesSpectraS3Request *GetTapeDrivesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetTapeDrivesSpectraS3Request {
-    getTapeDrivesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getTapeDrivesSpectraS3Request
+	getTapeDrivesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getTapeDrivesSpectraS3Request
 }
 
 func (getTapeDrivesSpectraS3Request *GetTapeDrivesSpectraS3Request) WithPartitionId(partitionId string) *GetTapeDrivesSpectraS3Request {
-    getTapeDrivesSpectraS3Request.PartitionId = &partitionId
-    return getTapeDrivesSpectraS3Request
+	getTapeDrivesSpectraS3Request.PartitionId = &partitionId
+	return getTapeDrivesSpectraS3Request
 }
 
 func (getTapeDrivesSpectraS3Request *GetTapeDrivesSpectraS3Request) WithReservedTaskType(reservedTaskType ReservedTaskType) *GetTapeDrivesSpectraS3Request {
-    getTapeDrivesSpectraS3Request.ReservedTaskType = reservedTaskType
-    return getTapeDrivesSpectraS3Request
+	getTapeDrivesSpectraS3Request.ReservedTaskType = reservedTaskType
+	return getTapeDrivesSpectraS3Request
 }
 
 func (getTapeDrivesSpectraS3Request *GetTapeDrivesSpectraS3Request) WithSerialNumber(serialNumber string) *GetTapeDrivesSpectraS3Request {
-    getTapeDrivesSpectraS3Request.SerialNumber = &serialNumber
-    return getTapeDrivesSpectraS3Request
+	getTapeDrivesSpectraS3Request.SerialNumber = &serialNumber
+	return getTapeDrivesSpectraS3Request
 }
 
 func (getTapeDrivesSpectraS3Request *GetTapeDrivesSpectraS3Request) WithState(state TapeDriveState) *GetTapeDrivesSpectraS3Request {
-    getTapeDrivesSpectraS3Request.State = state
-    return getTapeDrivesSpectraS3Request
+	getTapeDrivesSpectraS3Request.State = state
+	return getTapeDrivesSpectraS3Request
 }
 
 func (getTapeDrivesSpectraS3Request *GetTapeDrivesSpectraS3Request) WithTapeDriveType(tapeDriveType TapeDriveType) *GetTapeDrivesSpectraS3Request {
-    getTapeDrivesSpectraS3Request.TapeDriveType = tapeDriveType
-    return getTapeDrivesSpectraS3Request
+	getTapeDrivesSpectraS3Request.TapeDriveType = tapeDriveType
+	return getTapeDrivesSpectraS3Request
 }
 
 type GetTapeFailuresSpectraS3Request struct {
-    ErrorMessage *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    TapeDriveId *string
-    TapeFailureType TapeFailureType
-    TapeId *string
+	ErrorMessage    *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	TapeDriveId     *string
+	TapeFailureType TapeFailureType
+	TapeId          *string
 }
 
 func NewGetTapeFailuresSpectraS3Request() *GetTapeFailuresSpectraS3Request {
-    return &GetTapeFailuresSpectraS3Request{
-    }
+	return &GetTapeFailuresSpectraS3Request{}
 }
 
 func (getTapeFailuresSpectraS3Request *GetTapeFailuresSpectraS3Request) WithErrorMessage(errorMessage string) *GetTapeFailuresSpectraS3Request {
-    getTapeFailuresSpectraS3Request.ErrorMessage = &errorMessage
-    return getTapeFailuresSpectraS3Request
+	getTapeFailuresSpectraS3Request.ErrorMessage = &errorMessage
+	return getTapeFailuresSpectraS3Request
 }
 
 func (getTapeFailuresSpectraS3Request *GetTapeFailuresSpectraS3Request) WithLastPage() *GetTapeFailuresSpectraS3Request {
-    getTapeFailuresSpectraS3Request.LastPage = true
-    return getTapeFailuresSpectraS3Request
+	getTapeFailuresSpectraS3Request.LastPage = true
+	return getTapeFailuresSpectraS3Request
 }
 
 func (getTapeFailuresSpectraS3Request *GetTapeFailuresSpectraS3Request) WithPageLength(pageLength int) *GetTapeFailuresSpectraS3Request {
-    getTapeFailuresSpectraS3Request.PageLength = &pageLength
-    return getTapeFailuresSpectraS3Request
+	getTapeFailuresSpectraS3Request.PageLength = &pageLength
+	return getTapeFailuresSpectraS3Request
 }
 
 func (getTapeFailuresSpectraS3Request *GetTapeFailuresSpectraS3Request) WithPageOffset(pageOffset int) *GetTapeFailuresSpectraS3Request {
-    getTapeFailuresSpectraS3Request.PageOffset = &pageOffset
-    return getTapeFailuresSpectraS3Request
+	getTapeFailuresSpectraS3Request.PageOffset = &pageOffset
+	return getTapeFailuresSpectraS3Request
 }
 
 func (getTapeFailuresSpectraS3Request *GetTapeFailuresSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetTapeFailuresSpectraS3Request {
-    getTapeFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getTapeFailuresSpectraS3Request
+	getTapeFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getTapeFailuresSpectraS3Request
 }
 
 func (getTapeFailuresSpectraS3Request *GetTapeFailuresSpectraS3Request) WithTapeDriveId(tapeDriveId string) *GetTapeFailuresSpectraS3Request {
-    getTapeFailuresSpectraS3Request.TapeDriveId = &tapeDriveId
-    return getTapeFailuresSpectraS3Request
+	getTapeFailuresSpectraS3Request.TapeDriveId = &tapeDriveId
+	return getTapeFailuresSpectraS3Request
 }
 
 func (getTapeFailuresSpectraS3Request *GetTapeFailuresSpectraS3Request) WithTapeId(tapeId string) *GetTapeFailuresSpectraS3Request {
-    getTapeFailuresSpectraS3Request.TapeId = &tapeId
-    return getTapeFailuresSpectraS3Request
+	getTapeFailuresSpectraS3Request.TapeId = &tapeId
+	return getTapeFailuresSpectraS3Request
 }
 
 func (getTapeFailuresSpectraS3Request *GetTapeFailuresSpectraS3Request) WithTapeFailureType(tapeFailureType TapeFailureType) *GetTapeFailuresSpectraS3Request {
-    getTapeFailuresSpectraS3Request.TapeFailureType = tapeFailureType
-    return getTapeFailuresSpectraS3Request
+	getTapeFailuresSpectraS3Request.TapeFailureType = tapeFailureType
+	return getTapeFailuresSpectraS3Request
 }
 
 type GetTapeLibrariesSpectraS3Request struct {
-    LastPage bool
-    ManagementUrl *string
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    SerialNumber *string
+	LastPage        bool
+	ManagementUrl   *string
+	Name            *string
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	SerialNumber    *string
 }
 
 func NewGetTapeLibrariesSpectraS3Request() *GetTapeLibrariesSpectraS3Request {
-    return &GetTapeLibrariesSpectraS3Request{
-    }
+	return &GetTapeLibrariesSpectraS3Request{}
 }
 
 func (getTapeLibrariesSpectraS3Request *GetTapeLibrariesSpectraS3Request) WithLastPage() *GetTapeLibrariesSpectraS3Request {
-    getTapeLibrariesSpectraS3Request.LastPage = true
-    return getTapeLibrariesSpectraS3Request
+	getTapeLibrariesSpectraS3Request.LastPage = true
+	return getTapeLibrariesSpectraS3Request
 }
 
 func (getTapeLibrariesSpectraS3Request *GetTapeLibrariesSpectraS3Request) WithManagementUrl(managementUrl string) *GetTapeLibrariesSpectraS3Request {
-    getTapeLibrariesSpectraS3Request.ManagementUrl = &managementUrl
-    return getTapeLibrariesSpectraS3Request
+	getTapeLibrariesSpectraS3Request.ManagementUrl = &managementUrl
+	return getTapeLibrariesSpectraS3Request
 }
 
 func (getTapeLibrariesSpectraS3Request *GetTapeLibrariesSpectraS3Request) WithName(name string) *GetTapeLibrariesSpectraS3Request {
-    getTapeLibrariesSpectraS3Request.Name = &name
-    return getTapeLibrariesSpectraS3Request
+	getTapeLibrariesSpectraS3Request.Name = &name
+	return getTapeLibrariesSpectraS3Request
 }
 
 func (getTapeLibrariesSpectraS3Request *GetTapeLibrariesSpectraS3Request) WithPageLength(pageLength int) *GetTapeLibrariesSpectraS3Request {
-    getTapeLibrariesSpectraS3Request.PageLength = &pageLength
-    return getTapeLibrariesSpectraS3Request
+	getTapeLibrariesSpectraS3Request.PageLength = &pageLength
+	return getTapeLibrariesSpectraS3Request
 }
 
 func (getTapeLibrariesSpectraS3Request *GetTapeLibrariesSpectraS3Request) WithPageOffset(pageOffset int) *GetTapeLibrariesSpectraS3Request {
-    getTapeLibrariesSpectraS3Request.PageOffset = &pageOffset
-    return getTapeLibrariesSpectraS3Request
+	getTapeLibrariesSpectraS3Request.PageOffset = &pageOffset
+	return getTapeLibrariesSpectraS3Request
 }
 
 func (getTapeLibrariesSpectraS3Request *GetTapeLibrariesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetTapeLibrariesSpectraS3Request {
-    getTapeLibrariesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getTapeLibrariesSpectraS3Request
+	getTapeLibrariesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getTapeLibrariesSpectraS3Request
 }
 
 func (getTapeLibrariesSpectraS3Request *GetTapeLibrariesSpectraS3Request) WithSerialNumber(serialNumber string) *GetTapeLibrariesSpectraS3Request {
-    getTapeLibrariesSpectraS3Request.SerialNumber = &serialNumber
-    return getTapeLibrariesSpectraS3Request
+	getTapeLibrariesSpectraS3Request.SerialNumber = &serialNumber
+	return getTapeLibrariesSpectraS3Request
 }
 
 type GetTapeLibrarySpectraS3Request struct {
-    TapeLibraryId string
+	TapeLibraryId string
 }
 
 func NewGetTapeLibrarySpectraS3Request(tapeLibraryId string) *GetTapeLibrarySpectraS3Request {
-    return &GetTapeLibrarySpectraS3Request{
-        TapeLibraryId: tapeLibraryId,
-    }
+	return &GetTapeLibrarySpectraS3Request{
+		TapeLibraryId: tapeLibraryId,
+	}
 }
 
 type GetTapePartitionFailuresSpectraS3Request struct {
-    ErrorMessage *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PartitionId *string
-    TapePartitionFailureType TapePartitionFailureType
+	ErrorMessage             *string
+	LastPage                 bool
+	PageLength               *int
+	PageOffset               *int
+	PageStartMarker          *string
+	PartitionId              *string
+	TapePartitionFailureType TapePartitionFailureType
 }
 
 func NewGetTapePartitionFailuresSpectraS3Request() *GetTapePartitionFailuresSpectraS3Request {
-    return &GetTapePartitionFailuresSpectraS3Request{
-    }
+	return &GetTapePartitionFailuresSpectraS3Request{}
 }
 
 func (getTapePartitionFailuresSpectraS3Request *GetTapePartitionFailuresSpectraS3Request) WithErrorMessage(errorMessage string) *GetTapePartitionFailuresSpectraS3Request {
-    getTapePartitionFailuresSpectraS3Request.ErrorMessage = &errorMessage
-    return getTapePartitionFailuresSpectraS3Request
+	getTapePartitionFailuresSpectraS3Request.ErrorMessage = &errorMessage
+	return getTapePartitionFailuresSpectraS3Request
 }
 
 func (getTapePartitionFailuresSpectraS3Request *GetTapePartitionFailuresSpectraS3Request) WithLastPage() *GetTapePartitionFailuresSpectraS3Request {
-    getTapePartitionFailuresSpectraS3Request.LastPage = true
-    return getTapePartitionFailuresSpectraS3Request
+	getTapePartitionFailuresSpectraS3Request.LastPage = true
+	return getTapePartitionFailuresSpectraS3Request
 }
 
 func (getTapePartitionFailuresSpectraS3Request *GetTapePartitionFailuresSpectraS3Request) WithPageLength(pageLength int) *GetTapePartitionFailuresSpectraS3Request {
-    getTapePartitionFailuresSpectraS3Request.PageLength = &pageLength
-    return getTapePartitionFailuresSpectraS3Request
+	getTapePartitionFailuresSpectraS3Request.PageLength = &pageLength
+	return getTapePartitionFailuresSpectraS3Request
 }
 
 func (getTapePartitionFailuresSpectraS3Request *GetTapePartitionFailuresSpectraS3Request) WithPageOffset(pageOffset int) *GetTapePartitionFailuresSpectraS3Request {
-    getTapePartitionFailuresSpectraS3Request.PageOffset = &pageOffset
-    return getTapePartitionFailuresSpectraS3Request
+	getTapePartitionFailuresSpectraS3Request.PageOffset = &pageOffset
+	return getTapePartitionFailuresSpectraS3Request
 }
 
 func (getTapePartitionFailuresSpectraS3Request *GetTapePartitionFailuresSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetTapePartitionFailuresSpectraS3Request {
-    getTapePartitionFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getTapePartitionFailuresSpectraS3Request
+	getTapePartitionFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getTapePartitionFailuresSpectraS3Request
 }
 
 func (getTapePartitionFailuresSpectraS3Request *GetTapePartitionFailuresSpectraS3Request) WithPartitionId(partitionId string) *GetTapePartitionFailuresSpectraS3Request {
-    getTapePartitionFailuresSpectraS3Request.PartitionId = &partitionId
-    return getTapePartitionFailuresSpectraS3Request
+	getTapePartitionFailuresSpectraS3Request.PartitionId = &partitionId
+	return getTapePartitionFailuresSpectraS3Request
 }
 
 func (getTapePartitionFailuresSpectraS3Request *GetTapePartitionFailuresSpectraS3Request) WithTapePartitionFailureType(tapePartitionFailureType TapePartitionFailureType) *GetTapePartitionFailuresSpectraS3Request {
-    getTapePartitionFailuresSpectraS3Request.TapePartitionFailureType = tapePartitionFailureType
-    return getTapePartitionFailuresSpectraS3Request
+	getTapePartitionFailuresSpectraS3Request.TapePartitionFailureType = tapePartitionFailureType
+	return getTapePartitionFailuresSpectraS3Request
 }
 
 type GetTapePartitionSpectraS3Request struct {
-    TapePartition string
+	TapePartition string
 }
 
 func NewGetTapePartitionSpectraS3Request(tapePartition string) *GetTapePartitionSpectraS3Request {
-    return &GetTapePartitionSpectraS3Request{
-        TapePartition: tapePartition,
-    }
+	return &GetTapePartitionSpectraS3Request{
+		TapePartition: tapePartition,
+	}
 }
 
 type GetTapePartitionWithFullDetailsSpectraS3Request struct {
-    TapePartition string
+	TapePartition string
 }
 
 func NewGetTapePartitionWithFullDetailsSpectraS3Request(tapePartition string) *GetTapePartitionWithFullDetailsSpectraS3Request {
-    return &GetTapePartitionWithFullDetailsSpectraS3Request{
-        TapePartition: tapePartition,
-    }
+	return &GetTapePartitionWithFullDetailsSpectraS3Request{
+		TapePartition: tapePartition,
+	}
 }
 
 type GetTapePartitionsSpectraS3Request struct {
-    ImportExportConfiguration ImportExportConfiguration
-    LastPage bool
-    LibraryId *string
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    Quiesced Quiesced
-    SerialNumber *string
-    State TapePartitionState
+	ImportExportConfiguration ImportExportConfiguration
+	LastPage                  bool
+	LibraryId                 *string
+	Name                      *string
+	PageLength                *int
+	PageOffset                *int
+	PageStartMarker           *string
+	Quiesced                  Quiesced
+	SerialNumber              *string
+	State                     TapePartitionState
 }
 
 func NewGetTapePartitionsSpectraS3Request() *GetTapePartitionsSpectraS3Request {
-    return &GetTapePartitionsSpectraS3Request{
-    }
+	return &GetTapePartitionsSpectraS3Request{}
 }
 
 func (getTapePartitionsSpectraS3Request *GetTapePartitionsSpectraS3Request) WithImportExportConfiguration(importExportConfiguration ImportExportConfiguration) *GetTapePartitionsSpectraS3Request {
-    getTapePartitionsSpectraS3Request.ImportExportConfiguration = importExportConfiguration
-    return getTapePartitionsSpectraS3Request
+	getTapePartitionsSpectraS3Request.ImportExportConfiguration = importExportConfiguration
+	return getTapePartitionsSpectraS3Request
 }
 
 func (getTapePartitionsSpectraS3Request *GetTapePartitionsSpectraS3Request) WithLastPage() *GetTapePartitionsSpectraS3Request {
-    getTapePartitionsSpectraS3Request.LastPage = true
-    return getTapePartitionsSpectraS3Request
+	getTapePartitionsSpectraS3Request.LastPage = true
+	return getTapePartitionsSpectraS3Request
 }
 
 func (getTapePartitionsSpectraS3Request *GetTapePartitionsSpectraS3Request) WithLibraryId(libraryId string) *GetTapePartitionsSpectraS3Request {
-    getTapePartitionsSpectraS3Request.LibraryId = &libraryId
-    return getTapePartitionsSpectraS3Request
+	getTapePartitionsSpectraS3Request.LibraryId = &libraryId
+	return getTapePartitionsSpectraS3Request
 }
 
 func (getTapePartitionsSpectraS3Request *GetTapePartitionsSpectraS3Request) WithName(name string) *GetTapePartitionsSpectraS3Request {
-    getTapePartitionsSpectraS3Request.Name = &name
-    return getTapePartitionsSpectraS3Request
+	getTapePartitionsSpectraS3Request.Name = &name
+	return getTapePartitionsSpectraS3Request
 }
 
 func (getTapePartitionsSpectraS3Request *GetTapePartitionsSpectraS3Request) WithPageLength(pageLength int) *GetTapePartitionsSpectraS3Request {
-    getTapePartitionsSpectraS3Request.PageLength = &pageLength
-    return getTapePartitionsSpectraS3Request
+	getTapePartitionsSpectraS3Request.PageLength = &pageLength
+	return getTapePartitionsSpectraS3Request
 }
 
 func (getTapePartitionsSpectraS3Request *GetTapePartitionsSpectraS3Request) WithPageOffset(pageOffset int) *GetTapePartitionsSpectraS3Request {
-    getTapePartitionsSpectraS3Request.PageOffset = &pageOffset
-    return getTapePartitionsSpectraS3Request
+	getTapePartitionsSpectraS3Request.PageOffset = &pageOffset
+	return getTapePartitionsSpectraS3Request
 }
 
 func (getTapePartitionsSpectraS3Request *GetTapePartitionsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetTapePartitionsSpectraS3Request {
-    getTapePartitionsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getTapePartitionsSpectraS3Request
+	getTapePartitionsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getTapePartitionsSpectraS3Request
 }
 
 func (getTapePartitionsSpectraS3Request *GetTapePartitionsSpectraS3Request) WithQuiesced(quiesced Quiesced) *GetTapePartitionsSpectraS3Request {
-    getTapePartitionsSpectraS3Request.Quiesced = quiesced
-    return getTapePartitionsSpectraS3Request
+	getTapePartitionsSpectraS3Request.Quiesced = quiesced
+	return getTapePartitionsSpectraS3Request
 }
 
 func (getTapePartitionsSpectraS3Request *GetTapePartitionsSpectraS3Request) WithSerialNumber(serialNumber string) *GetTapePartitionsSpectraS3Request {
-    getTapePartitionsSpectraS3Request.SerialNumber = &serialNumber
-    return getTapePartitionsSpectraS3Request
+	getTapePartitionsSpectraS3Request.SerialNumber = &serialNumber
+	return getTapePartitionsSpectraS3Request
 }
 
 func (getTapePartitionsSpectraS3Request *GetTapePartitionsSpectraS3Request) WithState(state TapePartitionState) *GetTapePartitionsSpectraS3Request {
-    getTapePartitionsSpectraS3Request.State = state
-    return getTapePartitionsSpectraS3Request
+	getTapePartitionsSpectraS3Request.State = state
+	return getTapePartitionsSpectraS3Request
 }
 
 type GetTapePartitionsWithFullDetailsSpectraS3Request struct {
-    ImportExportConfiguration ImportExportConfiguration
-    LastPage bool
-    LibraryId *string
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    Quiesced Quiesced
-    SerialNumber *string
-    State TapePartitionState
+	ImportExportConfiguration ImportExportConfiguration
+	LastPage                  bool
+	LibraryId                 *string
+	Name                      *string
+	PageLength                *int
+	PageOffset                *int
+	PageStartMarker           *string
+	Quiesced                  Quiesced
+	SerialNumber              *string
+	State                     TapePartitionState
 }
 
 func NewGetTapePartitionsWithFullDetailsSpectraS3Request() *GetTapePartitionsWithFullDetailsSpectraS3Request {
-    return &GetTapePartitionsWithFullDetailsSpectraS3Request{
-    }
+	return &GetTapePartitionsWithFullDetailsSpectraS3Request{}
 }
 
 func (getTapePartitionsWithFullDetailsSpectraS3Request *GetTapePartitionsWithFullDetailsSpectraS3Request) WithImportExportConfiguration(importExportConfiguration ImportExportConfiguration) *GetTapePartitionsWithFullDetailsSpectraS3Request {
-    getTapePartitionsWithFullDetailsSpectraS3Request.ImportExportConfiguration = importExportConfiguration
-    return getTapePartitionsWithFullDetailsSpectraS3Request
+	getTapePartitionsWithFullDetailsSpectraS3Request.ImportExportConfiguration = importExportConfiguration
+	return getTapePartitionsWithFullDetailsSpectraS3Request
 }
 
 func (getTapePartitionsWithFullDetailsSpectraS3Request *GetTapePartitionsWithFullDetailsSpectraS3Request) WithLastPage() *GetTapePartitionsWithFullDetailsSpectraS3Request {
-    getTapePartitionsWithFullDetailsSpectraS3Request.LastPage = true
-    return getTapePartitionsWithFullDetailsSpectraS3Request
+	getTapePartitionsWithFullDetailsSpectraS3Request.LastPage = true
+	return getTapePartitionsWithFullDetailsSpectraS3Request
 }
 
 func (getTapePartitionsWithFullDetailsSpectraS3Request *GetTapePartitionsWithFullDetailsSpectraS3Request) WithLibraryId(libraryId string) *GetTapePartitionsWithFullDetailsSpectraS3Request {
-    getTapePartitionsWithFullDetailsSpectraS3Request.LibraryId = &libraryId
-    return getTapePartitionsWithFullDetailsSpectraS3Request
+	getTapePartitionsWithFullDetailsSpectraS3Request.LibraryId = &libraryId
+	return getTapePartitionsWithFullDetailsSpectraS3Request
 }
 
 func (getTapePartitionsWithFullDetailsSpectraS3Request *GetTapePartitionsWithFullDetailsSpectraS3Request) WithName(name string) *GetTapePartitionsWithFullDetailsSpectraS3Request {
-    getTapePartitionsWithFullDetailsSpectraS3Request.Name = &name
-    return getTapePartitionsWithFullDetailsSpectraS3Request
+	getTapePartitionsWithFullDetailsSpectraS3Request.Name = &name
+	return getTapePartitionsWithFullDetailsSpectraS3Request
 }
 
 func (getTapePartitionsWithFullDetailsSpectraS3Request *GetTapePartitionsWithFullDetailsSpectraS3Request) WithPageLength(pageLength int) *GetTapePartitionsWithFullDetailsSpectraS3Request {
-    getTapePartitionsWithFullDetailsSpectraS3Request.PageLength = &pageLength
-    return getTapePartitionsWithFullDetailsSpectraS3Request
+	getTapePartitionsWithFullDetailsSpectraS3Request.PageLength = &pageLength
+	return getTapePartitionsWithFullDetailsSpectraS3Request
 }
 
 func (getTapePartitionsWithFullDetailsSpectraS3Request *GetTapePartitionsWithFullDetailsSpectraS3Request) WithPageOffset(pageOffset int) *GetTapePartitionsWithFullDetailsSpectraS3Request {
-    getTapePartitionsWithFullDetailsSpectraS3Request.PageOffset = &pageOffset
-    return getTapePartitionsWithFullDetailsSpectraS3Request
+	getTapePartitionsWithFullDetailsSpectraS3Request.PageOffset = &pageOffset
+	return getTapePartitionsWithFullDetailsSpectraS3Request
 }
 
 func (getTapePartitionsWithFullDetailsSpectraS3Request *GetTapePartitionsWithFullDetailsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetTapePartitionsWithFullDetailsSpectraS3Request {
-    getTapePartitionsWithFullDetailsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getTapePartitionsWithFullDetailsSpectraS3Request
+	getTapePartitionsWithFullDetailsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getTapePartitionsWithFullDetailsSpectraS3Request
 }
 
 func (getTapePartitionsWithFullDetailsSpectraS3Request *GetTapePartitionsWithFullDetailsSpectraS3Request) WithQuiesced(quiesced Quiesced) *GetTapePartitionsWithFullDetailsSpectraS3Request {
-    getTapePartitionsWithFullDetailsSpectraS3Request.Quiesced = quiesced
-    return getTapePartitionsWithFullDetailsSpectraS3Request
+	getTapePartitionsWithFullDetailsSpectraS3Request.Quiesced = quiesced
+	return getTapePartitionsWithFullDetailsSpectraS3Request
 }
 
 func (getTapePartitionsWithFullDetailsSpectraS3Request *GetTapePartitionsWithFullDetailsSpectraS3Request) WithSerialNumber(serialNumber string) *GetTapePartitionsWithFullDetailsSpectraS3Request {
-    getTapePartitionsWithFullDetailsSpectraS3Request.SerialNumber = &serialNumber
-    return getTapePartitionsWithFullDetailsSpectraS3Request
+	getTapePartitionsWithFullDetailsSpectraS3Request.SerialNumber = &serialNumber
+	return getTapePartitionsWithFullDetailsSpectraS3Request
 }
 
 func (getTapePartitionsWithFullDetailsSpectraS3Request *GetTapePartitionsWithFullDetailsSpectraS3Request) WithState(state TapePartitionState) *GetTapePartitionsWithFullDetailsSpectraS3Request {
-    getTapePartitionsWithFullDetailsSpectraS3Request.State = state
-    return getTapePartitionsWithFullDetailsSpectraS3Request
+	getTapePartitionsWithFullDetailsSpectraS3Request.State = state
+	return getTapePartitionsWithFullDetailsSpectraS3Request
 }
 
 type GetTapeSpectraS3Request struct {
-    TapeId string
+	TapeId string
 }
 
 func NewGetTapeSpectraS3Request(tapeId string) *GetTapeSpectraS3Request {
-    return &GetTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &GetTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 type GetTapesSpectraS3Request struct {
-    Bucket *string
-    AssignedToStorageDomain *bool
-    AvailableRawCapacity *int64
-    BarCode *string
-    BucketId *string
-    EjectLabel *string
-    EjectLocation *string
-    FullOfData *bool
-    LastPage bool
-    LastVerified *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PartiallyVerifiedEndOfTape *string
-    Partition *string
-    PartitionId *string
-    PreviousState TapeState
-    SerialNumber *string
-    SortBy *string
-    State TapeState
-    StorageDomain *string
-    StorageDomainMemberId *string
-    String *string
-    VerifyPending Priority
-    WriteProtected *bool
+	Bucket                     *string
+	AssignedToStorageDomain    *bool
+	AvailableRawCapacity       *int64
+	BarCode                    *string
+	BucketId                   *string
+	EjectLabel                 *string
+	EjectLocation              *string
+	FullOfData                 *bool
+	LastPage                   bool
+	LastVerified               *string
+	PageLength                 *int
+	PageOffset                 *int
+	PageStartMarker            *string
+	PartiallyVerifiedEndOfTape *string
+	Partition                  *string
+	PartitionId                *string
+	PreviousState              TapeState
+	SerialNumber               *string
+	SortBy                     *string
+	State                      TapeState
+	StorageDomain              *string
+	StorageDomainMemberId      *string
+	String                     *string
+	VerifyPending              Priority
+	WriteProtected             *bool
 }
 
 func NewGetTapesSpectraS3Request() *GetTapesSpectraS3Request {
-    return &GetTapesSpectraS3Request{
-    }
+	return &GetTapesSpectraS3Request{}
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithAssignedToStorageDomain(assignedToStorageDomain bool) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.AssignedToStorageDomain = &assignedToStorageDomain
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.AssignedToStorageDomain = &assignedToStorageDomain
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithAvailableRawCapacity(availableRawCapacity int64) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.AvailableRawCapacity = &availableRawCapacity
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.AvailableRawCapacity = &availableRawCapacity
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithBarCode(barCode string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.BarCode = &barCode
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.BarCode = &barCode
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithBucket(bucket string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.Bucket = &bucket
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.Bucket = &bucket
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithBucketId(bucketId string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.BucketId = &bucketId
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.BucketId = &bucketId
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithEjectLabel(ejectLabel string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.EjectLabel = &ejectLabel
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.EjectLabel = &ejectLabel
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithEjectLocation(ejectLocation string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.EjectLocation = &ejectLocation
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.EjectLocation = &ejectLocation
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithFullOfData(fullOfData bool) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.FullOfData = &fullOfData
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.FullOfData = &fullOfData
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithLastPage() *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.LastPage = true
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.LastPage = true
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithLastVerified(lastVerified string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.LastVerified = &lastVerified
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.LastVerified = &lastVerified
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithPageLength(pageLength int) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.PageLength = &pageLength
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.PageLength = &pageLength
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithPageOffset(pageOffset int) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.PageOffset = &pageOffset
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.PageOffset = &pageOffset
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithPartiallyVerifiedEndOfTape(partiallyVerifiedEndOfTape string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.PartiallyVerifiedEndOfTape = &partiallyVerifiedEndOfTape
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.PartiallyVerifiedEndOfTape = &partiallyVerifiedEndOfTape
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithPartition(partition string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.Partition = &partition
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.Partition = &partition
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithPartitionId(partitionId string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.PartitionId = &partitionId
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.PartitionId = &partitionId
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithPreviousState(previousState TapeState) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.PreviousState = previousState
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.PreviousState = previousState
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithSerialNumber(serialNumber string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.SerialNumber = &serialNumber
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.SerialNumber = &serialNumber
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithSortBy(sortBy string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.SortBy = &sortBy
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.SortBy = &sortBy
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithState(state TapeState) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.State = state
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.State = state
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithStorageDomain(storageDomain string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.StorageDomain = &storageDomain
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.StorageDomain = &storageDomain
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithStorageDomainMemberId(storageDomainMemberId string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.StorageDomainMemberId = &storageDomainMemberId
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.StorageDomainMemberId = &storageDomainMemberId
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithString(string string) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.String = &string
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.String = &string
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithVerifyPending(verifyPending Priority) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.VerifyPending = verifyPending
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.VerifyPending = verifyPending
+	return getTapesSpectraS3Request
 }
 
 func (getTapesSpectraS3Request *GetTapesSpectraS3Request) WithWriteProtected(writeProtected bool) *GetTapesSpectraS3Request {
-    getTapesSpectraS3Request.WriteProtected = &writeProtected
-    return getTapesSpectraS3Request
+	getTapesSpectraS3Request.WriteProtected = &writeProtected
+	return getTapesSpectraS3Request
 }
 
 type ImportAllTapesSpectraS3Request struct {
-    DataPolicyId *string
-    Priority Priority
-    StorageDomainId *string
-    UserId *string
-    VerifyDataAfterImport Priority
-    VerifyDataPriorToImport *bool
+	DataPolicyId            *string
+	Priority                Priority
+	StorageDomainId         *string
+	UserId                  *string
+	VerifyDataAfterImport   Priority
+	VerifyDataPriorToImport *bool
 }
 
 func NewImportAllTapesSpectraS3Request() *ImportAllTapesSpectraS3Request {
-    return &ImportAllTapesSpectraS3Request{
-    }
+	return &ImportAllTapesSpectraS3Request{}
 }
 
 func (importAllTapesSpectraS3Request *ImportAllTapesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *ImportAllTapesSpectraS3Request {
-    importAllTapesSpectraS3Request.DataPolicyId = &dataPolicyId
-    return importAllTapesSpectraS3Request
+	importAllTapesSpectraS3Request.DataPolicyId = &dataPolicyId
+	return importAllTapesSpectraS3Request
 }
 
 func (importAllTapesSpectraS3Request *ImportAllTapesSpectraS3Request) WithPriority(priority Priority) *ImportAllTapesSpectraS3Request {
-    importAllTapesSpectraS3Request.Priority = priority
-    return importAllTapesSpectraS3Request
+	importAllTapesSpectraS3Request.Priority = priority
+	return importAllTapesSpectraS3Request
 }
 
 func (importAllTapesSpectraS3Request *ImportAllTapesSpectraS3Request) WithStorageDomainId(storageDomainId string) *ImportAllTapesSpectraS3Request {
-    importAllTapesSpectraS3Request.StorageDomainId = &storageDomainId
-    return importAllTapesSpectraS3Request
+	importAllTapesSpectraS3Request.StorageDomainId = &storageDomainId
+	return importAllTapesSpectraS3Request
 }
 
 func (importAllTapesSpectraS3Request *ImportAllTapesSpectraS3Request) WithUserId(userId string) *ImportAllTapesSpectraS3Request {
-    importAllTapesSpectraS3Request.UserId = &userId
-    return importAllTapesSpectraS3Request
+	importAllTapesSpectraS3Request.UserId = &userId
+	return importAllTapesSpectraS3Request
 }
 
 func (importAllTapesSpectraS3Request *ImportAllTapesSpectraS3Request) WithVerifyDataAfterImport(verifyDataAfterImport Priority) *ImportAllTapesSpectraS3Request {
-    importAllTapesSpectraS3Request.VerifyDataAfterImport = verifyDataAfterImport
-    return importAllTapesSpectraS3Request
+	importAllTapesSpectraS3Request.VerifyDataAfterImport = verifyDataAfterImport
+	return importAllTapesSpectraS3Request
 }
 
 func (importAllTapesSpectraS3Request *ImportAllTapesSpectraS3Request) WithVerifyDataPriorToImport(verifyDataPriorToImport bool) *ImportAllTapesSpectraS3Request {
-    importAllTapesSpectraS3Request.VerifyDataPriorToImport = &verifyDataPriorToImport
-    return importAllTapesSpectraS3Request
+	importAllTapesSpectraS3Request.VerifyDataPriorToImport = &verifyDataPriorToImport
+	return importAllTapesSpectraS3Request
 }
 
 type ImportTapeSpectraS3Request struct {
-    DataPolicyId *string
-    Priority Priority
-    StorageDomainId *string
-    TapeId string
-    UserId *string
-    VerifyDataAfterImport Priority
-    VerifyDataPriorToImport *bool
+	DataPolicyId            *string
+	Priority                Priority
+	StorageDomainId         *string
+	TapeId                  string
+	UserId                  *string
+	VerifyDataAfterImport   Priority
+	VerifyDataPriorToImport *bool
 }
 
 func NewImportTapeSpectraS3Request(tapeId string) *ImportTapeSpectraS3Request {
-    return &ImportTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &ImportTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 func (importTapeSpectraS3Request *ImportTapeSpectraS3Request) WithDataPolicyId(dataPolicyId string) *ImportTapeSpectraS3Request {
-    importTapeSpectraS3Request.DataPolicyId = &dataPolicyId
-    return importTapeSpectraS3Request
+	importTapeSpectraS3Request.DataPolicyId = &dataPolicyId
+	return importTapeSpectraS3Request
 }
 
 func (importTapeSpectraS3Request *ImportTapeSpectraS3Request) WithPriority(priority Priority) *ImportTapeSpectraS3Request {
-    importTapeSpectraS3Request.Priority = priority
-    return importTapeSpectraS3Request
+	importTapeSpectraS3Request.Priority = priority
+	return importTapeSpectraS3Request
 }
 
 func (importTapeSpectraS3Request *ImportTapeSpectraS3Request) WithStorageDomainId(storageDomainId string) *ImportTapeSpectraS3Request {
-    importTapeSpectraS3Request.StorageDomainId = &storageDomainId
-    return importTapeSpectraS3Request
+	importTapeSpectraS3Request.StorageDomainId = &storageDomainId
+	return importTapeSpectraS3Request
 }
 
 func (importTapeSpectraS3Request *ImportTapeSpectraS3Request) WithUserId(userId string) *ImportTapeSpectraS3Request {
-    importTapeSpectraS3Request.UserId = &userId
-    return importTapeSpectraS3Request
+	importTapeSpectraS3Request.UserId = &userId
+	return importTapeSpectraS3Request
 }
 
 func (importTapeSpectraS3Request *ImportTapeSpectraS3Request) WithVerifyDataAfterImport(verifyDataAfterImport Priority) *ImportTapeSpectraS3Request {
-    importTapeSpectraS3Request.VerifyDataAfterImport = verifyDataAfterImport
-    return importTapeSpectraS3Request
+	importTapeSpectraS3Request.VerifyDataAfterImport = verifyDataAfterImport
+	return importTapeSpectraS3Request
 }
 
 func (importTapeSpectraS3Request *ImportTapeSpectraS3Request) WithVerifyDataPriorToImport(verifyDataPriorToImport bool) *ImportTapeSpectraS3Request {
-    importTapeSpectraS3Request.VerifyDataPriorToImport = &verifyDataPriorToImport
-    return importTapeSpectraS3Request
+	importTapeSpectraS3Request.VerifyDataPriorToImport = &verifyDataPriorToImport
+	return importTapeSpectraS3Request
 }
 
 type InspectAllTapesSpectraS3Request struct {
-    TaskPriority Priority
+	TaskPriority Priority
 }
 
 func NewInspectAllTapesSpectraS3Request() *InspectAllTapesSpectraS3Request {
-    return &InspectAllTapesSpectraS3Request{
-    }
+	return &InspectAllTapesSpectraS3Request{}
 }
 
 func (inspectAllTapesSpectraS3Request *InspectAllTapesSpectraS3Request) WithTaskPriority(taskPriority Priority) *InspectAllTapesSpectraS3Request {
-    inspectAllTapesSpectraS3Request.TaskPriority = taskPriority
-    return inspectAllTapesSpectraS3Request
+	inspectAllTapesSpectraS3Request.TaskPriority = taskPriority
+	return inspectAllTapesSpectraS3Request
 }
 
 type InspectTapeSpectraS3Request struct {
-    TapeId string
-    TaskPriority Priority
+	TapeId       string
+	TaskPriority Priority
 }
 
 func NewInspectTapeSpectraS3Request(tapeId string) *InspectTapeSpectraS3Request {
-    return &InspectTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &InspectTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 func (inspectTapeSpectraS3Request *InspectTapeSpectraS3Request) WithTaskPriority(taskPriority Priority) *InspectTapeSpectraS3Request {
-    inspectTapeSpectraS3Request.TaskPriority = taskPriority
-    return inspectTapeSpectraS3Request
+	inspectTapeSpectraS3Request.TaskPriority = taskPriority
+	return inspectTapeSpectraS3Request
 }
 
 type MarkTapeForCompactionSpectraS3Request struct {
-    TapeId string
+	TapeId string
 }
 
 func NewMarkTapeForCompactionSpectraS3Request(tapeId string) *MarkTapeForCompactionSpectraS3Request {
-    return &MarkTapeForCompactionSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &MarkTapeForCompactionSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 type ModifyAllTapePartitionsSpectraS3Request struct {
-    Quiesced Quiesced
+	Quiesced Quiesced
 }
 
 func NewModifyAllTapePartitionsSpectraS3Request(quiesced Quiesced) *ModifyAllTapePartitionsSpectraS3Request {
-    return &ModifyAllTapePartitionsSpectraS3Request{
-        Quiesced: quiesced,
-    }
+	return &ModifyAllTapePartitionsSpectraS3Request{
+		Quiesced: quiesced,
+	}
 }
 
 type ModifyTapeDriveSpectraS3Request struct {
-    MaxFailedTapes *int
-    MinimumTaskPriority Priority
-    Quiesced Quiesced
-    ReservedTaskType ReservedTaskType
-    TapeDriveId string
+	MaxFailedTapes      *int
+	MinimumTaskPriority Priority
+	Quiesced            Quiesced
+	ReservedTaskType    ReservedTaskType
+	TapeDriveId         string
 }
 
 func NewModifyTapeDriveSpectraS3Request(tapeDriveId string) *ModifyTapeDriveSpectraS3Request {
-    return &ModifyTapeDriveSpectraS3Request{
-        TapeDriveId: tapeDriveId,
-    }
+	return &ModifyTapeDriveSpectraS3Request{
+		TapeDriveId: tapeDriveId,
+	}
 }
 
 func (modifyTapeDriveSpectraS3Request *ModifyTapeDriveSpectraS3Request) WithMaxFailedTapes(maxFailedTapes int) *ModifyTapeDriveSpectraS3Request {
-    modifyTapeDriveSpectraS3Request.MaxFailedTapes = &maxFailedTapes
-    return modifyTapeDriveSpectraS3Request
+	modifyTapeDriveSpectraS3Request.MaxFailedTapes = &maxFailedTapes
+	return modifyTapeDriveSpectraS3Request
 }
 
 func (modifyTapeDriveSpectraS3Request *ModifyTapeDriveSpectraS3Request) WithMinimumTaskPriority(minimumTaskPriority Priority) *ModifyTapeDriveSpectraS3Request {
-    modifyTapeDriveSpectraS3Request.MinimumTaskPriority = minimumTaskPriority
-    return modifyTapeDriveSpectraS3Request
+	modifyTapeDriveSpectraS3Request.MinimumTaskPriority = minimumTaskPriority
+	return modifyTapeDriveSpectraS3Request
 }
 
 func (modifyTapeDriveSpectraS3Request *ModifyTapeDriveSpectraS3Request) WithQuiesced(quiesced Quiesced) *ModifyTapeDriveSpectraS3Request {
-    modifyTapeDriveSpectraS3Request.Quiesced = quiesced
-    return modifyTapeDriveSpectraS3Request
+	modifyTapeDriveSpectraS3Request.Quiesced = quiesced
+	return modifyTapeDriveSpectraS3Request
 }
 
 func (modifyTapeDriveSpectraS3Request *ModifyTapeDriveSpectraS3Request) WithReservedTaskType(reservedTaskType ReservedTaskType) *ModifyTapeDriveSpectraS3Request {
-    modifyTapeDriveSpectraS3Request.ReservedTaskType = reservedTaskType
-    return modifyTapeDriveSpectraS3Request
+	modifyTapeDriveSpectraS3Request.ReservedTaskType = reservedTaskType
+	return modifyTapeDriveSpectraS3Request
 }
 
 type ModifyTapePartitionSpectraS3Request struct {
-    AutoCompactionEnabled *bool
-    AutoQuiesceEnabled *bool
-    DriveIdleTimeoutInMinutes *int
-    MinimumReadReservedDrives *int
-    MinimumWriteReservedDrives *int
-    Quiesced Quiesced
-    SerialNumber *string
-    TapePartition string
+	AutoCompactionEnabled      *bool
+	AutoQuiesceEnabled         *bool
+	DriveIdleTimeoutInMinutes  *int
+	MinimumReadReservedDrives  *int
+	MinimumWriteReservedDrives *int
+	Quiesced                   Quiesced
+	SerialNumber               *string
+	TapePartition              string
 }
 
 func NewModifyTapePartitionSpectraS3Request(tapePartition string) *ModifyTapePartitionSpectraS3Request {
-    return &ModifyTapePartitionSpectraS3Request{
-        TapePartition: tapePartition,
-    }
+	return &ModifyTapePartitionSpectraS3Request{
+		TapePartition: tapePartition,
+	}
 }
 
 func (modifyTapePartitionSpectraS3Request *ModifyTapePartitionSpectraS3Request) WithAutoCompactionEnabled(autoCompactionEnabled bool) *ModifyTapePartitionSpectraS3Request {
-    modifyTapePartitionSpectraS3Request.AutoCompactionEnabled = &autoCompactionEnabled
-    return modifyTapePartitionSpectraS3Request
+	modifyTapePartitionSpectraS3Request.AutoCompactionEnabled = &autoCompactionEnabled
+	return modifyTapePartitionSpectraS3Request
 }
 
 func (modifyTapePartitionSpectraS3Request *ModifyTapePartitionSpectraS3Request) WithAutoQuiesceEnabled(autoQuiesceEnabled bool) *ModifyTapePartitionSpectraS3Request {
-    modifyTapePartitionSpectraS3Request.AutoQuiesceEnabled = &autoQuiesceEnabled
-    return modifyTapePartitionSpectraS3Request
+	modifyTapePartitionSpectraS3Request.AutoQuiesceEnabled = &autoQuiesceEnabled
+	return modifyTapePartitionSpectraS3Request
 }
 
 func (modifyTapePartitionSpectraS3Request *ModifyTapePartitionSpectraS3Request) WithDriveIdleTimeoutInMinutes(driveIdleTimeoutInMinutes int) *ModifyTapePartitionSpectraS3Request {
-    modifyTapePartitionSpectraS3Request.DriveIdleTimeoutInMinutes = &driveIdleTimeoutInMinutes
-    return modifyTapePartitionSpectraS3Request
+	modifyTapePartitionSpectraS3Request.DriveIdleTimeoutInMinutes = &driveIdleTimeoutInMinutes
+	return modifyTapePartitionSpectraS3Request
 }
 
 func (modifyTapePartitionSpectraS3Request *ModifyTapePartitionSpectraS3Request) WithMinimumReadReservedDrives(minimumReadReservedDrives int) *ModifyTapePartitionSpectraS3Request {
-    modifyTapePartitionSpectraS3Request.MinimumReadReservedDrives = &minimumReadReservedDrives
-    return modifyTapePartitionSpectraS3Request
+	modifyTapePartitionSpectraS3Request.MinimumReadReservedDrives = &minimumReadReservedDrives
+	return modifyTapePartitionSpectraS3Request
 }
 
 func (modifyTapePartitionSpectraS3Request *ModifyTapePartitionSpectraS3Request) WithMinimumWriteReservedDrives(minimumWriteReservedDrives int) *ModifyTapePartitionSpectraS3Request {
-    modifyTapePartitionSpectraS3Request.MinimumWriteReservedDrives = &minimumWriteReservedDrives
-    return modifyTapePartitionSpectraS3Request
+	modifyTapePartitionSpectraS3Request.MinimumWriteReservedDrives = &minimumWriteReservedDrives
+	return modifyTapePartitionSpectraS3Request
 }
 
 func (modifyTapePartitionSpectraS3Request *ModifyTapePartitionSpectraS3Request) WithQuiesced(quiesced Quiesced) *ModifyTapePartitionSpectraS3Request {
-    modifyTapePartitionSpectraS3Request.Quiesced = quiesced
-    return modifyTapePartitionSpectraS3Request
+	modifyTapePartitionSpectraS3Request.Quiesced = quiesced
+	return modifyTapePartitionSpectraS3Request
 }
 
 func (modifyTapePartitionSpectraS3Request *ModifyTapePartitionSpectraS3Request) WithSerialNumber(serialNumber string) *ModifyTapePartitionSpectraS3Request {
-    modifyTapePartitionSpectraS3Request.SerialNumber = &serialNumber
-    return modifyTapePartitionSpectraS3Request
+	modifyTapePartitionSpectraS3Request.SerialNumber = &serialNumber
+	return modifyTapePartitionSpectraS3Request
 }
 
 type ModifyTapeSpectraS3Request struct {
-    EjectLabel *string
-    EjectLocation *string
-    Role TapeRole
-    State TapeState
-    TapeId string
+	EjectLabel    *string
+	EjectLocation *string
+	Role          TapeRole
+	State         TapeState
+	TapeId        string
 }
 
 func NewModifyTapeSpectraS3Request(tapeId string) *ModifyTapeSpectraS3Request {
-    return &ModifyTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &ModifyTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 func (modifyTapeSpectraS3Request *ModifyTapeSpectraS3Request) WithEjectLabel(ejectLabel string) *ModifyTapeSpectraS3Request {
-    modifyTapeSpectraS3Request.EjectLabel = &ejectLabel
-    return modifyTapeSpectraS3Request
+	modifyTapeSpectraS3Request.EjectLabel = &ejectLabel
+	return modifyTapeSpectraS3Request
 }
 
 func (modifyTapeSpectraS3Request *ModifyTapeSpectraS3Request) WithEjectLocation(ejectLocation string) *ModifyTapeSpectraS3Request {
-    modifyTapeSpectraS3Request.EjectLocation = &ejectLocation
-    return modifyTapeSpectraS3Request
+	modifyTapeSpectraS3Request.EjectLocation = &ejectLocation
+	return modifyTapeSpectraS3Request
 }
 
 func (modifyTapeSpectraS3Request *ModifyTapeSpectraS3Request) WithRole(role TapeRole) *ModifyTapeSpectraS3Request {
-    modifyTapeSpectraS3Request.Role = role
-    return modifyTapeSpectraS3Request
+	modifyTapeSpectraS3Request.Role = role
+	return modifyTapeSpectraS3Request
 }
 
 func (modifyTapeSpectraS3Request *ModifyTapeSpectraS3Request) WithState(state TapeState) *ModifyTapeSpectraS3Request {
-    modifyTapeSpectraS3Request.State = state
-    return modifyTapeSpectraS3Request
+	modifyTapeSpectraS3Request.State = state
+	return modifyTapeSpectraS3Request
 }
 
 type OnlineAllTapesSpectraS3Request struct {
 }
 
 func NewOnlineAllTapesSpectraS3Request() *OnlineAllTapesSpectraS3Request {
-    return &OnlineAllTapesSpectraS3Request{
-    }
+	return &OnlineAllTapesSpectraS3Request{}
 }
 
 type OnlineTapeSpectraS3Request struct {
-    TapeId string
+	TapeId string
 }
 
 func NewOnlineTapeSpectraS3Request(tapeId string) *OnlineTapeSpectraS3Request {
-    return &OnlineTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &OnlineTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 type RawImportAllTapesSpectraS3Request struct {
-    BucketId string
-    StorageDomainId *string
-    TaskPriority Priority
+	BucketId        string
+	StorageDomainId *string
+	TaskPriority    Priority
 }
 
 func NewRawImportAllTapesSpectraS3Request(bucketId string) *RawImportAllTapesSpectraS3Request {
-    return &RawImportAllTapesSpectraS3Request{
-        BucketId: bucketId,
-    }
+	return &RawImportAllTapesSpectraS3Request{
+		BucketId: bucketId,
+	}
 }
 
 func (rawImportAllTapesSpectraS3Request *RawImportAllTapesSpectraS3Request) WithStorageDomainId(storageDomainId string) *RawImportAllTapesSpectraS3Request {
-    rawImportAllTapesSpectraS3Request.StorageDomainId = &storageDomainId
-    return rawImportAllTapesSpectraS3Request
+	rawImportAllTapesSpectraS3Request.StorageDomainId = &storageDomainId
+	return rawImportAllTapesSpectraS3Request
 }
 
 func (rawImportAllTapesSpectraS3Request *RawImportAllTapesSpectraS3Request) WithTaskPriority(taskPriority Priority) *RawImportAllTapesSpectraS3Request {
-    rawImportAllTapesSpectraS3Request.TaskPriority = taskPriority
-    return rawImportAllTapesSpectraS3Request
+	rawImportAllTapesSpectraS3Request.TaskPriority = taskPriority
+	return rawImportAllTapesSpectraS3Request
 }
 
 type RawImportTapeSpectraS3Request struct {
-    BucketId string
-    StorageDomainId *string
-    TapeId string
-    TaskPriority Priority
+	BucketId        string
+	StorageDomainId *string
+	TapeId          string
+	TaskPriority    Priority
 }
 
 func NewRawImportTapeSpectraS3Request(bucketId string, tapeId string) *RawImportTapeSpectraS3Request {
-    return &RawImportTapeSpectraS3Request{
-        TapeId: tapeId,
-        BucketId: bucketId,
-    }
+	return &RawImportTapeSpectraS3Request{
+		TapeId:   tapeId,
+		BucketId: bucketId,
+	}
 }
 
 func (rawImportTapeSpectraS3Request *RawImportTapeSpectraS3Request) WithStorageDomainId(storageDomainId string) *RawImportTapeSpectraS3Request {
-    rawImportTapeSpectraS3Request.StorageDomainId = &storageDomainId
-    return rawImportTapeSpectraS3Request
+	rawImportTapeSpectraS3Request.StorageDomainId = &storageDomainId
+	return rawImportTapeSpectraS3Request
 }
 
 func (rawImportTapeSpectraS3Request *RawImportTapeSpectraS3Request) WithTaskPriority(taskPriority Priority) *RawImportTapeSpectraS3Request {
-    rawImportTapeSpectraS3Request.TaskPriority = taskPriority
-    return rawImportTapeSpectraS3Request
+	rawImportTapeSpectraS3Request.TaskPriority = taskPriority
+	return rawImportTapeSpectraS3Request
 }
 
 type TestTapeDriveSpectraS3Request struct {
-    SkipClean bool
-    TapeDriveId string
-    TapeId *string
+	SkipClean   bool
+	TapeDriveId string
+	TapeId      *string
 }
 
 func NewTestTapeDriveSpectraS3Request(tapeDriveId string) *TestTapeDriveSpectraS3Request {
-    return &TestTapeDriveSpectraS3Request{
-        TapeDriveId: tapeDriveId,
-    }
+	return &TestTapeDriveSpectraS3Request{
+		TapeDriveId: tapeDriveId,
+	}
 }
 
 func (testTapeDriveSpectraS3Request *TestTapeDriveSpectraS3Request) WithSkipClean() *TestTapeDriveSpectraS3Request {
-    testTapeDriveSpectraS3Request.SkipClean = true
-    return testTapeDriveSpectraS3Request
+	testTapeDriveSpectraS3Request.SkipClean = true
+	return testTapeDriveSpectraS3Request
 }
 
 func (testTapeDriveSpectraS3Request *TestTapeDriveSpectraS3Request) WithTapeId(tapeId string) *TestTapeDriveSpectraS3Request {
-    testTapeDriveSpectraS3Request.TapeId = &tapeId
-    return testTapeDriveSpectraS3Request
+	testTapeDriveSpectraS3Request.TapeId = &tapeId
+	return testTapeDriveSpectraS3Request
 }
 
 type VerifyAllTapesSpectraS3Request struct {
-    TaskPriority Priority
+	TaskPriority Priority
 }
 
 func NewVerifyAllTapesSpectraS3Request() *VerifyAllTapesSpectraS3Request {
-    return &VerifyAllTapesSpectraS3Request{
-    }
+	return &VerifyAllTapesSpectraS3Request{}
 }
 
 func (verifyAllTapesSpectraS3Request *VerifyAllTapesSpectraS3Request) WithTaskPriority(taskPriority Priority) *VerifyAllTapesSpectraS3Request {
-    verifyAllTapesSpectraS3Request.TaskPriority = taskPriority
-    return verifyAllTapesSpectraS3Request
+	verifyAllTapesSpectraS3Request.TaskPriority = taskPriority
+	return verifyAllTapesSpectraS3Request
 }
 
 type VerifyTapeSpectraS3Request struct {
-    TapeId string
-    TaskPriority Priority
+	TapeId       string
+	TaskPriority Priority
 }
 
 func NewVerifyTapeSpectraS3Request(tapeId string) *VerifyTapeSpectraS3Request {
-    return &VerifyTapeSpectraS3Request{
-        TapeId: tapeId,
-    }
+	return &VerifyTapeSpectraS3Request{
+		TapeId: tapeId,
+	}
 }
 
 func (verifyTapeSpectraS3Request *VerifyTapeSpectraS3Request) WithTaskPriority(taskPriority Priority) *VerifyTapeSpectraS3Request {
-    verifyTapeSpectraS3Request.TaskPriority = taskPriority
-    return verifyTapeSpectraS3Request
+	verifyTapeSpectraS3Request.TaskPriority = taskPriority
+	return verifyTapeSpectraS3Request
 }
 
 type ForceTargetEnvironmentRefreshSpectraS3Request struct {
 }
 
 func NewForceTargetEnvironmentRefreshSpectraS3Request() *ForceTargetEnvironmentRefreshSpectraS3Request {
-    return &ForceTargetEnvironmentRefreshSpectraS3Request{
-    }
+	return &ForceTargetEnvironmentRefreshSpectraS3Request{}
 }
 
 type PutAzureTargetBucketNameSpectraS3Request struct {
-    BucketId string
-    Name string
-    TargetId string
+	BucketId string
+	Name     string
+	TargetId string
 }
 
 func NewPutAzureTargetBucketNameSpectraS3Request(bucketId string, name string, targetId string) *PutAzureTargetBucketNameSpectraS3Request {
-    return &PutAzureTargetBucketNameSpectraS3Request{
-        BucketId: bucketId,
-        Name: name,
-        TargetId: targetId,
-    }
+	return &PutAzureTargetBucketNameSpectraS3Request{
+		BucketId: bucketId,
+		Name:     name,
+		TargetId: targetId,
+	}
 }
 
 type PutAzureTargetReadPreferenceSpectraS3Request struct {
-    BucketId string
-    ReadPreference TargetReadPreferenceType
-    TargetId string
+	BucketId       string
+	ReadPreference TargetReadPreferenceType
+	TargetId       string
 }
 
 func NewPutAzureTargetReadPreferenceSpectraS3Request(bucketId string, readPreference TargetReadPreferenceType, targetId string) *PutAzureTargetReadPreferenceSpectraS3Request {
-    return &PutAzureTargetReadPreferenceSpectraS3Request{
-        BucketId: bucketId,
-        ReadPreference: readPreference,
-        TargetId: targetId,
-    }
+	return &PutAzureTargetReadPreferenceSpectraS3Request{
+		BucketId:       bucketId,
+		ReadPreference: readPreference,
+		TargetId:       targetId,
+	}
 }
 
 type DeleteAzureTargetBucketNameSpectraS3Request struct {
-    AzureTargetBucketName string
+	AzureTargetBucketName string
 }
 
 func NewDeleteAzureTargetBucketNameSpectraS3Request(azureTargetBucketName string) *DeleteAzureTargetBucketNameSpectraS3Request {
-    return &DeleteAzureTargetBucketNameSpectraS3Request{
-        AzureTargetBucketName: azureTargetBucketName,
-    }
+	return &DeleteAzureTargetBucketNameSpectraS3Request{
+		AzureTargetBucketName: azureTargetBucketName,
+	}
 }
 
 type DeleteAzureTargetFailureSpectraS3Request struct {
-    AzureTargetFailure string
+	AzureTargetFailure string
 }
 
 func NewDeleteAzureTargetFailureSpectraS3Request(azureTargetFailure string) *DeleteAzureTargetFailureSpectraS3Request {
-    return &DeleteAzureTargetFailureSpectraS3Request{
-        AzureTargetFailure: azureTargetFailure,
-    }
+	return &DeleteAzureTargetFailureSpectraS3Request{
+		AzureTargetFailure: azureTargetFailure,
+	}
 }
 
 type DeleteAzureTargetReadPreferenceSpectraS3Request struct {
-    AzureTargetReadPreference string
+	AzureTargetReadPreference string
 }
 
 func NewDeleteAzureTargetReadPreferenceSpectraS3Request(azureTargetReadPreference string) *DeleteAzureTargetReadPreferenceSpectraS3Request {
-    return &DeleteAzureTargetReadPreferenceSpectraS3Request{
-        AzureTargetReadPreference: azureTargetReadPreference,
-    }
+	return &DeleteAzureTargetReadPreferenceSpectraS3Request{
+		AzureTargetReadPreference: azureTargetReadPreference,
+	}
 }
 
 type DeleteAzureTargetSpectraS3Request struct {
-    AzureTarget string
+	AzureTarget string
 }
 
 func NewDeleteAzureTargetSpectraS3Request(azureTarget string) *DeleteAzureTargetSpectraS3Request {
-    return &DeleteAzureTargetSpectraS3Request{
-        AzureTarget: azureTarget,
-    }
+	return &DeleteAzureTargetSpectraS3Request{
+		AzureTarget: azureTarget,
+	}
 }
 
 type GetAzureTargetBucketNamesSpectraS3Request struct {
-    BucketId *string
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    TargetId *string
+	BucketId        *string
+	LastPage        bool
+	Name            *string
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	TargetId        *string
 }
 
 func NewGetAzureTargetBucketNamesSpectraS3Request() *GetAzureTargetBucketNamesSpectraS3Request {
-    return &GetAzureTargetBucketNamesSpectraS3Request{
-    }
+	return &GetAzureTargetBucketNamesSpectraS3Request{}
 }
 
 func (getAzureTargetBucketNamesSpectraS3Request *GetAzureTargetBucketNamesSpectraS3Request) WithBucketId(bucketId string) *GetAzureTargetBucketNamesSpectraS3Request {
-    getAzureTargetBucketNamesSpectraS3Request.BucketId = &bucketId
-    return getAzureTargetBucketNamesSpectraS3Request
+	getAzureTargetBucketNamesSpectraS3Request.BucketId = &bucketId
+	return getAzureTargetBucketNamesSpectraS3Request
 }
 
 func (getAzureTargetBucketNamesSpectraS3Request *GetAzureTargetBucketNamesSpectraS3Request) WithLastPage() *GetAzureTargetBucketNamesSpectraS3Request {
-    getAzureTargetBucketNamesSpectraS3Request.LastPage = true
-    return getAzureTargetBucketNamesSpectraS3Request
+	getAzureTargetBucketNamesSpectraS3Request.LastPage = true
+	return getAzureTargetBucketNamesSpectraS3Request
 }
 
 func (getAzureTargetBucketNamesSpectraS3Request *GetAzureTargetBucketNamesSpectraS3Request) WithName(name string) *GetAzureTargetBucketNamesSpectraS3Request {
-    getAzureTargetBucketNamesSpectraS3Request.Name = &name
-    return getAzureTargetBucketNamesSpectraS3Request
+	getAzureTargetBucketNamesSpectraS3Request.Name = &name
+	return getAzureTargetBucketNamesSpectraS3Request
 }
 
 func (getAzureTargetBucketNamesSpectraS3Request *GetAzureTargetBucketNamesSpectraS3Request) WithPageLength(pageLength int) *GetAzureTargetBucketNamesSpectraS3Request {
-    getAzureTargetBucketNamesSpectraS3Request.PageLength = &pageLength
-    return getAzureTargetBucketNamesSpectraS3Request
+	getAzureTargetBucketNamesSpectraS3Request.PageLength = &pageLength
+	return getAzureTargetBucketNamesSpectraS3Request
 }
 
 func (getAzureTargetBucketNamesSpectraS3Request *GetAzureTargetBucketNamesSpectraS3Request) WithPageOffset(pageOffset int) *GetAzureTargetBucketNamesSpectraS3Request {
-    getAzureTargetBucketNamesSpectraS3Request.PageOffset = &pageOffset
-    return getAzureTargetBucketNamesSpectraS3Request
+	getAzureTargetBucketNamesSpectraS3Request.PageOffset = &pageOffset
+	return getAzureTargetBucketNamesSpectraS3Request
 }
 
 func (getAzureTargetBucketNamesSpectraS3Request *GetAzureTargetBucketNamesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetAzureTargetBucketNamesSpectraS3Request {
-    getAzureTargetBucketNamesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getAzureTargetBucketNamesSpectraS3Request
+	getAzureTargetBucketNamesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getAzureTargetBucketNamesSpectraS3Request
 }
 
 func (getAzureTargetBucketNamesSpectraS3Request *GetAzureTargetBucketNamesSpectraS3Request) WithTargetId(targetId string) *GetAzureTargetBucketNamesSpectraS3Request {
-    getAzureTargetBucketNamesSpectraS3Request.TargetId = &targetId
-    return getAzureTargetBucketNamesSpectraS3Request
+	getAzureTargetBucketNamesSpectraS3Request.TargetId = &targetId
+	return getAzureTargetBucketNamesSpectraS3Request
 }
 
 type GetAzureTargetFailuresSpectraS3Request struct {
-    ErrorMessage *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    TargetFailureType TargetFailureType
-    TargetId *string
+	ErrorMessage      *string
+	LastPage          bool
+	PageLength        *int
+	PageOffset        *int
+	PageStartMarker   *string
+	TargetFailureType TargetFailureType
+	TargetId          *string
 }
 
 func NewGetAzureTargetFailuresSpectraS3Request() *GetAzureTargetFailuresSpectraS3Request {
-    return &GetAzureTargetFailuresSpectraS3Request{
-    }
+	return &GetAzureTargetFailuresSpectraS3Request{}
 }
 
 func (getAzureTargetFailuresSpectraS3Request *GetAzureTargetFailuresSpectraS3Request) WithErrorMessage(errorMessage string) *GetAzureTargetFailuresSpectraS3Request {
-    getAzureTargetFailuresSpectraS3Request.ErrorMessage = &errorMessage
-    return getAzureTargetFailuresSpectraS3Request
+	getAzureTargetFailuresSpectraS3Request.ErrorMessage = &errorMessage
+	return getAzureTargetFailuresSpectraS3Request
 }
 
 func (getAzureTargetFailuresSpectraS3Request *GetAzureTargetFailuresSpectraS3Request) WithLastPage() *GetAzureTargetFailuresSpectraS3Request {
-    getAzureTargetFailuresSpectraS3Request.LastPage = true
-    return getAzureTargetFailuresSpectraS3Request
+	getAzureTargetFailuresSpectraS3Request.LastPage = true
+	return getAzureTargetFailuresSpectraS3Request
 }
 
 func (getAzureTargetFailuresSpectraS3Request *GetAzureTargetFailuresSpectraS3Request) WithPageLength(pageLength int) *GetAzureTargetFailuresSpectraS3Request {
-    getAzureTargetFailuresSpectraS3Request.PageLength = &pageLength
-    return getAzureTargetFailuresSpectraS3Request
+	getAzureTargetFailuresSpectraS3Request.PageLength = &pageLength
+	return getAzureTargetFailuresSpectraS3Request
 }
 
 func (getAzureTargetFailuresSpectraS3Request *GetAzureTargetFailuresSpectraS3Request) WithPageOffset(pageOffset int) *GetAzureTargetFailuresSpectraS3Request {
-    getAzureTargetFailuresSpectraS3Request.PageOffset = &pageOffset
-    return getAzureTargetFailuresSpectraS3Request
+	getAzureTargetFailuresSpectraS3Request.PageOffset = &pageOffset
+	return getAzureTargetFailuresSpectraS3Request
 }
 
 func (getAzureTargetFailuresSpectraS3Request *GetAzureTargetFailuresSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetAzureTargetFailuresSpectraS3Request {
-    getAzureTargetFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getAzureTargetFailuresSpectraS3Request
+	getAzureTargetFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getAzureTargetFailuresSpectraS3Request
 }
 
 func (getAzureTargetFailuresSpectraS3Request *GetAzureTargetFailuresSpectraS3Request) WithTargetId(targetId string) *GetAzureTargetFailuresSpectraS3Request {
-    getAzureTargetFailuresSpectraS3Request.TargetId = &targetId
-    return getAzureTargetFailuresSpectraS3Request
+	getAzureTargetFailuresSpectraS3Request.TargetId = &targetId
+	return getAzureTargetFailuresSpectraS3Request
 }
 
 func (getAzureTargetFailuresSpectraS3Request *GetAzureTargetFailuresSpectraS3Request) WithTargetFailureType(targetFailureType TargetFailureType) *GetAzureTargetFailuresSpectraS3Request {
-    getAzureTargetFailuresSpectraS3Request.TargetFailureType = targetFailureType
-    return getAzureTargetFailuresSpectraS3Request
+	getAzureTargetFailuresSpectraS3Request.TargetFailureType = targetFailureType
+	return getAzureTargetFailuresSpectraS3Request
 }
 
 type GetAzureTargetReadPreferenceSpectraS3Request struct {
-    AzureTargetReadPreference string
+	AzureTargetReadPreference string
 }
 
 func NewGetAzureTargetReadPreferenceSpectraS3Request(azureTargetReadPreference string) *GetAzureTargetReadPreferenceSpectraS3Request {
-    return &GetAzureTargetReadPreferenceSpectraS3Request{
-        AzureTargetReadPreference: azureTargetReadPreference,
-    }
+	return &GetAzureTargetReadPreferenceSpectraS3Request{
+		AzureTargetReadPreference: azureTargetReadPreference,
+	}
 }
 
 type GetAzureTargetReadPreferencesSpectraS3Request struct {
-    BucketId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    ReadPreference TargetReadPreferenceType
-    TargetId *string
+	BucketId        *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	ReadPreference  TargetReadPreferenceType
+	TargetId        *string
 }
 
 func NewGetAzureTargetReadPreferencesSpectraS3Request() *GetAzureTargetReadPreferencesSpectraS3Request {
-    return &GetAzureTargetReadPreferencesSpectraS3Request{
-    }
+	return &GetAzureTargetReadPreferencesSpectraS3Request{}
 }
 
 func (getAzureTargetReadPreferencesSpectraS3Request *GetAzureTargetReadPreferencesSpectraS3Request) WithBucketId(bucketId string) *GetAzureTargetReadPreferencesSpectraS3Request {
-    getAzureTargetReadPreferencesSpectraS3Request.BucketId = &bucketId
-    return getAzureTargetReadPreferencesSpectraS3Request
+	getAzureTargetReadPreferencesSpectraS3Request.BucketId = &bucketId
+	return getAzureTargetReadPreferencesSpectraS3Request
 }
 
 func (getAzureTargetReadPreferencesSpectraS3Request *GetAzureTargetReadPreferencesSpectraS3Request) WithLastPage() *GetAzureTargetReadPreferencesSpectraS3Request {
-    getAzureTargetReadPreferencesSpectraS3Request.LastPage = true
-    return getAzureTargetReadPreferencesSpectraS3Request
+	getAzureTargetReadPreferencesSpectraS3Request.LastPage = true
+	return getAzureTargetReadPreferencesSpectraS3Request
 }
 
 func (getAzureTargetReadPreferencesSpectraS3Request *GetAzureTargetReadPreferencesSpectraS3Request) WithPageLength(pageLength int) *GetAzureTargetReadPreferencesSpectraS3Request {
-    getAzureTargetReadPreferencesSpectraS3Request.PageLength = &pageLength
-    return getAzureTargetReadPreferencesSpectraS3Request
+	getAzureTargetReadPreferencesSpectraS3Request.PageLength = &pageLength
+	return getAzureTargetReadPreferencesSpectraS3Request
 }
 
 func (getAzureTargetReadPreferencesSpectraS3Request *GetAzureTargetReadPreferencesSpectraS3Request) WithPageOffset(pageOffset int) *GetAzureTargetReadPreferencesSpectraS3Request {
-    getAzureTargetReadPreferencesSpectraS3Request.PageOffset = &pageOffset
-    return getAzureTargetReadPreferencesSpectraS3Request
+	getAzureTargetReadPreferencesSpectraS3Request.PageOffset = &pageOffset
+	return getAzureTargetReadPreferencesSpectraS3Request
 }
 
 func (getAzureTargetReadPreferencesSpectraS3Request *GetAzureTargetReadPreferencesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetAzureTargetReadPreferencesSpectraS3Request {
-    getAzureTargetReadPreferencesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getAzureTargetReadPreferencesSpectraS3Request
+	getAzureTargetReadPreferencesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getAzureTargetReadPreferencesSpectraS3Request
 }
 
 func (getAzureTargetReadPreferencesSpectraS3Request *GetAzureTargetReadPreferencesSpectraS3Request) WithReadPreference(readPreference TargetReadPreferenceType) *GetAzureTargetReadPreferencesSpectraS3Request {
-    getAzureTargetReadPreferencesSpectraS3Request.ReadPreference = readPreference
-    return getAzureTargetReadPreferencesSpectraS3Request
+	getAzureTargetReadPreferencesSpectraS3Request.ReadPreference = readPreference
+	return getAzureTargetReadPreferencesSpectraS3Request
 }
 
 func (getAzureTargetReadPreferencesSpectraS3Request *GetAzureTargetReadPreferencesSpectraS3Request) WithTargetId(targetId string) *GetAzureTargetReadPreferencesSpectraS3Request {
-    getAzureTargetReadPreferencesSpectraS3Request.TargetId = &targetId
-    return getAzureTargetReadPreferencesSpectraS3Request
+	getAzureTargetReadPreferencesSpectraS3Request.TargetId = &targetId
+	return getAzureTargetReadPreferencesSpectraS3Request
 }
 
 type GetAzureTargetSpectraS3Request struct {
-    AzureTarget string
+	AzureTarget string
 }
 
 func NewGetAzureTargetSpectraS3Request(azureTarget string) *GetAzureTargetSpectraS3Request {
-    return &GetAzureTargetSpectraS3Request{
-        AzureTarget: azureTarget,
-    }
+	return &GetAzureTargetSpectraS3Request{
+		AzureTarget: azureTarget,
+	}
 }
 
 type GetAzureTargetsSpectraS3Request struct {
-    AccountName *string
-    DefaultReadPreference TargetReadPreferenceType
-    Https *bool
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PermitGoingOutOfSync *bool
-    Quiesced Quiesced
-    State TargetState
+	AccountName           *string
+	DefaultReadPreference TargetReadPreferenceType
+	Https                 *bool
+	LastPage              bool
+	Name                  *string
+	PageLength            *int
+	PageOffset            *int
+	PageStartMarker       *string
+	PermitGoingOutOfSync  *bool
+	Quiesced              Quiesced
+	State                 TargetState
 }
 
 func NewGetAzureTargetsSpectraS3Request() *GetAzureTargetsSpectraS3Request {
-    return &GetAzureTargetsSpectraS3Request{
-    }
+	return &GetAzureTargetsSpectraS3Request{}
 }
 
 func (getAzureTargetsSpectraS3Request *GetAzureTargetsSpectraS3Request) WithAccountName(accountName string) *GetAzureTargetsSpectraS3Request {
-    getAzureTargetsSpectraS3Request.AccountName = &accountName
-    return getAzureTargetsSpectraS3Request
+	getAzureTargetsSpectraS3Request.AccountName = &accountName
+	return getAzureTargetsSpectraS3Request
 }
 
 func (getAzureTargetsSpectraS3Request *GetAzureTargetsSpectraS3Request) WithDefaultReadPreference(defaultReadPreference TargetReadPreferenceType) *GetAzureTargetsSpectraS3Request {
-    getAzureTargetsSpectraS3Request.DefaultReadPreference = defaultReadPreference
-    return getAzureTargetsSpectraS3Request
+	getAzureTargetsSpectraS3Request.DefaultReadPreference = defaultReadPreference
+	return getAzureTargetsSpectraS3Request
 }
 
 func (getAzureTargetsSpectraS3Request *GetAzureTargetsSpectraS3Request) WithHttps(https bool) *GetAzureTargetsSpectraS3Request {
-    getAzureTargetsSpectraS3Request.Https = &https
-    return getAzureTargetsSpectraS3Request
+	getAzureTargetsSpectraS3Request.Https = &https
+	return getAzureTargetsSpectraS3Request
 }
 
 func (getAzureTargetsSpectraS3Request *GetAzureTargetsSpectraS3Request) WithLastPage() *GetAzureTargetsSpectraS3Request {
-    getAzureTargetsSpectraS3Request.LastPage = true
-    return getAzureTargetsSpectraS3Request
+	getAzureTargetsSpectraS3Request.LastPage = true
+	return getAzureTargetsSpectraS3Request
 }
 
 func (getAzureTargetsSpectraS3Request *GetAzureTargetsSpectraS3Request) WithName(name string) *GetAzureTargetsSpectraS3Request {
-    getAzureTargetsSpectraS3Request.Name = &name
-    return getAzureTargetsSpectraS3Request
+	getAzureTargetsSpectraS3Request.Name = &name
+	return getAzureTargetsSpectraS3Request
 }
 
 func (getAzureTargetsSpectraS3Request *GetAzureTargetsSpectraS3Request) WithPageLength(pageLength int) *GetAzureTargetsSpectraS3Request {
-    getAzureTargetsSpectraS3Request.PageLength = &pageLength
-    return getAzureTargetsSpectraS3Request
+	getAzureTargetsSpectraS3Request.PageLength = &pageLength
+	return getAzureTargetsSpectraS3Request
 }
 
 func (getAzureTargetsSpectraS3Request *GetAzureTargetsSpectraS3Request) WithPageOffset(pageOffset int) *GetAzureTargetsSpectraS3Request {
-    getAzureTargetsSpectraS3Request.PageOffset = &pageOffset
-    return getAzureTargetsSpectraS3Request
+	getAzureTargetsSpectraS3Request.PageOffset = &pageOffset
+	return getAzureTargetsSpectraS3Request
 }
 
 func (getAzureTargetsSpectraS3Request *GetAzureTargetsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetAzureTargetsSpectraS3Request {
-    getAzureTargetsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getAzureTargetsSpectraS3Request
+	getAzureTargetsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getAzureTargetsSpectraS3Request
 }
 
 func (getAzureTargetsSpectraS3Request *GetAzureTargetsSpectraS3Request) WithPermitGoingOutOfSync(permitGoingOutOfSync bool) *GetAzureTargetsSpectraS3Request {
-    getAzureTargetsSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
-    return getAzureTargetsSpectraS3Request
+	getAzureTargetsSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
+	return getAzureTargetsSpectraS3Request
 }
 
 func (getAzureTargetsSpectraS3Request *GetAzureTargetsSpectraS3Request) WithQuiesced(quiesced Quiesced) *GetAzureTargetsSpectraS3Request {
-    getAzureTargetsSpectraS3Request.Quiesced = quiesced
-    return getAzureTargetsSpectraS3Request
+	getAzureTargetsSpectraS3Request.Quiesced = quiesced
+	return getAzureTargetsSpectraS3Request
 }
 
 func (getAzureTargetsSpectraS3Request *GetAzureTargetsSpectraS3Request) WithState(state TargetState) *GetAzureTargetsSpectraS3Request {
-    getAzureTargetsSpectraS3Request.State = state
-    return getAzureTargetsSpectraS3Request
+	getAzureTargetsSpectraS3Request.State = state
+	return getAzureTargetsSpectraS3Request
 }
 
 type GetBlobsOnAzureTargetSpectraS3Request struct {
-    AzureTarget string
+	AzureTarget string
 }
 
 func NewGetBlobsOnAzureTargetSpectraS3Request(azureTarget string) *GetBlobsOnAzureTargetSpectraS3Request {
-    return &GetBlobsOnAzureTargetSpectraS3Request{
-        AzureTarget: azureTarget,
-    }
+	return &GetBlobsOnAzureTargetSpectraS3Request{
+		AzureTarget: azureTarget,
+	}
 }
 
 type ImportAzureTargetSpectraS3Request struct {
-    AzureTarget string
-    CloudBucketName string
-    DataPolicyId *string
-    Priority Priority
-    UserId *string
+	AzureTarget     string
+	CloudBucketName string
+	DataPolicyId    *string
+	Priority        Priority
+	UserId          *string
 }
 
 func NewImportAzureTargetSpectraS3Request(azureTarget string, cloudBucketName string) *ImportAzureTargetSpectraS3Request {
-    return &ImportAzureTargetSpectraS3Request{
-        AzureTarget: azureTarget,
-        CloudBucketName: cloudBucketName,
-    }
+	return &ImportAzureTargetSpectraS3Request{
+		AzureTarget:     azureTarget,
+		CloudBucketName: cloudBucketName,
+	}
 }
 
 func (importAzureTargetSpectraS3Request *ImportAzureTargetSpectraS3Request) WithDataPolicyId(dataPolicyId string) *ImportAzureTargetSpectraS3Request {
-    importAzureTargetSpectraS3Request.DataPolicyId = &dataPolicyId
-    return importAzureTargetSpectraS3Request
+	importAzureTargetSpectraS3Request.DataPolicyId = &dataPolicyId
+	return importAzureTargetSpectraS3Request
 }
 
 func (importAzureTargetSpectraS3Request *ImportAzureTargetSpectraS3Request) WithPriority(priority Priority) *ImportAzureTargetSpectraS3Request {
-    importAzureTargetSpectraS3Request.Priority = priority
-    return importAzureTargetSpectraS3Request
+	importAzureTargetSpectraS3Request.Priority = priority
+	return importAzureTargetSpectraS3Request
 }
 
 func (importAzureTargetSpectraS3Request *ImportAzureTargetSpectraS3Request) WithUserId(userId string) *ImportAzureTargetSpectraS3Request {
-    importAzureTargetSpectraS3Request.UserId = &userId
-    return importAzureTargetSpectraS3Request
+	importAzureTargetSpectraS3Request.UserId = &userId
+	return importAzureTargetSpectraS3Request
 }
 
 type ModifyAllAzureTargetsSpectraS3Request struct {
-    Quiesced Quiesced
+	Quiesced Quiesced
 }
 
 func NewModifyAllAzureTargetsSpectraS3Request(quiesced Quiesced) *ModifyAllAzureTargetsSpectraS3Request {
-    return &ModifyAllAzureTargetsSpectraS3Request{
-        Quiesced: quiesced,
-    }
+	return &ModifyAllAzureTargetsSpectraS3Request{
+		Quiesced: quiesced,
+	}
 }
 
 type ModifyAzureTargetSpectraS3Request struct {
-    AccountKey *string
-    AccountName *string
-    AutoVerifyFrequencyInDays *int
-    AzureTarget string
-    CloudBucketPrefix *string
-    CloudBucketSuffix *string
-    DefaultReadPreference TargetReadPreferenceType
-    Https *bool
-    Name *string
-    PermitGoingOutOfSync *bool
-    Quiesced Quiesced
+	AccountKey                *string
+	AccountName               *string
+	AutoVerifyFrequencyInDays *int
+	AzureTarget               string
+	CloudBucketPrefix         *string
+	CloudBucketSuffix         *string
+	DefaultReadPreference     TargetReadPreferenceType
+	Https                     *bool
+	Name                      *string
+	PermitGoingOutOfSync      *bool
+	Quiesced                  Quiesced
 }
 
 func NewModifyAzureTargetSpectraS3Request(azureTarget string) *ModifyAzureTargetSpectraS3Request {
-    return &ModifyAzureTargetSpectraS3Request{
-        AzureTarget: azureTarget,
-    }
+	return &ModifyAzureTargetSpectraS3Request{
+		AzureTarget: azureTarget,
+	}
 }
 
 func (modifyAzureTargetSpectraS3Request *ModifyAzureTargetSpectraS3Request) WithAccountKey(accountKey string) *ModifyAzureTargetSpectraS3Request {
-    modifyAzureTargetSpectraS3Request.AccountKey = &accountKey
-    return modifyAzureTargetSpectraS3Request
+	modifyAzureTargetSpectraS3Request.AccountKey = &accountKey
+	return modifyAzureTargetSpectraS3Request
 }
 
 func (modifyAzureTargetSpectraS3Request *ModifyAzureTargetSpectraS3Request) WithAccountName(accountName string) *ModifyAzureTargetSpectraS3Request {
-    modifyAzureTargetSpectraS3Request.AccountName = &accountName
-    return modifyAzureTargetSpectraS3Request
+	modifyAzureTargetSpectraS3Request.AccountName = &accountName
+	return modifyAzureTargetSpectraS3Request
 }
 
 func (modifyAzureTargetSpectraS3Request *ModifyAzureTargetSpectraS3Request) WithAutoVerifyFrequencyInDays(autoVerifyFrequencyInDays int) *ModifyAzureTargetSpectraS3Request {
-    modifyAzureTargetSpectraS3Request.AutoVerifyFrequencyInDays = &autoVerifyFrequencyInDays
-    return modifyAzureTargetSpectraS3Request
+	modifyAzureTargetSpectraS3Request.AutoVerifyFrequencyInDays = &autoVerifyFrequencyInDays
+	return modifyAzureTargetSpectraS3Request
 }
 
 func (modifyAzureTargetSpectraS3Request *ModifyAzureTargetSpectraS3Request) WithCloudBucketPrefix(cloudBucketPrefix string) *ModifyAzureTargetSpectraS3Request {
-    modifyAzureTargetSpectraS3Request.CloudBucketPrefix = &cloudBucketPrefix
-    return modifyAzureTargetSpectraS3Request
+	modifyAzureTargetSpectraS3Request.CloudBucketPrefix = &cloudBucketPrefix
+	return modifyAzureTargetSpectraS3Request
 }
 
 func (modifyAzureTargetSpectraS3Request *ModifyAzureTargetSpectraS3Request) WithCloudBucketSuffix(cloudBucketSuffix string) *ModifyAzureTargetSpectraS3Request {
-    modifyAzureTargetSpectraS3Request.CloudBucketSuffix = &cloudBucketSuffix
-    return modifyAzureTargetSpectraS3Request
+	modifyAzureTargetSpectraS3Request.CloudBucketSuffix = &cloudBucketSuffix
+	return modifyAzureTargetSpectraS3Request
 }
 
 func (modifyAzureTargetSpectraS3Request *ModifyAzureTargetSpectraS3Request) WithDefaultReadPreference(defaultReadPreference TargetReadPreferenceType) *ModifyAzureTargetSpectraS3Request {
-    modifyAzureTargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
-    return modifyAzureTargetSpectraS3Request
+	modifyAzureTargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
+	return modifyAzureTargetSpectraS3Request
 }
 
 func (modifyAzureTargetSpectraS3Request *ModifyAzureTargetSpectraS3Request) WithHttps(https bool) *ModifyAzureTargetSpectraS3Request {
-    modifyAzureTargetSpectraS3Request.Https = &https
-    return modifyAzureTargetSpectraS3Request
+	modifyAzureTargetSpectraS3Request.Https = &https
+	return modifyAzureTargetSpectraS3Request
 }
 
 func (modifyAzureTargetSpectraS3Request *ModifyAzureTargetSpectraS3Request) WithName(name string) *ModifyAzureTargetSpectraS3Request {
-    modifyAzureTargetSpectraS3Request.Name = &name
-    return modifyAzureTargetSpectraS3Request
+	modifyAzureTargetSpectraS3Request.Name = &name
+	return modifyAzureTargetSpectraS3Request
 }
 
 func (modifyAzureTargetSpectraS3Request *ModifyAzureTargetSpectraS3Request) WithPermitGoingOutOfSync(permitGoingOutOfSync bool) *ModifyAzureTargetSpectraS3Request {
-    modifyAzureTargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
-    return modifyAzureTargetSpectraS3Request
+	modifyAzureTargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
+	return modifyAzureTargetSpectraS3Request
 }
 
 func (modifyAzureTargetSpectraS3Request *ModifyAzureTargetSpectraS3Request) WithQuiesced(quiesced Quiesced) *ModifyAzureTargetSpectraS3Request {
-    modifyAzureTargetSpectraS3Request.Quiesced = quiesced
-    return modifyAzureTargetSpectraS3Request
+	modifyAzureTargetSpectraS3Request.Quiesced = quiesced
+	return modifyAzureTargetSpectraS3Request
 }
 
 type RegisterAzureTargetSpectraS3Request struct {
-    AccountKey string
-    AccountName string
-    AutoVerifyFrequencyInDays *int
-    CloudBucketPrefix *string
-    CloudBucketSuffix *string
-    DefaultReadPreference TargetReadPreferenceType
-    Https *bool
-    Name string
-    PermitGoingOutOfSync *bool
+	AccountKey                string
+	AccountName               string
+	AutoVerifyFrequencyInDays *int
+	CloudBucketPrefix         *string
+	CloudBucketSuffix         *string
+	DefaultReadPreference     TargetReadPreferenceType
+	Https                     *bool
+	Name                      string
+	PermitGoingOutOfSync      *bool
 }
 
 func NewRegisterAzureTargetSpectraS3Request(accountKey string, accountName string, name string) *RegisterAzureTargetSpectraS3Request {
-    return &RegisterAzureTargetSpectraS3Request{
-        AccountKey: accountKey,
-        AccountName: accountName,
-        Name: name,
-    }
+	return &RegisterAzureTargetSpectraS3Request{
+		AccountKey:  accountKey,
+		AccountName: accountName,
+		Name:        name,
+	}
 }
 
 func (registerAzureTargetSpectraS3Request *RegisterAzureTargetSpectraS3Request) WithAutoVerifyFrequencyInDays(autoVerifyFrequencyInDays int) *RegisterAzureTargetSpectraS3Request {
-    registerAzureTargetSpectraS3Request.AutoVerifyFrequencyInDays = &autoVerifyFrequencyInDays
-    return registerAzureTargetSpectraS3Request
+	registerAzureTargetSpectraS3Request.AutoVerifyFrequencyInDays = &autoVerifyFrequencyInDays
+	return registerAzureTargetSpectraS3Request
 }
 
 func (registerAzureTargetSpectraS3Request *RegisterAzureTargetSpectraS3Request) WithCloudBucketPrefix(cloudBucketPrefix string) *RegisterAzureTargetSpectraS3Request {
-    registerAzureTargetSpectraS3Request.CloudBucketPrefix = &cloudBucketPrefix
-    return registerAzureTargetSpectraS3Request
+	registerAzureTargetSpectraS3Request.CloudBucketPrefix = &cloudBucketPrefix
+	return registerAzureTargetSpectraS3Request
 }
 
 func (registerAzureTargetSpectraS3Request *RegisterAzureTargetSpectraS3Request) WithCloudBucketSuffix(cloudBucketSuffix string) *RegisterAzureTargetSpectraS3Request {
-    registerAzureTargetSpectraS3Request.CloudBucketSuffix = &cloudBucketSuffix
-    return registerAzureTargetSpectraS3Request
+	registerAzureTargetSpectraS3Request.CloudBucketSuffix = &cloudBucketSuffix
+	return registerAzureTargetSpectraS3Request
 }
 
 func (registerAzureTargetSpectraS3Request *RegisterAzureTargetSpectraS3Request) WithDefaultReadPreference(defaultReadPreference TargetReadPreferenceType) *RegisterAzureTargetSpectraS3Request {
-    registerAzureTargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
-    return registerAzureTargetSpectraS3Request
+	registerAzureTargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
+	return registerAzureTargetSpectraS3Request
 }
 
 func (registerAzureTargetSpectraS3Request *RegisterAzureTargetSpectraS3Request) WithHttps(https bool) *RegisterAzureTargetSpectraS3Request {
-    registerAzureTargetSpectraS3Request.Https = &https
-    return registerAzureTargetSpectraS3Request
+	registerAzureTargetSpectraS3Request.Https = &https
+	return registerAzureTargetSpectraS3Request
 }
 
 func (registerAzureTargetSpectraS3Request *RegisterAzureTargetSpectraS3Request) WithPermitGoingOutOfSync(permitGoingOutOfSync bool) *RegisterAzureTargetSpectraS3Request {
-    registerAzureTargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
-    return registerAzureTargetSpectraS3Request
+	registerAzureTargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
+	return registerAzureTargetSpectraS3Request
 }
 
 type VerifyAzureTargetSpectraS3Request struct {
-    AzureTarget string
-    FullDetails bool
+	AzureTarget string
+	FullDetails bool
 }
 
 func NewVerifyAzureTargetSpectraS3Request(azureTarget string) *VerifyAzureTargetSpectraS3Request {
-    return &VerifyAzureTargetSpectraS3Request{
-        AzureTarget: azureTarget,
-    }
+	return &VerifyAzureTargetSpectraS3Request{
+		AzureTarget: azureTarget,
+	}
 }
 
 func (verifyAzureTargetSpectraS3Request *VerifyAzureTargetSpectraS3Request) WithFullDetails() *VerifyAzureTargetSpectraS3Request {
-    verifyAzureTargetSpectraS3Request.FullDetails = true
-    return verifyAzureTargetSpectraS3Request
+	verifyAzureTargetSpectraS3Request.FullDetails = true
+	return verifyAzureTargetSpectraS3Request
 }
 
 type PutDs3TargetReadPreferenceSpectraS3Request struct {
-    BucketId string
-    ReadPreference TargetReadPreferenceType
-    TargetId string
+	BucketId       string
+	ReadPreference TargetReadPreferenceType
+	TargetId       string
 }
 
 func NewPutDs3TargetReadPreferenceSpectraS3Request(bucketId string, readPreference TargetReadPreferenceType, targetId string) *PutDs3TargetReadPreferenceSpectraS3Request {
-    return &PutDs3TargetReadPreferenceSpectraS3Request{
-        BucketId: bucketId,
-        ReadPreference: readPreference,
-        TargetId: targetId,
-    }
+	return &PutDs3TargetReadPreferenceSpectraS3Request{
+		BucketId:       bucketId,
+		ReadPreference: readPreference,
+		TargetId:       targetId,
+	}
 }
 
 type DeleteDs3TargetFailureSpectraS3Request struct {
-    Ds3TargetFailure string
+	Ds3TargetFailure string
 }
 
 func NewDeleteDs3TargetFailureSpectraS3Request(ds3TargetFailure string) *DeleteDs3TargetFailureSpectraS3Request {
-    return &DeleteDs3TargetFailureSpectraS3Request{
-        Ds3TargetFailure: ds3TargetFailure,
-    }
+	return &DeleteDs3TargetFailureSpectraS3Request{
+		Ds3TargetFailure: ds3TargetFailure,
+	}
 }
 
 type DeleteDs3TargetReadPreferenceSpectraS3Request struct {
-    Ds3TargetReadPreference string
+	Ds3TargetReadPreference string
 }
 
 func NewDeleteDs3TargetReadPreferenceSpectraS3Request(ds3TargetReadPreference string) *DeleteDs3TargetReadPreferenceSpectraS3Request {
-    return &DeleteDs3TargetReadPreferenceSpectraS3Request{
-        Ds3TargetReadPreference: ds3TargetReadPreference,
-    }
+	return &DeleteDs3TargetReadPreferenceSpectraS3Request{
+		Ds3TargetReadPreference: ds3TargetReadPreference,
+	}
 }
 
 type DeleteDs3TargetSpectraS3Request struct {
-    Ds3Target string
+	Ds3Target string
 }
 
 func NewDeleteDs3TargetSpectraS3Request(ds3Target string) *DeleteDs3TargetSpectraS3Request {
-    return &DeleteDs3TargetSpectraS3Request{
-        Ds3Target: ds3Target,
-    }
+	return &DeleteDs3TargetSpectraS3Request{
+		Ds3Target: ds3Target,
+	}
 }
 
 type GetBlobsOnDs3TargetSpectraS3Request struct {
-    Ds3Target string
+	Ds3Target string
 }
 
 func NewGetBlobsOnDs3TargetSpectraS3Request(ds3Target string) *GetBlobsOnDs3TargetSpectraS3Request {
-    return &GetBlobsOnDs3TargetSpectraS3Request{
-        Ds3Target: ds3Target,
-    }
+	return &GetBlobsOnDs3TargetSpectraS3Request{
+		Ds3Target: ds3Target,
+	}
 }
 
 type GetDs3TargetDataPoliciesSpectraS3Request struct {
-    Ds3TargetDataPolicies string
+	Ds3TargetDataPolicies string
 }
 
 func NewGetDs3TargetDataPoliciesSpectraS3Request(ds3TargetDataPolicies string) *GetDs3TargetDataPoliciesSpectraS3Request {
-    return &GetDs3TargetDataPoliciesSpectraS3Request{
-        Ds3TargetDataPolicies: ds3TargetDataPolicies,
-    }
+	return &GetDs3TargetDataPoliciesSpectraS3Request{
+		Ds3TargetDataPolicies: ds3TargetDataPolicies,
+	}
 }
 
 type GetDs3TargetFailuresSpectraS3Request struct {
-    ErrorMessage *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    TargetFailureType TargetFailureType
-    TargetId *string
+	ErrorMessage      *string
+	LastPage          bool
+	PageLength        *int
+	PageOffset        *int
+	PageStartMarker   *string
+	TargetFailureType TargetFailureType
+	TargetId          *string
 }
 
 func NewGetDs3TargetFailuresSpectraS3Request() *GetDs3TargetFailuresSpectraS3Request {
-    return &GetDs3TargetFailuresSpectraS3Request{
-    }
+	return &GetDs3TargetFailuresSpectraS3Request{}
 }
 
 func (getDs3TargetFailuresSpectraS3Request *GetDs3TargetFailuresSpectraS3Request) WithErrorMessage(errorMessage string) *GetDs3TargetFailuresSpectraS3Request {
-    getDs3TargetFailuresSpectraS3Request.ErrorMessage = &errorMessage
-    return getDs3TargetFailuresSpectraS3Request
+	getDs3TargetFailuresSpectraS3Request.ErrorMessage = &errorMessage
+	return getDs3TargetFailuresSpectraS3Request
 }
 
 func (getDs3TargetFailuresSpectraS3Request *GetDs3TargetFailuresSpectraS3Request) WithLastPage() *GetDs3TargetFailuresSpectraS3Request {
-    getDs3TargetFailuresSpectraS3Request.LastPage = true
-    return getDs3TargetFailuresSpectraS3Request
+	getDs3TargetFailuresSpectraS3Request.LastPage = true
+	return getDs3TargetFailuresSpectraS3Request
 }
 
 func (getDs3TargetFailuresSpectraS3Request *GetDs3TargetFailuresSpectraS3Request) WithPageLength(pageLength int) *GetDs3TargetFailuresSpectraS3Request {
-    getDs3TargetFailuresSpectraS3Request.PageLength = &pageLength
-    return getDs3TargetFailuresSpectraS3Request
+	getDs3TargetFailuresSpectraS3Request.PageLength = &pageLength
+	return getDs3TargetFailuresSpectraS3Request
 }
 
 func (getDs3TargetFailuresSpectraS3Request *GetDs3TargetFailuresSpectraS3Request) WithPageOffset(pageOffset int) *GetDs3TargetFailuresSpectraS3Request {
-    getDs3TargetFailuresSpectraS3Request.PageOffset = &pageOffset
-    return getDs3TargetFailuresSpectraS3Request
+	getDs3TargetFailuresSpectraS3Request.PageOffset = &pageOffset
+	return getDs3TargetFailuresSpectraS3Request
 }
 
 func (getDs3TargetFailuresSpectraS3Request *GetDs3TargetFailuresSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDs3TargetFailuresSpectraS3Request {
-    getDs3TargetFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDs3TargetFailuresSpectraS3Request
+	getDs3TargetFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDs3TargetFailuresSpectraS3Request
 }
 
 func (getDs3TargetFailuresSpectraS3Request *GetDs3TargetFailuresSpectraS3Request) WithTargetId(targetId string) *GetDs3TargetFailuresSpectraS3Request {
-    getDs3TargetFailuresSpectraS3Request.TargetId = &targetId
-    return getDs3TargetFailuresSpectraS3Request
+	getDs3TargetFailuresSpectraS3Request.TargetId = &targetId
+	return getDs3TargetFailuresSpectraS3Request
 }
 
 func (getDs3TargetFailuresSpectraS3Request *GetDs3TargetFailuresSpectraS3Request) WithTargetFailureType(targetFailureType TargetFailureType) *GetDs3TargetFailuresSpectraS3Request {
-    getDs3TargetFailuresSpectraS3Request.TargetFailureType = targetFailureType
-    return getDs3TargetFailuresSpectraS3Request
+	getDs3TargetFailuresSpectraS3Request.TargetFailureType = targetFailureType
+	return getDs3TargetFailuresSpectraS3Request
 }
 
 type GetDs3TargetReadPreferenceSpectraS3Request struct {
-    Ds3TargetReadPreference string
+	Ds3TargetReadPreference string
 }
 
 func NewGetDs3TargetReadPreferenceSpectraS3Request(ds3TargetReadPreference string) *GetDs3TargetReadPreferenceSpectraS3Request {
-    return &GetDs3TargetReadPreferenceSpectraS3Request{
-        Ds3TargetReadPreference: ds3TargetReadPreference,
-    }
+	return &GetDs3TargetReadPreferenceSpectraS3Request{
+		Ds3TargetReadPreference: ds3TargetReadPreference,
+	}
 }
 
 type GetDs3TargetReadPreferencesSpectraS3Request struct {
-    BucketId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    ReadPreference TargetReadPreferenceType
-    TargetId *string
+	BucketId        *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	ReadPreference  TargetReadPreferenceType
+	TargetId        *string
 }
 
 func NewGetDs3TargetReadPreferencesSpectraS3Request() *GetDs3TargetReadPreferencesSpectraS3Request {
-    return &GetDs3TargetReadPreferencesSpectraS3Request{
-    }
+	return &GetDs3TargetReadPreferencesSpectraS3Request{}
 }
 
 func (getDs3TargetReadPreferencesSpectraS3Request *GetDs3TargetReadPreferencesSpectraS3Request) WithBucketId(bucketId string) *GetDs3TargetReadPreferencesSpectraS3Request {
-    getDs3TargetReadPreferencesSpectraS3Request.BucketId = &bucketId
-    return getDs3TargetReadPreferencesSpectraS3Request
+	getDs3TargetReadPreferencesSpectraS3Request.BucketId = &bucketId
+	return getDs3TargetReadPreferencesSpectraS3Request
 }
 
 func (getDs3TargetReadPreferencesSpectraS3Request *GetDs3TargetReadPreferencesSpectraS3Request) WithLastPage() *GetDs3TargetReadPreferencesSpectraS3Request {
-    getDs3TargetReadPreferencesSpectraS3Request.LastPage = true
-    return getDs3TargetReadPreferencesSpectraS3Request
+	getDs3TargetReadPreferencesSpectraS3Request.LastPage = true
+	return getDs3TargetReadPreferencesSpectraS3Request
 }
 
 func (getDs3TargetReadPreferencesSpectraS3Request *GetDs3TargetReadPreferencesSpectraS3Request) WithPageLength(pageLength int) *GetDs3TargetReadPreferencesSpectraS3Request {
-    getDs3TargetReadPreferencesSpectraS3Request.PageLength = &pageLength
-    return getDs3TargetReadPreferencesSpectraS3Request
+	getDs3TargetReadPreferencesSpectraS3Request.PageLength = &pageLength
+	return getDs3TargetReadPreferencesSpectraS3Request
 }
 
 func (getDs3TargetReadPreferencesSpectraS3Request *GetDs3TargetReadPreferencesSpectraS3Request) WithPageOffset(pageOffset int) *GetDs3TargetReadPreferencesSpectraS3Request {
-    getDs3TargetReadPreferencesSpectraS3Request.PageOffset = &pageOffset
-    return getDs3TargetReadPreferencesSpectraS3Request
+	getDs3TargetReadPreferencesSpectraS3Request.PageOffset = &pageOffset
+	return getDs3TargetReadPreferencesSpectraS3Request
 }
 
 func (getDs3TargetReadPreferencesSpectraS3Request *GetDs3TargetReadPreferencesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDs3TargetReadPreferencesSpectraS3Request {
-    getDs3TargetReadPreferencesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDs3TargetReadPreferencesSpectraS3Request
+	getDs3TargetReadPreferencesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDs3TargetReadPreferencesSpectraS3Request
 }
 
 func (getDs3TargetReadPreferencesSpectraS3Request *GetDs3TargetReadPreferencesSpectraS3Request) WithReadPreference(readPreference TargetReadPreferenceType) *GetDs3TargetReadPreferencesSpectraS3Request {
-    getDs3TargetReadPreferencesSpectraS3Request.ReadPreference = readPreference
-    return getDs3TargetReadPreferencesSpectraS3Request
+	getDs3TargetReadPreferencesSpectraS3Request.ReadPreference = readPreference
+	return getDs3TargetReadPreferencesSpectraS3Request
 }
 
 func (getDs3TargetReadPreferencesSpectraS3Request *GetDs3TargetReadPreferencesSpectraS3Request) WithTargetId(targetId string) *GetDs3TargetReadPreferencesSpectraS3Request {
-    getDs3TargetReadPreferencesSpectraS3Request.TargetId = &targetId
-    return getDs3TargetReadPreferencesSpectraS3Request
+	getDs3TargetReadPreferencesSpectraS3Request.TargetId = &targetId
+	return getDs3TargetReadPreferencesSpectraS3Request
 }
 
 type GetDs3TargetSpectraS3Request struct {
-    Ds3Target string
+	Ds3Target string
 }
 
 func NewGetDs3TargetSpectraS3Request(ds3Target string) *GetDs3TargetSpectraS3Request {
-    return &GetDs3TargetSpectraS3Request{
-        Ds3Target: ds3Target,
-    }
+	return &GetDs3TargetSpectraS3Request{
+		Ds3Target: ds3Target,
+	}
 }
 
 type GetDs3TargetsSpectraS3Request struct {
-    AdminAuthId *string
-    DataPathEndPoint *string
-    DataPathHttps *bool
-    DataPathPort *int
-    DataPathProxy *string
-    DataPathVerifyCertificate *bool
-    DefaultReadPreference TargetReadPreferenceType
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PermitGoingOutOfSync *bool
-    Quiesced Quiesced
-    State TargetState
+	AdminAuthId               *string
+	DataPathEndPoint          *string
+	DataPathHttps             *bool
+	DataPathPort              *int
+	DataPathProxy             *string
+	DataPathVerifyCertificate *bool
+	DefaultReadPreference     TargetReadPreferenceType
+	LastPage                  bool
+	Name                      *string
+	PageLength                *int
+	PageOffset                *int
+	PageStartMarker           *string
+	PermitGoingOutOfSync      *bool
+	Quiesced                  Quiesced
+	State                     TargetState
 }
 
 func NewGetDs3TargetsSpectraS3Request() *GetDs3TargetsSpectraS3Request {
-    return &GetDs3TargetsSpectraS3Request{
-    }
+	return &GetDs3TargetsSpectraS3Request{}
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithAdminAuthId(adminAuthId string) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.AdminAuthId = &adminAuthId
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.AdminAuthId = &adminAuthId
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithDataPathEndPoint(dataPathEndPoint string) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithDataPathHttps(dataPathHttps bool) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.DataPathHttps = &dataPathHttps
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.DataPathHttps = &dataPathHttps
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithDataPathPort(dataPathPort int) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.DataPathPort = &dataPathPort
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.DataPathPort = &dataPathPort
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithDataPathProxy(dataPathProxy string) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.DataPathProxy = &dataPathProxy
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.DataPathProxy = &dataPathProxy
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithDataPathVerifyCertificate(dataPathVerifyCertificate bool) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.DataPathVerifyCertificate = &dataPathVerifyCertificate
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.DataPathVerifyCertificate = &dataPathVerifyCertificate
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithDefaultReadPreference(defaultReadPreference TargetReadPreferenceType) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.DefaultReadPreference = defaultReadPreference
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.DefaultReadPreference = defaultReadPreference
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithLastPage() *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.LastPage = true
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.LastPage = true
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithName(name string) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.Name = &name
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.Name = &name
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithPageLength(pageLength int) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.PageLength = &pageLength
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.PageLength = &pageLength
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithPageOffset(pageOffset int) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.PageOffset = &pageOffset
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.PageOffset = &pageOffset
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithPermitGoingOutOfSync(permitGoingOutOfSync bool) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithQuiesced(quiesced Quiesced) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.Quiesced = quiesced
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.Quiesced = quiesced
+	return getDs3TargetsSpectraS3Request
 }
 
 func (getDs3TargetsSpectraS3Request *GetDs3TargetsSpectraS3Request) WithState(state TargetState) *GetDs3TargetsSpectraS3Request {
-    getDs3TargetsSpectraS3Request.State = state
-    return getDs3TargetsSpectraS3Request
+	getDs3TargetsSpectraS3Request.State = state
+	return getDs3TargetsSpectraS3Request
 }
 
 type ModifyAllDs3TargetsSpectraS3Request struct {
-    Quiesced Quiesced
+	Quiesced Quiesced
 }
 
 func NewModifyAllDs3TargetsSpectraS3Request(quiesced Quiesced) *ModifyAllDs3TargetsSpectraS3Request {
-    return &ModifyAllDs3TargetsSpectraS3Request{
-        Quiesced: quiesced,
-    }
+	return &ModifyAllDs3TargetsSpectraS3Request{
+		Quiesced: quiesced,
+	}
 }
 
 type ModifyDs3TargetSpectraS3Request struct {
-    AccessControlReplication Ds3TargetAccessControlReplication
-    AdminAuthId *string
-    AdminSecretKey *string
-    DataPathEndPoint *string
-    DataPathHttps *bool
-    DataPathPort *int
-    DataPathProxy *string
-    DataPathVerifyCertificate *bool
-    DefaultReadPreference TargetReadPreferenceType
-    Ds3Target string
-    Name *string
-    PermitGoingOutOfSync *bool
-    Quiesced Quiesced
-    ReplicatedUserDefaultDataPolicy *string
+	AccessControlReplication        Ds3TargetAccessControlReplication
+	AdminAuthId                     *string
+	AdminSecretKey                  *string
+	DataPathEndPoint                *string
+	DataPathHttps                   *bool
+	DataPathPort                    *int
+	DataPathProxy                   *string
+	DataPathVerifyCertificate       *bool
+	DefaultReadPreference           TargetReadPreferenceType
+	Ds3Target                       string
+	Name                            *string
+	PermitGoingOutOfSync            *bool
+	Quiesced                        Quiesced
+	ReplicatedUserDefaultDataPolicy *string
 }
 
 func NewModifyDs3TargetSpectraS3Request(ds3Target string) *ModifyDs3TargetSpectraS3Request {
-    return &ModifyDs3TargetSpectraS3Request{
-        Ds3Target: ds3Target,
-    }
+	return &ModifyDs3TargetSpectraS3Request{
+		Ds3Target: ds3Target,
+	}
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithAccessControlReplication(accessControlReplication Ds3TargetAccessControlReplication) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.AccessControlReplication = accessControlReplication
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.AccessControlReplication = accessControlReplication
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithAdminAuthId(adminAuthId string) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.AdminAuthId = &adminAuthId
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.AdminAuthId = &adminAuthId
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithAdminSecretKey(adminSecretKey string) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.AdminSecretKey = &adminSecretKey
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.AdminSecretKey = &adminSecretKey
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithDataPathEndPoint(dataPathEndPoint string) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithDataPathHttps(dataPathHttps bool) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.DataPathHttps = &dataPathHttps
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.DataPathHttps = &dataPathHttps
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithDataPathPort(dataPathPort int) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.DataPathPort = &dataPathPort
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.DataPathPort = &dataPathPort
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithDataPathProxy(dataPathProxy string) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.DataPathProxy = &dataPathProxy
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.DataPathProxy = &dataPathProxy
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithDataPathVerifyCertificate(dataPathVerifyCertificate bool) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.DataPathVerifyCertificate = &dataPathVerifyCertificate
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.DataPathVerifyCertificate = &dataPathVerifyCertificate
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithDefaultReadPreference(defaultReadPreference TargetReadPreferenceType) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithName(name string) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.Name = &name
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.Name = &name
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithPermitGoingOutOfSync(permitGoingOutOfSync bool) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithQuiesced(quiesced Quiesced) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.Quiesced = quiesced
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.Quiesced = quiesced
+	return modifyDs3TargetSpectraS3Request
 }
 
 func (modifyDs3TargetSpectraS3Request *ModifyDs3TargetSpectraS3Request) WithReplicatedUserDefaultDataPolicy(replicatedUserDefaultDataPolicy string) *ModifyDs3TargetSpectraS3Request {
-    modifyDs3TargetSpectraS3Request.ReplicatedUserDefaultDataPolicy = &replicatedUserDefaultDataPolicy
-    return modifyDs3TargetSpectraS3Request
+	modifyDs3TargetSpectraS3Request.ReplicatedUserDefaultDataPolicy = &replicatedUserDefaultDataPolicy
+	return modifyDs3TargetSpectraS3Request
 }
 
 type PairBackRegisteredDs3TargetSpectraS3Request struct {
-    AccessControlReplication Ds3TargetAccessControlReplication
-    AdminAuthId *string
-    AdminSecretKey *string
-    DataPathEndPoint *string
-    DataPathHttps *bool
-    DataPathPort *int
-    DataPathProxy *string
-    DataPathVerifyCertificate *bool
-    DefaultReadPreference TargetReadPreferenceType
-    Ds3Target string
-    Name *string
-    PermitGoingOutOfSync *bool
-    ReplicatedUserDefaultDataPolicy *string
+	AccessControlReplication        Ds3TargetAccessControlReplication
+	AdminAuthId                     *string
+	AdminSecretKey                  *string
+	DataPathEndPoint                *string
+	DataPathHttps                   *bool
+	DataPathPort                    *int
+	DataPathProxy                   *string
+	DataPathVerifyCertificate       *bool
+	DefaultReadPreference           TargetReadPreferenceType
+	Ds3Target                       string
+	Name                            *string
+	PermitGoingOutOfSync            *bool
+	ReplicatedUserDefaultDataPolicy *string
 }
 
 func NewPairBackRegisteredDs3TargetSpectraS3Request(ds3Target string) *PairBackRegisteredDs3TargetSpectraS3Request {
-    return &PairBackRegisteredDs3TargetSpectraS3Request{
-        Ds3Target: ds3Target,
-    }
+	return &PairBackRegisteredDs3TargetSpectraS3Request{
+		Ds3Target: ds3Target,
+	}
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithAccessControlReplication(accessControlReplication Ds3TargetAccessControlReplication) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.AccessControlReplication = accessControlReplication
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.AccessControlReplication = accessControlReplication
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithAdminAuthId(adminAuthId string) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.AdminAuthId = &adminAuthId
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.AdminAuthId = &adminAuthId
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithAdminSecretKey(adminSecretKey string) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.AdminSecretKey = &adminSecretKey
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.AdminSecretKey = &adminSecretKey
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithDataPathEndPoint(dataPathEndPoint string) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithDataPathHttps(dataPathHttps bool) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.DataPathHttps = &dataPathHttps
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.DataPathHttps = &dataPathHttps
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithDataPathPort(dataPathPort int) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.DataPathPort = &dataPathPort
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.DataPathPort = &dataPathPort
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithDataPathProxy(dataPathProxy string) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.DataPathProxy = &dataPathProxy
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.DataPathProxy = &dataPathProxy
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithDataPathVerifyCertificate(dataPathVerifyCertificate bool) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.DataPathVerifyCertificate = &dataPathVerifyCertificate
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.DataPathVerifyCertificate = &dataPathVerifyCertificate
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithDefaultReadPreference(defaultReadPreference TargetReadPreferenceType) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithName(name string) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.Name = &name
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.Name = &name
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithPermitGoingOutOfSync(permitGoingOutOfSync bool) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 func (pairBackRegisteredDs3TargetSpectraS3Request *PairBackRegisteredDs3TargetSpectraS3Request) WithReplicatedUserDefaultDataPolicy(replicatedUserDefaultDataPolicy string) *PairBackRegisteredDs3TargetSpectraS3Request {
-    pairBackRegisteredDs3TargetSpectraS3Request.ReplicatedUserDefaultDataPolicy = &replicatedUserDefaultDataPolicy
-    return pairBackRegisteredDs3TargetSpectraS3Request
+	pairBackRegisteredDs3TargetSpectraS3Request.ReplicatedUserDefaultDataPolicy = &replicatedUserDefaultDataPolicy
+	return pairBackRegisteredDs3TargetSpectraS3Request
 }
 
 type RegisterDs3TargetSpectraS3Request struct {
-    AccessControlReplication Ds3TargetAccessControlReplication
-    AdminAuthId string
-    AdminSecretKey string
-    DataPathEndPoint string
-    DataPathHttps *bool
-    DataPathPort *int
-    DataPathProxy *string
-    DataPathVerifyCertificate *bool
-    DefaultReadPreference TargetReadPreferenceType
-    Name string
-    PermitGoingOutOfSync *bool
-    ReplicatedUserDefaultDataPolicy *string
+	AccessControlReplication        Ds3TargetAccessControlReplication
+	AdminAuthId                     string
+	AdminSecretKey                  string
+	DataPathEndPoint                string
+	DataPathHttps                   *bool
+	DataPathPort                    *int
+	DataPathProxy                   *string
+	DataPathVerifyCertificate       *bool
+	DefaultReadPreference           TargetReadPreferenceType
+	Name                            string
+	PermitGoingOutOfSync            *bool
+	ReplicatedUserDefaultDataPolicy *string
 }
 
 func NewRegisterDs3TargetSpectraS3Request(adminAuthId string, adminSecretKey string, dataPathEndPoint string, name string) *RegisterDs3TargetSpectraS3Request {
-    return &RegisterDs3TargetSpectraS3Request{
-        AdminAuthId: adminAuthId,
-        AdminSecretKey: adminSecretKey,
-        DataPathEndPoint: dataPathEndPoint,
-        Name: name,
-    }
+	return &RegisterDs3TargetSpectraS3Request{
+		AdminAuthId:      adminAuthId,
+		AdminSecretKey:   adminSecretKey,
+		DataPathEndPoint: dataPathEndPoint,
+		Name:             name,
+	}
 }
 
 func (registerDs3TargetSpectraS3Request *RegisterDs3TargetSpectraS3Request) WithAccessControlReplication(accessControlReplication Ds3TargetAccessControlReplication) *RegisterDs3TargetSpectraS3Request {
-    registerDs3TargetSpectraS3Request.AccessControlReplication = accessControlReplication
-    return registerDs3TargetSpectraS3Request
+	registerDs3TargetSpectraS3Request.AccessControlReplication = accessControlReplication
+	return registerDs3TargetSpectraS3Request
 }
 
 func (registerDs3TargetSpectraS3Request *RegisterDs3TargetSpectraS3Request) WithDataPathHttps(dataPathHttps bool) *RegisterDs3TargetSpectraS3Request {
-    registerDs3TargetSpectraS3Request.DataPathHttps = &dataPathHttps
-    return registerDs3TargetSpectraS3Request
+	registerDs3TargetSpectraS3Request.DataPathHttps = &dataPathHttps
+	return registerDs3TargetSpectraS3Request
 }
 
 func (registerDs3TargetSpectraS3Request *RegisterDs3TargetSpectraS3Request) WithDataPathPort(dataPathPort int) *RegisterDs3TargetSpectraS3Request {
-    registerDs3TargetSpectraS3Request.DataPathPort = &dataPathPort
-    return registerDs3TargetSpectraS3Request
+	registerDs3TargetSpectraS3Request.DataPathPort = &dataPathPort
+	return registerDs3TargetSpectraS3Request
 }
 
 func (registerDs3TargetSpectraS3Request *RegisterDs3TargetSpectraS3Request) WithDataPathProxy(dataPathProxy string) *RegisterDs3TargetSpectraS3Request {
-    registerDs3TargetSpectraS3Request.DataPathProxy = &dataPathProxy
-    return registerDs3TargetSpectraS3Request
+	registerDs3TargetSpectraS3Request.DataPathProxy = &dataPathProxy
+	return registerDs3TargetSpectraS3Request
 }
 
 func (registerDs3TargetSpectraS3Request *RegisterDs3TargetSpectraS3Request) WithDataPathVerifyCertificate(dataPathVerifyCertificate bool) *RegisterDs3TargetSpectraS3Request {
-    registerDs3TargetSpectraS3Request.DataPathVerifyCertificate = &dataPathVerifyCertificate
-    return registerDs3TargetSpectraS3Request
+	registerDs3TargetSpectraS3Request.DataPathVerifyCertificate = &dataPathVerifyCertificate
+	return registerDs3TargetSpectraS3Request
 }
 
 func (registerDs3TargetSpectraS3Request *RegisterDs3TargetSpectraS3Request) WithDefaultReadPreference(defaultReadPreference TargetReadPreferenceType) *RegisterDs3TargetSpectraS3Request {
-    registerDs3TargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
-    return registerDs3TargetSpectraS3Request
+	registerDs3TargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
+	return registerDs3TargetSpectraS3Request
 }
 
 func (registerDs3TargetSpectraS3Request *RegisterDs3TargetSpectraS3Request) WithPermitGoingOutOfSync(permitGoingOutOfSync bool) *RegisterDs3TargetSpectraS3Request {
-    registerDs3TargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
-    return registerDs3TargetSpectraS3Request
+	registerDs3TargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
+	return registerDs3TargetSpectraS3Request
 }
 
 func (registerDs3TargetSpectraS3Request *RegisterDs3TargetSpectraS3Request) WithReplicatedUserDefaultDataPolicy(replicatedUserDefaultDataPolicy string) *RegisterDs3TargetSpectraS3Request {
-    registerDs3TargetSpectraS3Request.ReplicatedUserDefaultDataPolicy = &replicatedUserDefaultDataPolicy
-    return registerDs3TargetSpectraS3Request
+	registerDs3TargetSpectraS3Request.ReplicatedUserDefaultDataPolicy = &replicatedUserDefaultDataPolicy
+	return registerDs3TargetSpectraS3Request
 }
 
 type VerifyDs3TargetSpectraS3Request struct {
-    Ds3Target string
-    FullDetails bool
+	Ds3Target   string
+	FullDetails bool
 }
 
 func NewVerifyDs3TargetSpectraS3Request(ds3Target string) *VerifyDs3TargetSpectraS3Request {
-    return &VerifyDs3TargetSpectraS3Request{
-        Ds3Target: ds3Target,
-    }
+	return &VerifyDs3TargetSpectraS3Request{
+		Ds3Target: ds3Target,
+	}
 }
 
 func (verifyDs3TargetSpectraS3Request *VerifyDs3TargetSpectraS3Request) WithFullDetails() *VerifyDs3TargetSpectraS3Request {
-    verifyDs3TargetSpectraS3Request.FullDetails = true
-    return verifyDs3TargetSpectraS3Request
+	verifyDs3TargetSpectraS3Request.FullDetails = true
+	return verifyDs3TargetSpectraS3Request
 }
 
 type PutS3TargetBucketNameSpectraS3Request struct {
-    BucketId string
-    Name string
-    TargetId string
+	BucketId string
+	Name     string
+	TargetId string
 }
 
 func NewPutS3TargetBucketNameSpectraS3Request(bucketId string, name string, targetId string) *PutS3TargetBucketNameSpectraS3Request {
-    return &PutS3TargetBucketNameSpectraS3Request{
-        BucketId: bucketId,
-        Name: name,
-        TargetId: targetId,
-    }
+	return &PutS3TargetBucketNameSpectraS3Request{
+		BucketId: bucketId,
+		Name:     name,
+		TargetId: targetId,
+	}
 }
 
 type PutS3TargetReadPreferenceSpectraS3Request struct {
-    BucketId string
-    ReadPreference TargetReadPreferenceType
-    TargetId string
+	BucketId       string
+	ReadPreference TargetReadPreferenceType
+	TargetId       string
 }
 
 func NewPutS3TargetReadPreferenceSpectraS3Request(bucketId string, readPreference TargetReadPreferenceType, targetId string) *PutS3TargetReadPreferenceSpectraS3Request {
-    return &PutS3TargetReadPreferenceSpectraS3Request{
-        BucketId: bucketId,
-        ReadPreference: readPreference,
-        TargetId: targetId,
-    }
+	return &PutS3TargetReadPreferenceSpectraS3Request{
+		BucketId:       bucketId,
+		ReadPreference: readPreference,
+		TargetId:       targetId,
+	}
 }
 
 type DeleteS3TargetBucketNameSpectraS3Request struct {
-    S3TargetBucketName string
+	S3TargetBucketName string
 }
 
 func NewDeleteS3TargetBucketNameSpectraS3Request(s3TargetBucketName string) *DeleteS3TargetBucketNameSpectraS3Request {
-    return &DeleteS3TargetBucketNameSpectraS3Request{
-        S3TargetBucketName: s3TargetBucketName,
-    }
+	return &DeleteS3TargetBucketNameSpectraS3Request{
+		S3TargetBucketName: s3TargetBucketName,
+	}
 }
 
 type DeleteS3TargetFailureSpectraS3Request struct {
-    S3TargetFailure string
+	S3TargetFailure string
 }
 
 func NewDeleteS3TargetFailureSpectraS3Request(s3TargetFailure string) *DeleteS3TargetFailureSpectraS3Request {
-    return &DeleteS3TargetFailureSpectraS3Request{
-        S3TargetFailure: s3TargetFailure,
-    }
+	return &DeleteS3TargetFailureSpectraS3Request{
+		S3TargetFailure: s3TargetFailure,
+	}
 }
 
 type DeleteS3TargetReadPreferenceSpectraS3Request struct {
-    S3TargetReadPreference string
+	S3TargetReadPreference string
 }
 
 func NewDeleteS3TargetReadPreferenceSpectraS3Request(s3TargetReadPreference string) *DeleteS3TargetReadPreferenceSpectraS3Request {
-    return &DeleteS3TargetReadPreferenceSpectraS3Request{
-        S3TargetReadPreference: s3TargetReadPreference,
-    }
+	return &DeleteS3TargetReadPreferenceSpectraS3Request{
+		S3TargetReadPreference: s3TargetReadPreference,
+	}
 }
 
 type DeleteS3TargetSpectraS3Request struct {
-    S3Target string
+	S3Target string
 }
 
 func NewDeleteS3TargetSpectraS3Request(s3Target string) *DeleteS3TargetSpectraS3Request {
-    return &DeleteS3TargetSpectraS3Request{
-        S3Target: s3Target,
-    }
+	return &DeleteS3TargetSpectraS3Request{
+		S3Target: s3Target,
+	}
 }
 
 type GetBlobsOnS3TargetSpectraS3Request struct {
-    S3Target string
+	S3Target string
 }
 
 func NewGetBlobsOnS3TargetSpectraS3Request(s3Target string) *GetBlobsOnS3TargetSpectraS3Request {
-    return &GetBlobsOnS3TargetSpectraS3Request{
-        S3Target: s3Target,
-    }
+	return &GetBlobsOnS3TargetSpectraS3Request{
+		S3Target: s3Target,
+	}
 }
 
 type GetS3TargetBucketNamesSpectraS3Request struct {
-    BucketId *string
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    TargetId *string
+	BucketId        *string
+	LastPage        bool
+	Name            *string
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	TargetId        *string
 }
 
 func NewGetS3TargetBucketNamesSpectraS3Request() *GetS3TargetBucketNamesSpectraS3Request {
-    return &GetS3TargetBucketNamesSpectraS3Request{
-    }
+	return &GetS3TargetBucketNamesSpectraS3Request{}
 }
 
 func (getS3TargetBucketNamesSpectraS3Request *GetS3TargetBucketNamesSpectraS3Request) WithBucketId(bucketId string) *GetS3TargetBucketNamesSpectraS3Request {
-    getS3TargetBucketNamesSpectraS3Request.BucketId = &bucketId
-    return getS3TargetBucketNamesSpectraS3Request
+	getS3TargetBucketNamesSpectraS3Request.BucketId = &bucketId
+	return getS3TargetBucketNamesSpectraS3Request
 }
 
 func (getS3TargetBucketNamesSpectraS3Request *GetS3TargetBucketNamesSpectraS3Request) WithLastPage() *GetS3TargetBucketNamesSpectraS3Request {
-    getS3TargetBucketNamesSpectraS3Request.LastPage = true
-    return getS3TargetBucketNamesSpectraS3Request
+	getS3TargetBucketNamesSpectraS3Request.LastPage = true
+	return getS3TargetBucketNamesSpectraS3Request
 }
 
 func (getS3TargetBucketNamesSpectraS3Request *GetS3TargetBucketNamesSpectraS3Request) WithName(name string) *GetS3TargetBucketNamesSpectraS3Request {
-    getS3TargetBucketNamesSpectraS3Request.Name = &name
-    return getS3TargetBucketNamesSpectraS3Request
+	getS3TargetBucketNamesSpectraS3Request.Name = &name
+	return getS3TargetBucketNamesSpectraS3Request
 }
 
 func (getS3TargetBucketNamesSpectraS3Request *GetS3TargetBucketNamesSpectraS3Request) WithPageLength(pageLength int) *GetS3TargetBucketNamesSpectraS3Request {
-    getS3TargetBucketNamesSpectraS3Request.PageLength = &pageLength
-    return getS3TargetBucketNamesSpectraS3Request
+	getS3TargetBucketNamesSpectraS3Request.PageLength = &pageLength
+	return getS3TargetBucketNamesSpectraS3Request
 }
 
 func (getS3TargetBucketNamesSpectraS3Request *GetS3TargetBucketNamesSpectraS3Request) WithPageOffset(pageOffset int) *GetS3TargetBucketNamesSpectraS3Request {
-    getS3TargetBucketNamesSpectraS3Request.PageOffset = &pageOffset
-    return getS3TargetBucketNamesSpectraS3Request
+	getS3TargetBucketNamesSpectraS3Request.PageOffset = &pageOffset
+	return getS3TargetBucketNamesSpectraS3Request
 }
 
 func (getS3TargetBucketNamesSpectraS3Request *GetS3TargetBucketNamesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetS3TargetBucketNamesSpectraS3Request {
-    getS3TargetBucketNamesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getS3TargetBucketNamesSpectraS3Request
+	getS3TargetBucketNamesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getS3TargetBucketNamesSpectraS3Request
 }
 
 func (getS3TargetBucketNamesSpectraS3Request *GetS3TargetBucketNamesSpectraS3Request) WithTargetId(targetId string) *GetS3TargetBucketNamesSpectraS3Request {
-    getS3TargetBucketNamesSpectraS3Request.TargetId = &targetId
-    return getS3TargetBucketNamesSpectraS3Request
+	getS3TargetBucketNamesSpectraS3Request.TargetId = &targetId
+	return getS3TargetBucketNamesSpectraS3Request
 }
 
 type GetS3TargetFailuresSpectraS3Request struct {
-    ErrorMessage *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    TargetFailureType TargetFailureType
-    TargetId *string
+	ErrorMessage      *string
+	LastPage          bool
+	PageLength        *int
+	PageOffset        *int
+	PageStartMarker   *string
+	TargetFailureType TargetFailureType
+	TargetId          *string
 }
 
 func NewGetS3TargetFailuresSpectraS3Request() *GetS3TargetFailuresSpectraS3Request {
-    return &GetS3TargetFailuresSpectraS3Request{
-    }
+	return &GetS3TargetFailuresSpectraS3Request{}
 }
 
 func (getS3TargetFailuresSpectraS3Request *GetS3TargetFailuresSpectraS3Request) WithErrorMessage(errorMessage string) *GetS3TargetFailuresSpectraS3Request {
-    getS3TargetFailuresSpectraS3Request.ErrorMessage = &errorMessage
-    return getS3TargetFailuresSpectraS3Request
+	getS3TargetFailuresSpectraS3Request.ErrorMessage = &errorMessage
+	return getS3TargetFailuresSpectraS3Request
 }
 
 func (getS3TargetFailuresSpectraS3Request *GetS3TargetFailuresSpectraS3Request) WithLastPage() *GetS3TargetFailuresSpectraS3Request {
-    getS3TargetFailuresSpectraS3Request.LastPage = true
-    return getS3TargetFailuresSpectraS3Request
+	getS3TargetFailuresSpectraS3Request.LastPage = true
+	return getS3TargetFailuresSpectraS3Request
 }
 
 func (getS3TargetFailuresSpectraS3Request *GetS3TargetFailuresSpectraS3Request) WithPageLength(pageLength int) *GetS3TargetFailuresSpectraS3Request {
-    getS3TargetFailuresSpectraS3Request.PageLength = &pageLength
-    return getS3TargetFailuresSpectraS3Request
+	getS3TargetFailuresSpectraS3Request.PageLength = &pageLength
+	return getS3TargetFailuresSpectraS3Request
 }
 
 func (getS3TargetFailuresSpectraS3Request *GetS3TargetFailuresSpectraS3Request) WithPageOffset(pageOffset int) *GetS3TargetFailuresSpectraS3Request {
-    getS3TargetFailuresSpectraS3Request.PageOffset = &pageOffset
-    return getS3TargetFailuresSpectraS3Request
+	getS3TargetFailuresSpectraS3Request.PageOffset = &pageOffset
+	return getS3TargetFailuresSpectraS3Request
 }
 
 func (getS3TargetFailuresSpectraS3Request *GetS3TargetFailuresSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetS3TargetFailuresSpectraS3Request {
-    getS3TargetFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getS3TargetFailuresSpectraS3Request
+	getS3TargetFailuresSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getS3TargetFailuresSpectraS3Request
 }
 
 func (getS3TargetFailuresSpectraS3Request *GetS3TargetFailuresSpectraS3Request) WithTargetId(targetId string) *GetS3TargetFailuresSpectraS3Request {
-    getS3TargetFailuresSpectraS3Request.TargetId = &targetId
-    return getS3TargetFailuresSpectraS3Request
+	getS3TargetFailuresSpectraS3Request.TargetId = &targetId
+	return getS3TargetFailuresSpectraS3Request
 }
 
 func (getS3TargetFailuresSpectraS3Request *GetS3TargetFailuresSpectraS3Request) WithTargetFailureType(targetFailureType TargetFailureType) *GetS3TargetFailuresSpectraS3Request {
-    getS3TargetFailuresSpectraS3Request.TargetFailureType = targetFailureType
-    return getS3TargetFailuresSpectraS3Request
+	getS3TargetFailuresSpectraS3Request.TargetFailureType = targetFailureType
+	return getS3TargetFailuresSpectraS3Request
 }
 
 type GetS3TargetReadPreferenceSpectraS3Request struct {
-    S3TargetReadPreference string
+	S3TargetReadPreference string
 }
 
 func NewGetS3TargetReadPreferenceSpectraS3Request(s3TargetReadPreference string) *GetS3TargetReadPreferenceSpectraS3Request {
-    return &GetS3TargetReadPreferenceSpectraS3Request{
-        S3TargetReadPreference: s3TargetReadPreference,
-    }
+	return &GetS3TargetReadPreferenceSpectraS3Request{
+		S3TargetReadPreference: s3TargetReadPreference,
+	}
 }
 
 type GetS3TargetReadPreferencesSpectraS3Request struct {
-    BucketId *string
-    LastPage bool
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    ReadPreference TargetReadPreferenceType
-    TargetId *string
+	BucketId        *string
+	LastPage        bool
+	PageLength      *int
+	PageOffset      *int
+	PageStartMarker *string
+	ReadPreference  TargetReadPreferenceType
+	TargetId        *string
 }
 
 func NewGetS3TargetReadPreferencesSpectraS3Request() *GetS3TargetReadPreferencesSpectraS3Request {
-    return &GetS3TargetReadPreferencesSpectraS3Request{
-    }
+	return &GetS3TargetReadPreferencesSpectraS3Request{}
 }
 
 func (getS3TargetReadPreferencesSpectraS3Request *GetS3TargetReadPreferencesSpectraS3Request) WithBucketId(bucketId string) *GetS3TargetReadPreferencesSpectraS3Request {
-    getS3TargetReadPreferencesSpectraS3Request.BucketId = &bucketId
-    return getS3TargetReadPreferencesSpectraS3Request
+	getS3TargetReadPreferencesSpectraS3Request.BucketId = &bucketId
+	return getS3TargetReadPreferencesSpectraS3Request
 }
 
 func (getS3TargetReadPreferencesSpectraS3Request *GetS3TargetReadPreferencesSpectraS3Request) WithLastPage() *GetS3TargetReadPreferencesSpectraS3Request {
-    getS3TargetReadPreferencesSpectraS3Request.LastPage = true
-    return getS3TargetReadPreferencesSpectraS3Request
+	getS3TargetReadPreferencesSpectraS3Request.LastPage = true
+	return getS3TargetReadPreferencesSpectraS3Request
 }
 
 func (getS3TargetReadPreferencesSpectraS3Request *GetS3TargetReadPreferencesSpectraS3Request) WithPageLength(pageLength int) *GetS3TargetReadPreferencesSpectraS3Request {
-    getS3TargetReadPreferencesSpectraS3Request.PageLength = &pageLength
-    return getS3TargetReadPreferencesSpectraS3Request
+	getS3TargetReadPreferencesSpectraS3Request.PageLength = &pageLength
+	return getS3TargetReadPreferencesSpectraS3Request
 }
 
 func (getS3TargetReadPreferencesSpectraS3Request *GetS3TargetReadPreferencesSpectraS3Request) WithPageOffset(pageOffset int) *GetS3TargetReadPreferencesSpectraS3Request {
-    getS3TargetReadPreferencesSpectraS3Request.PageOffset = &pageOffset
-    return getS3TargetReadPreferencesSpectraS3Request
+	getS3TargetReadPreferencesSpectraS3Request.PageOffset = &pageOffset
+	return getS3TargetReadPreferencesSpectraS3Request
 }
 
 func (getS3TargetReadPreferencesSpectraS3Request *GetS3TargetReadPreferencesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetS3TargetReadPreferencesSpectraS3Request {
-    getS3TargetReadPreferencesSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getS3TargetReadPreferencesSpectraS3Request
+	getS3TargetReadPreferencesSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getS3TargetReadPreferencesSpectraS3Request
 }
 
 func (getS3TargetReadPreferencesSpectraS3Request *GetS3TargetReadPreferencesSpectraS3Request) WithReadPreference(readPreference TargetReadPreferenceType) *GetS3TargetReadPreferencesSpectraS3Request {
-    getS3TargetReadPreferencesSpectraS3Request.ReadPreference = readPreference
-    return getS3TargetReadPreferencesSpectraS3Request
+	getS3TargetReadPreferencesSpectraS3Request.ReadPreference = readPreference
+	return getS3TargetReadPreferencesSpectraS3Request
 }
 
 func (getS3TargetReadPreferencesSpectraS3Request *GetS3TargetReadPreferencesSpectraS3Request) WithTargetId(targetId string) *GetS3TargetReadPreferencesSpectraS3Request {
-    getS3TargetReadPreferencesSpectraS3Request.TargetId = &targetId
-    return getS3TargetReadPreferencesSpectraS3Request
+	getS3TargetReadPreferencesSpectraS3Request.TargetId = &targetId
+	return getS3TargetReadPreferencesSpectraS3Request
 }
 
 type GetS3TargetSpectraS3Request struct {
-    S3Target string
+	S3Target string
 }
 
 func NewGetS3TargetSpectraS3Request(s3Target string) *GetS3TargetSpectraS3Request {
-    return &GetS3TargetSpectraS3Request{
-        S3Target: s3Target,
-    }
+	return &GetS3TargetSpectraS3Request{
+		S3Target: s3Target,
+	}
 }
 
 type GetS3TargetsSpectraS3Request struct {
-    AccessKey *string
-    DataPathEndPoint *string
-    DefaultReadPreference TargetReadPreferenceType
-    Https *bool
-    LastPage bool
-    Name *string
-    NamingMode CloudNamingMode
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
-    PermitGoingOutOfSync *bool
-    Quiesced Quiesced
-    Region S3Region
-    State TargetState
+	AccessKey             *string
+	DataPathEndPoint      *string
+	DefaultReadPreference TargetReadPreferenceType
+	Https                 *bool
+	LastPage              bool
+	Name                  *string
+	NamingMode            CloudNamingMode
+	PageLength            *int
+	PageOffset            *int
+	PageStartMarker       *string
+	PermitGoingOutOfSync  *bool
+	Quiesced              Quiesced
+	Region                S3Region
+	State                 TargetState
 }
 
 func NewGetS3TargetsSpectraS3Request() *GetS3TargetsSpectraS3Request {
-    return &GetS3TargetsSpectraS3Request{
-    }
+	return &GetS3TargetsSpectraS3Request{}
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithAccessKey(accessKey string) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.AccessKey = &accessKey
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.AccessKey = &accessKey
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithDataPathEndPoint(dataPathEndPoint string) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithDefaultReadPreference(defaultReadPreference TargetReadPreferenceType) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.DefaultReadPreference = defaultReadPreference
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.DefaultReadPreference = defaultReadPreference
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithHttps(https bool) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.Https = &https
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.Https = &https
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithLastPage() *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.LastPage = true
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.LastPage = true
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithName(name string) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.Name = &name
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.Name = &name
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithNamingMode(namingMode CloudNamingMode) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.NamingMode = namingMode
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.NamingMode = namingMode
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithPageLength(pageLength int) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.PageLength = &pageLength
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.PageLength = &pageLength
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithPageOffset(pageOffset int) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.PageOffset = &pageOffset
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.PageOffset = &pageOffset
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithPermitGoingOutOfSync(permitGoingOutOfSync bool) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithQuiesced(quiesced Quiesced) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.Quiesced = quiesced
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.Quiesced = quiesced
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithRegion(region S3Region) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.Region = region
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.Region = region
+	return getS3TargetsSpectraS3Request
 }
 
 func (getS3TargetsSpectraS3Request *GetS3TargetsSpectraS3Request) WithState(state TargetState) *GetS3TargetsSpectraS3Request {
-    getS3TargetsSpectraS3Request.State = state
-    return getS3TargetsSpectraS3Request
+	getS3TargetsSpectraS3Request.State = state
+	return getS3TargetsSpectraS3Request
 }
 
 type ImportS3TargetSpectraS3Request struct {
-    CloudBucketName string
-    DataPolicyId *string
-    Priority Priority
-    S3Target string
-    UserId *string
+	CloudBucketName string
+	DataPolicyId    *string
+	Priority        Priority
+	S3Target        string
+	UserId          *string
 }
 
 func NewImportS3TargetSpectraS3Request(cloudBucketName string, s3Target string) *ImportS3TargetSpectraS3Request {
-    return &ImportS3TargetSpectraS3Request{
-        S3Target: s3Target,
-        CloudBucketName: cloudBucketName,
-    }
+	return &ImportS3TargetSpectraS3Request{
+		S3Target:        s3Target,
+		CloudBucketName: cloudBucketName,
+	}
 }
 
 func (importS3TargetSpectraS3Request *ImportS3TargetSpectraS3Request) WithDataPolicyId(dataPolicyId string) *ImportS3TargetSpectraS3Request {
-    importS3TargetSpectraS3Request.DataPolicyId = &dataPolicyId
-    return importS3TargetSpectraS3Request
+	importS3TargetSpectraS3Request.DataPolicyId = &dataPolicyId
+	return importS3TargetSpectraS3Request
 }
 
 func (importS3TargetSpectraS3Request *ImportS3TargetSpectraS3Request) WithPriority(priority Priority) *ImportS3TargetSpectraS3Request {
-    importS3TargetSpectraS3Request.Priority = priority
-    return importS3TargetSpectraS3Request
+	importS3TargetSpectraS3Request.Priority = priority
+	return importS3TargetSpectraS3Request
 }
 
 func (importS3TargetSpectraS3Request *ImportS3TargetSpectraS3Request) WithUserId(userId string) *ImportS3TargetSpectraS3Request {
-    importS3TargetSpectraS3Request.UserId = &userId
-    return importS3TargetSpectraS3Request
+	importS3TargetSpectraS3Request.UserId = &userId
+	return importS3TargetSpectraS3Request
 }
 
 type ModifyAllS3TargetsSpectraS3Request struct {
-    Quiesced Quiesced
+	Quiesced Quiesced
 }
 
 func NewModifyAllS3TargetsSpectraS3Request(quiesced Quiesced) *ModifyAllS3TargetsSpectraS3Request {
-    return &ModifyAllS3TargetsSpectraS3Request{
-        Quiesced: quiesced,
-    }
+	return &ModifyAllS3TargetsSpectraS3Request{
+		Quiesced: quiesced,
+	}
 }
 
 type ModifyS3TargetSpectraS3Request struct {
-    AccessKey *string
-    AutoVerifyFrequencyInDays *int
-    CloudBucketPrefix *string
-    CloudBucketSuffix *string
-    DataPathEndPoint *string
-    DefaultReadPreference TargetReadPreferenceType
-    Https *bool
-    Name *string
-    NamingMode CloudNamingMode
-    OfflineDataStagingWindowInTb *int
-    PermitGoingOutOfSync *bool
-    ProxyDomain *string
-    ProxyHost *string
-    ProxyPassword *string
-    ProxyPort *int
-    ProxyUsername *string
-    Quiesced Quiesced
-    Region S3Region
-    RestrictedAccess *bool
-    S3Target string
-    SecretKey *string
-    StagedDataExpirationInDays *int
+	AccessKey                    *string
+	AutoVerifyFrequencyInDays    *int
+	CloudBucketPrefix            *string
+	CloudBucketSuffix            *string
+	DataPathEndPoint             *string
+	DefaultReadPreference        TargetReadPreferenceType
+	Https                        *bool
+	Name                         *string
+	NamingMode                   CloudNamingMode
+	OfflineDataStagingWindowInTb *int
+	PermitGoingOutOfSync         *bool
+	ProxyDomain                  *string
+	ProxyHost                    *string
+	ProxyPassword                *string
+	ProxyPort                    *int
+	ProxyUsername                *string
+	Quiesced                     Quiesced
+	Region                       S3Region
+	RestrictedAccess             *bool
+	S3Target                     string
+	SecretKey                    *string
+	StagedDataExpirationInDays   *int
 }
 
 func NewModifyS3TargetSpectraS3Request(s3Target string) *ModifyS3TargetSpectraS3Request {
-    return &ModifyS3TargetSpectraS3Request{
-        S3Target: s3Target,
-    }
+	return &ModifyS3TargetSpectraS3Request{
+		S3Target: s3Target,
+	}
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithAccessKey(accessKey string) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.AccessKey = &accessKey
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.AccessKey = &accessKey
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithAutoVerifyFrequencyInDays(autoVerifyFrequencyInDays int) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.AutoVerifyFrequencyInDays = &autoVerifyFrequencyInDays
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.AutoVerifyFrequencyInDays = &autoVerifyFrequencyInDays
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithCloudBucketPrefix(cloudBucketPrefix string) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.CloudBucketPrefix = &cloudBucketPrefix
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.CloudBucketPrefix = &cloudBucketPrefix
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithCloudBucketSuffix(cloudBucketSuffix string) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.CloudBucketSuffix = &cloudBucketSuffix
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.CloudBucketSuffix = &cloudBucketSuffix
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithDataPathEndPoint(dataPathEndPoint string) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithDefaultReadPreference(defaultReadPreference TargetReadPreferenceType) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithHttps(https bool) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.Https = &https
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.Https = &https
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithName(name string) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.Name = &name
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.Name = &name
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithNamingMode(namingMode CloudNamingMode) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.NamingMode = namingMode
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.NamingMode = namingMode
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithOfflineDataStagingWindowInTb(offlineDataStagingWindowInTb int) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.OfflineDataStagingWindowInTb = &offlineDataStagingWindowInTb
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.OfflineDataStagingWindowInTb = &offlineDataStagingWindowInTb
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithPermitGoingOutOfSync(permitGoingOutOfSync bool) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithProxyDomain(proxyDomain string) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.ProxyDomain = &proxyDomain
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.ProxyDomain = &proxyDomain
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithProxyHost(proxyHost string) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.ProxyHost = &proxyHost
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.ProxyHost = &proxyHost
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithProxyPassword(proxyPassword string) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.ProxyPassword = &proxyPassword
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.ProxyPassword = &proxyPassword
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithProxyPort(proxyPort int) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.ProxyPort = &proxyPort
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.ProxyPort = &proxyPort
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithProxyUsername(proxyUsername string) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.ProxyUsername = &proxyUsername
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.ProxyUsername = &proxyUsername
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithQuiesced(quiesced Quiesced) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.Quiesced = quiesced
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.Quiesced = quiesced
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithRegion(region S3Region) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.Region = region
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.Region = region
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithRestrictedAccess(restrictedAccess bool) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.RestrictedAccess = &restrictedAccess
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.RestrictedAccess = &restrictedAccess
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithSecretKey(secretKey string) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.SecretKey = &secretKey
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.SecretKey = &secretKey
+	return modifyS3TargetSpectraS3Request
 }
 
 func (modifyS3TargetSpectraS3Request *ModifyS3TargetSpectraS3Request) WithStagedDataExpirationInDays(stagedDataExpirationInDays int) *ModifyS3TargetSpectraS3Request {
-    modifyS3TargetSpectraS3Request.StagedDataExpirationInDays = &stagedDataExpirationInDays
-    return modifyS3TargetSpectraS3Request
+	modifyS3TargetSpectraS3Request.StagedDataExpirationInDays = &stagedDataExpirationInDays
+	return modifyS3TargetSpectraS3Request
 }
 
 type RegisterS3TargetSpectraS3Request struct {
-    AccessKey string
-    AutoVerifyFrequencyInDays *int
-    CloudBucketPrefix *string
-    CloudBucketSuffix *string
-    DataPathEndPoint *string
-    DefaultReadPreference TargetReadPreferenceType
-    Https *bool
-    Name string
-    NamingMode CloudNamingMode
-    OfflineDataStagingWindowInTb *int
-    PermitGoingOutOfSync *bool
-    ProxyDomain *string
-    ProxyHost *string
-    ProxyPassword *string
-    ProxyPort *int
-    ProxyUsername *string
-    Region S3Region
-    RestrictedAccess *bool
-    SecretKey string
-    StagedDataExpirationInDays *int
+	AccessKey                    string
+	AutoVerifyFrequencyInDays    *int
+	CloudBucketPrefix            *string
+	CloudBucketSuffix            *string
+	DataPathEndPoint             *string
+	DefaultReadPreference        TargetReadPreferenceType
+	Https                        *bool
+	Name                         string
+	NamingMode                   CloudNamingMode
+	OfflineDataStagingWindowInTb *int
+	PermitGoingOutOfSync         *bool
+	ProxyDomain                  *string
+	ProxyHost                    *string
+	ProxyPassword                *string
+	ProxyPort                    *int
+	ProxyUsername                *string
+	Region                       S3Region
+	RestrictedAccess             *bool
+	SecretKey                    string
+	StagedDataExpirationInDays   *int
 }
 
 func NewRegisterS3TargetSpectraS3Request(accessKey string, name string, secretKey string) *RegisterS3TargetSpectraS3Request {
-    return &RegisterS3TargetSpectraS3Request{
-        AccessKey: accessKey,
-        Name: name,
-        SecretKey: secretKey,
-    }
+	return &RegisterS3TargetSpectraS3Request{
+		AccessKey: accessKey,
+		Name:      name,
+		SecretKey: secretKey,
+	}
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithAutoVerifyFrequencyInDays(autoVerifyFrequencyInDays int) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.AutoVerifyFrequencyInDays = &autoVerifyFrequencyInDays
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.AutoVerifyFrequencyInDays = &autoVerifyFrequencyInDays
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithCloudBucketPrefix(cloudBucketPrefix string) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.CloudBucketPrefix = &cloudBucketPrefix
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.CloudBucketPrefix = &cloudBucketPrefix
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithCloudBucketSuffix(cloudBucketSuffix string) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.CloudBucketSuffix = &cloudBucketSuffix
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.CloudBucketSuffix = &cloudBucketSuffix
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithDataPathEndPoint(dataPathEndPoint string) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.DataPathEndPoint = &dataPathEndPoint
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithDefaultReadPreference(defaultReadPreference TargetReadPreferenceType) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.DefaultReadPreference = defaultReadPreference
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithHttps(https bool) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.Https = &https
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.Https = &https
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithNamingMode(namingMode CloudNamingMode) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.NamingMode = namingMode
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.NamingMode = namingMode
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithOfflineDataStagingWindowInTb(offlineDataStagingWindowInTb int) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.OfflineDataStagingWindowInTb = &offlineDataStagingWindowInTb
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.OfflineDataStagingWindowInTb = &offlineDataStagingWindowInTb
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithPermitGoingOutOfSync(permitGoingOutOfSync bool) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.PermitGoingOutOfSync = &permitGoingOutOfSync
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithProxyDomain(proxyDomain string) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.ProxyDomain = &proxyDomain
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.ProxyDomain = &proxyDomain
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithProxyHost(proxyHost string) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.ProxyHost = &proxyHost
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.ProxyHost = &proxyHost
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithProxyPassword(proxyPassword string) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.ProxyPassword = &proxyPassword
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.ProxyPassword = &proxyPassword
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithProxyPort(proxyPort int) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.ProxyPort = &proxyPort
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.ProxyPort = &proxyPort
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithProxyUsername(proxyUsername string) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.ProxyUsername = &proxyUsername
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.ProxyUsername = &proxyUsername
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithRegion(region S3Region) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.Region = region
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.Region = region
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithRestrictedAccess(restrictedAccess bool) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.RestrictedAccess = &restrictedAccess
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.RestrictedAccess = &restrictedAccess
+	return registerS3TargetSpectraS3Request
 }
 
 func (registerS3TargetSpectraS3Request *RegisterS3TargetSpectraS3Request) WithStagedDataExpirationInDays(stagedDataExpirationInDays int) *RegisterS3TargetSpectraS3Request {
-    registerS3TargetSpectraS3Request.StagedDataExpirationInDays = &stagedDataExpirationInDays
-    return registerS3TargetSpectraS3Request
+	registerS3TargetSpectraS3Request.StagedDataExpirationInDays = &stagedDataExpirationInDays
+	return registerS3TargetSpectraS3Request
 }
 
 type VerifyS3TargetSpectraS3Request struct {
-    FullDetails bool
-    S3Target string
+	FullDetails bool
+	S3Target    string
 }
 
 func NewVerifyS3TargetSpectraS3Request(s3Target string) *VerifyS3TargetSpectraS3Request {
-    return &VerifyS3TargetSpectraS3Request{
-        S3Target: s3Target,
-    }
+	return &VerifyS3TargetSpectraS3Request{
+		S3Target: s3Target,
+	}
 }
 
 func (verifyS3TargetSpectraS3Request *VerifyS3TargetSpectraS3Request) WithFullDetails() *VerifyS3TargetSpectraS3Request {
-    verifyS3TargetSpectraS3Request.FullDetails = true
-    return verifyS3TargetSpectraS3Request
+	verifyS3TargetSpectraS3Request.FullDetails = true
+	return verifyS3TargetSpectraS3Request
 }
 
 type DelegateCreateUserSpectraS3Request struct {
-    DefaultDataPolicyId *string
-    Id *string
-    MaxBuckets *int
-    Name string
-    SecretKey *string
+	DefaultDataPolicyId *string
+	Id                  *string
+	MaxBuckets          *int
+	Name                string
+	SecretKey           *string
 }
 
 func NewDelegateCreateUserSpectraS3Request(name string) *DelegateCreateUserSpectraS3Request {
-    return &DelegateCreateUserSpectraS3Request{
-        Name: name,
-    }
+	return &DelegateCreateUserSpectraS3Request{
+		Name: name,
+	}
 }
 
 func (delegateCreateUserSpectraS3Request *DelegateCreateUserSpectraS3Request) WithDefaultDataPolicyId(defaultDataPolicyId string) *DelegateCreateUserSpectraS3Request {
-    delegateCreateUserSpectraS3Request.DefaultDataPolicyId = &defaultDataPolicyId
-    return delegateCreateUserSpectraS3Request
+	delegateCreateUserSpectraS3Request.DefaultDataPolicyId = &defaultDataPolicyId
+	return delegateCreateUserSpectraS3Request
 }
 
 func (delegateCreateUserSpectraS3Request *DelegateCreateUserSpectraS3Request) WithId(id string) *DelegateCreateUserSpectraS3Request {
-    delegateCreateUserSpectraS3Request.Id = &id
-    return delegateCreateUserSpectraS3Request
+	delegateCreateUserSpectraS3Request.Id = &id
+	return delegateCreateUserSpectraS3Request
 }
 
 func (delegateCreateUserSpectraS3Request *DelegateCreateUserSpectraS3Request) WithMaxBuckets(maxBuckets int) *DelegateCreateUserSpectraS3Request {
-    delegateCreateUserSpectraS3Request.MaxBuckets = &maxBuckets
-    return delegateCreateUserSpectraS3Request
+	delegateCreateUserSpectraS3Request.MaxBuckets = &maxBuckets
+	return delegateCreateUserSpectraS3Request
 }
 
 func (delegateCreateUserSpectraS3Request *DelegateCreateUserSpectraS3Request) WithSecretKey(secretKey string) *DelegateCreateUserSpectraS3Request {
-    delegateCreateUserSpectraS3Request.SecretKey = &secretKey
-    return delegateCreateUserSpectraS3Request
+	delegateCreateUserSpectraS3Request.SecretKey = &secretKey
+	return delegateCreateUserSpectraS3Request
 }
 
 type DelegateDeleteUserSpectraS3Request struct {
-    UserId string
+	UserId string
 }
 
 func NewDelegateDeleteUserSpectraS3Request(userId string) *DelegateDeleteUserSpectraS3Request {
-    return &DelegateDeleteUserSpectraS3Request{
-        UserId: userId,
-    }
+	return &DelegateDeleteUserSpectraS3Request{
+		UserId: userId,
+	}
 }
 
 type GetUserSpectraS3Request struct {
-    UserId string
+	UserId string
 }
 
 func NewGetUserSpectraS3Request(userId string) *GetUserSpectraS3Request {
-    return &GetUserSpectraS3Request{
-        UserId: userId,
-    }
+	return &GetUserSpectraS3Request{
+		UserId: userId,
+	}
 }
 
 type GetUsersSpectraS3Request struct {
-    AuthId *string
-    DefaultDataPolicyId *string
-    LastPage bool
-    Name *string
-    PageLength *int
-    PageOffset *int
-    PageStartMarker *string
+	AuthId              *string
+	DefaultDataPolicyId *string
+	LastPage            bool
+	Name                *string
+	PageLength          *int
+	PageOffset          *int
+	PageStartMarker     *string
 }
 
 func NewGetUsersSpectraS3Request() *GetUsersSpectraS3Request {
-    return &GetUsersSpectraS3Request{
-    }
+	return &GetUsersSpectraS3Request{}
 }
 
 func (getUsersSpectraS3Request *GetUsersSpectraS3Request) WithAuthId(authId string) *GetUsersSpectraS3Request {
-    getUsersSpectraS3Request.AuthId = &authId
-    return getUsersSpectraS3Request
+	getUsersSpectraS3Request.AuthId = &authId
+	return getUsersSpectraS3Request
 }
 
 func (getUsersSpectraS3Request *GetUsersSpectraS3Request) WithDefaultDataPolicyId(defaultDataPolicyId string) *GetUsersSpectraS3Request {
-    getUsersSpectraS3Request.DefaultDataPolicyId = &defaultDataPolicyId
-    return getUsersSpectraS3Request
+	getUsersSpectraS3Request.DefaultDataPolicyId = &defaultDataPolicyId
+	return getUsersSpectraS3Request
 }
 
 func (getUsersSpectraS3Request *GetUsersSpectraS3Request) WithLastPage() *GetUsersSpectraS3Request {
-    getUsersSpectraS3Request.LastPage = true
-    return getUsersSpectraS3Request
+	getUsersSpectraS3Request.LastPage = true
+	return getUsersSpectraS3Request
 }
 
 func (getUsersSpectraS3Request *GetUsersSpectraS3Request) WithName(name string) *GetUsersSpectraS3Request {
-    getUsersSpectraS3Request.Name = &name
-    return getUsersSpectraS3Request
+	getUsersSpectraS3Request.Name = &name
+	return getUsersSpectraS3Request
 }
 
 func (getUsersSpectraS3Request *GetUsersSpectraS3Request) WithPageLength(pageLength int) *GetUsersSpectraS3Request {
-    getUsersSpectraS3Request.PageLength = &pageLength
-    return getUsersSpectraS3Request
+	getUsersSpectraS3Request.PageLength = &pageLength
+	return getUsersSpectraS3Request
 }
 
 func (getUsersSpectraS3Request *GetUsersSpectraS3Request) WithPageOffset(pageOffset int) *GetUsersSpectraS3Request {
-    getUsersSpectraS3Request.PageOffset = &pageOffset
-    return getUsersSpectraS3Request
+	getUsersSpectraS3Request.PageOffset = &pageOffset
+	return getUsersSpectraS3Request
 }
 
 func (getUsersSpectraS3Request *GetUsersSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetUsersSpectraS3Request {
-    getUsersSpectraS3Request.PageStartMarker = &pageStartMarker
-    return getUsersSpectraS3Request
+	getUsersSpectraS3Request.PageStartMarker = &pageStartMarker
+	return getUsersSpectraS3Request
 }
 
 type ModifyUserSpectraS3Request struct {
-    DefaultDataPolicyId *string
-    MaxBuckets *int
-    Name *string
-    SecretKey *string
-    UserId string
+	DefaultDataPolicyId *string
+	MaxBuckets          *int
+	Name                *string
+	SecretKey           *string
+	UserId              string
 }
 
 func NewModifyUserSpectraS3Request(userId string) *ModifyUserSpectraS3Request {
-    return &ModifyUserSpectraS3Request{
-        UserId: userId,
-    }
+	return &ModifyUserSpectraS3Request{
+		UserId: userId,
+	}
 }
 
 func (modifyUserSpectraS3Request *ModifyUserSpectraS3Request) WithDefaultDataPolicyId(defaultDataPolicyId string) *ModifyUserSpectraS3Request {
-    modifyUserSpectraS3Request.DefaultDataPolicyId = &defaultDataPolicyId
-    return modifyUserSpectraS3Request
+	modifyUserSpectraS3Request.DefaultDataPolicyId = &defaultDataPolicyId
+	return modifyUserSpectraS3Request
 }
 
 func (modifyUserSpectraS3Request *ModifyUserSpectraS3Request) WithMaxBuckets(maxBuckets int) *ModifyUserSpectraS3Request {
-    modifyUserSpectraS3Request.MaxBuckets = &maxBuckets
-    return modifyUserSpectraS3Request
+	modifyUserSpectraS3Request.MaxBuckets = &maxBuckets
+	return modifyUserSpectraS3Request
 }
 
 func (modifyUserSpectraS3Request *ModifyUserSpectraS3Request) WithName(name string) *ModifyUserSpectraS3Request {
-    modifyUserSpectraS3Request.Name = &name
-    return modifyUserSpectraS3Request
+	modifyUserSpectraS3Request.Name = &name
+	return modifyUserSpectraS3Request
 }
 
 func (modifyUserSpectraS3Request *ModifyUserSpectraS3Request) WithSecretKey(secretKey string) *ModifyUserSpectraS3Request {
-    modifyUserSpectraS3Request.SecretKey = &secretKey
-    return modifyUserSpectraS3Request
+	modifyUserSpectraS3Request.SecretKey = &secretKey
+	return modifyUserSpectraS3Request
 }
 
 type RegenerateUserSecretKeySpectraS3Request struct {
-    UserId string
+	UserId string
 }
 
 func NewRegenerateUserSecretKeySpectraS3Request(userId string) *RegenerateUserSecretKeySpectraS3Request {
-    return &RegenerateUserSecretKeySpectraS3Request{
-        UserId: userId,
-    }
+	return &RegenerateUserSecretKeySpectraS3Request{
+		UserId: userId,
+	}
 }
-

--- a/ds3/models/requests.go
+++ b/ds3/models/requests.go
@@ -3077,7 +3077,6 @@ type GetBulkJobSpectraS3Request struct {
 }
 
 func NewGetBulkJobSpectraS3Request(bucketName string, objectNames []string) *GetBulkJobSpectraS3Request {
-
 	return &GetBulkJobSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
@@ -3085,7 +3084,6 @@ func NewGetBulkJobSpectraS3Request(bucketName string, objectNames []string) *Get
 }
 
 func NewGetBulkJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *GetBulkJobSpectraS3Request {
-
 	return &GetBulkJobSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    objects,
@@ -3220,7 +3218,6 @@ type VerifyBulkJobSpectraS3Request struct {
 }
 
 func NewVerifyBulkJobSpectraS3Request(bucketName string, objectNames []string) *VerifyBulkJobSpectraS3Request {
-
 	return &VerifyBulkJobSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
@@ -3228,7 +3225,6 @@ func NewVerifyBulkJobSpectraS3Request(bucketName string, objectNames []string) *
 }
 
 func NewVerifyBulkJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *VerifyBulkJobSpectraS3Request {
-
 	return &VerifyBulkJobSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    objects,
@@ -3775,7 +3771,6 @@ type StageObjectsJobSpectraS3Request struct {
 }
 
 func NewStageObjectsJobSpectraS3Request(bucketName string, objectNames []string) *StageObjectsJobSpectraS3Request {
-
 	return &StageObjectsJobSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
@@ -3783,7 +3778,6 @@ func NewStageObjectsJobSpectraS3Request(bucketName string, objectNames []string)
 }
 
 func NewStageObjectsJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *StageObjectsJobSpectraS3Request {
-
 	return &StageObjectsJobSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    objects,
@@ -5454,7 +5448,6 @@ type GetPhysicalPlacementForObjectsSpectraS3Request struct {
 }
 
 func NewGetPhysicalPlacementForObjectsSpectraS3Request(bucketName string, objectNames []string) *GetPhysicalPlacementForObjectsSpectraS3Request {
-
 	return &GetPhysicalPlacementForObjectsSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
@@ -5462,7 +5455,6 @@ func NewGetPhysicalPlacementForObjectsSpectraS3Request(bucketName string, object
 }
 
 func NewGetPhysicalPlacementForObjectsSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *GetPhysicalPlacementForObjectsSpectraS3Request {
-
 	return &GetPhysicalPlacementForObjectsSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    objects,
@@ -5481,7 +5473,6 @@ type GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request struct {
 }
 
 func NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName string, objectNames []string) *GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
-
 	return &GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
@@ -5489,7 +5480,6 @@ func NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName
 }
 
 func NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
-
 	return &GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    objects,
@@ -5526,7 +5516,6 @@ type VerifyPhysicalPlacementForObjectsSpectraS3Request struct {
 }
 
 func NewVerifyPhysicalPlacementForObjectsSpectraS3Request(bucketName string, objectNames []string) *VerifyPhysicalPlacementForObjectsSpectraS3Request {
-
 	return &VerifyPhysicalPlacementForObjectsSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
@@ -5534,7 +5523,6 @@ func NewVerifyPhysicalPlacementForObjectsSpectraS3Request(bucketName string, obj
 }
 
 func NewVerifyPhysicalPlacementForObjectsSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *VerifyPhysicalPlacementForObjectsSpectraS3Request {
-
 	return &VerifyPhysicalPlacementForObjectsSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    objects,
@@ -5553,7 +5541,6 @@ type VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request struct {
 }
 
 func NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketName string, objectNames []string) *VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
-
 	return &VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    buildDs3GetObjectSliceFromNames(objectNames),
@@ -5561,7 +5548,6 @@ func NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request(bucketN
 }
 
 func NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request {
-
 	return &VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request{
 		BucketName: bucketName,
 		Objects:    objects,
@@ -6933,7 +6919,6 @@ type EjectStorageDomainBlobsSpectraS3Request struct {
 }
 
 func NewEjectStorageDomainBlobsSpectraS3Request(bucketId string, storageDomain string, objectNames []string) *EjectStorageDomainBlobsSpectraS3Request {
-
 	return &EjectStorageDomainBlobsSpectraS3Request{
 		BucketId:      bucketId,
 		StorageDomain: storageDomain,
@@ -6942,7 +6927,6 @@ func NewEjectStorageDomainBlobsSpectraS3Request(bucketId string, storageDomain s
 }
 
 func NewEjectStorageDomainBlobsSpectraS3RequestWithPartialObjects(bucketId string, storageDomain string, objects []Ds3GetObject) *EjectStorageDomainBlobsSpectraS3Request {
-
 	return &EjectStorageDomainBlobsSpectraS3Request{
 		BucketId:      bucketId,
 		StorageDomain: storageDomain,

--- a/ds3/models/responseHandlingUtil.go
+++ b/ds3/models/responseHandlingUtil.go
@@ -12,56 +12,56 @@
 package models
 
 import (
-    "encoding/xml"
-    "io"
-    "io/ioutil"
+	"encoding/xml"
+	"io"
+	"io/ioutil"
 )
 
 type modelParser interface {
-    parse(node *XmlNode, aggErr *AggregateError)
+	parse(node *XmlNode, aggErr *AggregateError)
 }
 
 // Parses a response payload into the specified model parser. A best effort parsing
 // is performed, and all errors that occur during parsing are captured within an aggregate error.
 func parseResponsePayload(webResponse WebResponse, parsedBody modelParser) error {
-    // Clean up the response body.
-    body := webResponse.Body()
+	// Clean up the response body.
+	body := webResponse.Body()
 
-    // Create the xml tree
-    root, err := parseXmlTree(body)
-    if err != nil {
-        return err
-    }
+	// Create the xml tree
+	root, err := parseXmlTree(body)
+	if err != nil {
+		return err
+	}
 
-    // Parse the response
-    var aggErr AggregateError
-    parsedBody.parse(root, &aggErr)
-    return aggErr.GetErrors()
+	// Parse the response
+	var aggErr AggregateError
+	parsedBody.parse(root, &aggErr)
+	return aggErr.GetErrors()
 }
 
 // Converts the contents of the reader into an xml node tree
 func parseXmlTree(reader io.ReadCloser) (*XmlNode, error) {
 
-    var xmlNode XmlNode
-    dec := xml.NewDecoder(reader)
-    xmlTreeErr := dec.Decode(&xmlNode)
-    if xmlTreeErr != nil {
-        return nil, xmlTreeErr
-    }
+	var xmlNode XmlNode
+	dec := xml.NewDecoder(reader)
+	xmlTreeErr := dec.Decode(&xmlNode)
+	if xmlTreeErr != nil {
+		return nil, xmlTreeErr
+	}
 
-    return &xmlNode, nil
+	return &xmlNode, nil
 }
 
 func getResponseBodyAsString(webResponse WebResponse) (string, error) {
-    // Clean up the response body.
-    body := webResponse.Body()
+	// Clean up the response body.
+	body := webResponse.Body()
 
-    // Get the bytes or forward the error
-    bytes, err := ioutil.ReadAll(body)
-    if err != nil {
-        return "", err
-    }
+	// Get the bytes or forward the error
+	bytes, err := ioutil.ReadAll(body)
+	if err != nil {
+		return "", err
+	}
 
-    // Convert the bytes into a string
-    return string(bytes), nil
+	// Convert the bytes into a string
+	return string(bytes), nil
 }

--- a/ds3/models/responseModels.go
+++ b/ds3/models/responseModels.go
@@ -7243,7 +7243,6 @@ func (jobNode *JobNode) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 			log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing JobNode.", attr.Name.Local)
 		}
 	}
-
 }
 
 func parseJobNodeSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []JobNode {

--- a/ds3/models/responseModels.go
+++ b/ds3/models/responseModels.go
@@ -14,8770 +14,9467 @@
 package models
 
 import (
-    "errors"
-    "fmt"
-    "bytes"
-    "log"
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
 )
 
 type PhysicalPlacement struct {
-    AzureTargets []AzureTarget
-    Ds3Targets []Ds3Target
-    Pools []Pool
-    S3Targets []S3Target
-    Tapes []Tape
+	AzureTargets []AzureTarget
+	Ds3Targets   []Ds3Target
+	Pools        []Pool
+	S3Targets    []S3Target
+	Tapes        []Tape
 }
 
 func (physicalPlacement *PhysicalPlacement) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AzureTargets":
-            physicalPlacement.AzureTargets = parseAzureTargetSlice("AzureTarget", child.Children, aggErr)
-        case "Ds3Targets":
-            physicalPlacement.Ds3Targets = parseDs3TargetSlice("Ds3Target", child.Children, aggErr)
-        case "Pools":
-            physicalPlacement.Pools = parsePoolSlice("Pool", child.Children, aggErr)
-        case "S3Targets":
-            physicalPlacement.S3Targets = parseS3TargetSlice("S3Target", child.Children, aggErr)
-        case "Tapes":
-            physicalPlacement.Tapes = parseTapeSlice("Tape", child.Children, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PhysicalPlacement.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AzureTargets":
+			physicalPlacement.AzureTargets = parseAzureTargetSlice("AzureTarget", child.Children, aggErr)
+		case "Ds3Targets":
+			physicalPlacement.Ds3Targets = parseDs3TargetSlice("Ds3Target", child.Children, aggErr)
+		case "Pools":
+			physicalPlacement.Pools = parsePoolSlice("Pool", child.Children, aggErr)
+		case "S3Targets":
+			physicalPlacement.S3Targets = parseS3TargetSlice("S3Target", child.Children, aggErr)
+		case "Tapes":
+			physicalPlacement.Tapes = parseTapeSlice("Tape", child.Children, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PhysicalPlacement.", child.XMLName.Local)
+		}
+	}
 }
 
 type AutoInspectMode Enum
 
 const (
-    AUTO_INSPECT_MODE_NEVER AutoInspectMode = 1 + iota
-    AUTO_INSPECT_MODE_MINIMAL AutoInspectMode = 1 + iota
-    AUTO_INSPECT_MODE_FULL AutoInspectMode = 1 + iota
+	AUTO_INSPECT_MODE_NEVER   AutoInspectMode = 1 + iota
+	AUTO_INSPECT_MODE_MINIMAL AutoInspectMode = 1 + iota
+	AUTO_INSPECT_MODE_FULL    AutoInspectMode = 1 + iota
 )
 
 func (autoInspectMode *AutoInspectMode) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *autoInspectMode = UNDEFINED
-        case "NEVER": *autoInspectMode = AUTO_INSPECT_MODE_NEVER
-        case "MINIMAL": *autoInspectMode = AUTO_INSPECT_MODE_MINIMAL
-        case "FULL": *autoInspectMode = AUTO_INSPECT_MODE_FULL
-        default:
-            *autoInspectMode = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into AutoInspectMode", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*autoInspectMode = UNDEFINED
+	case "NEVER":
+		*autoInspectMode = AUTO_INSPECT_MODE_NEVER
+	case "MINIMAL":
+		*autoInspectMode = AUTO_INSPECT_MODE_MINIMAL
+	case "FULL":
+		*autoInspectMode = AUTO_INSPECT_MODE_FULL
+	default:
+		*autoInspectMode = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into AutoInspectMode", str))
+	}
+	return nil
 }
 
 func (autoInspectMode AutoInspectMode) String() string {
-    switch autoInspectMode {
-        case AUTO_INSPECT_MODE_NEVER: return "NEVER"
-        case AUTO_INSPECT_MODE_MINIMAL: return "MINIMAL"
-        case AUTO_INSPECT_MODE_FULL: return "FULL"
-        default:
-            log.Printf("Error: invalid AutoInspectMode represented by '%d'", autoInspectMode)
-            return ""
-    }
+	switch autoInspectMode {
+	case AUTO_INSPECT_MODE_NEVER:
+		return "NEVER"
+	case AUTO_INSPECT_MODE_MINIMAL:
+		return "MINIMAL"
+	case AUTO_INSPECT_MODE_FULL:
+		return "FULL"
+	default:
+		log.Printf("Error: invalid AutoInspectMode represented by '%d'", autoInspectMode)
+		return ""
+	}
 }
 
 func (autoInspectMode AutoInspectMode) StringPtr() *string {
-    if autoInspectMode == UNDEFINED {
-        return nil
-    }
-    result := autoInspectMode.String()
-    return &result
+	if autoInspectMode == UNDEFINED {
+		return nil
+	}
+	result := autoInspectMode.String()
+	return &result
 }
 
 func newAutoInspectModeFromContent(content []byte, aggErr *AggregateError) *AutoInspectMode {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(AutoInspectMode)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(AutoInspectMode)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type AzureDataReplicationRule struct {
-    DataPolicyId string
-    Id string
-    MaxBlobPartSizeInBytes int64
-    ReplicateDeletes bool
-    State DataPlacementRuleState
-    TargetId string
-    Type DataReplicationRuleType
+	DataPolicyId           string
+	Id                     string
+	MaxBlobPartSizeInBytes int64
+	ReplicateDeletes       bool
+	State                  DataPlacementRuleState
+	TargetId               string
+	Type                   DataReplicationRuleType
 }
 
 func (azureDataReplicationRule *AzureDataReplicationRule) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DataPolicyId":
-            azureDataReplicationRule.DataPolicyId = parseString(child.Content)
-        case "Id":
-            azureDataReplicationRule.Id = parseString(child.Content)
-        case "MaxBlobPartSizeInBytes":
-            azureDataReplicationRule.MaxBlobPartSizeInBytes = parseInt64(child.Content, aggErr)
-        case "ReplicateDeletes":
-            azureDataReplicationRule.ReplicateDeletes = parseBool(child.Content, aggErr)
-        case "State":
-            parseEnum(child.Content, &azureDataReplicationRule.State, aggErr)
-        case "TargetId":
-            azureDataReplicationRule.TargetId = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &azureDataReplicationRule.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureDataReplicationRule.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DataPolicyId":
+			azureDataReplicationRule.DataPolicyId = parseString(child.Content)
+		case "Id":
+			azureDataReplicationRule.Id = parseString(child.Content)
+		case "MaxBlobPartSizeInBytes":
+			azureDataReplicationRule.MaxBlobPartSizeInBytes = parseInt64(child.Content, aggErr)
+		case "ReplicateDeletes":
+			azureDataReplicationRule.ReplicateDeletes = parseBool(child.Content, aggErr)
+		case "State":
+			parseEnum(child.Content, &azureDataReplicationRule.State, aggErr)
+		case "TargetId":
+			azureDataReplicationRule.TargetId = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &azureDataReplicationRule.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureDataReplicationRule.", child.XMLName.Local)
+		}
+	}
 }
 
 type Blob struct {
-    ByteOffset int64
-    Checksum *string
-    ChecksumType *ChecksumType
-    Id string
-    Length int64
-    ObjectId string
+	ByteOffset   int64
+	Checksum     *string
+	ChecksumType *ChecksumType
+	Id           string
+	Length       int64
+	ObjectId     string
 }
 
 func (blob *Blob) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "ByteOffset":
-            blob.ByteOffset = parseInt64(child.Content, aggErr)
-        case "Checksum":
-            blob.Checksum = parseNullableString(child.Content)
-        case "ChecksumType":
-            blob.ChecksumType = newChecksumTypeFromContent(child.Content, aggErr)
-        case "Id":
-            blob.Id = parseString(child.Content)
-        case "Length":
-            blob.Length = parseInt64(child.Content, aggErr)
-        case "ObjectId":
-            blob.ObjectId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Blob.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "ByteOffset":
+			blob.ByteOffset = parseInt64(child.Content, aggErr)
+		case "Checksum":
+			blob.Checksum = parseNullableString(child.Content)
+		case "ChecksumType":
+			blob.ChecksumType = newChecksumTypeFromContent(child.Content, aggErr)
+		case "Id":
+			blob.Id = parseString(child.Content)
+		case "Length":
+			blob.Length = parseInt64(child.Content, aggErr)
+		case "ObjectId":
+			blob.ObjectId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Blob.", child.XMLName.Local)
+		}
+	}
 }
 
 type Priority Enum
 
 const (
-    PRIORITY_CRITICAL Priority = 1 + iota
-    PRIORITY_URGENT Priority = 1 + iota
-    PRIORITY_HIGH Priority = 1 + iota
-    PRIORITY_NORMAL Priority = 1 + iota
-    PRIORITY_LOW Priority = 1 + iota
-    PRIORITY_BACKGROUND Priority = 1 + iota
+	PRIORITY_CRITICAL   Priority = 1 + iota
+	PRIORITY_URGENT     Priority = 1 + iota
+	PRIORITY_HIGH       Priority = 1 + iota
+	PRIORITY_NORMAL     Priority = 1 + iota
+	PRIORITY_LOW        Priority = 1 + iota
+	PRIORITY_BACKGROUND Priority = 1 + iota
 )
 
 func (priority *Priority) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *priority = UNDEFINED
-        case "CRITICAL": *priority = PRIORITY_CRITICAL
-        case "URGENT": *priority = PRIORITY_URGENT
-        case "HIGH": *priority = PRIORITY_HIGH
-        case "NORMAL": *priority = PRIORITY_NORMAL
-        case "LOW": *priority = PRIORITY_LOW
-        case "BACKGROUND": *priority = PRIORITY_BACKGROUND
-        default:
-            *priority = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into Priority", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*priority = UNDEFINED
+	case "CRITICAL":
+		*priority = PRIORITY_CRITICAL
+	case "URGENT":
+		*priority = PRIORITY_URGENT
+	case "HIGH":
+		*priority = PRIORITY_HIGH
+	case "NORMAL":
+		*priority = PRIORITY_NORMAL
+	case "LOW":
+		*priority = PRIORITY_LOW
+	case "BACKGROUND":
+		*priority = PRIORITY_BACKGROUND
+	default:
+		*priority = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into Priority", str))
+	}
+	return nil
 }
 
 func (priority Priority) String() string {
-    switch priority {
-        case PRIORITY_CRITICAL: return "CRITICAL"
-        case PRIORITY_URGENT: return "URGENT"
-        case PRIORITY_HIGH: return "HIGH"
-        case PRIORITY_NORMAL: return "NORMAL"
-        case PRIORITY_LOW: return "LOW"
-        case PRIORITY_BACKGROUND: return "BACKGROUND"
-        default:
-            log.Printf("Error: invalid Priority represented by '%d'", priority)
-            return ""
-    }
+	switch priority {
+	case PRIORITY_CRITICAL:
+		return "CRITICAL"
+	case PRIORITY_URGENT:
+		return "URGENT"
+	case PRIORITY_HIGH:
+		return "HIGH"
+	case PRIORITY_NORMAL:
+		return "NORMAL"
+	case PRIORITY_LOW:
+		return "LOW"
+	case PRIORITY_BACKGROUND:
+		return "BACKGROUND"
+	default:
+		log.Printf("Error: invalid Priority represented by '%d'", priority)
+		return ""
+	}
 }
 
 func (priority Priority) StringPtr() *string {
-    if priority == UNDEFINED {
-        return nil
-    }
-    result := priority.String()
-    return &result
+	if priority == UNDEFINED {
+		return nil
+	}
+	result := priority.String()
+	return &result
 }
 
 func newPriorityFromContent(content []byte, aggErr *AggregateError) *Priority {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(Priority)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(Priority)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type Bucket struct {
-    CreationDate string
-    DataPolicyId string
-    Empty *bool
-    Id string
-    LastPreferredChunkSizeInBytes *int64
-    LogicalUsedCapacity *int64
-    Name *string
-    Protected bool
-    UserId string
+	CreationDate                  string
+	DataPolicyId                  string
+	Empty                         *bool
+	Id                            string
+	LastPreferredChunkSizeInBytes *int64
+	LogicalUsedCapacity           *int64
+	Name                          *string
+	Protected                     bool
+	UserId                        string
 }
 
 func (bucket *Bucket) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            bucket.CreationDate = parseString(child.Content)
-        case "DataPolicyId":
-            bucket.DataPolicyId = parseString(child.Content)
-        case "Empty":
-            bucket.Empty = parseNullableBool(child.Content, aggErr)
-        case "Id":
-            bucket.Id = parseString(child.Content)
-        case "LastPreferredChunkSizeInBytes":
-            bucket.LastPreferredChunkSizeInBytes = parseNullableInt64(child.Content, aggErr)
-        case "LogicalUsedCapacity":
-            bucket.LogicalUsedCapacity = parseNullableInt64(child.Content, aggErr)
-        case "Name":
-            bucket.Name = parseNullableString(child.Content)
-        case "Protected":
-            bucket.Protected = parseBool(child.Content, aggErr)
-        case "UserId":
-            bucket.UserId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Bucket.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			bucket.CreationDate = parseString(child.Content)
+		case "DataPolicyId":
+			bucket.DataPolicyId = parseString(child.Content)
+		case "Empty":
+			bucket.Empty = parseNullableBool(child.Content, aggErr)
+		case "Id":
+			bucket.Id = parseString(child.Content)
+		case "LastPreferredChunkSizeInBytes":
+			bucket.LastPreferredChunkSizeInBytes = parseNullableInt64(child.Content, aggErr)
+		case "LogicalUsedCapacity":
+			bucket.LogicalUsedCapacity = parseNullableInt64(child.Content, aggErr)
+		case "Name":
+			bucket.Name = parseNullableString(child.Content)
+		case "Protected":
+			bucket.Protected = parseBool(child.Content, aggErr)
+		case "UserId":
+			bucket.UserId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Bucket.", child.XMLName.Local)
+		}
+	}
 }
 
 type BucketAcl struct {
-    BucketId *string
-    GroupId *string
-    Id string
-    Permission BucketAclPermission
-    UserId *string
+	BucketId   *string
+	GroupId    *string
+	Id         string
+	Permission BucketAclPermission
+	UserId     *string
 }
 
 func (bucketAcl *BucketAcl) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketId":
-            bucketAcl.BucketId = parseNullableString(child.Content)
-        case "GroupId":
-            bucketAcl.GroupId = parseNullableString(child.Content)
-        case "Id":
-            bucketAcl.Id = parseString(child.Content)
-        case "Permission":
-            parseEnum(child.Content, &bucketAcl.Permission, aggErr)
-        case "UserId":
-            bucketAcl.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketAcl.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketId":
+			bucketAcl.BucketId = parseNullableString(child.Content)
+		case "GroupId":
+			bucketAcl.GroupId = parseNullableString(child.Content)
+		case "Id":
+			bucketAcl.Id = parseString(child.Content)
+		case "Permission":
+			parseEnum(child.Content, &bucketAcl.Permission, aggErr)
+		case "UserId":
+			bucketAcl.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketAcl.", child.XMLName.Local)
+		}
+	}
 }
 
 type BucketAclPermission Enum
 
 const (
-    BUCKET_ACL_PERMISSION_LIST BucketAclPermission = 1 + iota
-    BUCKET_ACL_PERMISSION_READ BucketAclPermission = 1 + iota
-    BUCKET_ACL_PERMISSION_WRITE BucketAclPermission = 1 + iota
-    BUCKET_ACL_PERMISSION_DELETE BucketAclPermission = 1 + iota
-    BUCKET_ACL_PERMISSION_JOB BucketAclPermission = 1 + iota
-    BUCKET_ACL_PERMISSION_OWNER BucketAclPermission = 1 + iota
+	BUCKET_ACL_PERMISSION_LIST   BucketAclPermission = 1 + iota
+	BUCKET_ACL_PERMISSION_READ   BucketAclPermission = 1 + iota
+	BUCKET_ACL_PERMISSION_WRITE  BucketAclPermission = 1 + iota
+	BUCKET_ACL_PERMISSION_DELETE BucketAclPermission = 1 + iota
+	BUCKET_ACL_PERMISSION_JOB    BucketAclPermission = 1 + iota
+	BUCKET_ACL_PERMISSION_OWNER  BucketAclPermission = 1 + iota
 )
 
 func (bucketAclPermission *BucketAclPermission) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *bucketAclPermission = UNDEFINED
-        case "LIST": *bucketAclPermission = BUCKET_ACL_PERMISSION_LIST
-        case "READ": *bucketAclPermission = BUCKET_ACL_PERMISSION_READ
-        case "WRITE": *bucketAclPermission = BUCKET_ACL_PERMISSION_WRITE
-        case "DELETE": *bucketAclPermission = BUCKET_ACL_PERMISSION_DELETE
-        case "JOB": *bucketAclPermission = BUCKET_ACL_PERMISSION_JOB
-        case "OWNER": *bucketAclPermission = BUCKET_ACL_PERMISSION_OWNER
-        default:
-            *bucketAclPermission = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into BucketAclPermission", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*bucketAclPermission = UNDEFINED
+	case "LIST":
+		*bucketAclPermission = BUCKET_ACL_PERMISSION_LIST
+	case "READ":
+		*bucketAclPermission = BUCKET_ACL_PERMISSION_READ
+	case "WRITE":
+		*bucketAclPermission = BUCKET_ACL_PERMISSION_WRITE
+	case "DELETE":
+		*bucketAclPermission = BUCKET_ACL_PERMISSION_DELETE
+	case "JOB":
+		*bucketAclPermission = BUCKET_ACL_PERMISSION_JOB
+	case "OWNER":
+		*bucketAclPermission = BUCKET_ACL_PERMISSION_OWNER
+	default:
+		*bucketAclPermission = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into BucketAclPermission", str))
+	}
+	return nil
 }
 
 func (bucketAclPermission BucketAclPermission) String() string {
-    switch bucketAclPermission {
-        case BUCKET_ACL_PERMISSION_LIST: return "LIST"
-        case BUCKET_ACL_PERMISSION_READ: return "READ"
-        case BUCKET_ACL_PERMISSION_WRITE: return "WRITE"
-        case BUCKET_ACL_PERMISSION_DELETE: return "DELETE"
-        case BUCKET_ACL_PERMISSION_JOB: return "JOB"
-        case BUCKET_ACL_PERMISSION_OWNER: return "OWNER"
-        default:
-            log.Printf("Error: invalid BucketAclPermission represented by '%d'", bucketAclPermission)
-            return ""
-    }
+	switch bucketAclPermission {
+	case BUCKET_ACL_PERMISSION_LIST:
+		return "LIST"
+	case BUCKET_ACL_PERMISSION_READ:
+		return "READ"
+	case BUCKET_ACL_PERMISSION_WRITE:
+		return "WRITE"
+	case BUCKET_ACL_PERMISSION_DELETE:
+		return "DELETE"
+	case BUCKET_ACL_PERMISSION_JOB:
+		return "JOB"
+	case BUCKET_ACL_PERMISSION_OWNER:
+		return "OWNER"
+	default:
+		log.Printf("Error: invalid BucketAclPermission represented by '%d'", bucketAclPermission)
+		return ""
+	}
 }
 
 func (bucketAclPermission BucketAclPermission) StringPtr() *string {
-    if bucketAclPermission == UNDEFINED {
-        return nil
-    }
-    result := bucketAclPermission.String()
-    return &result
+	if bucketAclPermission == UNDEFINED {
+		return nil
+	}
+	result := bucketAclPermission.String()
+	return &result
 }
 
 func newBucketAclPermissionFromContent(content []byte, aggErr *AggregateError) *BucketAclPermission {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(BucketAclPermission)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(BucketAclPermission)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type CanceledJob struct {
-    BucketId string
-    CachedSizeInBytes int64
-    CanceledDueToTimeout bool
-    ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
-    CompletedSizeInBytes int64
-    CreatedAt string
-    DateCanceled string
-    ErrorMessage *string
-    Id string
-    Naked bool
-    Name *string
-    OriginalSizeInBytes int64
-    Priority Priority
-    Rechunked *string
-    RequestType JobRequestType
-    Truncated bool
-    UserId string
+	BucketId                            string
+	CachedSizeInBytes                   int64
+	CanceledDueToTimeout                bool
+	ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
+	CompletedSizeInBytes                int64
+	CreatedAt                           string
+	DateCanceled                        string
+	ErrorMessage                        *string
+	Id                                  string
+	Naked                               bool
+	Name                                *string
+	OriginalSizeInBytes                 int64
+	Priority                            Priority
+	Rechunked                           *string
+	RequestType                         JobRequestType
+	Truncated                           bool
+	UserId                              string
 }
 
 func (canceledJob *CanceledJob) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketId":
-            canceledJob.BucketId = parseString(child.Content)
-        case "CachedSizeInBytes":
-            canceledJob.CachedSizeInBytes = parseInt64(child.Content, aggErr)
-        case "CanceledDueToTimeout":
-            canceledJob.CanceledDueToTimeout = parseBool(child.Content, aggErr)
-        case "ChunkClientProcessingOrderGuarantee":
-            parseEnum(child.Content, &canceledJob.ChunkClientProcessingOrderGuarantee, aggErr)
-        case "CompletedSizeInBytes":
-            canceledJob.CompletedSizeInBytes = parseInt64(child.Content, aggErr)
-        case "CreatedAt":
-            canceledJob.CreatedAt = parseString(child.Content)
-        case "DateCanceled":
-            canceledJob.DateCanceled = parseString(child.Content)
-        case "ErrorMessage":
-            canceledJob.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            canceledJob.Id = parseString(child.Content)
-        case "Naked":
-            canceledJob.Naked = parseBool(child.Content, aggErr)
-        case "Name":
-            canceledJob.Name = parseNullableString(child.Content)
-        case "OriginalSizeInBytes":
-            canceledJob.OriginalSizeInBytes = parseInt64(child.Content, aggErr)
-        case "Priority":
-            parseEnum(child.Content, &canceledJob.Priority, aggErr)
-        case "Rechunked":
-            canceledJob.Rechunked = parseNullableString(child.Content)
-        case "RequestType":
-            parseEnum(child.Content, &canceledJob.RequestType, aggErr)
-        case "Truncated":
-            canceledJob.Truncated = parseBool(child.Content, aggErr)
-        case "UserId":
-            canceledJob.UserId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CanceledJob.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketId":
+			canceledJob.BucketId = parseString(child.Content)
+		case "CachedSizeInBytes":
+			canceledJob.CachedSizeInBytes = parseInt64(child.Content, aggErr)
+		case "CanceledDueToTimeout":
+			canceledJob.CanceledDueToTimeout = parseBool(child.Content, aggErr)
+		case "ChunkClientProcessingOrderGuarantee":
+			parseEnum(child.Content, &canceledJob.ChunkClientProcessingOrderGuarantee, aggErr)
+		case "CompletedSizeInBytes":
+			canceledJob.CompletedSizeInBytes = parseInt64(child.Content, aggErr)
+		case "CreatedAt":
+			canceledJob.CreatedAt = parseString(child.Content)
+		case "DateCanceled":
+			canceledJob.DateCanceled = parseString(child.Content)
+		case "ErrorMessage":
+			canceledJob.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			canceledJob.Id = parseString(child.Content)
+		case "Naked":
+			canceledJob.Naked = parseBool(child.Content, aggErr)
+		case "Name":
+			canceledJob.Name = parseNullableString(child.Content)
+		case "OriginalSizeInBytes":
+			canceledJob.OriginalSizeInBytes = parseInt64(child.Content, aggErr)
+		case "Priority":
+			parseEnum(child.Content, &canceledJob.Priority, aggErr)
+		case "Rechunked":
+			canceledJob.Rechunked = parseNullableString(child.Content)
+		case "RequestType":
+			parseEnum(child.Content, &canceledJob.RequestType, aggErr)
+		case "Truncated":
+			canceledJob.Truncated = parseBool(child.Content, aggErr)
+		case "UserId":
+			canceledJob.UserId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CanceledJob.", child.XMLName.Local)
+		}
+	}
 }
 
 type CapacitySummaryContainer struct {
-    Pool StorageDomainCapacitySummary
-    Tape StorageDomainCapacitySummary
+	Pool StorageDomainCapacitySummary
+	Tape StorageDomainCapacitySummary
 }
 
 func (capacitySummaryContainer *CapacitySummaryContainer) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Pool":
-            capacitySummaryContainer.Pool.parse(&child, aggErr)
-        case "Tape":
-            capacitySummaryContainer.Tape.parse(&child, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CapacitySummaryContainer.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Pool":
+			capacitySummaryContainer.Pool.parse(&child, aggErr)
+		case "Tape":
+			capacitySummaryContainer.Tape.parse(&child, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CapacitySummaryContainer.", child.XMLName.Local)
+		}
+	}
 }
 
 type CloudNamingMode Enum
 
 const (
-    CLOUD_NAMING_MODE_BLACK_PEARL CloudNamingMode = 1 + iota
-    CLOUD_NAMING_MODE_AWS_S3 CloudNamingMode = 1 + iota
+	CLOUD_NAMING_MODE_BLACK_PEARL CloudNamingMode = 1 + iota
+	CLOUD_NAMING_MODE_AWS_S3      CloudNamingMode = 1 + iota
 )
 
 func (cloudNamingMode *CloudNamingMode) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *cloudNamingMode = UNDEFINED
-        case "BLACK_PEARL": *cloudNamingMode = CLOUD_NAMING_MODE_BLACK_PEARL
-        case "AWS_S3": *cloudNamingMode = CLOUD_NAMING_MODE_AWS_S3
-        default:
-            *cloudNamingMode = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into CloudNamingMode", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*cloudNamingMode = UNDEFINED
+	case "BLACK_PEARL":
+		*cloudNamingMode = CLOUD_NAMING_MODE_BLACK_PEARL
+	case "AWS_S3":
+		*cloudNamingMode = CLOUD_NAMING_MODE_AWS_S3
+	default:
+		*cloudNamingMode = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into CloudNamingMode", str))
+	}
+	return nil
 }
 
 func (cloudNamingMode CloudNamingMode) String() string {
-    switch cloudNamingMode {
-        case CLOUD_NAMING_MODE_BLACK_PEARL: return "BLACK_PEARL"
-        case CLOUD_NAMING_MODE_AWS_S3: return "AWS_S3"
-        default:
-            log.Printf("Error: invalid CloudNamingMode represented by '%d'", cloudNamingMode)
-            return ""
-    }
+	switch cloudNamingMode {
+	case CLOUD_NAMING_MODE_BLACK_PEARL:
+		return "BLACK_PEARL"
+	case CLOUD_NAMING_MODE_AWS_S3:
+		return "AWS_S3"
+	default:
+		log.Printf("Error: invalid CloudNamingMode represented by '%d'", cloudNamingMode)
+		return ""
+	}
 }
 
 func (cloudNamingMode CloudNamingMode) StringPtr() *string {
-    if cloudNamingMode == UNDEFINED {
-        return nil
-    }
-    result := cloudNamingMode.String()
-    return &result
+	if cloudNamingMode == UNDEFINED {
+		return nil
+	}
+	result := cloudNamingMode.String()
+	return &result
 }
 
 func newCloudNamingModeFromContent(content []byte, aggErr *AggregateError) *CloudNamingMode {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(CloudNamingMode)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(CloudNamingMode)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type CompletedJob struct {
-    BucketId string
-    CachedSizeInBytes int64
-    ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
-    CompletedSizeInBytes int64
-    CreatedAt string
-    DateCompleted string
-    ErrorMessage *string
-    Id string
-    Naked bool
-    Name *string
-    OriginalSizeInBytes int64
-    Priority Priority
-    Rechunked *string
-    RequestType JobRequestType
-    Truncated bool
-    UserId string
+	BucketId                            string
+	CachedSizeInBytes                   int64
+	ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
+	CompletedSizeInBytes                int64
+	CreatedAt                           string
+	DateCompleted                       string
+	ErrorMessage                        *string
+	Id                                  string
+	Naked                               bool
+	Name                                *string
+	OriginalSizeInBytes                 int64
+	Priority                            Priority
+	Rechunked                           *string
+	RequestType                         JobRequestType
+	Truncated                           bool
+	UserId                              string
 }
 
 func (completedJob *CompletedJob) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketId":
-            completedJob.BucketId = parseString(child.Content)
-        case "CachedSizeInBytes":
-            completedJob.CachedSizeInBytes = parseInt64(child.Content, aggErr)
-        case "ChunkClientProcessingOrderGuarantee":
-            parseEnum(child.Content, &completedJob.ChunkClientProcessingOrderGuarantee, aggErr)
-        case "CompletedSizeInBytes":
-            completedJob.CompletedSizeInBytes = parseInt64(child.Content, aggErr)
-        case "CreatedAt":
-            completedJob.CreatedAt = parseString(child.Content)
-        case "DateCompleted":
-            completedJob.DateCompleted = parseString(child.Content)
-        case "ErrorMessage":
-            completedJob.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            completedJob.Id = parseString(child.Content)
-        case "Naked":
-            completedJob.Naked = parseBool(child.Content, aggErr)
-        case "Name":
-            completedJob.Name = parseNullableString(child.Content)
-        case "OriginalSizeInBytes":
-            completedJob.OriginalSizeInBytes = parseInt64(child.Content, aggErr)
-        case "Priority":
-            parseEnum(child.Content, &completedJob.Priority, aggErr)
-        case "Rechunked":
-            completedJob.Rechunked = parseNullableString(child.Content)
-        case "RequestType":
-            parseEnum(child.Content, &completedJob.RequestType, aggErr)
-        case "Truncated":
-            completedJob.Truncated = parseBool(child.Content, aggErr)
-        case "UserId":
-            completedJob.UserId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CompletedJob.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketId":
+			completedJob.BucketId = parseString(child.Content)
+		case "CachedSizeInBytes":
+			completedJob.CachedSizeInBytes = parseInt64(child.Content, aggErr)
+		case "ChunkClientProcessingOrderGuarantee":
+			parseEnum(child.Content, &completedJob.ChunkClientProcessingOrderGuarantee, aggErr)
+		case "CompletedSizeInBytes":
+			completedJob.CompletedSizeInBytes = parseInt64(child.Content, aggErr)
+		case "CreatedAt":
+			completedJob.CreatedAt = parseString(child.Content)
+		case "DateCompleted":
+			completedJob.DateCompleted = parseString(child.Content)
+		case "ErrorMessage":
+			completedJob.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			completedJob.Id = parseString(child.Content)
+		case "Naked":
+			completedJob.Naked = parseBool(child.Content, aggErr)
+		case "Name":
+			completedJob.Name = parseNullableString(child.Content)
+		case "OriginalSizeInBytes":
+			completedJob.OriginalSizeInBytes = parseInt64(child.Content, aggErr)
+		case "Priority":
+			parseEnum(child.Content, &completedJob.Priority, aggErr)
+		case "Rechunked":
+			completedJob.Rechunked = parseNullableString(child.Content)
+		case "RequestType":
+			parseEnum(child.Content, &completedJob.RequestType, aggErr)
+		case "Truncated":
+			completedJob.Truncated = parseBool(child.Content, aggErr)
+		case "UserId":
+			completedJob.UserId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CompletedJob.", child.XMLName.Local)
+		}
+	}
 }
 
 type DataIsolationLevel Enum
 
 const (
-    DATA_ISOLATION_LEVEL_STANDARD DataIsolationLevel = 1 + iota
-    DATA_ISOLATION_LEVEL_BUCKET_ISOLATED DataIsolationLevel = 1 + iota
+	DATA_ISOLATION_LEVEL_STANDARD        DataIsolationLevel = 1 + iota
+	DATA_ISOLATION_LEVEL_BUCKET_ISOLATED DataIsolationLevel = 1 + iota
 )
 
 func (dataIsolationLevel *DataIsolationLevel) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *dataIsolationLevel = UNDEFINED
-        case "STANDARD": *dataIsolationLevel = DATA_ISOLATION_LEVEL_STANDARD
-        case "BUCKET_ISOLATED": *dataIsolationLevel = DATA_ISOLATION_LEVEL_BUCKET_ISOLATED
-        default:
-            *dataIsolationLevel = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into DataIsolationLevel", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*dataIsolationLevel = UNDEFINED
+	case "STANDARD":
+		*dataIsolationLevel = DATA_ISOLATION_LEVEL_STANDARD
+	case "BUCKET_ISOLATED":
+		*dataIsolationLevel = DATA_ISOLATION_LEVEL_BUCKET_ISOLATED
+	default:
+		*dataIsolationLevel = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into DataIsolationLevel", str))
+	}
+	return nil
 }
 
 func (dataIsolationLevel DataIsolationLevel) String() string {
-    switch dataIsolationLevel {
-        case DATA_ISOLATION_LEVEL_STANDARD: return "STANDARD"
-        case DATA_ISOLATION_LEVEL_BUCKET_ISOLATED: return "BUCKET_ISOLATED"
-        default:
-            log.Printf("Error: invalid DataIsolationLevel represented by '%d'", dataIsolationLevel)
-            return ""
-    }
+	switch dataIsolationLevel {
+	case DATA_ISOLATION_LEVEL_STANDARD:
+		return "STANDARD"
+	case DATA_ISOLATION_LEVEL_BUCKET_ISOLATED:
+		return "BUCKET_ISOLATED"
+	default:
+		log.Printf("Error: invalid DataIsolationLevel represented by '%d'", dataIsolationLevel)
+		return ""
+	}
 }
 
 func (dataIsolationLevel DataIsolationLevel) StringPtr() *string {
-    if dataIsolationLevel == UNDEFINED {
-        return nil
-    }
-    result := dataIsolationLevel.String()
-    return &result
+	if dataIsolationLevel == UNDEFINED {
+		return nil
+	}
+	result := dataIsolationLevel.String()
+	return &result
 }
 
 func newDataIsolationLevelFromContent(content []byte, aggErr *AggregateError) *DataIsolationLevel {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(DataIsolationLevel)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(DataIsolationLevel)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type DataPathBackend struct {
-    Activated bool
-    AllowNewJobRequests bool
-    AutoActivateTimeoutInMins *int
-    AutoInspect AutoInspectMode
-    CacheAvailableRetryAfterInSeconds int
-    DefaultVerifyDataAfterImport *Priority
-    DefaultVerifyDataPriorToImport bool
-    Id string
-    InstanceId string
-    IomCacheLimitationPercent float64
-    IomEnabled bool
-    LastHeartbeat string
-    MaxAggregatedBlobsPerChunk int
-    MaxNumberOfConcurrentJobs int
-    PartiallyVerifyLastPercentOfTapes *int
-    PoolSafetyEnabled bool
-    UnavailableMediaPolicy UnavailableMediaUsagePolicy
-    UnavailablePoolMaxJobRetryInMins int
-    UnavailableTapePartitionMaxJobRetryInMins int
-    VerifyCheckpointBeforeRead bool
+	Activated                                 bool
+	AllowNewJobRequests                       bool
+	AutoActivateTimeoutInMins                 *int
+	AutoInspect                               AutoInspectMode
+	CacheAvailableRetryAfterInSeconds         int
+	DefaultVerifyDataAfterImport              *Priority
+	DefaultVerifyDataPriorToImport            bool
+	Id                                        string
+	InstanceId                                string
+	IomCacheLimitationPercent                 float64
+	IomEnabled                                bool
+	LastHeartbeat                             string
+	MaxAggregatedBlobsPerChunk                int
+	MaxNumberOfConcurrentJobs                 int
+	PartiallyVerifyLastPercentOfTapes         *int
+	PoolSafetyEnabled                         bool
+	UnavailableMediaPolicy                    UnavailableMediaUsagePolicy
+	UnavailablePoolMaxJobRetryInMins          int
+	UnavailableTapePartitionMaxJobRetryInMins int
+	VerifyCheckpointBeforeRead                bool
 }
 
 func (dataPathBackend *DataPathBackend) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Activated":
-            dataPathBackend.Activated = parseBool(child.Content, aggErr)
-        case "AllowNewJobRequests":
-            dataPathBackend.AllowNewJobRequests = parseBool(child.Content, aggErr)
-        case "AutoActivateTimeoutInMins":
-            dataPathBackend.AutoActivateTimeoutInMins = parseNullableInt(child.Content, aggErr)
-        case "AutoInspect":
-            parseEnum(child.Content, &dataPathBackend.AutoInspect, aggErr)
-        case "CacheAvailableRetryAfterInSeconds":
-            dataPathBackend.CacheAvailableRetryAfterInSeconds = parseInt(child.Content, aggErr)
-        case "DefaultVerifyDataAfterImport":
-            dataPathBackend.DefaultVerifyDataAfterImport = newPriorityFromContent(child.Content, aggErr)
-        case "DefaultVerifyDataPriorToImport":
-            dataPathBackend.DefaultVerifyDataPriorToImport = parseBool(child.Content, aggErr)
-        case "Id":
-            dataPathBackend.Id = parseString(child.Content)
-        case "InstanceId":
-            dataPathBackend.InstanceId = parseString(child.Content)
-        case "IomCacheLimitationPercent":
-            dataPathBackend.IomCacheLimitationPercent = parseFloat64(child.Content, aggErr)
-        case "IomEnabled":
-            dataPathBackend.IomEnabled = parseBool(child.Content, aggErr)
-        case "LastHeartbeat":
-            dataPathBackend.LastHeartbeat = parseString(child.Content)
-        case "MaxAggregatedBlobsPerChunk":
-            dataPathBackend.MaxAggregatedBlobsPerChunk = parseInt(child.Content, aggErr)
-        case "MaxNumberOfConcurrentJobs":
-            dataPathBackend.MaxNumberOfConcurrentJobs = parseInt(child.Content, aggErr)
-        case "PartiallyVerifyLastPercentOfTapes":
-            dataPathBackend.PartiallyVerifyLastPercentOfTapes = parseNullableInt(child.Content, aggErr)
-        case "PoolSafetyEnabled":
-            dataPathBackend.PoolSafetyEnabled = parseBool(child.Content, aggErr)
-        case "UnavailableMediaPolicy":
-            parseEnum(child.Content, &dataPathBackend.UnavailableMediaPolicy, aggErr)
-        case "UnavailablePoolMaxJobRetryInMins":
-            dataPathBackend.UnavailablePoolMaxJobRetryInMins = parseInt(child.Content, aggErr)
-        case "UnavailableTapePartitionMaxJobRetryInMins":
-            dataPathBackend.UnavailableTapePartitionMaxJobRetryInMins = parseInt(child.Content, aggErr)
-        case "VerifyCheckpointBeforeRead":
-            dataPathBackend.VerifyCheckpointBeforeRead = parseBool(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPathBackend.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Activated":
+			dataPathBackend.Activated = parseBool(child.Content, aggErr)
+		case "AllowNewJobRequests":
+			dataPathBackend.AllowNewJobRequests = parseBool(child.Content, aggErr)
+		case "AutoActivateTimeoutInMins":
+			dataPathBackend.AutoActivateTimeoutInMins = parseNullableInt(child.Content, aggErr)
+		case "AutoInspect":
+			parseEnum(child.Content, &dataPathBackend.AutoInspect, aggErr)
+		case "CacheAvailableRetryAfterInSeconds":
+			dataPathBackend.CacheAvailableRetryAfterInSeconds = parseInt(child.Content, aggErr)
+		case "DefaultVerifyDataAfterImport":
+			dataPathBackend.DefaultVerifyDataAfterImport = newPriorityFromContent(child.Content, aggErr)
+		case "DefaultVerifyDataPriorToImport":
+			dataPathBackend.DefaultVerifyDataPriorToImport = parseBool(child.Content, aggErr)
+		case "Id":
+			dataPathBackend.Id = parseString(child.Content)
+		case "InstanceId":
+			dataPathBackend.InstanceId = parseString(child.Content)
+		case "IomCacheLimitationPercent":
+			dataPathBackend.IomCacheLimitationPercent = parseFloat64(child.Content, aggErr)
+		case "IomEnabled":
+			dataPathBackend.IomEnabled = parseBool(child.Content, aggErr)
+		case "LastHeartbeat":
+			dataPathBackend.LastHeartbeat = parseString(child.Content)
+		case "MaxAggregatedBlobsPerChunk":
+			dataPathBackend.MaxAggregatedBlobsPerChunk = parseInt(child.Content, aggErr)
+		case "MaxNumberOfConcurrentJobs":
+			dataPathBackend.MaxNumberOfConcurrentJobs = parseInt(child.Content, aggErr)
+		case "PartiallyVerifyLastPercentOfTapes":
+			dataPathBackend.PartiallyVerifyLastPercentOfTapes = parseNullableInt(child.Content, aggErr)
+		case "PoolSafetyEnabled":
+			dataPathBackend.PoolSafetyEnabled = parseBool(child.Content, aggErr)
+		case "UnavailableMediaPolicy":
+			parseEnum(child.Content, &dataPathBackend.UnavailableMediaPolicy, aggErr)
+		case "UnavailablePoolMaxJobRetryInMins":
+			dataPathBackend.UnavailablePoolMaxJobRetryInMins = parseInt(child.Content, aggErr)
+		case "UnavailableTapePartitionMaxJobRetryInMins":
+			dataPathBackend.UnavailableTapePartitionMaxJobRetryInMins = parseInt(child.Content, aggErr)
+		case "VerifyCheckpointBeforeRead":
+			dataPathBackend.VerifyCheckpointBeforeRead = parseBool(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPathBackend.", child.XMLName.Local)
+		}
+	}
 }
 
 type DataPersistenceRule struct {
-    DataPolicyId string
-    Id string
-    IsolationLevel DataIsolationLevel
-    MinimumDaysToRetain *int
-    State DataPlacementRuleState
-    StorageDomainId string
-    Type DataPersistenceRuleType
+	DataPolicyId        string
+	Id                  string
+	IsolationLevel      DataIsolationLevel
+	MinimumDaysToRetain *int
+	State               DataPlacementRuleState
+	StorageDomainId     string
+	Type                DataPersistenceRuleType
 }
 
 func (dataPersistenceRule *DataPersistenceRule) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DataPolicyId":
-            dataPersistenceRule.DataPolicyId = parseString(child.Content)
-        case "Id":
-            dataPersistenceRule.Id = parseString(child.Content)
-        case "IsolationLevel":
-            parseEnum(child.Content, &dataPersistenceRule.IsolationLevel, aggErr)
-        case "MinimumDaysToRetain":
-            dataPersistenceRule.MinimumDaysToRetain = parseNullableInt(child.Content, aggErr)
-        case "State":
-            parseEnum(child.Content, &dataPersistenceRule.State, aggErr)
-        case "StorageDomainId":
-            dataPersistenceRule.StorageDomainId = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &dataPersistenceRule.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPersistenceRule.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DataPolicyId":
+			dataPersistenceRule.DataPolicyId = parseString(child.Content)
+		case "Id":
+			dataPersistenceRule.Id = parseString(child.Content)
+		case "IsolationLevel":
+			parseEnum(child.Content, &dataPersistenceRule.IsolationLevel, aggErr)
+		case "MinimumDaysToRetain":
+			dataPersistenceRule.MinimumDaysToRetain = parseNullableInt(child.Content, aggErr)
+		case "State":
+			parseEnum(child.Content, &dataPersistenceRule.State, aggErr)
+		case "StorageDomainId":
+			dataPersistenceRule.StorageDomainId = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &dataPersistenceRule.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPersistenceRule.", child.XMLName.Local)
+		}
+	}
 }
 
 type DataPersistenceRuleType Enum
 
 const (
-    DATA_PERSISTENCE_RULE_TYPE_PERMANENT DataPersistenceRuleType = 1 + iota
-    DATA_PERSISTENCE_RULE_TYPE_TEMPORARY DataPersistenceRuleType = 1 + iota
-    DATA_PERSISTENCE_RULE_TYPE_RETIRED DataPersistenceRuleType = 1 + iota
+	DATA_PERSISTENCE_RULE_TYPE_PERMANENT DataPersistenceRuleType = 1 + iota
+	DATA_PERSISTENCE_RULE_TYPE_TEMPORARY DataPersistenceRuleType = 1 + iota
+	DATA_PERSISTENCE_RULE_TYPE_RETIRED   DataPersistenceRuleType = 1 + iota
 )
 
 func (dataPersistenceRuleType *DataPersistenceRuleType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *dataPersistenceRuleType = UNDEFINED
-        case "PERMANENT": *dataPersistenceRuleType = DATA_PERSISTENCE_RULE_TYPE_PERMANENT
-        case "TEMPORARY": *dataPersistenceRuleType = DATA_PERSISTENCE_RULE_TYPE_TEMPORARY
-        case "RETIRED": *dataPersistenceRuleType = DATA_PERSISTENCE_RULE_TYPE_RETIRED
-        default:
-            *dataPersistenceRuleType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into DataPersistenceRuleType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*dataPersistenceRuleType = UNDEFINED
+	case "PERMANENT":
+		*dataPersistenceRuleType = DATA_PERSISTENCE_RULE_TYPE_PERMANENT
+	case "TEMPORARY":
+		*dataPersistenceRuleType = DATA_PERSISTENCE_RULE_TYPE_TEMPORARY
+	case "RETIRED":
+		*dataPersistenceRuleType = DATA_PERSISTENCE_RULE_TYPE_RETIRED
+	default:
+		*dataPersistenceRuleType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into DataPersistenceRuleType", str))
+	}
+	return nil
 }
 
 func (dataPersistenceRuleType DataPersistenceRuleType) String() string {
-    switch dataPersistenceRuleType {
-        case DATA_PERSISTENCE_RULE_TYPE_PERMANENT: return "PERMANENT"
-        case DATA_PERSISTENCE_RULE_TYPE_TEMPORARY: return "TEMPORARY"
-        case DATA_PERSISTENCE_RULE_TYPE_RETIRED: return "RETIRED"
-        default:
-            log.Printf("Error: invalid DataPersistenceRuleType represented by '%d'", dataPersistenceRuleType)
-            return ""
-    }
+	switch dataPersistenceRuleType {
+	case DATA_PERSISTENCE_RULE_TYPE_PERMANENT:
+		return "PERMANENT"
+	case DATA_PERSISTENCE_RULE_TYPE_TEMPORARY:
+		return "TEMPORARY"
+	case DATA_PERSISTENCE_RULE_TYPE_RETIRED:
+		return "RETIRED"
+	default:
+		log.Printf("Error: invalid DataPersistenceRuleType represented by '%d'", dataPersistenceRuleType)
+		return ""
+	}
 }
 
 func (dataPersistenceRuleType DataPersistenceRuleType) StringPtr() *string {
-    if dataPersistenceRuleType == UNDEFINED {
-        return nil
-    }
-    result := dataPersistenceRuleType.String()
-    return &result
+	if dataPersistenceRuleType == UNDEFINED {
+		return nil
+	}
+	result := dataPersistenceRuleType.String()
+	return &result
 }
 
 func newDataPersistenceRuleTypeFromContent(content []byte, aggErr *AggregateError) *DataPersistenceRuleType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(DataPersistenceRuleType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(DataPersistenceRuleType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type DataPlacementRuleState Enum
 
 const (
-    DATA_PLACEMENT_RULE_STATE_NORMAL DataPlacementRuleState = 1 + iota
-    DATA_PLACEMENT_RULE_STATE_INCLUSION_IN_PROGRESS DataPlacementRuleState = 1 + iota
+	DATA_PLACEMENT_RULE_STATE_NORMAL                DataPlacementRuleState = 1 + iota
+	DATA_PLACEMENT_RULE_STATE_INCLUSION_IN_PROGRESS DataPlacementRuleState = 1 + iota
 )
 
 func (dataPlacementRuleState *DataPlacementRuleState) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *dataPlacementRuleState = UNDEFINED
-        case "NORMAL": *dataPlacementRuleState = DATA_PLACEMENT_RULE_STATE_NORMAL
-        case "INCLUSION_IN_PROGRESS": *dataPlacementRuleState = DATA_PLACEMENT_RULE_STATE_INCLUSION_IN_PROGRESS
-        default:
-            *dataPlacementRuleState = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into DataPlacementRuleState", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*dataPlacementRuleState = UNDEFINED
+	case "NORMAL":
+		*dataPlacementRuleState = DATA_PLACEMENT_RULE_STATE_NORMAL
+	case "INCLUSION_IN_PROGRESS":
+		*dataPlacementRuleState = DATA_PLACEMENT_RULE_STATE_INCLUSION_IN_PROGRESS
+	default:
+		*dataPlacementRuleState = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into DataPlacementRuleState", str))
+	}
+	return nil
 }
 
 func (dataPlacementRuleState DataPlacementRuleState) String() string {
-    switch dataPlacementRuleState {
-        case DATA_PLACEMENT_RULE_STATE_NORMAL: return "NORMAL"
-        case DATA_PLACEMENT_RULE_STATE_INCLUSION_IN_PROGRESS: return "INCLUSION_IN_PROGRESS"
-        default:
-            log.Printf("Error: invalid DataPlacementRuleState represented by '%d'", dataPlacementRuleState)
-            return ""
-    }
+	switch dataPlacementRuleState {
+	case DATA_PLACEMENT_RULE_STATE_NORMAL:
+		return "NORMAL"
+	case DATA_PLACEMENT_RULE_STATE_INCLUSION_IN_PROGRESS:
+		return "INCLUSION_IN_PROGRESS"
+	default:
+		log.Printf("Error: invalid DataPlacementRuleState represented by '%d'", dataPlacementRuleState)
+		return ""
+	}
 }
 
 func (dataPlacementRuleState DataPlacementRuleState) StringPtr() *string {
-    if dataPlacementRuleState == UNDEFINED {
-        return nil
-    }
-    result := dataPlacementRuleState.String()
-    return &result
+	if dataPlacementRuleState == UNDEFINED {
+		return nil
+	}
+	result := dataPlacementRuleState.String()
+	return &result
 }
 
 func newDataPlacementRuleStateFromContent(content []byte, aggErr *AggregateError) *DataPlacementRuleState {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(DataPlacementRuleState)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(DataPlacementRuleState)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type DataPolicy struct {
-    AlwaysForcePutJobCreation bool
-    AlwaysMinimizeSpanningAcrossMedia bool
-    BlobbingEnabled bool
-    ChecksumType ChecksumType
-    CreationDate string
-    DefaultBlobSize *int64
-    DefaultGetJobPriority Priority
-    DefaultPutJobPriority Priority
-    DefaultVerifyAfterWrite bool
-    DefaultVerifyJobPriority Priority
-    EndToEndCrcRequired bool
-    Id string
-    MaxVersionsToKeep int
-    Name *string
-    RebuildPriority Priority
-    Versioning VersioningLevel
+	AlwaysForcePutJobCreation         bool
+	AlwaysMinimizeSpanningAcrossMedia bool
+	BlobbingEnabled                   bool
+	ChecksumType                      ChecksumType
+	CreationDate                      string
+	DefaultBlobSize                   *int64
+	DefaultGetJobPriority             Priority
+	DefaultPutJobPriority             Priority
+	DefaultVerifyAfterWrite           bool
+	DefaultVerifyJobPriority          Priority
+	EndToEndCrcRequired               bool
+	Id                                string
+	MaxVersionsToKeep                 int
+	Name                              *string
+	RebuildPriority                   Priority
+	Versioning                        VersioningLevel
 }
 
 func (dataPolicy *DataPolicy) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AlwaysForcePutJobCreation":
-            dataPolicy.AlwaysForcePutJobCreation = parseBool(child.Content, aggErr)
-        case "AlwaysMinimizeSpanningAcrossMedia":
-            dataPolicy.AlwaysMinimizeSpanningAcrossMedia = parseBool(child.Content, aggErr)
-        case "BlobbingEnabled":
-            dataPolicy.BlobbingEnabled = parseBool(child.Content, aggErr)
-        case "ChecksumType":
-            parseEnum(child.Content, &dataPolicy.ChecksumType, aggErr)
-        case "CreationDate":
-            dataPolicy.CreationDate = parseString(child.Content)
-        case "DefaultBlobSize":
-            dataPolicy.DefaultBlobSize = parseNullableInt64(child.Content, aggErr)
-        case "DefaultGetJobPriority":
-            parseEnum(child.Content, &dataPolicy.DefaultGetJobPriority, aggErr)
-        case "DefaultPutJobPriority":
-            parseEnum(child.Content, &dataPolicy.DefaultPutJobPriority, aggErr)
-        case "DefaultVerifyAfterWrite":
-            dataPolicy.DefaultVerifyAfterWrite = parseBool(child.Content, aggErr)
-        case "DefaultVerifyJobPriority":
-            parseEnum(child.Content, &dataPolicy.DefaultVerifyJobPriority, aggErr)
-        case "EndToEndCrcRequired":
-            dataPolicy.EndToEndCrcRequired = parseBool(child.Content, aggErr)
-        case "Id":
-            dataPolicy.Id = parseString(child.Content)
-        case "MaxVersionsToKeep":
-            dataPolicy.MaxVersionsToKeep = parseInt(child.Content, aggErr)
-        case "Name":
-            dataPolicy.Name = parseNullableString(child.Content)
-        case "RebuildPriority":
-            parseEnum(child.Content, &dataPolicy.RebuildPriority, aggErr)
-        case "Versioning":
-            parseEnum(child.Content, &dataPolicy.Versioning, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPolicy.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AlwaysForcePutJobCreation":
+			dataPolicy.AlwaysForcePutJobCreation = parseBool(child.Content, aggErr)
+		case "AlwaysMinimizeSpanningAcrossMedia":
+			dataPolicy.AlwaysMinimizeSpanningAcrossMedia = parseBool(child.Content, aggErr)
+		case "BlobbingEnabled":
+			dataPolicy.BlobbingEnabled = parseBool(child.Content, aggErr)
+		case "ChecksumType":
+			parseEnum(child.Content, &dataPolicy.ChecksumType, aggErr)
+		case "CreationDate":
+			dataPolicy.CreationDate = parseString(child.Content)
+		case "DefaultBlobSize":
+			dataPolicy.DefaultBlobSize = parseNullableInt64(child.Content, aggErr)
+		case "DefaultGetJobPriority":
+			parseEnum(child.Content, &dataPolicy.DefaultGetJobPriority, aggErr)
+		case "DefaultPutJobPriority":
+			parseEnum(child.Content, &dataPolicy.DefaultPutJobPriority, aggErr)
+		case "DefaultVerifyAfterWrite":
+			dataPolicy.DefaultVerifyAfterWrite = parseBool(child.Content, aggErr)
+		case "DefaultVerifyJobPriority":
+			parseEnum(child.Content, &dataPolicy.DefaultVerifyJobPriority, aggErr)
+		case "EndToEndCrcRequired":
+			dataPolicy.EndToEndCrcRequired = parseBool(child.Content, aggErr)
+		case "Id":
+			dataPolicy.Id = parseString(child.Content)
+		case "MaxVersionsToKeep":
+			dataPolicy.MaxVersionsToKeep = parseInt(child.Content, aggErr)
+		case "Name":
+			dataPolicy.Name = parseNullableString(child.Content)
+		case "RebuildPriority":
+			parseEnum(child.Content, &dataPolicy.RebuildPriority, aggErr)
+		case "Versioning":
+			parseEnum(child.Content, &dataPolicy.Versioning, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPolicy.", child.XMLName.Local)
+		}
+	}
 }
 
 type DataPolicyAcl struct {
-    DataPolicyId *string
-    GroupId *string
-    Id string
-    UserId *string
+	DataPolicyId *string
+	GroupId      *string
+	Id           string
+	UserId       *string
 }
 
 func (dataPolicyAcl *DataPolicyAcl) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DataPolicyId":
-            dataPolicyAcl.DataPolicyId = parseNullableString(child.Content)
-        case "GroupId":
-            dataPolicyAcl.GroupId = parseNullableString(child.Content)
-        case "Id":
-            dataPolicyAcl.Id = parseString(child.Content)
-        case "UserId":
-            dataPolicyAcl.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPolicyAcl.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DataPolicyId":
+			dataPolicyAcl.DataPolicyId = parseNullableString(child.Content)
+		case "GroupId":
+			dataPolicyAcl.GroupId = parseNullableString(child.Content)
+		case "Id":
+			dataPolicyAcl.Id = parseString(child.Content)
+		case "UserId":
+			dataPolicyAcl.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPolicyAcl.", child.XMLName.Local)
+		}
+	}
 }
 
 type DataReplicationRuleType Enum
 
 const (
-    DATA_REPLICATION_RULE_TYPE_PERMANENT DataReplicationRuleType = 1 + iota
-    DATA_REPLICATION_RULE_TYPE_RETIRED DataReplicationRuleType = 1 + iota
+	DATA_REPLICATION_RULE_TYPE_PERMANENT DataReplicationRuleType = 1 + iota
+	DATA_REPLICATION_RULE_TYPE_RETIRED   DataReplicationRuleType = 1 + iota
 )
 
 func (dataReplicationRuleType *DataReplicationRuleType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *dataReplicationRuleType = UNDEFINED
-        case "PERMANENT": *dataReplicationRuleType = DATA_REPLICATION_RULE_TYPE_PERMANENT
-        case "RETIRED": *dataReplicationRuleType = DATA_REPLICATION_RULE_TYPE_RETIRED
-        default:
-            *dataReplicationRuleType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into DataReplicationRuleType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*dataReplicationRuleType = UNDEFINED
+	case "PERMANENT":
+		*dataReplicationRuleType = DATA_REPLICATION_RULE_TYPE_PERMANENT
+	case "RETIRED":
+		*dataReplicationRuleType = DATA_REPLICATION_RULE_TYPE_RETIRED
+	default:
+		*dataReplicationRuleType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into DataReplicationRuleType", str))
+	}
+	return nil
 }
 
 func (dataReplicationRuleType DataReplicationRuleType) String() string {
-    switch dataReplicationRuleType {
-        case DATA_REPLICATION_RULE_TYPE_PERMANENT: return "PERMANENT"
-        case DATA_REPLICATION_RULE_TYPE_RETIRED: return "RETIRED"
-        default:
-            log.Printf("Error: invalid DataReplicationRuleType represented by '%d'", dataReplicationRuleType)
-            return ""
-    }
+	switch dataReplicationRuleType {
+	case DATA_REPLICATION_RULE_TYPE_PERMANENT:
+		return "PERMANENT"
+	case DATA_REPLICATION_RULE_TYPE_RETIRED:
+		return "RETIRED"
+	default:
+		log.Printf("Error: invalid DataReplicationRuleType represented by '%d'", dataReplicationRuleType)
+		return ""
+	}
 }
 
 func (dataReplicationRuleType DataReplicationRuleType) StringPtr() *string {
-    if dataReplicationRuleType == UNDEFINED {
-        return nil
-    }
-    result := dataReplicationRuleType.String()
-    return &result
+	if dataReplicationRuleType == UNDEFINED {
+		return nil
+	}
+	result := dataReplicationRuleType.String()
+	return &result
 }
 
 func newDataReplicationRuleTypeFromContent(content []byte, aggErr *AggregateError) *DataReplicationRuleType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(DataReplicationRuleType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(DataReplicationRuleType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type DegradedBlob struct {
-    AzureReplicationRuleId *string
-    BlobId string
-    BucketId string
-    Ds3ReplicationRuleId *string
-    Id string
-    PersistenceRuleId *string
-    S3ReplicationRuleId *string
+	AzureReplicationRuleId *string
+	BlobId                 string
+	BucketId               string
+	Ds3ReplicationRuleId   *string
+	Id                     string
+	PersistenceRuleId      *string
+	S3ReplicationRuleId    *string
 }
 
 func (degradedBlob *DegradedBlob) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AzureReplicationRuleId":
-            degradedBlob.AzureReplicationRuleId = parseNullableString(child.Content)
-        case "BlobId":
-            degradedBlob.BlobId = parseString(child.Content)
-        case "BucketId":
-            degradedBlob.BucketId = parseString(child.Content)
-        case "Ds3ReplicationRuleId":
-            degradedBlob.Ds3ReplicationRuleId = parseNullableString(child.Content)
-        case "Id":
-            degradedBlob.Id = parseString(child.Content)
-        case "PersistenceRuleId":
-            degradedBlob.PersistenceRuleId = parseNullableString(child.Content)
-        case "S3ReplicationRuleId":
-            degradedBlob.S3ReplicationRuleId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DegradedBlob.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AzureReplicationRuleId":
+			degradedBlob.AzureReplicationRuleId = parseNullableString(child.Content)
+		case "BlobId":
+			degradedBlob.BlobId = parseString(child.Content)
+		case "BucketId":
+			degradedBlob.BucketId = parseString(child.Content)
+		case "Ds3ReplicationRuleId":
+			degradedBlob.Ds3ReplicationRuleId = parseNullableString(child.Content)
+		case "Id":
+			degradedBlob.Id = parseString(child.Content)
+		case "PersistenceRuleId":
+			degradedBlob.PersistenceRuleId = parseNullableString(child.Content)
+		case "S3ReplicationRuleId":
+			degradedBlob.S3ReplicationRuleId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DegradedBlob.", child.XMLName.Local)
+		}
+	}
 }
 
 type Ds3DataReplicationRule struct {
-    DataPolicyId string
-    Id string
-    ReplicateDeletes bool
-    State DataPlacementRuleState
-    TargetDataPolicy *string
-    TargetId string
-    Type DataReplicationRuleType
+	DataPolicyId     string
+	Id               string
+	ReplicateDeletes bool
+	State            DataPlacementRuleState
+	TargetDataPolicy *string
+	TargetId         string
+	Type             DataReplicationRuleType
 }
 
 func (ds3DataReplicationRule *Ds3DataReplicationRule) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DataPolicyId":
-            ds3DataReplicationRule.DataPolicyId = parseString(child.Content)
-        case "Id":
-            ds3DataReplicationRule.Id = parseString(child.Content)
-        case "ReplicateDeletes":
-            ds3DataReplicationRule.ReplicateDeletes = parseBool(child.Content, aggErr)
-        case "State":
-            parseEnum(child.Content, &ds3DataReplicationRule.State, aggErr)
-        case "TargetDataPolicy":
-            ds3DataReplicationRule.TargetDataPolicy = parseNullableString(child.Content)
-        case "TargetId":
-            ds3DataReplicationRule.TargetId = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &ds3DataReplicationRule.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3DataReplicationRule.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DataPolicyId":
+			ds3DataReplicationRule.DataPolicyId = parseString(child.Content)
+		case "Id":
+			ds3DataReplicationRule.Id = parseString(child.Content)
+		case "ReplicateDeletes":
+			ds3DataReplicationRule.ReplicateDeletes = parseBool(child.Content, aggErr)
+		case "State":
+			parseEnum(child.Content, &ds3DataReplicationRule.State, aggErr)
+		case "TargetDataPolicy":
+			ds3DataReplicationRule.TargetDataPolicy = parseNullableString(child.Content)
+		case "TargetId":
+			ds3DataReplicationRule.TargetId = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &ds3DataReplicationRule.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3DataReplicationRule.", child.XMLName.Local)
+		}
+	}
 }
 
 type FeatureKey struct {
-    CurrentValue *int64
-    ErrorMessage *string
-    ExpirationDate *string
-    Id string
-    Key FeatureKeyType
-    LimitValue *int64
+	CurrentValue   *int64
+	ErrorMessage   *string
+	ExpirationDate *string
+	Id             string
+	Key            FeatureKeyType
+	LimitValue     *int64
 }
 
 func (featureKey *FeatureKey) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CurrentValue":
-            featureKey.CurrentValue = parseNullableInt64(child.Content, aggErr)
-        case "ErrorMessage":
-            featureKey.ErrorMessage = parseNullableString(child.Content)
-        case "ExpirationDate":
-            featureKey.ExpirationDate = parseNullableString(child.Content)
-        case "Id":
-            featureKey.Id = parseString(child.Content)
-        case "Key":
-            parseEnum(child.Content, &featureKey.Key, aggErr)
-        case "LimitValue":
-            featureKey.LimitValue = parseNullableInt64(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing FeatureKey.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CurrentValue":
+			featureKey.CurrentValue = parseNullableInt64(child.Content, aggErr)
+		case "ErrorMessage":
+			featureKey.ErrorMessage = parseNullableString(child.Content)
+		case "ExpirationDate":
+			featureKey.ExpirationDate = parseNullableString(child.Content)
+		case "Id":
+			featureKey.Id = parseString(child.Content)
+		case "Key":
+			parseEnum(child.Content, &featureKey.Key, aggErr)
+		case "LimitValue":
+			featureKey.LimitValue = parseNullableInt64(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing FeatureKey.", child.XMLName.Local)
+		}
+	}
 }
 
 type FeatureKeyType Enum
 
 const (
-    FEATURE_KEY_TYPE_AWS_S3_CLOUD_OUT FeatureKeyType = 1 + iota
-    FEATURE_KEY_TYPE_MICROSOFT_AZURE_CLOUD_OUT FeatureKeyType = 1 + iota
+	FEATURE_KEY_TYPE_AWS_S3_CLOUD_OUT          FeatureKeyType = 1 + iota
+	FEATURE_KEY_TYPE_MICROSOFT_AZURE_CLOUD_OUT FeatureKeyType = 1 + iota
 )
 
 func (featureKeyType *FeatureKeyType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *featureKeyType = UNDEFINED
-        case "AWS_S3_CLOUD_OUT": *featureKeyType = FEATURE_KEY_TYPE_AWS_S3_CLOUD_OUT
-        case "MICROSOFT_AZURE_CLOUD_OUT": *featureKeyType = FEATURE_KEY_TYPE_MICROSOFT_AZURE_CLOUD_OUT
-        default:
-            *featureKeyType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into FeatureKeyType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*featureKeyType = UNDEFINED
+	case "AWS_S3_CLOUD_OUT":
+		*featureKeyType = FEATURE_KEY_TYPE_AWS_S3_CLOUD_OUT
+	case "MICROSOFT_AZURE_CLOUD_OUT":
+		*featureKeyType = FEATURE_KEY_TYPE_MICROSOFT_AZURE_CLOUD_OUT
+	default:
+		*featureKeyType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into FeatureKeyType", str))
+	}
+	return nil
 }
 
 func (featureKeyType FeatureKeyType) String() string {
-    switch featureKeyType {
-        case FEATURE_KEY_TYPE_AWS_S3_CLOUD_OUT: return "AWS_S3_CLOUD_OUT"
-        case FEATURE_KEY_TYPE_MICROSOFT_AZURE_CLOUD_OUT: return "MICROSOFT_AZURE_CLOUD_OUT"
-        default:
-            log.Printf("Error: invalid FeatureKeyType represented by '%d'", featureKeyType)
-            return ""
-    }
+	switch featureKeyType {
+	case FEATURE_KEY_TYPE_AWS_S3_CLOUD_OUT:
+		return "AWS_S3_CLOUD_OUT"
+	case FEATURE_KEY_TYPE_MICROSOFT_AZURE_CLOUD_OUT:
+		return "MICROSOFT_AZURE_CLOUD_OUT"
+	default:
+		log.Printf("Error: invalid FeatureKeyType represented by '%d'", featureKeyType)
+		return ""
+	}
 }
 
 func (featureKeyType FeatureKeyType) StringPtr() *string {
-    if featureKeyType == UNDEFINED {
-        return nil
-    }
-    result := featureKeyType.String()
-    return &result
+	if featureKeyType == UNDEFINED {
+		return nil
+	}
+	result := featureKeyType.String()
+	return &result
 }
 
 func newFeatureKeyTypeFromContent(content []byte, aggErr *AggregateError) *FeatureKeyType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(FeatureKeyType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(FeatureKeyType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type Group struct {
-    BuiltIn bool
-    Id string
-    Name *string
+	BuiltIn bool
+	Id      string
+	Name    *string
 }
 
 func (group *Group) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BuiltIn":
-            group.BuiltIn = parseBool(child.Content, aggErr)
-        case "Id":
-            group.Id = parseString(child.Content)
-        case "Name":
-            group.Name = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Group.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BuiltIn":
+			group.BuiltIn = parseBool(child.Content, aggErr)
+		case "Id":
+			group.Id = parseString(child.Content)
+		case "Name":
+			group.Name = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Group.", child.XMLName.Local)
+		}
+	}
 }
 
 type GroupMember struct {
-    GroupId string
-    Id string
-    MemberGroupId *string
-    MemberUserId *string
+	GroupId       string
+	Id            string
+	MemberGroupId *string
+	MemberUserId  *string
 }
 
 func (groupMember *GroupMember) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "GroupId":
-            groupMember.GroupId = parseString(child.Content)
-        case "Id":
-            groupMember.Id = parseString(child.Content)
-        case "MemberGroupId":
-            groupMember.MemberGroupId = parseNullableString(child.Content)
-        case "MemberUserId":
-            groupMember.MemberUserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing GroupMember.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "GroupId":
+			groupMember.GroupId = parseString(child.Content)
+		case "Id":
+			groupMember.Id = parseString(child.Content)
+		case "MemberGroupId":
+			groupMember.MemberGroupId = parseNullableString(child.Content)
+		case "MemberUserId":
+			groupMember.MemberUserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing GroupMember.", child.XMLName.Local)
+		}
+	}
 }
 
 type ActiveJob struct {
-    Aggregating bool
-    BucketId string
-    CachedSizeInBytes int64
-    ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
-    CompletedSizeInBytes int64
-    CreatedAt string
-    DeadJobCleanupAllowed bool
-    ErrorMessage *string
-    Id string
-    ImplicitJobIdResolution bool
-    MinimizeSpanningAcrossMedia bool
-    Naked bool
-    Name *string
-    OriginalSizeInBytes int64
-    Priority Priority
-    Protected bool
-    Rechunked *string
-    Replicating bool
-    RequestType JobRequestType
-    Restore JobRestore
-    Truncated bool
-    TruncatedDueToTimeout bool
-    UserId string
-    VerifyAfterWrite bool
+	Aggregating                         bool
+	BucketId                            string
+	CachedSizeInBytes                   int64
+	ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
+	CompletedSizeInBytes                int64
+	CreatedAt                           string
+	DeadJobCleanupAllowed               bool
+	ErrorMessage                        *string
+	Id                                  string
+	ImplicitJobIdResolution             bool
+	MinimizeSpanningAcrossMedia         bool
+	Naked                               bool
+	Name                                *string
+	OriginalSizeInBytes                 int64
+	Priority                            Priority
+	Protected                           bool
+	Rechunked                           *string
+	Replicating                         bool
+	RequestType                         JobRequestType
+	Restore                             JobRestore
+	Truncated                           bool
+	TruncatedDueToTimeout               bool
+	UserId                              string
+	VerifyAfterWrite                    bool
 }
 
 func (activeJob *ActiveJob) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Aggregating":
-            activeJob.Aggregating = parseBool(child.Content, aggErr)
-        case "BucketId":
-            activeJob.BucketId = parseString(child.Content)
-        case "CachedSizeInBytes":
-            activeJob.CachedSizeInBytes = parseInt64(child.Content, aggErr)
-        case "ChunkClientProcessingOrderGuarantee":
-            parseEnum(child.Content, &activeJob.ChunkClientProcessingOrderGuarantee, aggErr)
-        case "CompletedSizeInBytes":
-            activeJob.CompletedSizeInBytes = parseInt64(child.Content, aggErr)
-        case "CreatedAt":
-            activeJob.CreatedAt = parseString(child.Content)
-        case "DeadJobCleanupAllowed":
-            activeJob.DeadJobCleanupAllowed = parseBool(child.Content, aggErr)
-        case "ErrorMessage":
-            activeJob.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            activeJob.Id = parseString(child.Content)
-        case "ImplicitJobIdResolution":
-            activeJob.ImplicitJobIdResolution = parseBool(child.Content, aggErr)
-        case "MinimizeSpanningAcrossMedia":
-            activeJob.MinimizeSpanningAcrossMedia = parseBool(child.Content, aggErr)
-        case "Naked":
-            activeJob.Naked = parseBool(child.Content, aggErr)
-        case "Name":
-            activeJob.Name = parseNullableString(child.Content)
-        case "OriginalSizeInBytes":
-            activeJob.OriginalSizeInBytes = parseInt64(child.Content, aggErr)
-        case "Priority":
-            parseEnum(child.Content, &activeJob.Priority, aggErr)
-        case "Protected":
-            activeJob.Protected = parseBool(child.Content, aggErr)
-        case "Rechunked":
-            activeJob.Rechunked = parseNullableString(child.Content)
-        case "Replicating":
-            activeJob.Replicating = parseBool(child.Content, aggErr)
-        case "RequestType":
-            parseEnum(child.Content, &activeJob.RequestType, aggErr)
-        case "Restore":
-            parseEnum(child.Content, &activeJob.Restore, aggErr)
-        case "Truncated":
-            activeJob.Truncated = parseBool(child.Content, aggErr)
-        case "TruncatedDueToTimeout":
-            activeJob.TruncatedDueToTimeout = parseBool(child.Content, aggErr)
-        case "UserId":
-            activeJob.UserId = parseString(child.Content)
-        case "VerifyAfterWrite":
-            activeJob.VerifyAfterWrite = parseBool(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ActiveJob.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Aggregating":
+			activeJob.Aggregating = parseBool(child.Content, aggErr)
+		case "BucketId":
+			activeJob.BucketId = parseString(child.Content)
+		case "CachedSizeInBytes":
+			activeJob.CachedSizeInBytes = parseInt64(child.Content, aggErr)
+		case "ChunkClientProcessingOrderGuarantee":
+			parseEnum(child.Content, &activeJob.ChunkClientProcessingOrderGuarantee, aggErr)
+		case "CompletedSizeInBytes":
+			activeJob.CompletedSizeInBytes = parseInt64(child.Content, aggErr)
+		case "CreatedAt":
+			activeJob.CreatedAt = parseString(child.Content)
+		case "DeadJobCleanupAllowed":
+			activeJob.DeadJobCleanupAllowed = parseBool(child.Content, aggErr)
+		case "ErrorMessage":
+			activeJob.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			activeJob.Id = parseString(child.Content)
+		case "ImplicitJobIdResolution":
+			activeJob.ImplicitJobIdResolution = parseBool(child.Content, aggErr)
+		case "MinimizeSpanningAcrossMedia":
+			activeJob.MinimizeSpanningAcrossMedia = parseBool(child.Content, aggErr)
+		case "Naked":
+			activeJob.Naked = parseBool(child.Content, aggErr)
+		case "Name":
+			activeJob.Name = parseNullableString(child.Content)
+		case "OriginalSizeInBytes":
+			activeJob.OriginalSizeInBytes = parseInt64(child.Content, aggErr)
+		case "Priority":
+			parseEnum(child.Content, &activeJob.Priority, aggErr)
+		case "Protected":
+			activeJob.Protected = parseBool(child.Content, aggErr)
+		case "Rechunked":
+			activeJob.Rechunked = parseNullableString(child.Content)
+		case "Replicating":
+			activeJob.Replicating = parseBool(child.Content, aggErr)
+		case "RequestType":
+			parseEnum(child.Content, &activeJob.RequestType, aggErr)
+		case "Restore":
+			parseEnum(child.Content, &activeJob.Restore, aggErr)
+		case "Truncated":
+			activeJob.Truncated = parseBool(child.Content, aggErr)
+		case "TruncatedDueToTimeout":
+			activeJob.TruncatedDueToTimeout = parseBool(child.Content, aggErr)
+		case "UserId":
+			activeJob.UserId = parseString(child.Content)
+		case "VerifyAfterWrite":
+			activeJob.VerifyAfterWrite = parseBool(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ActiveJob.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobChunk struct {
-    BlobStoreState JobChunkBlobStoreState
-    ChunkNumber int
-    Id string
-    JobCreationDate string
-    JobId string
-    NodeId *string
-    PendingTargetCommit bool
-    ReadFromAzureTargetId *string
-    ReadFromDs3TargetId *string
-    ReadFromPoolId *string
-    ReadFromS3TargetId *string
-    ReadFromTapeId *string
+	BlobStoreState        JobChunkBlobStoreState
+	ChunkNumber           int
+	Id                    string
+	JobCreationDate       string
+	JobId                 string
+	NodeId                *string
+	PendingTargetCommit   bool
+	ReadFromAzureTargetId *string
+	ReadFromDs3TargetId   *string
+	ReadFromPoolId        *string
+	ReadFromS3TargetId    *string
+	ReadFromTapeId        *string
 }
 
 func (jobChunk *JobChunk) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BlobStoreState":
-            parseEnum(child.Content, &jobChunk.BlobStoreState, aggErr)
-        case "ChunkNumber":
-            jobChunk.ChunkNumber = parseInt(child.Content, aggErr)
-        case "Id":
-            jobChunk.Id = parseString(child.Content)
-        case "JobCreationDate":
-            jobChunk.JobCreationDate = parseString(child.Content)
-        case "JobId":
-            jobChunk.JobId = parseString(child.Content)
-        case "NodeId":
-            jobChunk.NodeId = parseNullableString(child.Content)
-        case "PendingTargetCommit":
-            jobChunk.PendingTargetCommit = parseBool(child.Content, aggErr)
-        case "ReadFromAzureTargetId":
-            jobChunk.ReadFromAzureTargetId = parseNullableString(child.Content)
-        case "ReadFromDs3TargetId":
-            jobChunk.ReadFromDs3TargetId = parseNullableString(child.Content)
-        case "ReadFromPoolId":
-            jobChunk.ReadFromPoolId = parseNullableString(child.Content)
-        case "ReadFromS3TargetId":
-            jobChunk.ReadFromS3TargetId = parseNullableString(child.Content)
-        case "ReadFromTapeId":
-            jobChunk.ReadFromTapeId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobChunk.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BlobStoreState":
+			parseEnum(child.Content, &jobChunk.BlobStoreState, aggErr)
+		case "ChunkNumber":
+			jobChunk.ChunkNumber = parseInt(child.Content, aggErr)
+		case "Id":
+			jobChunk.Id = parseString(child.Content)
+		case "JobCreationDate":
+			jobChunk.JobCreationDate = parseString(child.Content)
+		case "JobId":
+			jobChunk.JobId = parseString(child.Content)
+		case "NodeId":
+			jobChunk.NodeId = parseNullableString(child.Content)
+		case "PendingTargetCommit":
+			jobChunk.PendingTargetCommit = parseBool(child.Content, aggErr)
+		case "ReadFromAzureTargetId":
+			jobChunk.ReadFromAzureTargetId = parseNullableString(child.Content)
+		case "ReadFromDs3TargetId":
+			jobChunk.ReadFromDs3TargetId = parseNullableString(child.Content)
+		case "ReadFromPoolId":
+			jobChunk.ReadFromPoolId = parseNullableString(child.Content)
+		case "ReadFromS3TargetId":
+			jobChunk.ReadFromS3TargetId = parseNullableString(child.Content)
+		case "ReadFromTapeId":
+			jobChunk.ReadFromTapeId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobChunk.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobChunkBlobStoreState Enum
 
 const (
-    JOB_CHUNK_BLOB_STORE_STATE_PENDING JobChunkBlobStoreState = 1 + iota
-    JOB_CHUNK_BLOB_STORE_STATE_IN_PROGRESS JobChunkBlobStoreState = 1 + iota
-    JOB_CHUNK_BLOB_STORE_STATE_COMPLETED JobChunkBlobStoreState = 1 + iota
+	JOB_CHUNK_BLOB_STORE_STATE_PENDING     JobChunkBlobStoreState = 1 + iota
+	JOB_CHUNK_BLOB_STORE_STATE_IN_PROGRESS JobChunkBlobStoreState = 1 + iota
+	JOB_CHUNK_BLOB_STORE_STATE_COMPLETED   JobChunkBlobStoreState = 1 + iota
 )
 
 func (jobChunkBlobStoreState *JobChunkBlobStoreState) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *jobChunkBlobStoreState = UNDEFINED
-        case "PENDING": *jobChunkBlobStoreState = JOB_CHUNK_BLOB_STORE_STATE_PENDING
-        case "IN_PROGRESS": *jobChunkBlobStoreState = JOB_CHUNK_BLOB_STORE_STATE_IN_PROGRESS
-        case "COMPLETED": *jobChunkBlobStoreState = JOB_CHUNK_BLOB_STORE_STATE_COMPLETED
-        default:
-            *jobChunkBlobStoreState = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobChunkBlobStoreState", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*jobChunkBlobStoreState = UNDEFINED
+	case "PENDING":
+		*jobChunkBlobStoreState = JOB_CHUNK_BLOB_STORE_STATE_PENDING
+	case "IN_PROGRESS":
+		*jobChunkBlobStoreState = JOB_CHUNK_BLOB_STORE_STATE_IN_PROGRESS
+	case "COMPLETED":
+		*jobChunkBlobStoreState = JOB_CHUNK_BLOB_STORE_STATE_COMPLETED
+	default:
+		*jobChunkBlobStoreState = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobChunkBlobStoreState", str))
+	}
+	return nil
 }
 
 func (jobChunkBlobStoreState JobChunkBlobStoreState) String() string {
-    switch jobChunkBlobStoreState {
-        case JOB_CHUNK_BLOB_STORE_STATE_PENDING: return "PENDING"
-        case JOB_CHUNK_BLOB_STORE_STATE_IN_PROGRESS: return "IN_PROGRESS"
-        case JOB_CHUNK_BLOB_STORE_STATE_COMPLETED: return "COMPLETED"
-        default:
-            log.Printf("Error: invalid JobChunkBlobStoreState represented by '%d'", jobChunkBlobStoreState)
-            return ""
-    }
+	switch jobChunkBlobStoreState {
+	case JOB_CHUNK_BLOB_STORE_STATE_PENDING:
+		return "PENDING"
+	case JOB_CHUNK_BLOB_STORE_STATE_IN_PROGRESS:
+		return "IN_PROGRESS"
+	case JOB_CHUNK_BLOB_STORE_STATE_COMPLETED:
+		return "COMPLETED"
+	default:
+		log.Printf("Error: invalid JobChunkBlobStoreState represented by '%d'", jobChunkBlobStoreState)
+		return ""
+	}
 }
 
 func (jobChunkBlobStoreState JobChunkBlobStoreState) StringPtr() *string {
-    if jobChunkBlobStoreState == UNDEFINED {
-        return nil
-    }
-    result := jobChunkBlobStoreState.String()
-    return &result
+	if jobChunkBlobStoreState == UNDEFINED {
+		return nil
+	}
+	result := jobChunkBlobStoreState.String()
+	return &result
 }
 
 func newJobChunkBlobStoreStateFromContent(content []byte, aggErr *AggregateError) *JobChunkBlobStoreState {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(JobChunkBlobStoreState)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(JobChunkBlobStoreState)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type JobChunkClientProcessingOrderGuarantee Enum
 
 const (
-    JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_NONE JobChunkClientProcessingOrderGuarantee = 1 + iota
-    JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER JobChunkClientProcessingOrderGuarantee = 1 + iota
+	JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_NONE     JobChunkClientProcessingOrderGuarantee = 1 + iota
+	JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER JobChunkClientProcessingOrderGuarantee = 1 + iota
 )
 
 func (jobChunkClientProcessingOrderGuarantee *JobChunkClientProcessingOrderGuarantee) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *jobChunkClientProcessingOrderGuarantee = UNDEFINED
-        case "NONE": *jobChunkClientProcessingOrderGuarantee = JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_NONE
-        case "IN_ORDER": *jobChunkClientProcessingOrderGuarantee = JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER
-        default:
-            *jobChunkClientProcessingOrderGuarantee = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobChunkClientProcessingOrderGuarantee", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*jobChunkClientProcessingOrderGuarantee = UNDEFINED
+	case "NONE":
+		*jobChunkClientProcessingOrderGuarantee = JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_NONE
+	case "IN_ORDER":
+		*jobChunkClientProcessingOrderGuarantee = JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER
+	default:
+		*jobChunkClientProcessingOrderGuarantee = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobChunkClientProcessingOrderGuarantee", str))
+	}
+	return nil
 }
 
 func (jobChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee) String() string {
-    switch jobChunkClientProcessingOrderGuarantee {
-        case JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_NONE: return "NONE"
-        case JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER: return "IN_ORDER"
-        default:
-            log.Printf("Error: invalid JobChunkClientProcessingOrderGuarantee represented by '%d'", jobChunkClientProcessingOrderGuarantee)
-            return ""
-    }
+	switch jobChunkClientProcessingOrderGuarantee {
+	case JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_NONE:
+		return "NONE"
+	case JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER:
+		return "IN_ORDER"
+	default:
+		log.Printf("Error: invalid JobChunkClientProcessingOrderGuarantee represented by '%d'", jobChunkClientProcessingOrderGuarantee)
+		return ""
+	}
 }
 
 func (jobChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee) StringPtr() *string {
-    if jobChunkClientProcessingOrderGuarantee == UNDEFINED {
-        return nil
-    }
-    result := jobChunkClientProcessingOrderGuarantee.String()
-    return &result
+	if jobChunkClientProcessingOrderGuarantee == UNDEFINED {
+		return nil
+	}
+	result := jobChunkClientProcessingOrderGuarantee.String()
+	return &result
 }
 
 func newJobChunkClientProcessingOrderGuaranteeFromContent(content []byte, aggErr *AggregateError) *JobChunkClientProcessingOrderGuarantee {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(JobChunkClientProcessingOrderGuarantee)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(JobChunkClientProcessingOrderGuarantee)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type JobCreationFailed struct {
-    Date string
-    ErrorMessage *string
-    Id string
-    TapeBarCodes *string
-    Type JobCreationFailedType
-    UserName *string
+	Date         string
+	ErrorMessage *string
+	Id           string
+	TapeBarCodes *string
+	Type         JobCreationFailedType
+	UserName     *string
 }
 
 func (jobCreationFailed *JobCreationFailed) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Date":
-            jobCreationFailed.Date = parseString(child.Content)
-        case "ErrorMessage":
-            jobCreationFailed.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            jobCreationFailed.Id = parseString(child.Content)
-        case "TapeBarCodes":
-            jobCreationFailed.TapeBarCodes = parseNullableString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &jobCreationFailed.Type, aggErr)
-        case "UserName":
-            jobCreationFailed.UserName = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreationFailed.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Date":
+			jobCreationFailed.Date = parseString(child.Content)
+		case "ErrorMessage":
+			jobCreationFailed.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			jobCreationFailed.Id = parseString(child.Content)
+		case "TapeBarCodes":
+			jobCreationFailed.TapeBarCodes = parseNullableString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &jobCreationFailed.Type, aggErr)
+		case "UserName":
+			jobCreationFailed.UserName = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreationFailed.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobCreationFailedType Enum
 
 const (
-    JOB_CREATION_FAILED_TYPE_TAPES_MUST_BE_ONLINED JobCreationFailedType = 1 + iota
+	JOB_CREATION_FAILED_TYPE_TAPES_MUST_BE_ONLINED JobCreationFailedType = 1 + iota
 )
 
 func (jobCreationFailedType *JobCreationFailedType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *jobCreationFailedType = UNDEFINED
-        case "TAPES_MUST_BE_ONLINED": *jobCreationFailedType = JOB_CREATION_FAILED_TYPE_TAPES_MUST_BE_ONLINED
-        default:
-            *jobCreationFailedType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobCreationFailedType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*jobCreationFailedType = UNDEFINED
+	case "TAPES_MUST_BE_ONLINED":
+		*jobCreationFailedType = JOB_CREATION_FAILED_TYPE_TAPES_MUST_BE_ONLINED
+	default:
+		*jobCreationFailedType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobCreationFailedType", str))
+	}
+	return nil
 }
 
 func (jobCreationFailedType JobCreationFailedType) String() string {
-    switch jobCreationFailedType {
-        case JOB_CREATION_FAILED_TYPE_TAPES_MUST_BE_ONLINED: return "TAPES_MUST_BE_ONLINED"
-        default:
-            log.Printf("Error: invalid JobCreationFailedType represented by '%d'", jobCreationFailedType)
-            return ""
-    }
+	switch jobCreationFailedType {
+	case JOB_CREATION_FAILED_TYPE_TAPES_MUST_BE_ONLINED:
+		return "TAPES_MUST_BE_ONLINED"
+	default:
+		log.Printf("Error: invalid JobCreationFailedType represented by '%d'", jobCreationFailedType)
+		return ""
+	}
 }
 
 func (jobCreationFailedType JobCreationFailedType) StringPtr() *string {
-    if jobCreationFailedType == UNDEFINED {
-        return nil
-    }
-    result := jobCreationFailedType.String()
-    return &result
+	if jobCreationFailedType == UNDEFINED {
+		return nil
+	}
+	result := jobCreationFailedType.String()
+	return &result
 }
 
 func newJobCreationFailedTypeFromContent(content []byte, aggErr *AggregateError) *JobCreationFailedType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(JobCreationFailedType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(JobCreationFailedType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type JobRequestType Enum
 
 const (
-    JOB_REQUEST_TYPE_PUT JobRequestType = 1 + iota
-    JOB_REQUEST_TYPE_GET JobRequestType = 1 + iota
-    JOB_REQUEST_TYPE_VERIFY JobRequestType = 1 + iota
+	JOB_REQUEST_TYPE_PUT    JobRequestType = 1 + iota
+	JOB_REQUEST_TYPE_GET    JobRequestType = 1 + iota
+	JOB_REQUEST_TYPE_VERIFY JobRequestType = 1 + iota
 )
 
 func (jobRequestType *JobRequestType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *jobRequestType = UNDEFINED
-        case "PUT": *jobRequestType = JOB_REQUEST_TYPE_PUT
-        case "GET": *jobRequestType = JOB_REQUEST_TYPE_GET
-        case "VERIFY": *jobRequestType = JOB_REQUEST_TYPE_VERIFY
-        default:
-            *jobRequestType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobRequestType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*jobRequestType = UNDEFINED
+	case "PUT":
+		*jobRequestType = JOB_REQUEST_TYPE_PUT
+	case "GET":
+		*jobRequestType = JOB_REQUEST_TYPE_GET
+	case "VERIFY":
+		*jobRequestType = JOB_REQUEST_TYPE_VERIFY
+	default:
+		*jobRequestType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobRequestType", str))
+	}
+	return nil
 }
 
 func (jobRequestType JobRequestType) String() string {
-    switch jobRequestType {
-        case JOB_REQUEST_TYPE_PUT: return "PUT"
-        case JOB_REQUEST_TYPE_GET: return "GET"
-        case JOB_REQUEST_TYPE_VERIFY: return "VERIFY"
-        default:
-            log.Printf("Error: invalid JobRequestType represented by '%d'", jobRequestType)
-            return ""
-    }
+	switch jobRequestType {
+	case JOB_REQUEST_TYPE_PUT:
+		return "PUT"
+	case JOB_REQUEST_TYPE_GET:
+		return "GET"
+	case JOB_REQUEST_TYPE_VERIFY:
+		return "VERIFY"
+	default:
+		log.Printf("Error: invalid JobRequestType represented by '%d'", jobRequestType)
+		return ""
+	}
 }
 
 func (jobRequestType JobRequestType) StringPtr() *string {
-    if jobRequestType == UNDEFINED {
-        return nil
-    }
-    result := jobRequestType.String()
-    return &result
+	if jobRequestType == UNDEFINED {
+		return nil
+	}
+	result := jobRequestType.String()
+	return &result
 }
 
 func newJobRequestTypeFromContent(content []byte, aggErr *AggregateError) *JobRequestType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(JobRequestType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(JobRequestType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type JobRestore Enum
 
 const (
-    JOB_RESTORE_NO JobRestore = 1 + iota
-    JOB_RESTORE_YES JobRestore = 1 + iota
-    JOB_RESTORE_PERMANENT_ONLY JobRestore = 1 + iota
+	JOB_RESTORE_NO             JobRestore = 1 + iota
+	JOB_RESTORE_YES            JobRestore = 1 + iota
+	JOB_RESTORE_PERMANENT_ONLY JobRestore = 1 + iota
 )
 
 func (jobRestore *JobRestore) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *jobRestore = UNDEFINED
-        case "NO": *jobRestore = JOB_RESTORE_NO
-        case "YES": *jobRestore = JOB_RESTORE_YES
-        case "PERMANENT_ONLY": *jobRestore = JOB_RESTORE_PERMANENT_ONLY
-        default:
-            *jobRestore = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobRestore", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*jobRestore = UNDEFINED
+	case "NO":
+		*jobRestore = JOB_RESTORE_NO
+	case "YES":
+		*jobRestore = JOB_RESTORE_YES
+	case "PERMANENT_ONLY":
+		*jobRestore = JOB_RESTORE_PERMANENT_ONLY
+	default:
+		*jobRestore = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobRestore", str))
+	}
+	return nil
 }
 
 func (jobRestore JobRestore) String() string {
-    switch jobRestore {
-        case JOB_RESTORE_NO: return "NO"
-        case JOB_RESTORE_YES: return "YES"
-        case JOB_RESTORE_PERMANENT_ONLY: return "PERMANENT_ONLY"
-        default:
-            log.Printf("Error: invalid JobRestore represented by '%d'", jobRestore)
-            return ""
-    }
+	switch jobRestore {
+	case JOB_RESTORE_NO:
+		return "NO"
+	case JOB_RESTORE_YES:
+		return "YES"
+	case JOB_RESTORE_PERMANENT_ONLY:
+		return "PERMANENT_ONLY"
+	default:
+		log.Printf("Error: invalid JobRestore represented by '%d'", jobRestore)
+		return ""
+	}
 }
 
 func (jobRestore JobRestore) StringPtr() *string {
-    if jobRestore == UNDEFINED {
-        return nil
-    }
-    result := jobRestore.String()
-    return &result
+	if jobRestore == UNDEFINED {
+		return nil
+	}
+	result := jobRestore.String()
+	return &result
 }
 
 func newJobRestoreFromContent(content []byte, aggErr *AggregateError) *JobRestore {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(JobRestore)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(JobRestore)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type LtfsFileNamingMode Enum
 
 const (
-    LTFS_FILE_NAMING_MODE_OBJECT_NAME LtfsFileNamingMode = 1 + iota
-    LTFS_FILE_NAMING_MODE_OBJECT_ID LtfsFileNamingMode = 1 + iota
+	LTFS_FILE_NAMING_MODE_OBJECT_NAME LtfsFileNamingMode = 1 + iota
+	LTFS_FILE_NAMING_MODE_OBJECT_ID   LtfsFileNamingMode = 1 + iota
 )
 
 func (ltfsFileNamingMode *LtfsFileNamingMode) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *ltfsFileNamingMode = UNDEFINED
-        case "OBJECT_NAME": *ltfsFileNamingMode = LTFS_FILE_NAMING_MODE_OBJECT_NAME
-        case "OBJECT_ID": *ltfsFileNamingMode = LTFS_FILE_NAMING_MODE_OBJECT_ID
-        default:
-            *ltfsFileNamingMode = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into LtfsFileNamingMode", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*ltfsFileNamingMode = UNDEFINED
+	case "OBJECT_NAME":
+		*ltfsFileNamingMode = LTFS_FILE_NAMING_MODE_OBJECT_NAME
+	case "OBJECT_ID":
+		*ltfsFileNamingMode = LTFS_FILE_NAMING_MODE_OBJECT_ID
+	default:
+		*ltfsFileNamingMode = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into LtfsFileNamingMode", str))
+	}
+	return nil
 }
 
 func (ltfsFileNamingMode LtfsFileNamingMode) String() string {
-    switch ltfsFileNamingMode {
-        case LTFS_FILE_NAMING_MODE_OBJECT_NAME: return "OBJECT_NAME"
-        case LTFS_FILE_NAMING_MODE_OBJECT_ID: return "OBJECT_ID"
-        default:
-            log.Printf("Error: invalid LtfsFileNamingMode represented by '%d'", ltfsFileNamingMode)
-            return ""
-    }
+	switch ltfsFileNamingMode {
+	case LTFS_FILE_NAMING_MODE_OBJECT_NAME:
+		return "OBJECT_NAME"
+	case LTFS_FILE_NAMING_MODE_OBJECT_ID:
+		return "OBJECT_ID"
+	default:
+		log.Printf("Error: invalid LtfsFileNamingMode represented by '%d'", ltfsFileNamingMode)
+		return ""
+	}
 }
 
 func (ltfsFileNamingMode LtfsFileNamingMode) StringPtr() *string {
-    if ltfsFileNamingMode == UNDEFINED {
-        return nil
-    }
-    result := ltfsFileNamingMode.String()
-    return &result
+	if ltfsFileNamingMode == UNDEFINED {
+		return nil
+	}
+	result := ltfsFileNamingMode.String()
+	return &result
 }
 
 func newLtfsFileNamingModeFromContent(content []byte, aggErr *AggregateError) *LtfsFileNamingMode {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(LtfsFileNamingMode)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(LtfsFileNamingMode)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type Node struct {
-    DataPathHttpPort *int
-    DataPathHttpsPort *int
-    DataPathIpAddress *string
-    DnsName *string
-    Id string
-    LastHeartbeat string
-    Name *string
-    SerialNumber *string
+	DataPathHttpPort  *int
+	DataPathHttpsPort *int
+	DataPathIpAddress *string
+	DnsName           *string
+	Id                string
+	LastHeartbeat     string
+	Name              *string
+	SerialNumber      *string
 }
 
 func (node *Node) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DataPathHttpPort":
-            node.DataPathHttpPort = parseNullableInt(child.Content, aggErr)
-        case "DataPathHttpsPort":
-            node.DataPathHttpsPort = parseNullableInt(child.Content, aggErr)
-        case "DataPathIpAddress":
-            node.DataPathIpAddress = parseNullableString(child.Content)
-        case "DnsName":
-            node.DnsName = parseNullableString(child.Content)
-        case "Id":
-            node.Id = parseString(child.Content)
-        case "LastHeartbeat":
-            node.LastHeartbeat = parseString(child.Content)
-        case "Name":
-            node.Name = parseNullableString(child.Content)
-        case "SerialNumber":
-            node.SerialNumber = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Node.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DataPathHttpPort":
+			node.DataPathHttpPort = parseNullableInt(child.Content, aggErr)
+		case "DataPathHttpsPort":
+			node.DataPathHttpsPort = parseNullableInt(child.Content, aggErr)
+		case "DataPathIpAddress":
+			node.DataPathIpAddress = parseNullableString(child.Content)
+		case "DnsName":
+			node.DnsName = parseNullableString(child.Content)
+		case "Id":
+			node.Id = parseString(child.Content)
+		case "LastHeartbeat":
+			node.LastHeartbeat = parseString(child.Content)
+		case "Name":
+			node.Name = parseNullableString(child.Content)
+		case "SerialNumber":
+			node.SerialNumber = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Node.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3DataReplicationRule struct {
-    DataPolicyId string
-    Id string
-    InitialDataPlacement S3InitialDataPlacementPolicy
-    MaxBlobPartSizeInBytes int64
-    ReplicateDeletes bool
-    State DataPlacementRuleState
-    TargetId string
-    Type DataReplicationRuleType
+	DataPolicyId           string
+	Id                     string
+	InitialDataPlacement   S3InitialDataPlacementPolicy
+	MaxBlobPartSizeInBytes int64
+	ReplicateDeletes       bool
+	State                  DataPlacementRuleState
+	TargetId               string
+	Type                   DataReplicationRuleType
 }
 
 func (s3DataReplicationRule *S3DataReplicationRule) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DataPolicyId":
-            s3DataReplicationRule.DataPolicyId = parseString(child.Content)
-        case "Id":
-            s3DataReplicationRule.Id = parseString(child.Content)
-        case "InitialDataPlacement":
-            parseEnum(child.Content, &s3DataReplicationRule.InitialDataPlacement, aggErr)
-        case "MaxBlobPartSizeInBytes":
-            s3DataReplicationRule.MaxBlobPartSizeInBytes = parseInt64(child.Content, aggErr)
-        case "ReplicateDeletes":
-            s3DataReplicationRule.ReplicateDeletes = parseBool(child.Content, aggErr)
-        case "State":
-            parseEnum(child.Content, &s3DataReplicationRule.State, aggErr)
-        case "TargetId":
-            s3DataReplicationRule.TargetId = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &s3DataReplicationRule.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3DataReplicationRule.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DataPolicyId":
+			s3DataReplicationRule.DataPolicyId = parseString(child.Content)
+		case "Id":
+			s3DataReplicationRule.Id = parseString(child.Content)
+		case "InitialDataPlacement":
+			parseEnum(child.Content, &s3DataReplicationRule.InitialDataPlacement, aggErr)
+		case "MaxBlobPartSizeInBytes":
+			s3DataReplicationRule.MaxBlobPartSizeInBytes = parseInt64(child.Content, aggErr)
+		case "ReplicateDeletes":
+			s3DataReplicationRule.ReplicateDeletes = parseBool(child.Content, aggErr)
+		case "State":
+			parseEnum(child.Content, &s3DataReplicationRule.State, aggErr)
+		case "TargetId":
+			s3DataReplicationRule.TargetId = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &s3DataReplicationRule.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3DataReplicationRule.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3InitialDataPlacementPolicy Enum
 
 const (
-    S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD S3InitialDataPlacementPolicy = 1 + iota
-    S3_INITIAL_DATA_PLACEMENT_POLICY_REDUCED_REDUNDANCY S3InitialDataPlacementPolicy = 1 + iota
-    S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD_IA S3InitialDataPlacementPolicy = 1 + iota
-    S3_INITIAL_DATA_PLACEMENT_POLICY_GLACIER S3InitialDataPlacementPolicy = 1 + iota
-    S3_INITIAL_DATA_PLACEMENT_POLICY_DEEP_ARCHIVE S3InitialDataPlacementPolicy = 1 + iota
+	S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD           S3InitialDataPlacementPolicy = 1 + iota
+	S3_INITIAL_DATA_PLACEMENT_POLICY_REDUCED_REDUNDANCY S3InitialDataPlacementPolicy = 1 + iota
+	S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD_IA        S3InitialDataPlacementPolicy = 1 + iota
+	S3_INITIAL_DATA_PLACEMENT_POLICY_GLACIER            S3InitialDataPlacementPolicy = 1 + iota
+	S3_INITIAL_DATA_PLACEMENT_POLICY_DEEP_ARCHIVE       S3InitialDataPlacementPolicy = 1 + iota
 )
 
 func (s3InitialDataPlacementPolicy *S3InitialDataPlacementPolicy) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *s3InitialDataPlacementPolicy = UNDEFINED
-        case "STANDARD": *s3InitialDataPlacementPolicy = S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD
-        case "REDUCED_REDUNDANCY": *s3InitialDataPlacementPolicy = S3_INITIAL_DATA_PLACEMENT_POLICY_REDUCED_REDUNDANCY
-        case "STANDARD_IA": *s3InitialDataPlacementPolicy = S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD_IA
-        case "GLACIER": *s3InitialDataPlacementPolicy = S3_INITIAL_DATA_PLACEMENT_POLICY_GLACIER
-        case "DEEP_ARCHIVE": *s3InitialDataPlacementPolicy = S3_INITIAL_DATA_PLACEMENT_POLICY_DEEP_ARCHIVE
-        default:
-            *s3InitialDataPlacementPolicy = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into S3InitialDataPlacementPolicy", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*s3InitialDataPlacementPolicy = UNDEFINED
+	case "STANDARD":
+		*s3InitialDataPlacementPolicy = S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD
+	case "REDUCED_REDUNDANCY":
+		*s3InitialDataPlacementPolicy = S3_INITIAL_DATA_PLACEMENT_POLICY_REDUCED_REDUNDANCY
+	case "STANDARD_IA":
+		*s3InitialDataPlacementPolicy = S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD_IA
+	case "GLACIER":
+		*s3InitialDataPlacementPolicy = S3_INITIAL_DATA_PLACEMENT_POLICY_GLACIER
+	case "DEEP_ARCHIVE":
+		*s3InitialDataPlacementPolicy = S3_INITIAL_DATA_PLACEMENT_POLICY_DEEP_ARCHIVE
+	default:
+		*s3InitialDataPlacementPolicy = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into S3InitialDataPlacementPolicy", str))
+	}
+	return nil
 }
 
 func (s3InitialDataPlacementPolicy S3InitialDataPlacementPolicy) String() string {
-    switch s3InitialDataPlacementPolicy {
-        case S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD: return "STANDARD"
-        case S3_INITIAL_DATA_PLACEMENT_POLICY_REDUCED_REDUNDANCY: return "REDUCED_REDUNDANCY"
-        case S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD_IA: return "STANDARD_IA"
-        case S3_INITIAL_DATA_PLACEMENT_POLICY_GLACIER: return "GLACIER"
-        case S3_INITIAL_DATA_PLACEMENT_POLICY_DEEP_ARCHIVE: return "DEEP_ARCHIVE"
-        default:
-            log.Printf("Error: invalid S3InitialDataPlacementPolicy represented by '%d'", s3InitialDataPlacementPolicy)
-            return ""
-    }
+	switch s3InitialDataPlacementPolicy {
+	case S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD:
+		return "STANDARD"
+	case S3_INITIAL_DATA_PLACEMENT_POLICY_REDUCED_REDUNDANCY:
+		return "REDUCED_REDUNDANCY"
+	case S3_INITIAL_DATA_PLACEMENT_POLICY_STANDARD_IA:
+		return "STANDARD_IA"
+	case S3_INITIAL_DATA_PLACEMENT_POLICY_GLACIER:
+		return "GLACIER"
+	case S3_INITIAL_DATA_PLACEMENT_POLICY_DEEP_ARCHIVE:
+		return "DEEP_ARCHIVE"
+	default:
+		log.Printf("Error: invalid S3InitialDataPlacementPolicy represented by '%d'", s3InitialDataPlacementPolicy)
+		return ""
+	}
 }
 
 func (s3InitialDataPlacementPolicy S3InitialDataPlacementPolicy) StringPtr() *string {
-    if s3InitialDataPlacementPolicy == UNDEFINED {
-        return nil
-    }
-    result := s3InitialDataPlacementPolicy.String()
-    return &result
+	if s3InitialDataPlacementPolicy == UNDEFINED {
+		return nil
+	}
+	result := s3InitialDataPlacementPolicy.String()
+	return &result
 }
 
 func newS3InitialDataPlacementPolicyFromContent(content []byte, aggErr *AggregateError) *S3InitialDataPlacementPolicy {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(S3InitialDataPlacementPolicy)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(S3InitialDataPlacementPolicy)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type S3Object struct {
-    BucketId string
-    CreationDate *string
-    Id string
-    Latest bool
-    Name *string
-    Type S3ObjectType
+	BucketId     string
+	CreationDate *string
+	Id           string
+	Latest       bool
+	Name         *string
+	Type         S3ObjectType
 }
 
 func (s3Object *S3Object) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketId":
-            s3Object.BucketId = parseString(child.Content)
-        case "CreationDate":
-            s3Object.CreationDate = parseNullableString(child.Content)
-        case "Id":
-            s3Object.Id = parseString(child.Content)
-        case "Latest":
-            s3Object.Latest = parseBool(child.Content, aggErr)
-        case "Name":
-            s3Object.Name = parseNullableString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &s3Object.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3Object.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketId":
+			s3Object.BucketId = parseString(child.Content)
+		case "CreationDate":
+			s3Object.CreationDate = parseNullableString(child.Content)
+		case "Id":
+			s3Object.Id = parseString(child.Content)
+		case "Latest":
+			s3Object.Latest = parseBool(child.Content, aggErr)
+		case "Name":
+			s3Object.Name = parseNullableString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &s3Object.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3Object.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3ObjectType Enum
 
 const (
-    S3_OBJECT_TYPE_DATA S3ObjectType = 1 + iota
-    S3_OBJECT_TYPE_FOLDER S3ObjectType = 1 + iota
+	S3_OBJECT_TYPE_DATA   S3ObjectType = 1 + iota
+	S3_OBJECT_TYPE_FOLDER S3ObjectType = 1 + iota
 )
 
 func (s3ObjectType *S3ObjectType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *s3ObjectType = UNDEFINED
-        case "DATA": *s3ObjectType = S3_OBJECT_TYPE_DATA
-        case "FOLDER": *s3ObjectType = S3_OBJECT_TYPE_FOLDER
-        default:
-            *s3ObjectType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into S3ObjectType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*s3ObjectType = UNDEFINED
+	case "DATA":
+		*s3ObjectType = S3_OBJECT_TYPE_DATA
+	case "FOLDER":
+		*s3ObjectType = S3_OBJECT_TYPE_FOLDER
+	default:
+		*s3ObjectType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into S3ObjectType", str))
+	}
+	return nil
 }
 
 func (s3ObjectType S3ObjectType) String() string {
-    switch s3ObjectType {
-        case S3_OBJECT_TYPE_DATA: return "DATA"
-        case S3_OBJECT_TYPE_FOLDER: return "FOLDER"
-        default:
-            log.Printf("Error: invalid S3ObjectType represented by '%d'", s3ObjectType)
-            return ""
-    }
+	switch s3ObjectType {
+	case S3_OBJECT_TYPE_DATA:
+		return "DATA"
+	case S3_OBJECT_TYPE_FOLDER:
+		return "FOLDER"
+	default:
+		log.Printf("Error: invalid S3ObjectType represented by '%d'", s3ObjectType)
+		return ""
+	}
 }
 
 func (s3ObjectType S3ObjectType) StringPtr() *string {
-    if s3ObjectType == UNDEFINED {
-        return nil
-    }
-    result := s3ObjectType.String()
-    return &result
+	if s3ObjectType == UNDEFINED {
+		return nil
+	}
+	result := s3ObjectType.String()
+	return &result
 }
 
 func newS3ObjectTypeFromContent(content []byte, aggErr *AggregateError) *S3ObjectType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(S3ObjectType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(S3ObjectType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type S3Region Enum
 
 const (
-    S3_REGION_GOV_CLOUD S3Region = 1 + iota
-    S3_REGION_US_EAST_1 S3Region = 1 + iota
-    S3_REGION_US_EAST_2 S3Region = 1 + iota
-    S3_REGION_US_WEST_1 S3Region = 1 + iota
-    S3_REGION_US_WEST_2 S3Region = 1 + iota
-    S3_REGION_EU_WEST_1 S3Region = 1 + iota
-    S3_REGION_EU_WEST_2 S3Region = 1 + iota
-    S3_REGION_EU_CENTRAL_1 S3Region = 1 + iota
-    S3_REGION_AP_SOUTH_1 S3Region = 1 + iota
-    S3_REGION_AP_SOUTHEAST_1 S3Region = 1 + iota
-    S3_REGION_AP_SOUTHEAST_2 S3Region = 1 + iota
-    S3_REGION_AP_NORTHEAST_1 S3Region = 1 + iota
-    S3_REGION_AP_NORTHEAST_2 S3Region = 1 + iota
-    S3_REGION_SA_EAST_1 S3Region = 1 + iota
-    S3_REGION_CN_NORTH_1 S3Region = 1 + iota
-    S3_REGION_CA_CENTRAL_1 S3Region = 1 + iota
+	S3_REGION_GOV_CLOUD      S3Region = 1 + iota
+	S3_REGION_US_EAST_1      S3Region = 1 + iota
+	S3_REGION_US_EAST_2      S3Region = 1 + iota
+	S3_REGION_US_WEST_1      S3Region = 1 + iota
+	S3_REGION_US_WEST_2      S3Region = 1 + iota
+	S3_REGION_EU_WEST_1      S3Region = 1 + iota
+	S3_REGION_EU_WEST_2      S3Region = 1 + iota
+	S3_REGION_EU_CENTRAL_1   S3Region = 1 + iota
+	S3_REGION_AP_SOUTH_1     S3Region = 1 + iota
+	S3_REGION_AP_SOUTHEAST_1 S3Region = 1 + iota
+	S3_REGION_AP_SOUTHEAST_2 S3Region = 1 + iota
+	S3_REGION_AP_NORTHEAST_1 S3Region = 1 + iota
+	S3_REGION_AP_NORTHEAST_2 S3Region = 1 + iota
+	S3_REGION_SA_EAST_1      S3Region = 1 + iota
+	S3_REGION_CN_NORTH_1     S3Region = 1 + iota
+	S3_REGION_CA_CENTRAL_1   S3Region = 1 + iota
 )
 
 func (s3Region *S3Region) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *s3Region = UNDEFINED
-        case "GOV_CLOUD": *s3Region = S3_REGION_GOV_CLOUD
-        case "US_EAST_1": *s3Region = S3_REGION_US_EAST_1
-        case "US_EAST_2": *s3Region = S3_REGION_US_EAST_2
-        case "US_WEST_1": *s3Region = S3_REGION_US_WEST_1
-        case "US_WEST_2": *s3Region = S3_REGION_US_WEST_2
-        case "EU_WEST_1": *s3Region = S3_REGION_EU_WEST_1
-        case "EU_WEST_2": *s3Region = S3_REGION_EU_WEST_2
-        case "EU_CENTRAL_1": *s3Region = S3_REGION_EU_CENTRAL_1
-        case "AP_SOUTH_1": *s3Region = S3_REGION_AP_SOUTH_1
-        case "AP_SOUTHEAST_1": *s3Region = S3_REGION_AP_SOUTHEAST_1
-        case "AP_SOUTHEAST_2": *s3Region = S3_REGION_AP_SOUTHEAST_2
-        case "AP_NORTHEAST_1": *s3Region = S3_REGION_AP_NORTHEAST_1
-        case "AP_NORTHEAST_2": *s3Region = S3_REGION_AP_NORTHEAST_2
-        case "SA_EAST_1": *s3Region = S3_REGION_SA_EAST_1
-        case "CN_NORTH_1": *s3Region = S3_REGION_CN_NORTH_1
-        case "CA_CENTRAL_1": *s3Region = S3_REGION_CA_CENTRAL_1
-        default:
-            *s3Region = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into S3Region", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*s3Region = UNDEFINED
+	case "GOV_CLOUD":
+		*s3Region = S3_REGION_GOV_CLOUD
+	case "US_EAST_1":
+		*s3Region = S3_REGION_US_EAST_1
+	case "US_EAST_2":
+		*s3Region = S3_REGION_US_EAST_2
+	case "US_WEST_1":
+		*s3Region = S3_REGION_US_WEST_1
+	case "US_WEST_2":
+		*s3Region = S3_REGION_US_WEST_2
+	case "EU_WEST_1":
+		*s3Region = S3_REGION_EU_WEST_1
+	case "EU_WEST_2":
+		*s3Region = S3_REGION_EU_WEST_2
+	case "EU_CENTRAL_1":
+		*s3Region = S3_REGION_EU_CENTRAL_1
+	case "AP_SOUTH_1":
+		*s3Region = S3_REGION_AP_SOUTH_1
+	case "AP_SOUTHEAST_1":
+		*s3Region = S3_REGION_AP_SOUTHEAST_1
+	case "AP_SOUTHEAST_2":
+		*s3Region = S3_REGION_AP_SOUTHEAST_2
+	case "AP_NORTHEAST_1":
+		*s3Region = S3_REGION_AP_NORTHEAST_1
+	case "AP_NORTHEAST_2":
+		*s3Region = S3_REGION_AP_NORTHEAST_2
+	case "SA_EAST_1":
+		*s3Region = S3_REGION_SA_EAST_1
+	case "CN_NORTH_1":
+		*s3Region = S3_REGION_CN_NORTH_1
+	case "CA_CENTRAL_1":
+		*s3Region = S3_REGION_CA_CENTRAL_1
+	default:
+		*s3Region = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into S3Region", str))
+	}
+	return nil
 }
 
 func (s3Region S3Region) String() string {
-    switch s3Region {
-        case S3_REGION_GOV_CLOUD: return "GOV_CLOUD"
-        case S3_REGION_US_EAST_1: return "US_EAST_1"
-        case S3_REGION_US_EAST_2: return "US_EAST_2"
-        case S3_REGION_US_WEST_1: return "US_WEST_1"
-        case S3_REGION_US_WEST_2: return "US_WEST_2"
-        case S3_REGION_EU_WEST_1: return "EU_WEST_1"
-        case S3_REGION_EU_WEST_2: return "EU_WEST_2"
-        case S3_REGION_EU_CENTRAL_1: return "EU_CENTRAL_1"
-        case S3_REGION_AP_SOUTH_1: return "AP_SOUTH_1"
-        case S3_REGION_AP_SOUTHEAST_1: return "AP_SOUTHEAST_1"
-        case S3_REGION_AP_SOUTHEAST_2: return "AP_SOUTHEAST_2"
-        case S3_REGION_AP_NORTHEAST_1: return "AP_NORTHEAST_1"
-        case S3_REGION_AP_NORTHEAST_2: return "AP_NORTHEAST_2"
-        case S3_REGION_SA_EAST_1: return "SA_EAST_1"
-        case S3_REGION_CN_NORTH_1: return "CN_NORTH_1"
-        case S3_REGION_CA_CENTRAL_1: return "CA_CENTRAL_1"
-        default:
-            log.Printf("Error: invalid S3Region represented by '%d'", s3Region)
-            return ""
-    }
+	switch s3Region {
+	case S3_REGION_GOV_CLOUD:
+		return "GOV_CLOUD"
+	case S3_REGION_US_EAST_1:
+		return "US_EAST_1"
+	case S3_REGION_US_EAST_2:
+		return "US_EAST_2"
+	case S3_REGION_US_WEST_1:
+		return "US_WEST_1"
+	case S3_REGION_US_WEST_2:
+		return "US_WEST_2"
+	case S3_REGION_EU_WEST_1:
+		return "EU_WEST_1"
+	case S3_REGION_EU_WEST_2:
+		return "EU_WEST_2"
+	case S3_REGION_EU_CENTRAL_1:
+		return "EU_CENTRAL_1"
+	case S3_REGION_AP_SOUTH_1:
+		return "AP_SOUTH_1"
+	case S3_REGION_AP_SOUTHEAST_1:
+		return "AP_SOUTHEAST_1"
+	case S3_REGION_AP_SOUTHEAST_2:
+		return "AP_SOUTHEAST_2"
+	case S3_REGION_AP_NORTHEAST_1:
+		return "AP_NORTHEAST_1"
+	case S3_REGION_AP_NORTHEAST_2:
+		return "AP_NORTHEAST_2"
+	case S3_REGION_SA_EAST_1:
+		return "SA_EAST_1"
+	case S3_REGION_CN_NORTH_1:
+		return "CN_NORTH_1"
+	case S3_REGION_CA_CENTRAL_1:
+		return "CA_CENTRAL_1"
+	default:
+		log.Printf("Error: invalid S3Region represented by '%d'", s3Region)
+		return ""
+	}
 }
 
 func (s3Region S3Region) StringPtr() *string {
-    if s3Region == UNDEFINED {
-        return nil
-    }
-    result := s3Region.String()
-    return &result
+	if s3Region == UNDEFINED {
+		return nil
+	}
+	result := s3Region.String()
+	return &result
 }
 
 func newS3RegionFromContent(content []byte, aggErr *AggregateError) *S3Region {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(S3Region)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(S3Region)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type StorageDomain struct {
-    AutoEjectMediaFullThreshold *int64
-    AutoEjectUponCron *string
-    AutoEjectUponJobCancellation bool
-    AutoEjectUponJobCompletion bool
-    AutoEjectUponMediaFull bool
-    Id string
-    LtfsFileNaming LtfsFileNamingMode
-    MaxTapeFragmentationPercent int
-    MaximumAutoVerificationFrequencyInDays *int
-    MediaEjectionAllowed bool
-    Name *string
-    SecureMediaAllocation bool
-    VerifyPriorToAutoEject *Priority
-    WriteOptimization WriteOptimization
+	AutoEjectMediaFullThreshold            *int64
+	AutoEjectUponCron                      *string
+	AutoEjectUponJobCancellation           bool
+	AutoEjectUponJobCompletion             bool
+	AutoEjectUponMediaFull                 bool
+	Id                                     string
+	LtfsFileNaming                         LtfsFileNamingMode
+	MaxTapeFragmentationPercent            int
+	MaximumAutoVerificationFrequencyInDays *int
+	MediaEjectionAllowed                   bool
+	Name                                   *string
+	SecureMediaAllocation                  bool
+	VerifyPriorToAutoEject                 *Priority
+	WriteOptimization                      WriteOptimization
 }
 
 func (storageDomain *StorageDomain) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AutoEjectMediaFullThreshold":
-            storageDomain.AutoEjectMediaFullThreshold = parseNullableInt64(child.Content, aggErr)
-        case "AutoEjectUponCron":
-            storageDomain.AutoEjectUponCron = parseNullableString(child.Content)
-        case "AutoEjectUponJobCancellation":
-            storageDomain.AutoEjectUponJobCancellation = parseBool(child.Content, aggErr)
-        case "AutoEjectUponJobCompletion":
-            storageDomain.AutoEjectUponJobCompletion = parseBool(child.Content, aggErr)
-        case "AutoEjectUponMediaFull":
-            storageDomain.AutoEjectUponMediaFull = parseBool(child.Content, aggErr)
-        case "Id":
-            storageDomain.Id = parseString(child.Content)
-        case "LtfsFileNaming":
-            parseEnum(child.Content, &storageDomain.LtfsFileNaming, aggErr)
-        case "MaxTapeFragmentationPercent":
-            storageDomain.MaxTapeFragmentationPercent = parseInt(child.Content, aggErr)
-        case "MaximumAutoVerificationFrequencyInDays":
-            storageDomain.MaximumAutoVerificationFrequencyInDays = parseNullableInt(child.Content, aggErr)
-        case "MediaEjectionAllowed":
-            storageDomain.MediaEjectionAllowed = parseBool(child.Content, aggErr)
-        case "Name":
-            storageDomain.Name = parseNullableString(child.Content)
-        case "SecureMediaAllocation":
-            storageDomain.SecureMediaAllocation = parseBool(child.Content, aggErr)
-        case "VerifyPriorToAutoEject":
-            storageDomain.VerifyPriorToAutoEject = newPriorityFromContent(child.Content, aggErr)
-        case "WriteOptimization":
-            parseEnum(child.Content, &storageDomain.WriteOptimization, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomain.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AutoEjectMediaFullThreshold":
+			storageDomain.AutoEjectMediaFullThreshold = parseNullableInt64(child.Content, aggErr)
+		case "AutoEjectUponCron":
+			storageDomain.AutoEjectUponCron = parseNullableString(child.Content)
+		case "AutoEjectUponJobCancellation":
+			storageDomain.AutoEjectUponJobCancellation = parseBool(child.Content, aggErr)
+		case "AutoEjectUponJobCompletion":
+			storageDomain.AutoEjectUponJobCompletion = parseBool(child.Content, aggErr)
+		case "AutoEjectUponMediaFull":
+			storageDomain.AutoEjectUponMediaFull = parseBool(child.Content, aggErr)
+		case "Id":
+			storageDomain.Id = parseString(child.Content)
+		case "LtfsFileNaming":
+			parseEnum(child.Content, &storageDomain.LtfsFileNaming, aggErr)
+		case "MaxTapeFragmentationPercent":
+			storageDomain.MaxTapeFragmentationPercent = parseInt(child.Content, aggErr)
+		case "MaximumAutoVerificationFrequencyInDays":
+			storageDomain.MaximumAutoVerificationFrequencyInDays = parseNullableInt(child.Content, aggErr)
+		case "MediaEjectionAllowed":
+			storageDomain.MediaEjectionAllowed = parseBool(child.Content, aggErr)
+		case "Name":
+			storageDomain.Name = parseNullableString(child.Content)
+		case "SecureMediaAllocation":
+			storageDomain.SecureMediaAllocation = parseBool(child.Content, aggErr)
+		case "VerifyPriorToAutoEject":
+			storageDomain.VerifyPriorToAutoEject = newPriorityFromContent(child.Content, aggErr)
+		case "WriteOptimization":
+			parseEnum(child.Content, &storageDomain.WriteOptimization, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomain.", child.XMLName.Local)
+		}
+	}
 }
 
 type StorageDomainCapacitySummary struct {
-    PhysicalAllocated int64
-    PhysicalFree int64
-    PhysicalUsed int64
+	PhysicalAllocated int64
+	PhysicalFree      int64
+	PhysicalUsed      int64
 }
 
 func (storageDomainCapacitySummary *StorageDomainCapacitySummary) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "PhysicalAllocated":
-            storageDomainCapacitySummary.PhysicalAllocated = parseInt64(child.Content, aggErr)
-        case "PhysicalFree":
-            storageDomainCapacitySummary.PhysicalFree = parseInt64(child.Content, aggErr)
-        case "PhysicalUsed":
-            storageDomainCapacitySummary.PhysicalUsed = parseInt64(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainCapacitySummary.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "PhysicalAllocated":
+			storageDomainCapacitySummary.PhysicalAllocated = parseInt64(child.Content, aggErr)
+		case "PhysicalFree":
+			storageDomainCapacitySummary.PhysicalFree = parseInt64(child.Content, aggErr)
+		case "PhysicalUsed":
+			storageDomainCapacitySummary.PhysicalUsed = parseInt64(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainCapacitySummary.", child.XMLName.Local)
+		}
+	}
 }
 
 type StorageDomainFailure struct {
-    Date string
-    ErrorMessage *string
-    Id string
-    StorageDomainId string
-    Type StorageDomainFailureType
+	Date            string
+	ErrorMessage    *string
+	Id              string
+	StorageDomainId string
+	Type            StorageDomainFailureType
 }
 
 func (storageDomainFailure *StorageDomainFailure) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Date":
-            storageDomainFailure.Date = parseString(child.Content)
-        case "ErrorMessage":
-            storageDomainFailure.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            storageDomainFailure.Id = parseString(child.Content)
-        case "StorageDomainId":
-            storageDomainFailure.StorageDomainId = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &storageDomainFailure.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainFailure.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Date":
+			storageDomainFailure.Date = parseString(child.Content)
+		case "ErrorMessage":
+			storageDomainFailure.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			storageDomainFailure.Id = parseString(child.Content)
+		case "StorageDomainId":
+			storageDomainFailure.StorageDomainId = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &storageDomainFailure.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainFailure.", child.XMLName.Local)
+		}
+	}
 }
 
 type StorageDomainFailureType Enum
 
 const (
-    STORAGE_DOMAIN_FAILURE_TYPE_ILLEGAL_EJECTION_OCCURRED StorageDomainFailureType = 1 + iota
-    STORAGE_DOMAIN_FAILURE_TYPE_MEMBER_BECAME_READ_ONLY StorageDomainFailureType = 1 + iota
-    STORAGE_DOMAIN_FAILURE_TYPE_WRITES_STALLED_DUE_TO_NO_FREE_MEDIA_REMAINING StorageDomainFailureType = 1 + iota
+	STORAGE_DOMAIN_FAILURE_TYPE_ILLEGAL_EJECTION_OCCURRED                     StorageDomainFailureType = 1 + iota
+	STORAGE_DOMAIN_FAILURE_TYPE_MEMBER_BECAME_READ_ONLY                       StorageDomainFailureType = 1 + iota
+	STORAGE_DOMAIN_FAILURE_TYPE_WRITES_STALLED_DUE_TO_NO_FREE_MEDIA_REMAINING StorageDomainFailureType = 1 + iota
 )
 
 func (storageDomainFailureType *StorageDomainFailureType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *storageDomainFailureType = UNDEFINED
-        case "ILLEGAL_EJECTION_OCCURRED": *storageDomainFailureType = STORAGE_DOMAIN_FAILURE_TYPE_ILLEGAL_EJECTION_OCCURRED
-        case "MEMBER_BECAME_READ_ONLY": *storageDomainFailureType = STORAGE_DOMAIN_FAILURE_TYPE_MEMBER_BECAME_READ_ONLY
-        case "WRITES_STALLED_DUE_TO_NO_FREE_MEDIA_REMAINING": *storageDomainFailureType = STORAGE_DOMAIN_FAILURE_TYPE_WRITES_STALLED_DUE_TO_NO_FREE_MEDIA_REMAINING
-        default:
-            *storageDomainFailureType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into StorageDomainFailureType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*storageDomainFailureType = UNDEFINED
+	case "ILLEGAL_EJECTION_OCCURRED":
+		*storageDomainFailureType = STORAGE_DOMAIN_FAILURE_TYPE_ILLEGAL_EJECTION_OCCURRED
+	case "MEMBER_BECAME_READ_ONLY":
+		*storageDomainFailureType = STORAGE_DOMAIN_FAILURE_TYPE_MEMBER_BECAME_READ_ONLY
+	case "WRITES_STALLED_DUE_TO_NO_FREE_MEDIA_REMAINING":
+		*storageDomainFailureType = STORAGE_DOMAIN_FAILURE_TYPE_WRITES_STALLED_DUE_TO_NO_FREE_MEDIA_REMAINING
+	default:
+		*storageDomainFailureType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into StorageDomainFailureType", str))
+	}
+	return nil
 }
 
 func (storageDomainFailureType StorageDomainFailureType) String() string {
-    switch storageDomainFailureType {
-        case STORAGE_DOMAIN_FAILURE_TYPE_ILLEGAL_EJECTION_OCCURRED: return "ILLEGAL_EJECTION_OCCURRED"
-        case STORAGE_DOMAIN_FAILURE_TYPE_MEMBER_BECAME_READ_ONLY: return "MEMBER_BECAME_READ_ONLY"
-        case STORAGE_DOMAIN_FAILURE_TYPE_WRITES_STALLED_DUE_TO_NO_FREE_MEDIA_REMAINING: return "WRITES_STALLED_DUE_TO_NO_FREE_MEDIA_REMAINING"
-        default:
-            log.Printf("Error: invalid StorageDomainFailureType represented by '%d'", storageDomainFailureType)
-            return ""
-    }
+	switch storageDomainFailureType {
+	case STORAGE_DOMAIN_FAILURE_TYPE_ILLEGAL_EJECTION_OCCURRED:
+		return "ILLEGAL_EJECTION_OCCURRED"
+	case STORAGE_DOMAIN_FAILURE_TYPE_MEMBER_BECAME_READ_ONLY:
+		return "MEMBER_BECAME_READ_ONLY"
+	case STORAGE_DOMAIN_FAILURE_TYPE_WRITES_STALLED_DUE_TO_NO_FREE_MEDIA_REMAINING:
+		return "WRITES_STALLED_DUE_TO_NO_FREE_MEDIA_REMAINING"
+	default:
+		log.Printf("Error: invalid StorageDomainFailureType represented by '%d'", storageDomainFailureType)
+		return ""
+	}
 }
 
 func (storageDomainFailureType StorageDomainFailureType) StringPtr() *string {
-    if storageDomainFailureType == UNDEFINED {
-        return nil
-    }
-    result := storageDomainFailureType.String()
-    return &result
+	if storageDomainFailureType == UNDEFINED {
+		return nil
+	}
+	result := storageDomainFailureType.String()
+	return &result
 }
 
 func newStorageDomainFailureTypeFromContent(content []byte, aggErr *AggregateError) *StorageDomainFailureType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(StorageDomainFailureType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(StorageDomainFailureType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type StorageDomainMember struct {
-    AutoCompactionThreshold *int
-    Id string
-    PoolPartitionId *string
-    State StorageDomainMemberState
-    StorageDomainId string
-    TapePartitionId *string
-    TapeType *string
-    WritePreference WritePreferenceLevel
+	AutoCompactionThreshold *int
+	Id                      string
+	PoolPartitionId         *string
+	State                   StorageDomainMemberState
+	StorageDomainId         string
+	TapePartitionId         *string
+	TapeType                *string
+	WritePreference         WritePreferenceLevel
 }
 
 func (storageDomainMember *StorageDomainMember) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AutoCompactionThreshold":
-            storageDomainMember.AutoCompactionThreshold = parseNullableInt(child.Content, aggErr)
-        case "Id":
-            storageDomainMember.Id = parseString(child.Content)
-        case "PoolPartitionId":
-            storageDomainMember.PoolPartitionId = parseNullableString(child.Content)
-        case "State":
-            parseEnum(child.Content, &storageDomainMember.State, aggErr)
-        case "StorageDomainId":
-            storageDomainMember.StorageDomainId = parseString(child.Content)
-        case "TapePartitionId":
-            storageDomainMember.TapePartitionId = parseNullableString(child.Content)
-        case "TapeType":
-            storageDomainMember.TapeType = parseNullableString(child.Content)
-        case "WritePreference":
-            parseEnum(child.Content, &storageDomainMember.WritePreference, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainMember.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AutoCompactionThreshold":
+			storageDomainMember.AutoCompactionThreshold = parseNullableInt(child.Content, aggErr)
+		case "Id":
+			storageDomainMember.Id = parseString(child.Content)
+		case "PoolPartitionId":
+			storageDomainMember.PoolPartitionId = parseNullableString(child.Content)
+		case "State":
+			parseEnum(child.Content, &storageDomainMember.State, aggErr)
+		case "StorageDomainId":
+			storageDomainMember.StorageDomainId = parseString(child.Content)
+		case "TapePartitionId":
+			storageDomainMember.TapePartitionId = parseNullableString(child.Content)
+		case "TapeType":
+			storageDomainMember.TapeType = parseNullableString(child.Content)
+		case "WritePreference":
+			parseEnum(child.Content, &storageDomainMember.WritePreference, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainMember.", child.XMLName.Local)
+		}
+	}
 }
 
 type StorageDomainMemberState Enum
 
 const (
-    STORAGE_DOMAIN_MEMBER_STATE_NORMAL StorageDomainMemberState = 1 + iota
-    STORAGE_DOMAIN_MEMBER_STATE_EXCLUSION_IN_PROGRESS StorageDomainMemberState = 1 + iota
+	STORAGE_DOMAIN_MEMBER_STATE_NORMAL                StorageDomainMemberState = 1 + iota
+	STORAGE_DOMAIN_MEMBER_STATE_EXCLUSION_IN_PROGRESS StorageDomainMemberState = 1 + iota
 )
 
 func (storageDomainMemberState *StorageDomainMemberState) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *storageDomainMemberState = UNDEFINED
-        case "NORMAL": *storageDomainMemberState = STORAGE_DOMAIN_MEMBER_STATE_NORMAL
-        case "EXCLUSION_IN_PROGRESS": *storageDomainMemberState = STORAGE_DOMAIN_MEMBER_STATE_EXCLUSION_IN_PROGRESS
-        default:
-            *storageDomainMemberState = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into StorageDomainMemberState", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*storageDomainMemberState = UNDEFINED
+	case "NORMAL":
+		*storageDomainMemberState = STORAGE_DOMAIN_MEMBER_STATE_NORMAL
+	case "EXCLUSION_IN_PROGRESS":
+		*storageDomainMemberState = STORAGE_DOMAIN_MEMBER_STATE_EXCLUSION_IN_PROGRESS
+	default:
+		*storageDomainMemberState = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into StorageDomainMemberState", str))
+	}
+	return nil
 }
 
 func (storageDomainMemberState StorageDomainMemberState) String() string {
-    switch storageDomainMemberState {
-        case STORAGE_DOMAIN_MEMBER_STATE_NORMAL: return "NORMAL"
-        case STORAGE_DOMAIN_MEMBER_STATE_EXCLUSION_IN_PROGRESS: return "EXCLUSION_IN_PROGRESS"
-        default:
-            log.Printf("Error: invalid StorageDomainMemberState represented by '%d'", storageDomainMemberState)
-            return ""
-    }
+	switch storageDomainMemberState {
+	case STORAGE_DOMAIN_MEMBER_STATE_NORMAL:
+		return "NORMAL"
+	case STORAGE_DOMAIN_MEMBER_STATE_EXCLUSION_IN_PROGRESS:
+		return "EXCLUSION_IN_PROGRESS"
+	default:
+		log.Printf("Error: invalid StorageDomainMemberState represented by '%d'", storageDomainMemberState)
+		return ""
+	}
 }
 
 func (storageDomainMemberState StorageDomainMemberState) StringPtr() *string {
-    if storageDomainMemberState == UNDEFINED {
-        return nil
-    }
-    result := storageDomainMemberState.String()
-    return &result
+	if storageDomainMemberState == UNDEFINED {
+		return nil
+	}
+	result := storageDomainMemberState.String()
+	return &result
 }
 
 func newStorageDomainMemberStateFromContent(content []byte, aggErr *AggregateError) *StorageDomainMemberState {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(StorageDomainMemberState)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(StorageDomainMemberState)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type SystemFailure struct {
-    Date string
-    ErrorMessage *string
-    Id string
-    Type SystemFailureType
+	Date         string
+	ErrorMessage *string
+	Id           string
+	Type         SystemFailureType
 }
 
 func (systemFailure *SystemFailure) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Date":
-            systemFailure.Date = parseString(child.Content)
-        case "ErrorMessage":
-            systemFailure.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            systemFailure.Id = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &systemFailure.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SystemFailure.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Date":
+			systemFailure.Date = parseString(child.Content)
+		case "ErrorMessage":
+			systemFailure.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			systemFailure.Id = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &systemFailure.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SystemFailure.", child.XMLName.Local)
+		}
+	}
 }
 
 type SystemFailureType Enum
 
 const (
-    SYSTEM_FAILURE_TYPE_RECONCILE_TAPE_ENVIRONMENT_FAILED SystemFailureType = 1 + iota
-    SYSTEM_FAILURE_TYPE_RECONCILE_POOL_ENVIRONMENT_FAILED SystemFailureType = 1 + iota
-    SYSTEM_FAILURE_TYPE_CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION SystemFailureType = 1 + iota
-    SYSTEM_FAILURE_TYPE_MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE SystemFailureType = 1 + iota
-    SYSTEM_FAILURE_TYPE_AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE SystemFailureType = 1 + iota
-    SYSTEM_FAILURE_TYPE_DATABASE_RUNNING_OUT_OF_SPACE SystemFailureType = 1 + iota
+	SYSTEM_FAILURE_TYPE_RECONCILE_TAPE_ENVIRONMENT_FAILED                           SystemFailureType = 1 + iota
+	SYSTEM_FAILURE_TYPE_RECONCILE_POOL_ENVIRONMENT_FAILED                           SystemFailureType = 1 + iota
+	SYSTEM_FAILURE_TYPE_CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION SystemFailureType = 1 + iota
+	SYSTEM_FAILURE_TYPE_MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE              SystemFailureType = 1 + iota
+	SYSTEM_FAILURE_TYPE_AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE                       SystemFailureType = 1 + iota
+	SYSTEM_FAILURE_TYPE_DATABASE_RUNNING_OUT_OF_SPACE                               SystemFailureType = 1 + iota
 )
 
 func (systemFailureType *SystemFailureType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *systemFailureType = UNDEFINED
-        case "RECONCILE_TAPE_ENVIRONMENT_FAILED": *systemFailureType = SYSTEM_FAILURE_TYPE_RECONCILE_TAPE_ENVIRONMENT_FAILED
-        case "RECONCILE_POOL_ENVIRONMENT_FAILED": *systemFailureType = SYSTEM_FAILURE_TYPE_RECONCILE_POOL_ENVIRONMENT_FAILED
-        case "CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION": *systemFailureType = SYSTEM_FAILURE_TYPE_CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION
-        case "MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE": *systemFailureType = SYSTEM_FAILURE_TYPE_MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE
-        case "AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE": *systemFailureType = SYSTEM_FAILURE_TYPE_AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE
-        case "DATABASE_RUNNING_OUT_OF_SPACE": *systemFailureType = SYSTEM_FAILURE_TYPE_DATABASE_RUNNING_OUT_OF_SPACE
-        default:
-            *systemFailureType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into SystemFailureType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*systemFailureType = UNDEFINED
+	case "RECONCILE_TAPE_ENVIRONMENT_FAILED":
+		*systemFailureType = SYSTEM_FAILURE_TYPE_RECONCILE_TAPE_ENVIRONMENT_FAILED
+	case "RECONCILE_POOL_ENVIRONMENT_FAILED":
+		*systemFailureType = SYSTEM_FAILURE_TYPE_RECONCILE_POOL_ENVIRONMENT_FAILED
+	case "CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION":
+		*systemFailureType = SYSTEM_FAILURE_TYPE_CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION
+	case "MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE":
+		*systemFailureType = SYSTEM_FAILURE_TYPE_MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE
+	case "AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE":
+		*systemFailureType = SYSTEM_FAILURE_TYPE_AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE
+	case "DATABASE_RUNNING_OUT_OF_SPACE":
+		*systemFailureType = SYSTEM_FAILURE_TYPE_DATABASE_RUNNING_OUT_OF_SPACE
+	default:
+		*systemFailureType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into SystemFailureType", str))
+	}
+	return nil
 }
 
 func (systemFailureType SystemFailureType) String() string {
-    switch systemFailureType {
-        case SYSTEM_FAILURE_TYPE_RECONCILE_TAPE_ENVIRONMENT_FAILED: return "RECONCILE_TAPE_ENVIRONMENT_FAILED"
-        case SYSTEM_FAILURE_TYPE_RECONCILE_POOL_ENVIRONMENT_FAILED: return "RECONCILE_POOL_ENVIRONMENT_FAILED"
-        case SYSTEM_FAILURE_TYPE_CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION: return "CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION"
-        case SYSTEM_FAILURE_TYPE_MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE: return "MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE"
-        case SYSTEM_FAILURE_TYPE_AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE: return "AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE"
-        case SYSTEM_FAILURE_TYPE_DATABASE_RUNNING_OUT_OF_SPACE: return "DATABASE_RUNNING_OUT_OF_SPACE"
-        default:
-            log.Printf("Error: invalid SystemFailureType represented by '%d'", systemFailureType)
-            return ""
-    }
+	switch systemFailureType {
+	case SYSTEM_FAILURE_TYPE_RECONCILE_TAPE_ENVIRONMENT_FAILED:
+		return "RECONCILE_TAPE_ENVIRONMENT_FAILED"
+	case SYSTEM_FAILURE_TYPE_RECONCILE_POOL_ENVIRONMENT_FAILED:
+		return "RECONCILE_POOL_ENVIRONMENT_FAILED"
+	case SYSTEM_FAILURE_TYPE_CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION:
+		return "CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION"
+	case SYSTEM_FAILURE_TYPE_MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE:
+		return "MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE"
+	case SYSTEM_FAILURE_TYPE_AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE:
+		return "AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE"
+	case SYSTEM_FAILURE_TYPE_DATABASE_RUNNING_OUT_OF_SPACE:
+		return "DATABASE_RUNNING_OUT_OF_SPACE"
+	default:
+		log.Printf("Error: invalid SystemFailureType represented by '%d'", systemFailureType)
+		return ""
+	}
 }
 
 func (systemFailureType SystemFailureType) StringPtr() *string {
-    if systemFailureType == UNDEFINED {
-        return nil
-    }
-    result := systemFailureType.String()
-    return &result
+	if systemFailureType == UNDEFINED {
+		return nil
+	}
+	result := systemFailureType.String()
+	return &result
 }
 
 func newSystemFailureTypeFromContent(content []byte, aggErr *AggregateError) *SystemFailureType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(SystemFailureType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(SystemFailureType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type UnavailableMediaUsagePolicy Enum
 
 const (
-    UNAVAILABLE_MEDIA_USAGE_POLICY_ALLOW UnavailableMediaUsagePolicy = 1 + iota
-    UNAVAILABLE_MEDIA_USAGE_POLICY_DISCOURAGED UnavailableMediaUsagePolicy = 1 + iota
-    UNAVAILABLE_MEDIA_USAGE_POLICY_DISALLOW UnavailableMediaUsagePolicy = 1 + iota
+	UNAVAILABLE_MEDIA_USAGE_POLICY_ALLOW       UnavailableMediaUsagePolicy = 1 + iota
+	UNAVAILABLE_MEDIA_USAGE_POLICY_DISCOURAGED UnavailableMediaUsagePolicy = 1 + iota
+	UNAVAILABLE_MEDIA_USAGE_POLICY_DISALLOW    UnavailableMediaUsagePolicy = 1 + iota
 )
 
 func (unavailableMediaUsagePolicy *UnavailableMediaUsagePolicy) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *unavailableMediaUsagePolicy = UNDEFINED
-        case "ALLOW": *unavailableMediaUsagePolicy = UNAVAILABLE_MEDIA_USAGE_POLICY_ALLOW
-        case "DISCOURAGED": *unavailableMediaUsagePolicy = UNAVAILABLE_MEDIA_USAGE_POLICY_DISCOURAGED
-        case "DISALLOW": *unavailableMediaUsagePolicy = UNAVAILABLE_MEDIA_USAGE_POLICY_DISALLOW
-        default:
-            *unavailableMediaUsagePolicy = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into UnavailableMediaUsagePolicy", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*unavailableMediaUsagePolicy = UNDEFINED
+	case "ALLOW":
+		*unavailableMediaUsagePolicy = UNAVAILABLE_MEDIA_USAGE_POLICY_ALLOW
+	case "DISCOURAGED":
+		*unavailableMediaUsagePolicy = UNAVAILABLE_MEDIA_USAGE_POLICY_DISCOURAGED
+	case "DISALLOW":
+		*unavailableMediaUsagePolicy = UNAVAILABLE_MEDIA_USAGE_POLICY_DISALLOW
+	default:
+		*unavailableMediaUsagePolicy = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into UnavailableMediaUsagePolicy", str))
+	}
+	return nil
 }
 
 func (unavailableMediaUsagePolicy UnavailableMediaUsagePolicy) String() string {
-    switch unavailableMediaUsagePolicy {
-        case UNAVAILABLE_MEDIA_USAGE_POLICY_ALLOW: return "ALLOW"
-        case UNAVAILABLE_MEDIA_USAGE_POLICY_DISCOURAGED: return "DISCOURAGED"
-        case UNAVAILABLE_MEDIA_USAGE_POLICY_DISALLOW: return "DISALLOW"
-        default:
-            log.Printf("Error: invalid UnavailableMediaUsagePolicy represented by '%d'", unavailableMediaUsagePolicy)
-            return ""
-    }
+	switch unavailableMediaUsagePolicy {
+	case UNAVAILABLE_MEDIA_USAGE_POLICY_ALLOW:
+		return "ALLOW"
+	case UNAVAILABLE_MEDIA_USAGE_POLICY_DISCOURAGED:
+		return "DISCOURAGED"
+	case UNAVAILABLE_MEDIA_USAGE_POLICY_DISALLOW:
+		return "DISALLOW"
+	default:
+		log.Printf("Error: invalid UnavailableMediaUsagePolicy represented by '%d'", unavailableMediaUsagePolicy)
+		return ""
+	}
 }
 
 func (unavailableMediaUsagePolicy UnavailableMediaUsagePolicy) StringPtr() *string {
-    if unavailableMediaUsagePolicy == UNDEFINED {
-        return nil
-    }
-    result := unavailableMediaUsagePolicy.String()
-    return &result
+	if unavailableMediaUsagePolicy == UNDEFINED {
+		return nil
+	}
+	result := unavailableMediaUsagePolicy.String()
+	return &result
 }
 
 func newUnavailableMediaUsagePolicyFromContent(content []byte, aggErr *AggregateError) *UnavailableMediaUsagePolicy {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(UnavailableMediaUsagePolicy)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(UnavailableMediaUsagePolicy)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type SpectraUser struct {
-    AuthId *string
-    DefaultDataPolicyId *string
-    Id string
-    MaxBuckets int
-    Name *string
-    SecretKey *string
+	AuthId              *string
+	DefaultDataPolicyId *string
+	Id                  string
+	MaxBuckets          int
+	Name                *string
+	SecretKey           *string
 }
 
 func (spectraUser *SpectraUser) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AuthId":
-            spectraUser.AuthId = parseNullableString(child.Content)
-        case "DefaultDataPolicyId":
-            spectraUser.DefaultDataPolicyId = parseNullableString(child.Content)
-        case "Id":
-            spectraUser.Id = parseString(child.Content)
-        case "MaxBuckets":
-            spectraUser.MaxBuckets = parseInt(child.Content, aggErr)
-        case "Name":
-            spectraUser.Name = parseNullableString(child.Content)
-        case "SecretKey":
-            spectraUser.SecretKey = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SpectraUser.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AuthId":
+			spectraUser.AuthId = parseNullableString(child.Content)
+		case "DefaultDataPolicyId":
+			spectraUser.DefaultDataPolicyId = parseNullableString(child.Content)
+		case "Id":
+			spectraUser.Id = parseString(child.Content)
+		case "MaxBuckets":
+			spectraUser.MaxBuckets = parseInt(child.Content, aggErr)
+		case "Name":
+			spectraUser.Name = parseNullableString(child.Content)
+		case "SecretKey":
+			spectraUser.SecretKey = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SpectraUser.", child.XMLName.Local)
+		}
+	}
 }
 
 type VersioningLevel Enum
 
 const (
-    VERSIONING_LEVEL_NONE VersioningLevel = 1 + iota
-    VERSIONING_LEVEL_KEEP_LATEST VersioningLevel = 1 + iota
-    VERSIONING_LEVEL_KEEP_MULTIPLE_VERSIONS VersioningLevel = 1 + iota
+	VERSIONING_LEVEL_NONE                   VersioningLevel = 1 + iota
+	VERSIONING_LEVEL_KEEP_LATEST            VersioningLevel = 1 + iota
+	VERSIONING_LEVEL_KEEP_MULTIPLE_VERSIONS VersioningLevel = 1 + iota
 )
 
 func (versioningLevel *VersioningLevel) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *versioningLevel = UNDEFINED
-        case "NONE": *versioningLevel = VERSIONING_LEVEL_NONE
-        case "KEEP_LATEST": *versioningLevel = VERSIONING_LEVEL_KEEP_LATEST
-        case "KEEP_MULTIPLE_VERSIONS": *versioningLevel = VERSIONING_LEVEL_KEEP_MULTIPLE_VERSIONS
-        default:
-            *versioningLevel = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into VersioningLevel", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*versioningLevel = UNDEFINED
+	case "NONE":
+		*versioningLevel = VERSIONING_LEVEL_NONE
+	case "KEEP_LATEST":
+		*versioningLevel = VERSIONING_LEVEL_KEEP_LATEST
+	case "KEEP_MULTIPLE_VERSIONS":
+		*versioningLevel = VERSIONING_LEVEL_KEEP_MULTIPLE_VERSIONS
+	default:
+		*versioningLevel = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into VersioningLevel", str))
+	}
+	return nil
 }
 
 func (versioningLevel VersioningLevel) String() string {
-    switch versioningLevel {
-        case VERSIONING_LEVEL_NONE: return "NONE"
-        case VERSIONING_LEVEL_KEEP_LATEST: return "KEEP_LATEST"
-        case VERSIONING_LEVEL_KEEP_MULTIPLE_VERSIONS: return "KEEP_MULTIPLE_VERSIONS"
-        default:
-            log.Printf("Error: invalid VersioningLevel represented by '%d'", versioningLevel)
-            return ""
-    }
+	switch versioningLevel {
+	case VERSIONING_LEVEL_NONE:
+		return "NONE"
+	case VERSIONING_LEVEL_KEEP_LATEST:
+		return "KEEP_LATEST"
+	case VERSIONING_LEVEL_KEEP_MULTIPLE_VERSIONS:
+		return "KEEP_MULTIPLE_VERSIONS"
+	default:
+		log.Printf("Error: invalid VersioningLevel represented by '%d'", versioningLevel)
+		return ""
+	}
 }
 
 func (versioningLevel VersioningLevel) StringPtr() *string {
-    if versioningLevel == UNDEFINED {
-        return nil
-    }
-    result := versioningLevel.String()
-    return &result
+	if versioningLevel == UNDEFINED {
+		return nil
+	}
+	result := versioningLevel.String()
+	return &result
 }
 
 func newVersioningLevelFromContent(content []byte, aggErr *AggregateError) *VersioningLevel {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(VersioningLevel)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(VersioningLevel)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type WriteOptimization Enum
 
 const (
-    WRITE_OPTIMIZATION_CAPACITY WriteOptimization = 1 + iota
-    WRITE_OPTIMIZATION_PERFORMANCE WriteOptimization = 1 + iota
+	WRITE_OPTIMIZATION_CAPACITY    WriteOptimization = 1 + iota
+	WRITE_OPTIMIZATION_PERFORMANCE WriteOptimization = 1 + iota
 )
 
 func (writeOptimization *WriteOptimization) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *writeOptimization = UNDEFINED
-        case "CAPACITY": *writeOptimization = WRITE_OPTIMIZATION_CAPACITY
-        case "PERFORMANCE": *writeOptimization = WRITE_OPTIMIZATION_PERFORMANCE
-        default:
-            *writeOptimization = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into WriteOptimization", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*writeOptimization = UNDEFINED
+	case "CAPACITY":
+		*writeOptimization = WRITE_OPTIMIZATION_CAPACITY
+	case "PERFORMANCE":
+		*writeOptimization = WRITE_OPTIMIZATION_PERFORMANCE
+	default:
+		*writeOptimization = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into WriteOptimization", str))
+	}
+	return nil
 }
 
 func (writeOptimization WriteOptimization) String() string {
-    switch writeOptimization {
-        case WRITE_OPTIMIZATION_CAPACITY: return "CAPACITY"
-        case WRITE_OPTIMIZATION_PERFORMANCE: return "PERFORMANCE"
-        default:
-            log.Printf("Error: invalid WriteOptimization represented by '%d'", writeOptimization)
-            return ""
-    }
+	switch writeOptimization {
+	case WRITE_OPTIMIZATION_CAPACITY:
+		return "CAPACITY"
+	case WRITE_OPTIMIZATION_PERFORMANCE:
+		return "PERFORMANCE"
+	default:
+		log.Printf("Error: invalid WriteOptimization represented by '%d'", writeOptimization)
+		return ""
+	}
 }
 
 func (writeOptimization WriteOptimization) StringPtr() *string {
-    if writeOptimization == UNDEFINED {
-        return nil
-    }
-    result := writeOptimization.String()
-    return &result
+	if writeOptimization == UNDEFINED {
+		return nil
+	}
+	result := writeOptimization.String()
+	return &result
 }
 
 func newWriteOptimizationFromContent(content []byte, aggErr *AggregateError) *WriteOptimization {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(WriteOptimization)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(WriteOptimization)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type WritePreferenceLevel Enum
 
 const (
-    WRITE_PREFERENCE_LEVEL_HIGH WritePreferenceLevel = 1 + iota
-    WRITE_PREFERENCE_LEVEL_NORMAL WritePreferenceLevel = 1 + iota
-    WRITE_PREFERENCE_LEVEL_LOW WritePreferenceLevel = 1 + iota
-    WRITE_PREFERENCE_LEVEL_NEVER_SELECT WritePreferenceLevel = 1 + iota
+	WRITE_PREFERENCE_LEVEL_HIGH         WritePreferenceLevel = 1 + iota
+	WRITE_PREFERENCE_LEVEL_NORMAL       WritePreferenceLevel = 1 + iota
+	WRITE_PREFERENCE_LEVEL_LOW          WritePreferenceLevel = 1 + iota
+	WRITE_PREFERENCE_LEVEL_NEVER_SELECT WritePreferenceLevel = 1 + iota
 )
 
 func (writePreferenceLevel *WritePreferenceLevel) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *writePreferenceLevel = UNDEFINED
-        case "HIGH": *writePreferenceLevel = WRITE_PREFERENCE_LEVEL_HIGH
-        case "NORMAL": *writePreferenceLevel = WRITE_PREFERENCE_LEVEL_NORMAL
-        case "LOW": *writePreferenceLevel = WRITE_PREFERENCE_LEVEL_LOW
-        case "NEVER_SELECT": *writePreferenceLevel = WRITE_PREFERENCE_LEVEL_NEVER_SELECT
-        default:
-            *writePreferenceLevel = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into WritePreferenceLevel", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*writePreferenceLevel = UNDEFINED
+	case "HIGH":
+		*writePreferenceLevel = WRITE_PREFERENCE_LEVEL_HIGH
+	case "NORMAL":
+		*writePreferenceLevel = WRITE_PREFERENCE_LEVEL_NORMAL
+	case "LOW":
+		*writePreferenceLevel = WRITE_PREFERENCE_LEVEL_LOW
+	case "NEVER_SELECT":
+		*writePreferenceLevel = WRITE_PREFERENCE_LEVEL_NEVER_SELECT
+	default:
+		*writePreferenceLevel = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into WritePreferenceLevel", str))
+	}
+	return nil
 }
 
 func (writePreferenceLevel WritePreferenceLevel) String() string {
-    switch writePreferenceLevel {
-        case WRITE_PREFERENCE_LEVEL_HIGH: return "HIGH"
-        case WRITE_PREFERENCE_LEVEL_NORMAL: return "NORMAL"
-        case WRITE_PREFERENCE_LEVEL_LOW: return "LOW"
-        case WRITE_PREFERENCE_LEVEL_NEVER_SELECT: return "NEVER_SELECT"
-        default:
-            log.Printf("Error: invalid WritePreferenceLevel represented by '%d'", writePreferenceLevel)
-            return ""
-    }
+	switch writePreferenceLevel {
+	case WRITE_PREFERENCE_LEVEL_HIGH:
+		return "HIGH"
+	case WRITE_PREFERENCE_LEVEL_NORMAL:
+		return "NORMAL"
+	case WRITE_PREFERENCE_LEVEL_LOW:
+		return "LOW"
+	case WRITE_PREFERENCE_LEVEL_NEVER_SELECT:
+		return "NEVER_SELECT"
+	default:
+		log.Printf("Error: invalid WritePreferenceLevel represented by '%d'", writePreferenceLevel)
+		return ""
+	}
 }
 
 func (writePreferenceLevel WritePreferenceLevel) StringPtr() *string {
-    if writePreferenceLevel == UNDEFINED {
-        return nil
-    }
-    result := writePreferenceLevel.String()
-    return &result
+	if writePreferenceLevel == UNDEFINED {
+		return nil
+	}
+	result := writePreferenceLevel.String()
+	return &result
 }
 
 func newWritePreferenceLevelFromContent(content []byte, aggErr *AggregateError) *WritePreferenceLevel {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(WritePreferenceLevel)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(WritePreferenceLevel)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type AzureTargetFailureNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (azureTargetFailureNotificationRegistration *AzureTargetFailureNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            azureTargetFailureNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &azureTargetFailureNotificationRegistration.Format, aggErr)
-        case "Id":
-            azureTargetFailureNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            azureTargetFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            azureTargetFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            azureTargetFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &azureTargetFailureNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            azureTargetFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &azureTargetFailureNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            azureTargetFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            azureTargetFailureNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetFailureNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			azureTargetFailureNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &azureTargetFailureNotificationRegistration.Format, aggErr)
+		case "Id":
+			azureTargetFailureNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			azureTargetFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			azureTargetFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			azureTargetFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &azureTargetFailureNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			azureTargetFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &azureTargetFailureNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			azureTargetFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			azureTargetFailureNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetFailureNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type BucketChangesNotificationRegistration struct {
-    BucketId *string
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    LastSequenceNumber *int64
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	BucketId                         *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	LastSequenceNumber               *int64
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (bucketChangesNotificationRegistration *BucketChangesNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketId":
-            bucketChangesNotificationRegistration.BucketId = parseNullableString(child.Content)
-        case "CreationDate":
-            bucketChangesNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &bucketChangesNotificationRegistration.Format, aggErr)
-        case "Id":
-            bucketChangesNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            bucketChangesNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            bucketChangesNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            bucketChangesNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "LastSequenceNumber":
-            bucketChangesNotificationRegistration.LastSequenceNumber = parseNullableInt64(child.Content, aggErr)
-        case "NamingConvention":
-            parseEnum(child.Content, &bucketChangesNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            bucketChangesNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &bucketChangesNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            bucketChangesNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            bucketChangesNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketChangesNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketId":
+			bucketChangesNotificationRegistration.BucketId = parseNullableString(child.Content)
+		case "CreationDate":
+			bucketChangesNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &bucketChangesNotificationRegistration.Format, aggErr)
+		case "Id":
+			bucketChangesNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			bucketChangesNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			bucketChangesNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			bucketChangesNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "LastSequenceNumber":
+			bucketChangesNotificationRegistration.LastSequenceNumber = parseNullableInt64(child.Content, aggErr)
+		case "NamingConvention":
+			parseEnum(child.Content, &bucketChangesNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			bucketChangesNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &bucketChangesNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			bucketChangesNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			bucketChangesNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketChangesNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type BucketHistoryEvent struct {
-    BucketId string
-    Id string
-    ObjectCreationDate *string
-    ObjectName *string
-    SequenceNumber *int64
-    Type BucketHistoryEventType
-    VersionId string
+	BucketId           string
+	Id                 string
+	ObjectCreationDate *string
+	ObjectName         *string
+	SequenceNumber     *int64
+	Type               BucketHistoryEventType
+	VersionId          string
 }
 
 func (bucketHistoryEvent *BucketHistoryEvent) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketId":
-            bucketHistoryEvent.BucketId = parseString(child.Content)
-        case "Id":
-            bucketHistoryEvent.Id = parseString(child.Content)
-        case "ObjectCreationDate":
-            bucketHistoryEvent.ObjectCreationDate = parseNullableString(child.Content)
-        case "ObjectName":
-            bucketHistoryEvent.ObjectName = parseNullableString(child.Content)
-        case "SequenceNumber":
-            bucketHistoryEvent.SequenceNumber = parseNullableInt64(child.Content, aggErr)
-        case "Type":
-            parseEnum(child.Content, &bucketHistoryEvent.Type, aggErr)
-        case "VersionId":
-            bucketHistoryEvent.VersionId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketHistoryEvent.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketId":
+			bucketHistoryEvent.BucketId = parseString(child.Content)
+		case "Id":
+			bucketHistoryEvent.Id = parseString(child.Content)
+		case "ObjectCreationDate":
+			bucketHistoryEvent.ObjectCreationDate = parseNullableString(child.Content)
+		case "ObjectName":
+			bucketHistoryEvent.ObjectName = parseNullableString(child.Content)
+		case "SequenceNumber":
+			bucketHistoryEvent.SequenceNumber = parseNullableInt64(child.Content, aggErr)
+		case "Type":
+			parseEnum(child.Content, &bucketHistoryEvent.Type, aggErr)
+		case "VersionId":
+			bucketHistoryEvent.VersionId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketHistoryEvent.", child.XMLName.Local)
+		}
+	}
 }
 
 type BucketHistoryEventType Enum
 
 const (
-    BUCKET_HISTORY_EVENT_TYPE_DELETE BucketHistoryEventType = 1 + iota
-    BUCKET_HISTORY_EVENT_TYPE_MARK_LATEST BucketHistoryEventType = 1 + iota
-    BUCKET_HISTORY_EVENT_TYPE_UNMARK_LATEST BucketHistoryEventType = 1 + iota
-    BUCKET_HISTORY_EVENT_TYPE_CREATE BucketHistoryEventType = 1 + iota
+	BUCKET_HISTORY_EVENT_TYPE_DELETE        BucketHistoryEventType = 1 + iota
+	BUCKET_HISTORY_EVENT_TYPE_MARK_LATEST   BucketHistoryEventType = 1 + iota
+	BUCKET_HISTORY_EVENT_TYPE_UNMARK_LATEST BucketHistoryEventType = 1 + iota
+	BUCKET_HISTORY_EVENT_TYPE_CREATE        BucketHistoryEventType = 1 + iota
 )
 
 func (bucketHistoryEventType *BucketHistoryEventType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *bucketHistoryEventType = UNDEFINED
-        case "DELETE": *bucketHistoryEventType = BUCKET_HISTORY_EVENT_TYPE_DELETE
-        case "MARK_LATEST": *bucketHistoryEventType = BUCKET_HISTORY_EVENT_TYPE_MARK_LATEST
-        case "UNMARK_LATEST": *bucketHistoryEventType = BUCKET_HISTORY_EVENT_TYPE_UNMARK_LATEST
-        case "CREATE": *bucketHistoryEventType = BUCKET_HISTORY_EVENT_TYPE_CREATE
-        default:
-            *bucketHistoryEventType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into BucketHistoryEventType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*bucketHistoryEventType = UNDEFINED
+	case "DELETE":
+		*bucketHistoryEventType = BUCKET_HISTORY_EVENT_TYPE_DELETE
+	case "MARK_LATEST":
+		*bucketHistoryEventType = BUCKET_HISTORY_EVENT_TYPE_MARK_LATEST
+	case "UNMARK_LATEST":
+		*bucketHistoryEventType = BUCKET_HISTORY_EVENT_TYPE_UNMARK_LATEST
+	case "CREATE":
+		*bucketHistoryEventType = BUCKET_HISTORY_EVENT_TYPE_CREATE
+	default:
+		*bucketHistoryEventType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into BucketHistoryEventType", str))
+	}
+	return nil
 }
 
 func (bucketHistoryEventType BucketHistoryEventType) String() string {
-    switch bucketHistoryEventType {
-        case BUCKET_HISTORY_EVENT_TYPE_DELETE: return "DELETE"
-        case BUCKET_HISTORY_EVENT_TYPE_MARK_LATEST: return "MARK_LATEST"
-        case BUCKET_HISTORY_EVENT_TYPE_UNMARK_LATEST: return "UNMARK_LATEST"
-        case BUCKET_HISTORY_EVENT_TYPE_CREATE: return "CREATE"
-        default:
-            log.Printf("Error: invalid BucketHistoryEventType represented by '%d'", bucketHistoryEventType)
-            return ""
-    }
+	switch bucketHistoryEventType {
+	case BUCKET_HISTORY_EVENT_TYPE_DELETE:
+		return "DELETE"
+	case BUCKET_HISTORY_EVENT_TYPE_MARK_LATEST:
+		return "MARK_LATEST"
+	case BUCKET_HISTORY_EVENT_TYPE_UNMARK_LATEST:
+		return "UNMARK_LATEST"
+	case BUCKET_HISTORY_EVENT_TYPE_CREATE:
+		return "CREATE"
+	default:
+		log.Printf("Error: invalid BucketHistoryEventType represented by '%d'", bucketHistoryEventType)
+		return ""
+	}
 }
 
 func (bucketHistoryEventType BucketHistoryEventType) StringPtr() *string {
-    if bucketHistoryEventType == UNDEFINED {
-        return nil
-    }
-    result := bucketHistoryEventType.String()
-    return &result
+	if bucketHistoryEventType == UNDEFINED {
+		return nil
+	}
+	result := bucketHistoryEventType.String()
+	return &result
 }
 
 func newBucketHistoryEventTypeFromContent(content []byte, aggErr *AggregateError) *BucketHistoryEventType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(BucketHistoryEventType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(BucketHistoryEventType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type Ds3TargetFailureNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (ds3TargetFailureNotificationRegistration *Ds3TargetFailureNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            ds3TargetFailureNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &ds3TargetFailureNotificationRegistration.Format, aggErr)
-        case "Id":
-            ds3TargetFailureNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            ds3TargetFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            ds3TargetFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            ds3TargetFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &ds3TargetFailureNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            ds3TargetFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &ds3TargetFailureNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            ds3TargetFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            ds3TargetFailureNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetFailureNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			ds3TargetFailureNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &ds3TargetFailureNotificationRegistration.Format, aggErr)
+		case "Id":
+			ds3TargetFailureNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			ds3TargetFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			ds3TargetFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			ds3TargetFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &ds3TargetFailureNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			ds3TargetFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &ds3TargetFailureNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			ds3TargetFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			ds3TargetFailureNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetFailureNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobCompletedNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    JobId *string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	JobId                            *string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (jobCompletedNotificationRegistration *JobCompletedNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            jobCompletedNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &jobCompletedNotificationRegistration.Format, aggErr)
-        case "Id":
-            jobCompletedNotificationRegistration.Id = parseString(child.Content)
-        case "JobId":
-            jobCompletedNotificationRegistration.JobId = parseNullableString(child.Content)
-        case "LastFailure":
-            jobCompletedNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            jobCompletedNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            jobCompletedNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &jobCompletedNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            jobCompletedNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &jobCompletedNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            jobCompletedNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            jobCompletedNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCompletedNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			jobCompletedNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &jobCompletedNotificationRegistration.Format, aggErr)
+		case "Id":
+			jobCompletedNotificationRegistration.Id = parseString(child.Content)
+		case "JobId":
+			jobCompletedNotificationRegistration.JobId = parseNullableString(child.Content)
+		case "LastFailure":
+			jobCompletedNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			jobCompletedNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			jobCompletedNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &jobCompletedNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			jobCompletedNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &jobCompletedNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			jobCompletedNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			jobCompletedNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCompletedNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobCreatedNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (jobCreatedNotificationRegistration *JobCreatedNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            jobCreatedNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &jobCreatedNotificationRegistration.Format, aggErr)
-        case "Id":
-            jobCreatedNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            jobCreatedNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            jobCreatedNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            jobCreatedNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &jobCreatedNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            jobCreatedNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &jobCreatedNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            jobCreatedNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            jobCreatedNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreatedNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			jobCreatedNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &jobCreatedNotificationRegistration.Format, aggErr)
+		case "Id":
+			jobCreatedNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			jobCreatedNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			jobCreatedNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			jobCreatedNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &jobCreatedNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			jobCreatedNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &jobCreatedNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			jobCreatedNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			jobCreatedNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreatedNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobCreationFailedNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (jobCreationFailedNotificationRegistration *JobCreationFailedNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            jobCreationFailedNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &jobCreationFailedNotificationRegistration.Format, aggErr)
-        case "Id":
-            jobCreationFailedNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            jobCreationFailedNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            jobCreationFailedNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            jobCreationFailedNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &jobCreationFailedNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            jobCreationFailedNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &jobCreationFailedNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            jobCreationFailedNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            jobCreationFailedNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreationFailedNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			jobCreationFailedNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &jobCreationFailedNotificationRegistration.Format, aggErr)
+		case "Id":
+			jobCreationFailedNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			jobCreationFailedNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			jobCreationFailedNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			jobCreationFailedNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &jobCreationFailedNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			jobCreationFailedNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &jobCreationFailedNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			jobCreationFailedNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			jobCreationFailedNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreationFailedNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type PoolFailureNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (poolFailureNotificationRegistration *PoolFailureNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            poolFailureNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &poolFailureNotificationRegistration.Format, aggErr)
-        case "Id":
-            poolFailureNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            poolFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            poolFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            poolFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &poolFailureNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            poolFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &poolFailureNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            poolFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            poolFailureNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolFailureNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			poolFailureNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &poolFailureNotificationRegistration.Format, aggErr)
+		case "Id":
+			poolFailureNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			poolFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			poolFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			poolFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &poolFailureNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			poolFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &poolFailureNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			poolFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			poolFailureNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolFailureNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3ObjectCachedNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    JobId *string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	JobId                            *string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (s3ObjectCachedNotificationRegistration *S3ObjectCachedNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            s3ObjectCachedNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &s3ObjectCachedNotificationRegistration.Format, aggErr)
-        case "Id":
-            s3ObjectCachedNotificationRegistration.Id = parseString(child.Content)
-        case "JobId":
-            s3ObjectCachedNotificationRegistration.JobId = parseNullableString(child.Content)
-        case "LastFailure":
-            s3ObjectCachedNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            s3ObjectCachedNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            s3ObjectCachedNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &s3ObjectCachedNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            s3ObjectCachedNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &s3ObjectCachedNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            s3ObjectCachedNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            s3ObjectCachedNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectCachedNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			s3ObjectCachedNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &s3ObjectCachedNotificationRegistration.Format, aggErr)
+		case "Id":
+			s3ObjectCachedNotificationRegistration.Id = parseString(child.Content)
+		case "JobId":
+			s3ObjectCachedNotificationRegistration.JobId = parseNullableString(child.Content)
+		case "LastFailure":
+			s3ObjectCachedNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			s3ObjectCachedNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			s3ObjectCachedNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &s3ObjectCachedNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			s3ObjectCachedNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &s3ObjectCachedNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			s3ObjectCachedNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			s3ObjectCachedNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectCachedNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3ObjectLostNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (s3ObjectLostNotificationRegistration *S3ObjectLostNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            s3ObjectLostNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &s3ObjectLostNotificationRegistration.Format, aggErr)
-        case "Id":
-            s3ObjectLostNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            s3ObjectLostNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            s3ObjectLostNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            s3ObjectLostNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &s3ObjectLostNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            s3ObjectLostNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &s3ObjectLostNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            s3ObjectLostNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            s3ObjectLostNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectLostNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			s3ObjectLostNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &s3ObjectLostNotificationRegistration.Format, aggErr)
+		case "Id":
+			s3ObjectLostNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			s3ObjectLostNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			s3ObjectLostNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			s3ObjectLostNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &s3ObjectLostNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			s3ObjectLostNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &s3ObjectLostNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			s3ObjectLostNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			s3ObjectLostNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectLostNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3ObjectPersistedNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    JobId *string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	JobId                            *string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (s3ObjectPersistedNotificationRegistration *S3ObjectPersistedNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            s3ObjectPersistedNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &s3ObjectPersistedNotificationRegistration.Format, aggErr)
-        case "Id":
-            s3ObjectPersistedNotificationRegistration.Id = parseString(child.Content)
-        case "JobId":
-            s3ObjectPersistedNotificationRegistration.JobId = parseNullableString(child.Content)
-        case "LastFailure":
-            s3ObjectPersistedNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            s3ObjectPersistedNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            s3ObjectPersistedNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &s3ObjectPersistedNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            s3ObjectPersistedNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &s3ObjectPersistedNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            s3ObjectPersistedNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            s3ObjectPersistedNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectPersistedNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			s3ObjectPersistedNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &s3ObjectPersistedNotificationRegistration.Format, aggErr)
+		case "Id":
+			s3ObjectPersistedNotificationRegistration.Id = parseString(child.Content)
+		case "JobId":
+			s3ObjectPersistedNotificationRegistration.JobId = parseNullableString(child.Content)
+		case "LastFailure":
+			s3ObjectPersistedNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			s3ObjectPersistedNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			s3ObjectPersistedNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &s3ObjectPersistedNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			s3ObjectPersistedNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &s3ObjectPersistedNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			s3ObjectPersistedNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			s3ObjectPersistedNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectPersistedNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3TargetFailureNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (s3TargetFailureNotificationRegistration *S3TargetFailureNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            s3TargetFailureNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &s3TargetFailureNotificationRegistration.Format, aggErr)
-        case "Id":
-            s3TargetFailureNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            s3TargetFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            s3TargetFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            s3TargetFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &s3TargetFailureNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            s3TargetFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &s3TargetFailureNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            s3TargetFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            s3TargetFailureNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetFailureNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			s3TargetFailureNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &s3TargetFailureNotificationRegistration.Format, aggErr)
+		case "Id":
+			s3TargetFailureNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			s3TargetFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			s3TargetFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			s3TargetFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &s3TargetFailureNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			s3TargetFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &s3TargetFailureNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			s3TargetFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			s3TargetFailureNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetFailureNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type StorageDomainFailureNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (storageDomainFailureNotificationRegistration *StorageDomainFailureNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            storageDomainFailureNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &storageDomainFailureNotificationRegistration.Format, aggErr)
-        case "Id":
-            storageDomainFailureNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            storageDomainFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            storageDomainFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            storageDomainFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &storageDomainFailureNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            storageDomainFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &storageDomainFailureNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            storageDomainFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            storageDomainFailureNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainFailureNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			storageDomainFailureNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &storageDomainFailureNotificationRegistration.Format, aggErr)
+		case "Id":
+			storageDomainFailureNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			storageDomainFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			storageDomainFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			storageDomainFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &storageDomainFailureNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			storageDomainFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &storageDomainFailureNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			storageDomainFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			storageDomainFailureNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainFailureNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type SystemFailureNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (systemFailureNotificationRegistration *SystemFailureNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            systemFailureNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &systemFailureNotificationRegistration.Format, aggErr)
-        case "Id":
-            systemFailureNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            systemFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            systemFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            systemFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &systemFailureNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            systemFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &systemFailureNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            systemFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            systemFailureNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SystemFailureNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			systemFailureNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &systemFailureNotificationRegistration.Format, aggErr)
+		case "Id":
+			systemFailureNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			systemFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			systemFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			systemFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &systemFailureNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			systemFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &systemFailureNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			systemFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			systemFailureNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SystemFailureNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeFailureNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (tapeFailureNotificationRegistration *TapeFailureNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            tapeFailureNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &tapeFailureNotificationRegistration.Format, aggErr)
-        case "Id":
-            tapeFailureNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            tapeFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            tapeFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            tapeFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &tapeFailureNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            tapeFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &tapeFailureNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            tapeFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            tapeFailureNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeFailureNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			tapeFailureNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &tapeFailureNotificationRegistration.Format, aggErr)
+		case "Id":
+			tapeFailureNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			tapeFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			tapeFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			tapeFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &tapeFailureNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			tapeFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &tapeFailureNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			tapeFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			tapeFailureNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeFailureNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapePartitionFailureNotificationRegistration struct {
-    CreationDate string
-    Format HttpResponseFormatType
-    Id string
-    LastFailure *string
-    LastHttpResponseCode *int
-    LastNotification *string
-    NamingConvention NamingConventionType
-    NotificationEndPoint *string
-    NotificationHttpMethod RequestType
-    NumberOfFailuresSinceLastSuccess int
-    UserId *string
+	CreationDate                     string
+	Format                           HttpResponseFormatType
+	Id                               string
+	LastFailure                      *string
+	LastHttpResponseCode             *int
+	LastNotification                 *string
+	NamingConvention                 NamingConventionType
+	NotificationEndPoint             *string
+	NotificationHttpMethod           RequestType
+	NumberOfFailuresSinceLastSuccess int
+	UserId                           *string
 }
 
 func (tapePartitionFailureNotificationRegistration *TapePartitionFailureNotificationRegistration) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            tapePartitionFailureNotificationRegistration.CreationDate = parseString(child.Content)
-        case "Format":
-            parseEnum(child.Content, &tapePartitionFailureNotificationRegistration.Format, aggErr)
-        case "Id":
-            tapePartitionFailureNotificationRegistration.Id = parseString(child.Content)
-        case "LastFailure":
-            tapePartitionFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
-        case "LastHttpResponseCode":
-            tapePartitionFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
-        case "LastNotification":
-            tapePartitionFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
-        case "NamingConvention":
-            parseEnum(child.Content, &tapePartitionFailureNotificationRegistration.NamingConvention, aggErr)
-        case "NotificationEndPoint":
-            tapePartitionFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
-        case "NotificationHttpMethod":
-            parseEnum(child.Content, &tapePartitionFailureNotificationRegistration.NotificationHttpMethod, aggErr)
-        case "NumberOfFailuresSinceLastSuccess":
-            tapePartitionFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
-        case "UserId":
-            tapePartitionFailureNotificationRegistration.UserId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartitionFailureNotificationRegistration.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			tapePartitionFailureNotificationRegistration.CreationDate = parseString(child.Content)
+		case "Format":
+			parseEnum(child.Content, &tapePartitionFailureNotificationRegistration.Format, aggErr)
+		case "Id":
+			tapePartitionFailureNotificationRegistration.Id = parseString(child.Content)
+		case "LastFailure":
+			tapePartitionFailureNotificationRegistration.LastFailure = parseNullableString(child.Content)
+		case "LastHttpResponseCode":
+			tapePartitionFailureNotificationRegistration.LastHttpResponseCode = parseNullableInt(child.Content, aggErr)
+		case "LastNotification":
+			tapePartitionFailureNotificationRegistration.LastNotification = parseNullableString(child.Content)
+		case "NamingConvention":
+			parseEnum(child.Content, &tapePartitionFailureNotificationRegistration.NamingConvention, aggErr)
+		case "NotificationEndPoint":
+			tapePartitionFailureNotificationRegistration.NotificationEndPoint = parseNullableString(child.Content)
+		case "NotificationHttpMethod":
+			parseEnum(child.Content, &tapePartitionFailureNotificationRegistration.NotificationHttpMethod, aggErr)
+		case "NumberOfFailuresSinceLastSuccess":
+			tapePartitionFailureNotificationRegistration.NumberOfFailuresSinceLastSuccess = parseInt(child.Content, aggErr)
+		case "UserId":
+			tapePartitionFailureNotificationRegistration.UserId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartitionFailureNotificationRegistration.", child.XMLName.Local)
+		}
+	}
 }
 
 type CacheEntryState Enum
 
 const (
-    CACHE_ENTRY_STATE_ALLOCATED CacheEntryState = 1 + iota
-    CACHE_ENTRY_STATE_IN_CACHE CacheEntryState = 1 + iota
+	CACHE_ENTRY_STATE_ALLOCATED CacheEntryState = 1 + iota
+	CACHE_ENTRY_STATE_IN_CACHE  CacheEntryState = 1 + iota
 )
 
 func (cacheEntryState *CacheEntryState) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *cacheEntryState = UNDEFINED
-        case "ALLOCATED": *cacheEntryState = CACHE_ENTRY_STATE_ALLOCATED
-        case "IN_CACHE": *cacheEntryState = CACHE_ENTRY_STATE_IN_CACHE
-        default:
-            *cacheEntryState = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into CacheEntryState", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*cacheEntryState = UNDEFINED
+	case "ALLOCATED":
+		*cacheEntryState = CACHE_ENTRY_STATE_ALLOCATED
+	case "IN_CACHE":
+		*cacheEntryState = CACHE_ENTRY_STATE_IN_CACHE
+	default:
+		*cacheEntryState = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into CacheEntryState", str))
+	}
+	return nil
 }
 
 func (cacheEntryState CacheEntryState) String() string {
-    switch cacheEntryState {
-        case CACHE_ENTRY_STATE_ALLOCATED: return "ALLOCATED"
-        case CACHE_ENTRY_STATE_IN_CACHE: return "IN_CACHE"
-        default:
-            log.Printf("Error: invalid CacheEntryState represented by '%d'", cacheEntryState)
-            return ""
-    }
+	switch cacheEntryState {
+	case CACHE_ENTRY_STATE_ALLOCATED:
+		return "ALLOCATED"
+	case CACHE_ENTRY_STATE_IN_CACHE:
+		return "IN_CACHE"
+	default:
+		log.Printf("Error: invalid CacheEntryState represented by '%d'", cacheEntryState)
+		return ""
+	}
 }
 
 func (cacheEntryState CacheEntryState) StringPtr() *string {
-    if cacheEntryState == UNDEFINED {
-        return nil
-    }
-    result := cacheEntryState.String()
-    return &result
+	if cacheEntryState == UNDEFINED {
+		return nil
+	}
+	result := cacheEntryState.String()
+	return &result
 }
 
 func newCacheEntryStateFromContent(content []byte, aggErr *AggregateError) *CacheEntryState {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(CacheEntryState)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(CacheEntryState)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type CacheFilesystem struct {
-    AutoReclaimInitiateThreshold float64
-    AutoReclaimTerminateThreshold float64
-    BurstThreshold float64
-    CacheSafetyEnabled bool
-    Id string
-    MaxCapacityInBytes *int64
-    MaxPercentUtilizationOfFilesystem *float64
-    NeedsReconcile bool
-    NodeId string
-    Path *string
+	AutoReclaimInitiateThreshold      float64
+	AutoReclaimTerminateThreshold     float64
+	BurstThreshold                    float64
+	CacheSafetyEnabled                bool
+	Id                                string
+	MaxCapacityInBytes                *int64
+	MaxPercentUtilizationOfFilesystem *float64
+	NeedsReconcile                    bool
+	NodeId                            string
+	Path                              *string
 }
 
 func (cacheFilesystem *CacheFilesystem) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AutoReclaimInitiateThreshold":
-            cacheFilesystem.AutoReclaimInitiateThreshold = parseFloat64(child.Content, aggErr)
-        case "AutoReclaimTerminateThreshold":
-            cacheFilesystem.AutoReclaimTerminateThreshold = parseFloat64(child.Content, aggErr)
-        case "BurstThreshold":
-            cacheFilesystem.BurstThreshold = parseFloat64(child.Content, aggErr)
-        case "CacheSafetyEnabled":
-            cacheFilesystem.CacheSafetyEnabled = parseBool(child.Content, aggErr)
-        case "Id":
-            cacheFilesystem.Id = parseString(child.Content)
-        case "MaxCapacityInBytes":
-            cacheFilesystem.MaxCapacityInBytes = parseNullableInt64(child.Content, aggErr)
-        case "MaxPercentUtilizationOfFilesystem":
-            cacheFilesystem.MaxPercentUtilizationOfFilesystem = parseNullableFloat64(child.Content, aggErr)
-        case "NeedsReconcile":
-            cacheFilesystem.NeedsReconcile = parseBool(child.Content, aggErr)
-        case "NodeId":
-            cacheFilesystem.NodeId = parseString(child.Content)
-        case "Path":
-            cacheFilesystem.Path = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CacheFilesystem.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AutoReclaimInitiateThreshold":
+			cacheFilesystem.AutoReclaimInitiateThreshold = parseFloat64(child.Content, aggErr)
+		case "AutoReclaimTerminateThreshold":
+			cacheFilesystem.AutoReclaimTerminateThreshold = parseFloat64(child.Content, aggErr)
+		case "BurstThreshold":
+			cacheFilesystem.BurstThreshold = parseFloat64(child.Content, aggErr)
+		case "CacheSafetyEnabled":
+			cacheFilesystem.CacheSafetyEnabled = parseBool(child.Content, aggErr)
+		case "Id":
+			cacheFilesystem.Id = parseString(child.Content)
+		case "MaxCapacityInBytes":
+			cacheFilesystem.MaxCapacityInBytes = parseNullableInt64(child.Content, aggErr)
+		case "MaxPercentUtilizationOfFilesystem":
+			cacheFilesystem.MaxPercentUtilizationOfFilesystem = parseNullableFloat64(child.Content, aggErr)
+		case "NeedsReconcile":
+			cacheFilesystem.NeedsReconcile = parseBool(child.Content, aggErr)
+		case "NodeId":
+			cacheFilesystem.NodeId = parseString(child.Content)
+		case "Path":
+			cacheFilesystem.Path = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CacheFilesystem.", child.XMLName.Local)
+		}
+	}
 }
 
 type Pool struct {
-    AssignedToStorageDomain bool
-    AvailableCapacity int64
-    BucketId *string
-    Guid *string
-    Health PoolHealth
-    Id string
-    LastAccessed *string
-    LastModified *string
-    LastVerified *string
-    Mountpoint *string
-    Name *string
-    PartitionId *string
-    PoweredOn bool
-    Quiesced Quiesced
-    ReservedCapacity int64
-    State PoolState
-    StorageDomainMemberId *string
-    TotalCapacity int64
-    Type PoolType
-    UsedCapacity int64
+	AssignedToStorageDomain bool
+	AvailableCapacity       int64
+	BucketId                *string
+	Guid                    *string
+	Health                  PoolHealth
+	Id                      string
+	LastAccessed            *string
+	LastModified            *string
+	LastVerified            *string
+	Mountpoint              *string
+	Name                    *string
+	PartitionId             *string
+	PoweredOn               bool
+	Quiesced                Quiesced
+	ReservedCapacity        int64
+	State                   PoolState
+	StorageDomainMemberId   *string
+	TotalCapacity           int64
+	Type                    PoolType
+	UsedCapacity            int64
 }
 
 func (pool *Pool) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AssignedToStorageDomain":
-            pool.AssignedToStorageDomain = parseBool(child.Content, aggErr)
-        case "AvailableCapacity":
-            pool.AvailableCapacity = parseInt64(child.Content, aggErr)
-        case "BucketId":
-            pool.BucketId = parseNullableString(child.Content)
-        case "Guid":
-            pool.Guid = parseNullableString(child.Content)
-        case "Health":
-            parseEnum(child.Content, &pool.Health, aggErr)
-        case "Id":
-            pool.Id = parseString(child.Content)
-        case "LastAccessed":
-            pool.LastAccessed = parseNullableString(child.Content)
-        case "LastModified":
-            pool.LastModified = parseNullableString(child.Content)
-        case "LastVerified":
-            pool.LastVerified = parseNullableString(child.Content)
-        case "Mountpoint":
-            pool.Mountpoint = parseNullableString(child.Content)
-        case "Name":
-            pool.Name = parseNullableString(child.Content)
-        case "PartitionId":
-            pool.PartitionId = parseNullableString(child.Content)
-        case "PoweredOn":
-            pool.PoweredOn = parseBool(child.Content, aggErr)
-        case "Quiesced":
-            parseEnum(child.Content, &pool.Quiesced, aggErr)
-        case "ReservedCapacity":
-            pool.ReservedCapacity = parseInt64(child.Content, aggErr)
-        case "State":
-            parseEnum(child.Content, &pool.State, aggErr)
-        case "StorageDomainMemberId":
-            pool.StorageDomainMemberId = parseNullableString(child.Content)
-        case "TotalCapacity":
-            pool.TotalCapacity = parseInt64(child.Content, aggErr)
-        case "Type":
-            parseEnum(child.Content, &pool.Type, aggErr)
-        case "UsedCapacity":
-            pool.UsedCapacity = parseInt64(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Pool.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AssignedToStorageDomain":
+			pool.AssignedToStorageDomain = parseBool(child.Content, aggErr)
+		case "AvailableCapacity":
+			pool.AvailableCapacity = parseInt64(child.Content, aggErr)
+		case "BucketId":
+			pool.BucketId = parseNullableString(child.Content)
+		case "Guid":
+			pool.Guid = parseNullableString(child.Content)
+		case "Health":
+			parseEnum(child.Content, &pool.Health, aggErr)
+		case "Id":
+			pool.Id = parseString(child.Content)
+		case "LastAccessed":
+			pool.LastAccessed = parseNullableString(child.Content)
+		case "LastModified":
+			pool.LastModified = parseNullableString(child.Content)
+		case "LastVerified":
+			pool.LastVerified = parseNullableString(child.Content)
+		case "Mountpoint":
+			pool.Mountpoint = parseNullableString(child.Content)
+		case "Name":
+			pool.Name = parseNullableString(child.Content)
+		case "PartitionId":
+			pool.PartitionId = parseNullableString(child.Content)
+		case "PoweredOn":
+			pool.PoweredOn = parseBool(child.Content, aggErr)
+		case "Quiesced":
+			parseEnum(child.Content, &pool.Quiesced, aggErr)
+		case "ReservedCapacity":
+			pool.ReservedCapacity = parseInt64(child.Content, aggErr)
+		case "State":
+			parseEnum(child.Content, &pool.State, aggErr)
+		case "StorageDomainMemberId":
+			pool.StorageDomainMemberId = parseNullableString(child.Content)
+		case "TotalCapacity":
+			pool.TotalCapacity = parseInt64(child.Content, aggErr)
+		case "Type":
+			parseEnum(child.Content, &pool.Type, aggErr)
+		case "UsedCapacity":
+			pool.UsedCapacity = parseInt64(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Pool.", child.XMLName.Local)
+		}
+	}
 }
 
-
 func parsePoolSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []Pool {
-    var result []Pool
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult Pool
-            curResult.parse(&curXmlNode, aggErr)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing Pool struct.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []Pool
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult Pool
+			curResult.parse(&curXmlNode, aggErr)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing Pool struct.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }
 
 type PoolFailure struct {
-    Date string
-    ErrorMessage *string
-    Id string
-    PoolId string
-    Type PoolFailureType
+	Date         string
+	ErrorMessage *string
+	Id           string
+	PoolId       string
+	Type         PoolFailureType
 }
 
 func (poolFailure *PoolFailure) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Date":
-            poolFailure.Date = parseString(child.Content)
-        case "ErrorMessage":
-            poolFailure.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            poolFailure.Id = parseString(child.Content)
-        case "PoolId":
-            poolFailure.PoolId = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &poolFailure.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolFailure.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Date":
+			poolFailure.Date = parseString(child.Content)
+		case "ErrorMessage":
+			poolFailure.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			poolFailure.Id = parseString(child.Content)
+		case "PoolId":
+			poolFailure.PoolId = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &poolFailure.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolFailure.", child.XMLName.Local)
+		}
+	}
 }
 
 type PoolFailureType Enum
 
 const (
-    POOL_FAILURE_TYPE_BLOB_READ_FAILED PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_DATA_CHECKPOINT_MISSING PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_FORMAT_FAILED PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_IMPORT_FAILED PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_IMPORT_INCOMPLETE PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_INSPECT_FAILED PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_QUIESCED PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_READ_FAILED PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_VERIFY_FAILED PoolFailureType = 1 + iota
-    POOL_FAILURE_TYPE_WRITE_FAILED PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_BLOB_READ_FAILED                            PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE                     PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_DATA_CHECKPOINT_MISSING                     PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_FORMAT_FAILED                               PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_IMPORT_FAILED                               PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_IMPORT_INCOMPLETE                           PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY         PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_INSPECT_FAILED                              PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_QUIESCED                                    PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_READ_FAILED                                 PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_VERIFY_FAILED                               PoolFailureType = 1 + iota
+	POOL_FAILURE_TYPE_WRITE_FAILED                                PoolFailureType = 1 + iota
 )
 
 func (poolFailureType *PoolFailureType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *poolFailureType = UNDEFINED
-        case "BLOB_READ_FAILED": *poolFailureType = POOL_FAILURE_TYPE_BLOB_READ_FAILED
-        case "DATA_CHECKPOINT_FAILURE": *poolFailureType = POOL_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE
-        case "DATA_CHECKPOINT_MISSING": *poolFailureType = POOL_FAILURE_TYPE_DATA_CHECKPOINT_MISSING
-        case "FORMAT_FAILED": *poolFailureType = POOL_FAILURE_TYPE_FORMAT_FAILED
-        case "IMPORT_FAILED": *poolFailureType = POOL_FAILURE_TYPE_IMPORT_FAILED
-        case "IMPORT_INCOMPLETE": *poolFailureType = POOL_FAILURE_TYPE_IMPORT_INCOMPLETE
-        case "IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE": *poolFailureType = POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE
-        case "IMPORT_FAILED_DUE_TO_DATA_INTEGRITY": *poolFailureType = POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY
-        case "INSPECT_FAILED": *poolFailureType = POOL_FAILURE_TYPE_INSPECT_FAILED
-        case "QUIESCED": *poolFailureType = POOL_FAILURE_TYPE_QUIESCED
-        case "READ_FAILED": *poolFailureType = POOL_FAILURE_TYPE_READ_FAILED
-        case "VERIFY_FAILED": *poolFailureType = POOL_FAILURE_TYPE_VERIFY_FAILED
-        case "WRITE_FAILED": *poolFailureType = POOL_FAILURE_TYPE_WRITE_FAILED
-        default:
-            *poolFailureType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into PoolFailureType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*poolFailureType = UNDEFINED
+	case "BLOB_READ_FAILED":
+		*poolFailureType = POOL_FAILURE_TYPE_BLOB_READ_FAILED
+	case "DATA_CHECKPOINT_FAILURE":
+		*poolFailureType = POOL_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE
+	case "DATA_CHECKPOINT_MISSING":
+		*poolFailureType = POOL_FAILURE_TYPE_DATA_CHECKPOINT_MISSING
+	case "FORMAT_FAILED":
+		*poolFailureType = POOL_FAILURE_TYPE_FORMAT_FAILED
+	case "IMPORT_FAILED":
+		*poolFailureType = POOL_FAILURE_TYPE_IMPORT_FAILED
+	case "IMPORT_INCOMPLETE":
+		*poolFailureType = POOL_FAILURE_TYPE_IMPORT_INCOMPLETE
+	case "IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE":
+		*poolFailureType = POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE
+	case "IMPORT_FAILED_DUE_TO_DATA_INTEGRITY":
+		*poolFailureType = POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY
+	case "INSPECT_FAILED":
+		*poolFailureType = POOL_FAILURE_TYPE_INSPECT_FAILED
+	case "QUIESCED":
+		*poolFailureType = POOL_FAILURE_TYPE_QUIESCED
+	case "READ_FAILED":
+		*poolFailureType = POOL_FAILURE_TYPE_READ_FAILED
+	case "VERIFY_FAILED":
+		*poolFailureType = POOL_FAILURE_TYPE_VERIFY_FAILED
+	case "WRITE_FAILED":
+		*poolFailureType = POOL_FAILURE_TYPE_WRITE_FAILED
+	default:
+		*poolFailureType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into PoolFailureType", str))
+	}
+	return nil
 }
 
 func (poolFailureType PoolFailureType) String() string {
-    switch poolFailureType {
-        case POOL_FAILURE_TYPE_BLOB_READ_FAILED: return "BLOB_READ_FAILED"
-        case POOL_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE: return "DATA_CHECKPOINT_FAILURE"
-        case POOL_FAILURE_TYPE_DATA_CHECKPOINT_MISSING: return "DATA_CHECKPOINT_MISSING"
-        case POOL_FAILURE_TYPE_FORMAT_FAILED: return "FORMAT_FAILED"
-        case POOL_FAILURE_TYPE_IMPORT_FAILED: return "IMPORT_FAILED"
-        case POOL_FAILURE_TYPE_IMPORT_INCOMPLETE: return "IMPORT_INCOMPLETE"
-        case POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE: return "IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE"
-        case POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY: return "IMPORT_FAILED_DUE_TO_DATA_INTEGRITY"
-        case POOL_FAILURE_TYPE_INSPECT_FAILED: return "INSPECT_FAILED"
-        case POOL_FAILURE_TYPE_QUIESCED: return "QUIESCED"
-        case POOL_FAILURE_TYPE_READ_FAILED: return "READ_FAILED"
-        case POOL_FAILURE_TYPE_VERIFY_FAILED: return "VERIFY_FAILED"
-        case POOL_FAILURE_TYPE_WRITE_FAILED: return "WRITE_FAILED"
-        default:
-            log.Printf("Error: invalid PoolFailureType represented by '%d'", poolFailureType)
-            return ""
-    }
+	switch poolFailureType {
+	case POOL_FAILURE_TYPE_BLOB_READ_FAILED:
+		return "BLOB_READ_FAILED"
+	case POOL_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE:
+		return "DATA_CHECKPOINT_FAILURE"
+	case POOL_FAILURE_TYPE_DATA_CHECKPOINT_MISSING:
+		return "DATA_CHECKPOINT_MISSING"
+	case POOL_FAILURE_TYPE_FORMAT_FAILED:
+		return "FORMAT_FAILED"
+	case POOL_FAILURE_TYPE_IMPORT_FAILED:
+		return "IMPORT_FAILED"
+	case POOL_FAILURE_TYPE_IMPORT_INCOMPLETE:
+		return "IMPORT_INCOMPLETE"
+	case POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE:
+		return "IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE"
+	case POOL_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY:
+		return "IMPORT_FAILED_DUE_TO_DATA_INTEGRITY"
+	case POOL_FAILURE_TYPE_INSPECT_FAILED:
+		return "INSPECT_FAILED"
+	case POOL_FAILURE_TYPE_QUIESCED:
+		return "QUIESCED"
+	case POOL_FAILURE_TYPE_READ_FAILED:
+		return "READ_FAILED"
+	case POOL_FAILURE_TYPE_VERIFY_FAILED:
+		return "VERIFY_FAILED"
+	case POOL_FAILURE_TYPE_WRITE_FAILED:
+		return "WRITE_FAILED"
+	default:
+		log.Printf("Error: invalid PoolFailureType represented by '%d'", poolFailureType)
+		return ""
+	}
 }
 
 func (poolFailureType PoolFailureType) StringPtr() *string {
-    if poolFailureType == UNDEFINED {
-        return nil
-    }
-    result := poolFailureType.String()
-    return &result
+	if poolFailureType == UNDEFINED {
+		return nil
+	}
+	result := poolFailureType.String()
+	return &result
 }
 
 func newPoolFailureTypeFromContent(content []byte, aggErr *AggregateError) *PoolFailureType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(PoolFailureType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(PoolFailureType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type PoolHealth Enum
 
 const (
-    POOL_HEALTH_OK PoolHealth = 1 + iota
-    POOL_HEALTH_DEGRADED PoolHealth = 1 + iota
+	POOL_HEALTH_OK       PoolHealth = 1 + iota
+	POOL_HEALTH_DEGRADED PoolHealth = 1 + iota
 )
 
 func (poolHealth *PoolHealth) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *poolHealth = UNDEFINED
-        case "OK": *poolHealth = POOL_HEALTH_OK
-        case "DEGRADED": *poolHealth = POOL_HEALTH_DEGRADED
-        default:
-            *poolHealth = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into PoolHealth", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*poolHealth = UNDEFINED
+	case "OK":
+		*poolHealth = POOL_HEALTH_OK
+	case "DEGRADED":
+		*poolHealth = POOL_HEALTH_DEGRADED
+	default:
+		*poolHealth = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into PoolHealth", str))
+	}
+	return nil
 }
 
 func (poolHealth PoolHealth) String() string {
-    switch poolHealth {
-        case POOL_HEALTH_OK: return "OK"
-        case POOL_HEALTH_DEGRADED: return "DEGRADED"
-        default:
-            log.Printf("Error: invalid PoolHealth represented by '%d'", poolHealth)
-            return ""
-    }
+	switch poolHealth {
+	case POOL_HEALTH_OK:
+		return "OK"
+	case POOL_HEALTH_DEGRADED:
+		return "DEGRADED"
+	default:
+		log.Printf("Error: invalid PoolHealth represented by '%d'", poolHealth)
+		return ""
+	}
 }
 
 func (poolHealth PoolHealth) StringPtr() *string {
-    if poolHealth == UNDEFINED {
-        return nil
-    }
-    result := poolHealth.String()
-    return &result
+	if poolHealth == UNDEFINED {
+		return nil
+	}
+	result := poolHealth.String()
+	return &result
 }
 
 func newPoolHealthFromContent(content []byte, aggErr *AggregateError) *PoolHealth {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(PoolHealth)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(PoolHealth)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type PoolPartition struct {
-    Id string
-    Name *string
-    Type PoolType
+	Id   string
+	Name *string
+	Type PoolType
 }
 
 func (poolPartition *PoolPartition) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Id":
-            poolPartition.Id = parseString(child.Content)
-        case "Name":
-            poolPartition.Name = parseNullableString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &poolPartition.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolPartition.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Id":
+			poolPartition.Id = parseString(child.Content)
+		case "Name":
+			poolPartition.Name = parseNullableString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &poolPartition.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolPartition.", child.XMLName.Local)
+		}
+	}
 }
 
 type PoolState Enum
 
 const (
-    POOL_STATE_BLANK PoolState = 1 + iota
-    POOL_STATE_NORMAL PoolState = 1 + iota
-    POOL_STATE_LOST PoolState = 1 + iota
-    POOL_STATE_FOREIGN PoolState = 1 + iota
-    POOL_STATE_IMPORT_PENDING PoolState = 1 + iota
-    POOL_STATE_IMPORT_IN_PROGRESS PoolState = 1 + iota
+	POOL_STATE_BLANK              PoolState = 1 + iota
+	POOL_STATE_NORMAL             PoolState = 1 + iota
+	POOL_STATE_LOST               PoolState = 1 + iota
+	POOL_STATE_FOREIGN            PoolState = 1 + iota
+	POOL_STATE_IMPORT_PENDING     PoolState = 1 + iota
+	POOL_STATE_IMPORT_IN_PROGRESS PoolState = 1 + iota
 )
 
 func (poolState *PoolState) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *poolState = UNDEFINED
-        case "BLANK": *poolState = POOL_STATE_BLANK
-        case "NORMAL": *poolState = POOL_STATE_NORMAL
-        case "LOST": *poolState = POOL_STATE_LOST
-        case "FOREIGN": *poolState = POOL_STATE_FOREIGN
-        case "IMPORT_PENDING": *poolState = POOL_STATE_IMPORT_PENDING
-        case "IMPORT_IN_PROGRESS": *poolState = POOL_STATE_IMPORT_IN_PROGRESS
-        default:
-            *poolState = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into PoolState", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*poolState = UNDEFINED
+	case "BLANK":
+		*poolState = POOL_STATE_BLANK
+	case "NORMAL":
+		*poolState = POOL_STATE_NORMAL
+	case "LOST":
+		*poolState = POOL_STATE_LOST
+	case "FOREIGN":
+		*poolState = POOL_STATE_FOREIGN
+	case "IMPORT_PENDING":
+		*poolState = POOL_STATE_IMPORT_PENDING
+	case "IMPORT_IN_PROGRESS":
+		*poolState = POOL_STATE_IMPORT_IN_PROGRESS
+	default:
+		*poolState = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into PoolState", str))
+	}
+	return nil
 }
 
 func (poolState PoolState) String() string {
-    switch poolState {
-        case POOL_STATE_BLANK: return "BLANK"
-        case POOL_STATE_NORMAL: return "NORMAL"
-        case POOL_STATE_LOST: return "LOST"
-        case POOL_STATE_FOREIGN: return "FOREIGN"
-        case POOL_STATE_IMPORT_PENDING: return "IMPORT_PENDING"
-        case POOL_STATE_IMPORT_IN_PROGRESS: return "IMPORT_IN_PROGRESS"
-        default:
-            log.Printf("Error: invalid PoolState represented by '%d'", poolState)
-            return ""
-    }
+	switch poolState {
+	case POOL_STATE_BLANK:
+		return "BLANK"
+	case POOL_STATE_NORMAL:
+		return "NORMAL"
+	case POOL_STATE_LOST:
+		return "LOST"
+	case POOL_STATE_FOREIGN:
+		return "FOREIGN"
+	case POOL_STATE_IMPORT_PENDING:
+		return "IMPORT_PENDING"
+	case POOL_STATE_IMPORT_IN_PROGRESS:
+		return "IMPORT_IN_PROGRESS"
+	default:
+		log.Printf("Error: invalid PoolState represented by '%d'", poolState)
+		return ""
+	}
 }
 
 func (poolState PoolState) StringPtr() *string {
-    if poolState == UNDEFINED {
-        return nil
-    }
-    result := poolState.String()
-    return &result
+	if poolState == UNDEFINED {
+		return nil
+	}
+	result := poolState.String()
+	return &result
 }
 
 func newPoolStateFromContent(content []byte, aggErr *AggregateError) *PoolState {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(PoolState)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(PoolState)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type PoolType Enum
 
 const (
-    POOL_TYPE_NEARLINE PoolType = 1 + iota
-    POOL_TYPE_ONLINE PoolType = 1 + iota
+	POOL_TYPE_NEARLINE PoolType = 1 + iota
+	POOL_TYPE_ONLINE   PoolType = 1 + iota
 )
 
 func (poolType *PoolType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *poolType = UNDEFINED
-        case "NEARLINE": *poolType = POOL_TYPE_NEARLINE
-        case "ONLINE": *poolType = POOL_TYPE_ONLINE
-        default:
-            *poolType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into PoolType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*poolType = UNDEFINED
+	case "NEARLINE":
+		*poolType = POOL_TYPE_NEARLINE
+	case "ONLINE":
+		*poolType = POOL_TYPE_ONLINE
+	default:
+		*poolType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into PoolType", str))
+	}
+	return nil
 }
 
 func (poolType PoolType) String() string {
-    switch poolType {
-        case POOL_TYPE_NEARLINE: return "NEARLINE"
-        case POOL_TYPE_ONLINE: return "ONLINE"
-        default:
-            log.Printf("Error: invalid PoolType represented by '%d'", poolType)
-            return ""
-    }
+	switch poolType {
+	case POOL_TYPE_NEARLINE:
+		return "NEARLINE"
+	case POOL_TYPE_ONLINE:
+		return "ONLINE"
+	default:
+		log.Printf("Error: invalid PoolType represented by '%d'", poolType)
+		return ""
+	}
 }
 
 func (poolType PoolType) StringPtr() *string {
-    if poolType == UNDEFINED {
-        return nil
-    }
-    result := poolType.String()
-    return &result
+	if poolType == UNDEFINED {
+		return nil
+	}
+	result := poolType.String()
+	return &result
 }
 
 func newPoolTypeFromContent(content []byte, aggErr *AggregateError) *PoolType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(PoolType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(PoolType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type SuspectBlobPool struct {
-    BlobId string
-    BucketId string
-    DateWritten string
-    Id string
-    LastAccessed string
-    PoolId string
+	BlobId       string
+	BucketId     string
+	DateWritten  string
+	Id           string
+	LastAccessed string
+	PoolId       string
 }
 
 func (suspectBlobPool *SuspectBlobPool) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BlobId":
-            suspectBlobPool.BlobId = parseString(child.Content)
-        case "BucketId":
-            suspectBlobPool.BucketId = parseString(child.Content)
-        case "DateWritten":
-            suspectBlobPool.DateWritten = parseString(child.Content)
-        case "Id":
-            suspectBlobPool.Id = parseString(child.Content)
-        case "LastAccessed":
-            suspectBlobPool.LastAccessed = parseString(child.Content)
-        case "PoolId":
-            suspectBlobPool.PoolId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobPool.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BlobId":
+			suspectBlobPool.BlobId = parseString(child.Content)
+		case "BucketId":
+			suspectBlobPool.BucketId = parseString(child.Content)
+		case "DateWritten":
+			suspectBlobPool.DateWritten = parseString(child.Content)
+		case "Id":
+			suspectBlobPool.Id = parseString(child.Content)
+		case "LastAccessed":
+			suspectBlobPool.LastAccessed = parseString(child.Content)
+		case "PoolId":
+			suspectBlobPool.PoolId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobPool.", child.XMLName.Local)
+		}
+	}
 }
 
 type Quiesced Enum
 
 const (
-    QUIESCED_NO Quiesced = 1 + iota
-    QUIESCED_PENDING Quiesced = 1 + iota
-    QUIESCED_YES Quiesced = 1 + iota
+	QUIESCED_NO      Quiesced = 1 + iota
+	QUIESCED_PENDING Quiesced = 1 + iota
+	QUIESCED_YES     Quiesced = 1 + iota
 )
 
 func (quiesced *Quiesced) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *quiesced = UNDEFINED
-        case "NO": *quiesced = QUIESCED_NO
-        case "PENDING": *quiesced = QUIESCED_PENDING
-        case "YES": *quiesced = QUIESCED_YES
-        default:
-            *quiesced = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into Quiesced", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*quiesced = UNDEFINED
+	case "NO":
+		*quiesced = QUIESCED_NO
+	case "PENDING":
+		*quiesced = QUIESCED_PENDING
+	case "YES":
+		*quiesced = QUIESCED_YES
+	default:
+		*quiesced = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into Quiesced", str))
+	}
+	return nil
 }
 
 func (quiesced Quiesced) String() string {
-    switch quiesced {
-        case QUIESCED_NO: return "NO"
-        case QUIESCED_PENDING: return "PENDING"
-        case QUIESCED_YES: return "YES"
-        default:
-            log.Printf("Error: invalid Quiesced represented by '%d'", quiesced)
-            return ""
-    }
+	switch quiesced {
+	case QUIESCED_NO:
+		return "NO"
+	case QUIESCED_PENDING:
+		return "PENDING"
+	case QUIESCED_YES:
+		return "YES"
+	default:
+		log.Printf("Error: invalid Quiesced represented by '%d'", quiesced)
+		return ""
+	}
 }
 
 func (quiesced Quiesced) StringPtr() *string {
-    if quiesced == UNDEFINED {
-        return nil
-    }
-    result := quiesced.String()
-    return &result
+	if quiesced == UNDEFINED {
+		return nil
+	}
+	result := quiesced.String()
+	return &result
 }
 
 func newQuiescedFromContent(content []byte, aggErr *AggregateError) *Quiesced {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(Quiesced)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(Quiesced)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type ReservedTaskType Enum
 
 const (
-    RESERVED_TASK_TYPE_ANY ReservedTaskType = 1 + iota
-    RESERVED_TASK_TYPE_MAINTENANCE ReservedTaskType = 1 + iota
-    RESERVED_TASK_TYPE_READ ReservedTaskType = 1 + iota
-    RESERVED_TASK_TYPE_WRITE ReservedTaskType = 1 + iota
+	RESERVED_TASK_TYPE_ANY         ReservedTaskType = 1 + iota
+	RESERVED_TASK_TYPE_MAINTENANCE ReservedTaskType = 1 + iota
+	RESERVED_TASK_TYPE_READ        ReservedTaskType = 1 + iota
+	RESERVED_TASK_TYPE_WRITE       ReservedTaskType = 1 + iota
 )
 
 func (reservedTaskType *ReservedTaskType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *reservedTaskType = UNDEFINED
-        case "ANY": *reservedTaskType = RESERVED_TASK_TYPE_ANY
-        case "MAINTENANCE": *reservedTaskType = RESERVED_TASK_TYPE_MAINTENANCE
-        case "READ": *reservedTaskType = RESERVED_TASK_TYPE_READ
-        case "WRITE": *reservedTaskType = RESERVED_TASK_TYPE_WRITE
-        default:
-            *reservedTaskType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into ReservedTaskType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*reservedTaskType = UNDEFINED
+	case "ANY":
+		*reservedTaskType = RESERVED_TASK_TYPE_ANY
+	case "MAINTENANCE":
+		*reservedTaskType = RESERVED_TASK_TYPE_MAINTENANCE
+	case "READ":
+		*reservedTaskType = RESERVED_TASK_TYPE_READ
+	case "WRITE":
+		*reservedTaskType = RESERVED_TASK_TYPE_WRITE
+	default:
+		*reservedTaskType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into ReservedTaskType", str))
+	}
+	return nil
 }
 
 func (reservedTaskType ReservedTaskType) String() string {
-    switch reservedTaskType {
-        case RESERVED_TASK_TYPE_ANY: return "ANY"
-        case RESERVED_TASK_TYPE_MAINTENANCE: return "MAINTENANCE"
-        case RESERVED_TASK_TYPE_READ: return "READ"
-        case RESERVED_TASK_TYPE_WRITE: return "WRITE"
-        default:
-            log.Printf("Error: invalid ReservedTaskType represented by '%d'", reservedTaskType)
-            return ""
-    }
+	switch reservedTaskType {
+	case RESERVED_TASK_TYPE_ANY:
+		return "ANY"
+	case RESERVED_TASK_TYPE_MAINTENANCE:
+		return "MAINTENANCE"
+	case RESERVED_TASK_TYPE_READ:
+		return "READ"
+	case RESERVED_TASK_TYPE_WRITE:
+		return "WRITE"
+	default:
+		log.Printf("Error: invalid ReservedTaskType represented by '%d'", reservedTaskType)
+		return ""
+	}
 }
 
 func (reservedTaskType ReservedTaskType) StringPtr() *string {
-    if reservedTaskType == UNDEFINED {
-        return nil
-    }
-    result := reservedTaskType.String()
-    return &result
+	if reservedTaskType == UNDEFINED {
+		return nil
+	}
+	result := reservedTaskType.String()
+	return &result
 }
 
 func newReservedTaskTypeFromContent(content []byte, aggErr *AggregateError) *ReservedTaskType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(ReservedTaskType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(ReservedTaskType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type ImportExportConfiguration Enum
 
 const (
-    IMPORT_EXPORT_CONFIGURATION_SUPPORTED ImportExportConfiguration = 1 + iota
-    IMPORT_EXPORT_CONFIGURATION_NOT_SUPPORTED ImportExportConfiguration = 1 + iota
+	IMPORT_EXPORT_CONFIGURATION_SUPPORTED     ImportExportConfiguration = 1 + iota
+	IMPORT_EXPORT_CONFIGURATION_NOT_SUPPORTED ImportExportConfiguration = 1 + iota
 )
 
 func (importExportConfiguration *ImportExportConfiguration) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *importExportConfiguration = UNDEFINED
-        case "SUPPORTED": *importExportConfiguration = IMPORT_EXPORT_CONFIGURATION_SUPPORTED
-        case "NOT_SUPPORTED": *importExportConfiguration = IMPORT_EXPORT_CONFIGURATION_NOT_SUPPORTED
-        default:
-            *importExportConfiguration = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into ImportExportConfiguration", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*importExportConfiguration = UNDEFINED
+	case "SUPPORTED":
+		*importExportConfiguration = IMPORT_EXPORT_CONFIGURATION_SUPPORTED
+	case "NOT_SUPPORTED":
+		*importExportConfiguration = IMPORT_EXPORT_CONFIGURATION_NOT_SUPPORTED
+	default:
+		*importExportConfiguration = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into ImportExportConfiguration", str))
+	}
+	return nil
 }
 
 func (importExportConfiguration ImportExportConfiguration) String() string {
-    switch importExportConfiguration {
-        case IMPORT_EXPORT_CONFIGURATION_SUPPORTED: return "SUPPORTED"
-        case IMPORT_EXPORT_CONFIGURATION_NOT_SUPPORTED: return "NOT_SUPPORTED"
-        default:
-            log.Printf("Error: invalid ImportExportConfiguration represented by '%d'", importExportConfiguration)
-            return ""
-    }
+	switch importExportConfiguration {
+	case IMPORT_EXPORT_CONFIGURATION_SUPPORTED:
+		return "SUPPORTED"
+	case IMPORT_EXPORT_CONFIGURATION_NOT_SUPPORTED:
+		return "NOT_SUPPORTED"
+	default:
+		log.Printf("Error: invalid ImportExportConfiguration represented by '%d'", importExportConfiguration)
+		return ""
+	}
 }
 
 func (importExportConfiguration ImportExportConfiguration) StringPtr() *string {
-    if importExportConfiguration == UNDEFINED {
-        return nil
-    }
-    result := importExportConfiguration.String()
-    return &result
+	if importExportConfiguration == UNDEFINED {
+		return nil
+	}
+	result := importExportConfiguration.String()
+	return &result
 }
 
 func newImportExportConfigurationFromContent(content []byte, aggErr *AggregateError) *ImportExportConfiguration {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(ImportExportConfiguration)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(ImportExportConfiguration)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type SuspectBlobTape struct {
-    BlobId string
-    Id string
-    OrderIndex int
-    TapeId string
+	BlobId     string
+	Id         string
+	OrderIndex int
+	TapeId     string
 }
 
 func (suspectBlobTape *SuspectBlobTape) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BlobId":
-            suspectBlobTape.BlobId = parseString(child.Content)
-        case "Id":
-            suspectBlobTape.Id = parseString(child.Content)
-        case "OrderIndex":
-            suspectBlobTape.OrderIndex = parseInt(child.Content, aggErr)
-        case "TapeId":
-            suspectBlobTape.TapeId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobTape.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BlobId":
+			suspectBlobTape.BlobId = parseString(child.Content)
+		case "Id":
+			suspectBlobTape.Id = parseString(child.Content)
+		case "OrderIndex":
+			suspectBlobTape.OrderIndex = parseInt(child.Content, aggErr)
+		case "TapeId":
+			suspectBlobTape.TapeId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobTape.", child.XMLName.Local)
+		}
+	}
 }
 
 type Tape struct {
-    AssignedToStorageDomain bool
-    AvailableRawCapacity *int64
-    BarCode *string
-    BucketId *string
-    DescriptionForIdentification *string
-    EjectDate *string
-    EjectLabel *string
-    EjectLocation *string
-    EjectPending *string
-    FullOfData bool
-    Id string
-    LastAccessed *string
-    LastCheckpoint *string
-    LastModified *string
-    LastVerified *string
-    PartiallyVerifiedEndOfTape *string
-    PartitionId *string
-    PreviousState *TapeState
-    Role TapeRole
-    SerialNumber *string
-    State TapeState
-    StorageDomainMemberId *string
-    TakeOwnershipPending bool
-    TotalRawCapacity *int64
-    Type string
-    VerifyPending *Priority
-    WriteProtected bool
+	AssignedToStorageDomain      bool
+	AvailableRawCapacity         *int64
+	BarCode                      *string
+	BucketId                     *string
+	DescriptionForIdentification *string
+	EjectDate                    *string
+	EjectLabel                   *string
+	EjectLocation                *string
+	EjectPending                 *string
+	FullOfData                   bool
+	Id                           string
+	LastAccessed                 *string
+	LastCheckpoint               *string
+	LastModified                 *string
+	LastVerified                 *string
+	PartiallyVerifiedEndOfTape   *string
+	PartitionId                  *string
+	PreviousState                *TapeState
+	Role                         TapeRole
+	SerialNumber                 *string
+	State                        TapeState
+	StorageDomainMemberId        *string
+	TakeOwnershipPending         bool
+	TotalRawCapacity             *int64
+	Type                         string
+	VerifyPending                *Priority
+	WriteProtected               bool
 }
 
 func (tape *Tape) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AssignedToStorageDomain":
-            tape.AssignedToStorageDomain = parseBool(child.Content, aggErr)
-        case "AvailableRawCapacity":
-            tape.AvailableRawCapacity = parseNullableInt64(child.Content, aggErr)
-        case "BarCode":
-            tape.BarCode = parseNullableString(child.Content)
-        case "BucketId":
-            tape.BucketId = parseNullableString(child.Content)
-        case "DescriptionForIdentification":
-            tape.DescriptionForIdentification = parseNullableString(child.Content)
-        case "EjectDate":
-            tape.EjectDate = parseNullableString(child.Content)
-        case "EjectLabel":
-            tape.EjectLabel = parseNullableString(child.Content)
-        case "EjectLocation":
-            tape.EjectLocation = parseNullableString(child.Content)
-        case "EjectPending":
-            tape.EjectPending = parseNullableString(child.Content)
-        case "FullOfData":
-            tape.FullOfData = parseBool(child.Content, aggErr)
-        case "Id":
-            tape.Id = parseString(child.Content)
-        case "LastAccessed":
-            tape.LastAccessed = parseNullableString(child.Content)
-        case "LastCheckpoint":
-            tape.LastCheckpoint = parseNullableString(child.Content)
-        case "LastModified":
-            tape.LastModified = parseNullableString(child.Content)
-        case "LastVerified":
-            tape.LastVerified = parseNullableString(child.Content)
-        case "PartiallyVerifiedEndOfTape":
-            tape.PartiallyVerifiedEndOfTape = parseNullableString(child.Content)
-        case "PartitionId":
-            tape.PartitionId = parseNullableString(child.Content)
-        case "PreviousState":
-            tape.PreviousState = newTapeStateFromContent(child.Content, aggErr)
-        case "Role":
-            parseEnum(child.Content, &tape.Role, aggErr)
-        case "SerialNumber":
-            tape.SerialNumber = parseNullableString(child.Content)
-        case "State":
-            parseEnum(child.Content, &tape.State, aggErr)
-        case "StorageDomainMemberId":
-            tape.StorageDomainMemberId = parseNullableString(child.Content)
-        case "TakeOwnershipPending":
-            tape.TakeOwnershipPending = parseBool(child.Content, aggErr)
-        case "TotalRawCapacity":
-            tape.TotalRawCapacity = parseNullableInt64(child.Content, aggErr)
-        case "Type":
-            tape.Type = parseString(child.Content)
-        case "VerifyPending":
-            tape.VerifyPending = newPriorityFromContent(child.Content, aggErr)
-        case "WriteProtected":
-            tape.WriteProtected = parseBool(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Tape.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AssignedToStorageDomain":
+			tape.AssignedToStorageDomain = parseBool(child.Content, aggErr)
+		case "AvailableRawCapacity":
+			tape.AvailableRawCapacity = parseNullableInt64(child.Content, aggErr)
+		case "BarCode":
+			tape.BarCode = parseNullableString(child.Content)
+		case "BucketId":
+			tape.BucketId = parseNullableString(child.Content)
+		case "DescriptionForIdentification":
+			tape.DescriptionForIdentification = parseNullableString(child.Content)
+		case "EjectDate":
+			tape.EjectDate = parseNullableString(child.Content)
+		case "EjectLabel":
+			tape.EjectLabel = parseNullableString(child.Content)
+		case "EjectLocation":
+			tape.EjectLocation = parseNullableString(child.Content)
+		case "EjectPending":
+			tape.EjectPending = parseNullableString(child.Content)
+		case "FullOfData":
+			tape.FullOfData = parseBool(child.Content, aggErr)
+		case "Id":
+			tape.Id = parseString(child.Content)
+		case "LastAccessed":
+			tape.LastAccessed = parseNullableString(child.Content)
+		case "LastCheckpoint":
+			tape.LastCheckpoint = parseNullableString(child.Content)
+		case "LastModified":
+			tape.LastModified = parseNullableString(child.Content)
+		case "LastVerified":
+			tape.LastVerified = parseNullableString(child.Content)
+		case "PartiallyVerifiedEndOfTape":
+			tape.PartiallyVerifiedEndOfTape = parseNullableString(child.Content)
+		case "PartitionId":
+			tape.PartitionId = parseNullableString(child.Content)
+		case "PreviousState":
+			tape.PreviousState = newTapeStateFromContent(child.Content, aggErr)
+		case "Role":
+			parseEnum(child.Content, &tape.Role, aggErr)
+		case "SerialNumber":
+			tape.SerialNumber = parseNullableString(child.Content)
+		case "State":
+			parseEnum(child.Content, &tape.State, aggErr)
+		case "StorageDomainMemberId":
+			tape.StorageDomainMemberId = parseNullableString(child.Content)
+		case "TakeOwnershipPending":
+			tape.TakeOwnershipPending = parseBool(child.Content, aggErr)
+		case "TotalRawCapacity":
+			tape.TotalRawCapacity = parseNullableInt64(child.Content, aggErr)
+		case "Type":
+			tape.Type = parseString(child.Content)
+		case "VerifyPending":
+			tape.VerifyPending = newPriorityFromContent(child.Content, aggErr)
+		case "WriteProtected":
+			tape.WriteProtected = parseBool(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Tape.", child.XMLName.Local)
+		}
+	}
 }
 
-
 func parseTapeSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []Tape {
-    var result []Tape
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult Tape
-            curResult.parse(&curXmlNode, aggErr)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing Tape struct.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []Tape
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult Tape
+			curResult.parse(&curXmlNode, aggErr)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing Tape struct.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }
 
 type TapeDensityDirective struct {
-    Density TapeDriveType
-    Id string
-    PartitionId string
-    TapeType string
+	Density     TapeDriveType
+	Id          string
+	PartitionId string
+	TapeType    string
 }
 
 func (tapeDensityDirective *TapeDensityDirective) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Density":
-            parseEnum(child.Content, &tapeDensityDirective.Density, aggErr)
-        case "Id":
-            tapeDensityDirective.Id = parseString(child.Content)
-        case "PartitionId":
-            tapeDensityDirective.PartitionId = parseString(child.Content)
-        case "TapeType":
-            tapeDensityDirective.TapeType = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeDensityDirective.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Density":
+			parseEnum(child.Content, &tapeDensityDirective.Density, aggErr)
+		case "Id":
+			tapeDensityDirective.Id = parseString(child.Content)
+		case "PartitionId":
+			tapeDensityDirective.PartitionId = parseString(child.Content)
+		case "TapeType":
+			tapeDensityDirective.TapeType = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeDensityDirective.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeDrive struct {
-    CleaningRequired bool
-    ErrorMessage *string
-    ForceTapeRemoval bool
-    Id string
-    LastCleaned *string
-    MaxFailedTapes *int
-    MfgSerialNumber *string
-    MinimumTaskPriority *Priority
-    PartitionId string
-    Quiesced Quiesced
-    ReservedTaskType ReservedTaskType
-    SerialNumber *string
-    State TapeDriveState
-    TapeId *string
-    Type TapeDriveType
+	CleaningRequired    bool
+	ErrorMessage        *string
+	ForceTapeRemoval    bool
+	Id                  string
+	LastCleaned         *string
+	MaxFailedTapes      *int
+	MfgSerialNumber     *string
+	MinimumTaskPriority *Priority
+	PartitionId         string
+	Quiesced            Quiesced
+	ReservedTaskType    ReservedTaskType
+	SerialNumber        *string
+	State               TapeDriveState
+	TapeId              *string
+	Type                TapeDriveType
 }
 
 func (tapeDrive *TapeDrive) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CleaningRequired":
-            tapeDrive.CleaningRequired = parseBool(child.Content, aggErr)
-        case "ErrorMessage":
-            tapeDrive.ErrorMessage = parseNullableString(child.Content)
-        case "ForceTapeRemoval":
-            tapeDrive.ForceTapeRemoval = parseBool(child.Content, aggErr)
-        case "Id":
-            tapeDrive.Id = parseString(child.Content)
-        case "LastCleaned":
-            tapeDrive.LastCleaned = parseNullableString(child.Content)
-        case "MaxFailedTapes":
-            tapeDrive.MaxFailedTapes = parseNullableInt(child.Content, aggErr)
-        case "MfgSerialNumber":
-            tapeDrive.MfgSerialNumber = parseNullableString(child.Content)
-        case "MinimumTaskPriority":
-            tapeDrive.MinimumTaskPriority = newPriorityFromContent(child.Content, aggErr)
-        case "PartitionId":
-            tapeDrive.PartitionId = parseString(child.Content)
-        case "Quiesced":
-            parseEnum(child.Content, &tapeDrive.Quiesced, aggErr)
-        case "ReservedTaskType":
-            parseEnum(child.Content, &tapeDrive.ReservedTaskType, aggErr)
-        case "SerialNumber":
-            tapeDrive.SerialNumber = parseNullableString(child.Content)
-        case "State":
-            parseEnum(child.Content, &tapeDrive.State, aggErr)
-        case "TapeId":
-            tapeDrive.TapeId = parseNullableString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &tapeDrive.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeDrive.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CleaningRequired":
+			tapeDrive.CleaningRequired = parseBool(child.Content, aggErr)
+		case "ErrorMessage":
+			tapeDrive.ErrorMessage = parseNullableString(child.Content)
+		case "ForceTapeRemoval":
+			tapeDrive.ForceTapeRemoval = parseBool(child.Content, aggErr)
+		case "Id":
+			tapeDrive.Id = parseString(child.Content)
+		case "LastCleaned":
+			tapeDrive.LastCleaned = parseNullableString(child.Content)
+		case "MaxFailedTapes":
+			tapeDrive.MaxFailedTapes = parseNullableInt(child.Content, aggErr)
+		case "MfgSerialNumber":
+			tapeDrive.MfgSerialNumber = parseNullableString(child.Content)
+		case "MinimumTaskPriority":
+			tapeDrive.MinimumTaskPriority = newPriorityFromContent(child.Content, aggErr)
+		case "PartitionId":
+			tapeDrive.PartitionId = parseString(child.Content)
+		case "Quiesced":
+			parseEnum(child.Content, &tapeDrive.Quiesced, aggErr)
+		case "ReservedTaskType":
+			parseEnum(child.Content, &tapeDrive.ReservedTaskType, aggErr)
+		case "SerialNumber":
+			tapeDrive.SerialNumber = parseNullableString(child.Content)
+		case "State":
+			parseEnum(child.Content, &tapeDrive.State, aggErr)
+		case "TapeId":
+			tapeDrive.TapeId = parseNullableString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &tapeDrive.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeDrive.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeDriveState Enum
 
 const (
-    TAPE_DRIVE_STATE_OFFLINE TapeDriveState = 1 + iota
-    TAPE_DRIVE_STATE_NORMAL TapeDriveState = 1 + iota
-    TAPE_DRIVE_STATE_ERROR TapeDriveState = 1 + iota
-    TAPE_DRIVE_STATE_NOT_COMPATIBLE_IN_PARTITION_DUE_TO_NEWER_TAPE_DRIVES TapeDriveState = 1 + iota
+	TAPE_DRIVE_STATE_OFFLINE                                              TapeDriveState = 1 + iota
+	TAPE_DRIVE_STATE_NORMAL                                               TapeDriveState = 1 + iota
+	TAPE_DRIVE_STATE_ERROR                                                TapeDriveState = 1 + iota
+	TAPE_DRIVE_STATE_NOT_COMPATIBLE_IN_PARTITION_DUE_TO_NEWER_TAPE_DRIVES TapeDriveState = 1 + iota
 )
 
 func (tapeDriveState *TapeDriveState) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *tapeDriveState = UNDEFINED
-        case "OFFLINE": *tapeDriveState = TAPE_DRIVE_STATE_OFFLINE
-        case "NORMAL": *tapeDriveState = TAPE_DRIVE_STATE_NORMAL
-        case "ERROR": *tapeDriveState = TAPE_DRIVE_STATE_ERROR
-        case "NOT_COMPATIBLE_IN_PARTITION_DUE_TO_NEWER_TAPE_DRIVES": *tapeDriveState = TAPE_DRIVE_STATE_NOT_COMPATIBLE_IN_PARTITION_DUE_TO_NEWER_TAPE_DRIVES
-        default:
-            *tapeDriveState = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapeDriveState", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*tapeDriveState = UNDEFINED
+	case "OFFLINE":
+		*tapeDriveState = TAPE_DRIVE_STATE_OFFLINE
+	case "NORMAL":
+		*tapeDriveState = TAPE_DRIVE_STATE_NORMAL
+	case "ERROR":
+		*tapeDriveState = TAPE_DRIVE_STATE_ERROR
+	case "NOT_COMPATIBLE_IN_PARTITION_DUE_TO_NEWER_TAPE_DRIVES":
+		*tapeDriveState = TAPE_DRIVE_STATE_NOT_COMPATIBLE_IN_PARTITION_DUE_TO_NEWER_TAPE_DRIVES
+	default:
+		*tapeDriveState = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapeDriveState", str))
+	}
+	return nil
 }
 
 func (tapeDriveState TapeDriveState) String() string {
-    switch tapeDriveState {
-        case TAPE_DRIVE_STATE_OFFLINE: return "OFFLINE"
-        case TAPE_DRIVE_STATE_NORMAL: return "NORMAL"
-        case TAPE_DRIVE_STATE_ERROR: return "ERROR"
-        case TAPE_DRIVE_STATE_NOT_COMPATIBLE_IN_PARTITION_DUE_TO_NEWER_TAPE_DRIVES: return "NOT_COMPATIBLE_IN_PARTITION_DUE_TO_NEWER_TAPE_DRIVES"
-        default:
-            log.Printf("Error: invalid TapeDriveState represented by '%d'", tapeDriveState)
-            return ""
-    }
+	switch tapeDriveState {
+	case TAPE_DRIVE_STATE_OFFLINE:
+		return "OFFLINE"
+	case TAPE_DRIVE_STATE_NORMAL:
+		return "NORMAL"
+	case TAPE_DRIVE_STATE_ERROR:
+		return "ERROR"
+	case TAPE_DRIVE_STATE_NOT_COMPATIBLE_IN_PARTITION_DUE_TO_NEWER_TAPE_DRIVES:
+		return "NOT_COMPATIBLE_IN_PARTITION_DUE_TO_NEWER_TAPE_DRIVES"
+	default:
+		log.Printf("Error: invalid TapeDriveState represented by '%d'", tapeDriveState)
+		return ""
+	}
 }
 
 func (tapeDriveState TapeDriveState) StringPtr() *string {
-    if tapeDriveState == UNDEFINED {
-        return nil
-    }
-    result := tapeDriveState.String()
-    return &result
+	if tapeDriveState == UNDEFINED {
+		return nil
+	}
+	result := tapeDriveState.String()
+	return &result
 }
 
 func newTapeDriveStateFromContent(content []byte, aggErr *AggregateError) *TapeDriveState {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(TapeDriveState)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(TapeDriveState)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type TapeDriveType Enum
 
 const (
-    TAPE_DRIVE_TYPE_UNKNOWN TapeDriveType = 1 + iota
-    TAPE_DRIVE_TYPE_LTO5 TapeDriveType = 1 + iota
-    TAPE_DRIVE_TYPE_LTO6 TapeDriveType = 1 + iota
-    TAPE_DRIVE_TYPE_LTO7 TapeDriveType = 1 + iota
-    TAPE_DRIVE_TYPE_LTO8 TapeDriveType = 1 + iota
-    TAPE_DRIVE_TYPE_LTO9 TapeDriveType = 1 + iota
-    TAPE_DRIVE_TYPE_LTO10 TapeDriveType = 1 + iota
-    TAPE_DRIVE_TYPE_TS1140 TapeDriveType = 1 + iota
-    TAPE_DRIVE_TYPE_TS1150 TapeDriveType = 1 + iota
-    TAPE_DRIVE_TYPE_TS1155 TapeDriveType = 1 + iota
-    TAPE_DRIVE_TYPE_TS1160 TapeDriveType = 1 + iota
-    TAPE_DRIVE_TYPE_TS1170 TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_UNKNOWN TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_LTO5    TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_LTO6    TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_LTO7    TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_LTO8    TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_LTO9    TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_LTO10   TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_TS1140  TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_TS1150  TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_TS1155  TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_TS1160  TapeDriveType = 1 + iota
+	TAPE_DRIVE_TYPE_TS1170  TapeDriveType = 1 + iota
 )
 
 func (tapeDriveType *TapeDriveType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *tapeDriveType = UNDEFINED
-        case "UNKNOWN": *tapeDriveType = TAPE_DRIVE_TYPE_UNKNOWN
-        case "LTO5": *tapeDriveType = TAPE_DRIVE_TYPE_LTO5
-        case "LTO6": *tapeDriveType = TAPE_DRIVE_TYPE_LTO6
-        case "LTO7": *tapeDriveType = TAPE_DRIVE_TYPE_LTO7
-        case "LTO8": *tapeDriveType = TAPE_DRIVE_TYPE_LTO8
-        case "LTO9": *tapeDriveType = TAPE_DRIVE_TYPE_LTO9
-        case "LTO10": *tapeDriveType = TAPE_DRIVE_TYPE_LTO10
-        case "TS1140": *tapeDriveType = TAPE_DRIVE_TYPE_TS1140
-        case "TS1150": *tapeDriveType = TAPE_DRIVE_TYPE_TS1150
-        case "TS1155": *tapeDriveType = TAPE_DRIVE_TYPE_TS1155
-        case "TS1160": *tapeDriveType = TAPE_DRIVE_TYPE_TS1160
-        case "TS1170": *tapeDriveType = TAPE_DRIVE_TYPE_TS1170
-        default:
-            *tapeDriveType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapeDriveType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*tapeDriveType = UNDEFINED
+	case "UNKNOWN":
+		*tapeDriveType = TAPE_DRIVE_TYPE_UNKNOWN
+	case "LTO5":
+		*tapeDriveType = TAPE_DRIVE_TYPE_LTO5
+	case "LTO6":
+		*tapeDriveType = TAPE_DRIVE_TYPE_LTO6
+	case "LTO7":
+		*tapeDriveType = TAPE_DRIVE_TYPE_LTO7
+	case "LTO8":
+		*tapeDriveType = TAPE_DRIVE_TYPE_LTO8
+	case "LTO9":
+		*tapeDriveType = TAPE_DRIVE_TYPE_LTO9
+	case "LTO10":
+		*tapeDriveType = TAPE_DRIVE_TYPE_LTO10
+	case "TS1140":
+		*tapeDriveType = TAPE_DRIVE_TYPE_TS1140
+	case "TS1150":
+		*tapeDriveType = TAPE_DRIVE_TYPE_TS1150
+	case "TS1155":
+		*tapeDriveType = TAPE_DRIVE_TYPE_TS1155
+	case "TS1160":
+		*tapeDriveType = TAPE_DRIVE_TYPE_TS1160
+	case "TS1170":
+		*tapeDriveType = TAPE_DRIVE_TYPE_TS1170
+	default:
+		*tapeDriveType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapeDriveType", str))
+	}
+	return nil
 }
 
 func (tapeDriveType TapeDriveType) String() string {
-    switch tapeDriveType {
-        case TAPE_DRIVE_TYPE_UNKNOWN: return "UNKNOWN"
-        case TAPE_DRIVE_TYPE_LTO5: return "LTO5"
-        case TAPE_DRIVE_TYPE_LTO6: return "LTO6"
-        case TAPE_DRIVE_TYPE_LTO7: return "LTO7"
-        case TAPE_DRIVE_TYPE_LTO8: return "LTO8"
-        case TAPE_DRIVE_TYPE_LTO9: return "LTO9"
-        case TAPE_DRIVE_TYPE_LTO10: return "LTO10"
-        case TAPE_DRIVE_TYPE_TS1140: return "TS1140"
-        case TAPE_DRIVE_TYPE_TS1150: return "TS1150"
-        case TAPE_DRIVE_TYPE_TS1155: return "TS1155"
-        case TAPE_DRIVE_TYPE_TS1160: return "TS1160"
-        case TAPE_DRIVE_TYPE_TS1170: return "TS1170"
-        default:
-            log.Printf("Error: invalid TapeDriveType represented by '%d'", tapeDriveType)
-            return ""
-    }
+	switch tapeDriveType {
+	case TAPE_DRIVE_TYPE_UNKNOWN:
+		return "UNKNOWN"
+	case TAPE_DRIVE_TYPE_LTO5:
+		return "LTO5"
+	case TAPE_DRIVE_TYPE_LTO6:
+		return "LTO6"
+	case TAPE_DRIVE_TYPE_LTO7:
+		return "LTO7"
+	case TAPE_DRIVE_TYPE_LTO8:
+		return "LTO8"
+	case TAPE_DRIVE_TYPE_LTO9:
+		return "LTO9"
+	case TAPE_DRIVE_TYPE_LTO10:
+		return "LTO10"
+	case TAPE_DRIVE_TYPE_TS1140:
+		return "TS1140"
+	case TAPE_DRIVE_TYPE_TS1150:
+		return "TS1150"
+	case TAPE_DRIVE_TYPE_TS1155:
+		return "TS1155"
+	case TAPE_DRIVE_TYPE_TS1160:
+		return "TS1160"
+	case TAPE_DRIVE_TYPE_TS1170:
+		return "TS1170"
+	default:
+		log.Printf("Error: invalid TapeDriveType represented by '%d'", tapeDriveType)
+		return ""
+	}
 }
 
 func (tapeDriveType TapeDriveType) StringPtr() *string {
-    if tapeDriveType == UNDEFINED {
-        return nil
-    }
-    result := tapeDriveType.String()
-    return &result
+	if tapeDriveType == UNDEFINED {
+		return nil
+	}
+	result := tapeDriveType.String()
+	return &result
 }
 
 func newTapeDriveTypeFromContent(content []byte, aggErr *AggregateError) *TapeDriveType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(TapeDriveType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(TapeDriveType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type DetailedTapeFailure struct {
-    Date string
-    ErrorMessage *string
-    Id string
-    TapeDriveId string
-    TapeId string
-    Type TapeFailureType
+	Date         string
+	ErrorMessage *string
+	Id           string
+	TapeDriveId  string
+	TapeId       string
+	Type         TapeFailureType
 }
 
 func (detailedTapeFailure *DetailedTapeFailure) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Date":
-            detailedTapeFailure.Date = parseString(child.Content)
-        case "ErrorMessage":
-            detailedTapeFailure.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            detailedTapeFailure.Id = parseString(child.Content)
-        case "TapeDriveId":
-            detailedTapeFailure.TapeDriveId = parseString(child.Content)
-        case "TapeId":
-            detailedTapeFailure.TapeId = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &detailedTapeFailure.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DetailedTapeFailure.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Date":
+			detailedTapeFailure.Date = parseString(child.Content)
+		case "ErrorMessage":
+			detailedTapeFailure.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			detailedTapeFailure.Id = parseString(child.Content)
+		case "TapeDriveId":
+			detailedTapeFailure.TapeDriveId = parseString(child.Content)
+		case "TapeId":
+			detailedTapeFailure.TapeId = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &detailedTapeFailure.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DetailedTapeFailure.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeFailureType Enum
 
 const (
-    TAPE_FAILURE_TYPE_BAR_CODE_CHANGED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_BAR_CODE_DUPLICATE TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_BLOB_READ_FAILED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_CLEANING_TAPE_EXPIRED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_DATA_CHECKPOINT_MISSING TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_DELAYED_OWNERSHIP_FAILURE TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_DRIVE_CLEAN_FAILED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_DRIVE_CLEANED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_ALL_WRITES_TOO_SLOW TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_FORWARD_WRITES_TOO_SLOW TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_REVERSE_WRITES_TOO_SLOW TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_DRIVE_TEST_SUCCEEDED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_ENCRYPTION_ERROR TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_FORMAT_FAILED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_GET_TAPE_INFORMATION_FAILED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_HARDWARE_ERROR TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_IMPORT_FAILED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_IMPORT_INCOMPLETE TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_INCOMPATIBLE TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_INSPECT_FAILED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_MOVE_FAILED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_QUIESCING_DRIVE TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_READ_FAILED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_REIMPORT_REQUIRED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_SERIAL_NUMBER_MISMATCH TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_VERIFY_FAILED TapeFailureType = 1 + iota
-    TAPE_FAILURE_TYPE_WRITE_FAILED TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_BAR_CODE_CHANGED                            TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_BAR_CODE_DUPLICATE                          TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_BLOB_READ_FAILED                            TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_CLEANING_TAPE_EXPIRED                       TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE                     TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY    TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_DATA_CHECKPOINT_MISSING                     TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_DELAYED_OWNERSHIP_FAILURE                   TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_DRIVE_CLEAN_FAILED                          TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_DRIVE_CLEANED                               TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED                           TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_ALL_WRITES_TOO_SLOW       TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_FORWARD_WRITES_TOO_SLOW   TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_REVERSE_WRITES_TOO_SLOW   TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_DRIVE_TEST_SUCCEEDED                        TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_ENCRYPTION_ERROR                            TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_FORMAT_FAILED                               TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_GET_TAPE_INFORMATION_FAILED                 TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_HARDWARE_ERROR                              TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_IMPORT_FAILED                               TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_IMPORT_INCOMPLETE                           TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY         TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_INCOMPATIBLE                                TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_INSPECT_FAILED                              TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_MOVE_FAILED                                 TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_QUIESCING_DRIVE                             TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_READ_FAILED                                 TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_REIMPORT_REQUIRED                           TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_SERIAL_NUMBER_MISMATCH                      TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_VERIFY_FAILED                               TapeFailureType = 1 + iota
+	TAPE_FAILURE_TYPE_WRITE_FAILED                                TapeFailureType = 1 + iota
 )
 
 func (tapeFailureType *TapeFailureType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *tapeFailureType = UNDEFINED
-        case "BAR_CODE_CHANGED": *tapeFailureType = TAPE_FAILURE_TYPE_BAR_CODE_CHANGED
-        case "BAR_CODE_DUPLICATE": *tapeFailureType = TAPE_FAILURE_TYPE_BAR_CODE_DUPLICATE
-        case "BLOB_READ_FAILED": *tapeFailureType = TAPE_FAILURE_TYPE_BLOB_READ_FAILED
-        case "CLEANING_TAPE_EXPIRED": *tapeFailureType = TAPE_FAILURE_TYPE_CLEANING_TAPE_EXPIRED
-        case "DATA_CHECKPOINT_FAILURE": *tapeFailureType = TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE
-        case "DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY": *tapeFailureType = TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY
-        case "DATA_CHECKPOINT_MISSING": *tapeFailureType = TAPE_FAILURE_TYPE_DATA_CHECKPOINT_MISSING
-        case "DELAYED_OWNERSHIP_FAILURE": *tapeFailureType = TAPE_FAILURE_TYPE_DELAYED_OWNERSHIP_FAILURE
-        case "DRIVE_CLEAN_FAILED": *tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_CLEAN_FAILED
-        case "DRIVE_CLEANED": *tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_CLEANED
-        case "DRIVE_TEST_FAILED": *tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED
-        case "DRIVE_TEST_FAILED_ALL_WRITES_TOO_SLOW": *tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_ALL_WRITES_TOO_SLOW
-        case "DRIVE_TEST_FAILED_FORWARD_WRITES_TOO_SLOW": *tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_FORWARD_WRITES_TOO_SLOW
-        case "DRIVE_TEST_FAILED_REVERSE_WRITES_TOO_SLOW": *tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_REVERSE_WRITES_TOO_SLOW
-        case "DRIVE_TEST_SUCCEEDED": *tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_TEST_SUCCEEDED
-        case "ENCRYPTION_ERROR": *tapeFailureType = TAPE_FAILURE_TYPE_ENCRYPTION_ERROR
-        case "FORMAT_FAILED": *tapeFailureType = TAPE_FAILURE_TYPE_FORMAT_FAILED
-        case "GET_TAPE_INFORMATION_FAILED": *tapeFailureType = TAPE_FAILURE_TYPE_GET_TAPE_INFORMATION_FAILED
-        case "HARDWARE_ERROR": *tapeFailureType = TAPE_FAILURE_TYPE_HARDWARE_ERROR
-        case "IMPORT_FAILED": *tapeFailureType = TAPE_FAILURE_TYPE_IMPORT_FAILED
-        case "IMPORT_INCOMPLETE": *tapeFailureType = TAPE_FAILURE_TYPE_IMPORT_INCOMPLETE
-        case "IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE": *tapeFailureType = TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE
-        case "IMPORT_FAILED_DUE_TO_DATA_INTEGRITY": *tapeFailureType = TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY
-        case "INCOMPATIBLE": *tapeFailureType = TAPE_FAILURE_TYPE_INCOMPATIBLE
-        case "INSPECT_FAILED": *tapeFailureType = TAPE_FAILURE_TYPE_INSPECT_FAILED
-        case "MOVE_FAILED": *tapeFailureType = TAPE_FAILURE_TYPE_MOVE_FAILED
-        case "QUIESCING_DRIVE": *tapeFailureType = TAPE_FAILURE_TYPE_QUIESCING_DRIVE
-        case "READ_FAILED": *tapeFailureType = TAPE_FAILURE_TYPE_READ_FAILED
-        case "REIMPORT_REQUIRED": *tapeFailureType = TAPE_FAILURE_TYPE_REIMPORT_REQUIRED
-        case "SERIAL_NUMBER_MISMATCH": *tapeFailureType = TAPE_FAILURE_TYPE_SERIAL_NUMBER_MISMATCH
-        case "VERIFY_FAILED": *tapeFailureType = TAPE_FAILURE_TYPE_VERIFY_FAILED
-        case "WRITE_FAILED": *tapeFailureType = TAPE_FAILURE_TYPE_WRITE_FAILED
-        default:
-            *tapeFailureType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapeFailureType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*tapeFailureType = UNDEFINED
+	case "BAR_CODE_CHANGED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_BAR_CODE_CHANGED
+	case "BAR_CODE_DUPLICATE":
+		*tapeFailureType = TAPE_FAILURE_TYPE_BAR_CODE_DUPLICATE
+	case "BLOB_READ_FAILED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_BLOB_READ_FAILED
+	case "CLEANING_TAPE_EXPIRED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_CLEANING_TAPE_EXPIRED
+	case "DATA_CHECKPOINT_FAILURE":
+		*tapeFailureType = TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE
+	case "DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY":
+		*tapeFailureType = TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY
+	case "DATA_CHECKPOINT_MISSING":
+		*tapeFailureType = TAPE_FAILURE_TYPE_DATA_CHECKPOINT_MISSING
+	case "DELAYED_OWNERSHIP_FAILURE":
+		*tapeFailureType = TAPE_FAILURE_TYPE_DELAYED_OWNERSHIP_FAILURE
+	case "DRIVE_CLEAN_FAILED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_CLEAN_FAILED
+	case "DRIVE_CLEANED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_CLEANED
+	case "DRIVE_TEST_FAILED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED
+	case "DRIVE_TEST_FAILED_ALL_WRITES_TOO_SLOW":
+		*tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_ALL_WRITES_TOO_SLOW
+	case "DRIVE_TEST_FAILED_FORWARD_WRITES_TOO_SLOW":
+		*tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_FORWARD_WRITES_TOO_SLOW
+	case "DRIVE_TEST_FAILED_REVERSE_WRITES_TOO_SLOW":
+		*tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_REVERSE_WRITES_TOO_SLOW
+	case "DRIVE_TEST_SUCCEEDED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_DRIVE_TEST_SUCCEEDED
+	case "ENCRYPTION_ERROR":
+		*tapeFailureType = TAPE_FAILURE_TYPE_ENCRYPTION_ERROR
+	case "FORMAT_FAILED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_FORMAT_FAILED
+	case "GET_TAPE_INFORMATION_FAILED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_GET_TAPE_INFORMATION_FAILED
+	case "HARDWARE_ERROR":
+		*tapeFailureType = TAPE_FAILURE_TYPE_HARDWARE_ERROR
+	case "IMPORT_FAILED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_IMPORT_FAILED
+	case "IMPORT_INCOMPLETE":
+		*tapeFailureType = TAPE_FAILURE_TYPE_IMPORT_INCOMPLETE
+	case "IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE":
+		*tapeFailureType = TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE
+	case "IMPORT_FAILED_DUE_TO_DATA_INTEGRITY":
+		*tapeFailureType = TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY
+	case "INCOMPATIBLE":
+		*tapeFailureType = TAPE_FAILURE_TYPE_INCOMPATIBLE
+	case "INSPECT_FAILED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_INSPECT_FAILED
+	case "MOVE_FAILED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_MOVE_FAILED
+	case "QUIESCING_DRIVE":
+		*tapeFailureType = TAPE_FAILURE_TYPE_QUIESCING_DRIVE
+	case "READ_FAILED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_READ_FAILED
+	case "REIMPORT_REQUIRED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_REIMPORT_REQUIRED
+	case "SERIAL_NUMBER_MISMATCH":
+		*tapeFailureType = TAPE_FAILURE_TYPE_SERIAL_NUMBER_MISMATCH
+	case "VERIFY_FAILED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_VERIFY_FAILED
+	case "WRITE_FAILED":
+		*tapeFailureType = TAPE_FAILURE_TYPE_WRITE_FAILED
+	default:
+		*tapeFailureType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapeFailureType", str))
+	}
+	return nil
 }
 
 func (tapeFailureType TapeFailureType) String() string {
-    switch tapeFailureType {
-        case TAPE_FAILURE_TYPE_BAR_CODE_CHANGED: return "BAR_CODE_CHANGED"
-        case TAPE_FAILURE_TYPE_BAR_CODE_DUPLICATE: return "BAR_CODE_DUPLICATE"
-        case TAPE_FAILURE_TYPE_BLOB_READ_FAILED: return "BLOB_READ_FAILED"
-        case TAPE_FAILURE_TYPE_CLEANING_TAPE_EXPIRED: return "CLEANING_TAPE_EXPIRED"
-        case TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE: return "DATA_CHECKPOINT_FAILURE"
-        case TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY: return "DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY"
-        case TAPE_FAILURE_TYPE_DATA_CHECKPOINT_MISSING: return "DATA_CHECKPOINT_MISSING"
-        case TAPE_FAILURE_TYPE_DELAYED_OWNERSHIP_FAILURE: return "DELAYED_OWNERSHIP_FAILURE"
-        case TAPE_FAILURE_TYPE_DRIVE_CLEAN_FAILED: return "DRIVE_CLEAN_FAILED"
-        case TAPE_FAILURE_TYPE_DRIVE_CLEANED: return "DRIVE_CLEANED"
-        case TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED: return "DRIVE_TEST_FAILED"
-        case TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_ALL_WRITES_TOO_SLOW: return "DRIVE_TEST_FAILED_ALL_WRITES_TOO_SLOW"
-        case TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_FORWARD_WRITES_TOO_SLOW: return "DRIVE_TEST_FAILED_FORWARD_WRITES_TOO_SLOW"
-        case TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_REVERSE_WRITES_TOO_SLOW: return "DRIVE_TEST_FAILED_REVERSE_WRITES_TOO_SLOW"
-        case TAPE_FAILURE_TYPE_DRIVE_TEST_SUCCEEDED: return "DRIVE_TEST_SUCCEEDED"
-        case TAPE_FAILURE_TYPE_ENCRYPTION_ERROR: return "ENCRYPTION_ERROR"
-        case TAPE_FAILURE_TYPE_FORMAT_FAILED: return "FORMAT_FAILED"
-        case TAPE_FAILURE_TYPE_GET_TAPE_INFORMATION_FAILED: return "GET_TAPE_INFORMATION_FAILED"
-        case TAPE_FAILURE_TYPE_HARDWARE_ERROR: return "HARDWARE_ERROR"
-        case TAPE_FAILURE_TYPE_IMPORT_FAILED: return "IMPORT_FAILED"
-        case TAPE_FAILURE_TYPE_IMPORT_INCOMPLETE: return "IMPORT_INCOMPLETE"
-        case TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE: return "IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE"
-        case TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY: return "IMPORT_FAILED_DUE_TO_DATA_INTEGRITY"
-        case TAPE_FAILURE_TYPE_INCOMPATIBLE: return "INCOMPATIBLE"
-        case TAPE_FAILURE_TYPE_INSPECT_FAILED: return "INSPECT_FAILED"
-        case TAPE_FAILURE_TYPE_MOVE_FAILED: return "MOVE_FAILED"
-        case TAPE_FAILURE_TYPE_QUIESCING_DRIVE: return "QUIESCING_DRIVE"
-        case TAPE_FAILURE_TYPE_READ_FAILED: return "READ_FAILED"
-        case TAPE_FAILURE_TYPE_REIMPORT_REQUIRED: return "REIMPORT_REQUIRED"
-        case TAPE_FAILURE_TYPE_SERIAL_NUMBER_MISMATCH: return "SERIAL_NUMBER_MISMATCH"
-        case TAPE_FAILURE_TYPE_VERIFY_FAILED: return "VERIFY_FAILED"
-        case TAPE_FAILURE_TYPE_WRITE_FAILED: return "WRITE_FAILED"
-        default:
-            log.Printf("Error: invalid TapeFailureType represented by '%d'", tapeFailureType)
-            return ""
-    }
+	switch tapeFailureType {
+	case TAPE_FAILURE_TYPE_BAR_CODE_CHANGED:
+		return "BAR_CODE_CHANGED"
+	case TAPE_FAILURE_TYPE_BAR_CODE_DUPLICATE:
+		return "BAR_CODE_DUPLICATE"
+	case TAPE_FAILURE_TYPE_BLOB_READ_FAILED:
+		return "BLOB_READ_FAILED"
+	case TAPE_FAILURE_TYPE_CLEANING_TAPE_EXPIRED:
+		return "CLEANING_TAPE_EXPIRED"
+	case TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE:
+		return "DATA_CHECKPOINT_FAILURE"
+	case TAPE_FAILURE_TYPE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY:
+		return "DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY"
+	case TAPE_FAILURE_TYPE_DATA_CHECKPOINT_MISSING:
+		return "DATA_CHECKPOINT_MISSING"
+	case TAPE_FAILURE_TYPE_DELAYED_OWNERSHIP_FAILURE:
+		return "DELAYED_OWNERSHIP_FAILURE"
+	case TAPE_FAILURE_TYPE_DRIVE_CLEAN_FAILED:
+		return "DRIVE_CLEAN_FAILED"
+	case TAPE_FAILURE_TYPE_DRIVE_CLEANED:
+		return "DRIVE_CLEANED"
+	case TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED:
+		return "DRIVE_TEST_FAILED"
+	case TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_ALL_WRITES_TOO_SLOW:
+		return "DRIVE_TEST_FAILED_ALL_WRITES_TOO_SLOW"
+	case TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_FORWARD_WRITES_TOO_SLOW:
+		return "DRIVE_TEST_FAILED_FORWARD_WRITES_TOO_SLOW"
+	case TAPE_FAILURE_TYPE_DRIVE_TEST_FAILED_REVERSE_WRITES_TOO_SLOW:
+		return "DRIVE_TEST_FAILED_REVERSE_WRITES_TOO_SLOW"
+	case TAPE_FAILURE_TYPE_DRIVE_TEST_SUCCEEDED:
+		return "DRIVE_TEST_SUCCEEDED"
+	case TAPE_FAILURE_TYPE_ENCRYPTION_ERROR:
+		return "ENCRYPTION_ERROR"
+	case TAPE_FAILURE_TYPE_FORMAT_FAILED:
+		return "FORMAT_FAILED"
+	case TAPE_FAILURE_TYPE_GET_TAPE_INFORMATION_FAILED:
+		return "GET_TAPE_INFORMATION_FAILED"
+	case TAPE_FAILURE_TYPE_HARDWARE_ERROR:
+		return "HARDWARE_ERROR"
+	case TAPE_FAILURE_TYPE_IMPORT_FAILED:
+		return "IMPORT_FAILED"
+	case TAPE_FAILURE_TYPE_IMPORT_INCOMPLETE:
+		return "IMPORT_INCOMPLETE"
+	case TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE:
+		return "IMPORT_FAILED_DUE_TO_TAKE_OWNERSHIP_FAILURE"
+	case TAPE_FAILURE_TYPE_IMPORT_FAILED_DUE_TO_DATA_INTEGRITY:
+		return "IMPORT_FAILED_DUE_TO_DATA_INTEGRITY"
+	case TAPE_FAILURE_TYPE_INCOMPATIBLE:
+		return "INCOMPATIBLE"
+	case TAPE_FAILURE_TYPE_INSPECT_FAILED:
+		return "INSPECT_FAILED"
+	case TAPE_FAILURE_TYPE_MOVE_FAILED:
+		return "MOVE_FAILED"
+	case TAPE_FAILURE_TYPE_QUIESCING_DRIVE:
+		return "QUIESCING_DRIVE"
+	case TAPE_FAILURE_TYPE_READ_FAILED:
+		return "READ_FAILED"
+	case TAPE_FAILURE_TYPE_REIMPORT_REQUIRED:
+		return "REIMPORT_REQUIRED"
+	case TAPE_FAILURE_TYPE_SERIAL_NUMBER_MISMATCH:
+		return "SERIAL_NUMBER_MISMATCH"
+	case TAPE_FAILURE_TYPE_VERIFY_FAILED:
+		return "VERIFY_FAILED"
+	case TAPE_FAILURE_TYPE_WRITE_FAILED:
+		return "WRITE_FAILED"
+	default:
+		log.Printf("Error: invalid TapeFailureType represented by '%d'", tapeFailureType)
+		return ""
+	}
 }
 
 func (tapeFailureType TapeFailureType) StringPtr() *string {
-    if tapeFailureType == UNDEFINED {
-        return nil
-    }
-    result := tapeFailureType.String()
-    return &result
+	if tapeFailureType == UNDEFINED {
+		return nil
+	}
+	result := tapeFailureType.String()
+	return &result
 }
 
 func newTapeFailureTypeFromContent(content []byte, aggErr *AggregateError) *TapeFailureType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(TapeFailureType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(TapeFailureType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type TapeLibrary struct {
-    Id string
-    ManagementUrl *string
-    Name *string
-    SerialNumber *string
+	Id            string
+	ManagementUrl *string
+	Name          *string
+	SerialNumber  *string
 }
 
 func (tapeLibrary *TapeLibrary) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Id":
-            tapeLibrary.Id = parseString(child.Content)
-        case "ManagementUrl":
-            tapeLibrary.ManagementUrl = parseNullableString(child.Content)
-        case "Name":
-            tapeLibrary.Name = parseNullableString(child.Content)
-        case "SerialNumber":
-            tapeLibrary.SerialNumber = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeLibrary.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Id":
+			tapeLibrary.Id = parseString(child.Content)
+		case "ManagementUrl":
+			tapeLibrary.ManagementUrl = parseNullableString(child.Content)
+		case "Name":
+			tapeLibrary.Name = parseNullableString(child.Content)
+		case "SerialNumber":
+			tapeLibrary.SerialNumber = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeLibrary.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapePartition struct {
-    AutoCompactionEnabled bool
-    AutoQuiesceEnabled bool
-    DriveIdleTimeoutInMinutes *int
-    DriveType *TapeDriveType
-    ErrorMessage *string
-    Id string
-    ImportExportConfiguration ImportExportConfiguration
-    LibraryId string
-    MinimumReadReservedDrives int
-    MinimumWriteReservedDrives int
-    Name *string
-    Quiesced Quiesced
-    SerialNumber *string
-    State TapePartitionState
+	AutoCompactionEnabled      bool
+	AutoQuiesceEnabled         bool
+	DriveIdleTimeoutInMinutes  *int
+	DriveType                  *TapeDriveType
+	ErrorMessage               *string
+	Id                         string
+	ImportExportConfiguration  ImportExportConfiguration
+	LibraryId                  string
+	MinimumReadReservedDrives  int
+	MinimumWriteReservedDrives int
+	Name                       *string
+	Quiesced                   Quiesced
+	SerialNumber               *string
+	State                      TapePartitionState
 }
 
 func (tapePartition *TapePartition) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AutoCompactionEnabled":
-            tapePartition.AutoCompactionEnabled = parseBool(child.Content, aggErr)
-        case "AutoQuiesceEnabled":
-            tapePartition.AutoQuiesceEnabled = parseBool(child.Content, aggErr)
-        case "DriveIdleTimeoutInMinutes":
-            tapePartition.DriveIdleTimeoutInMinutes = parseNullableInt(child.Content, aggErr)
-        case "DriveType":
-            tapePartition.DriveType = newTapeDriveTypeFromContent(child.Content, aggErr)
-        case "ErrorMessage":
-            tapePartition.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            tapePartition.Id = parseString(child.Content)
-        case "ImportExportConfiguration":
-            parseEnum(child.Content, &tapePartition.ImportExportConfiguration, aggErr)
-        case "LibraryId":
-            tapePartition.LibraryId = parseString(child.Content)
-        case "MinimumReadReservedDrives":
-            tapePartition.MinimumReadReservedDrives = parseInt(child.Content, aggErr)
-        case "MinimumWriteReservedDrives":
-            tapePartition.MinimumWriteReservedDrives = parseInt(child.Content, aggErr)
-        case "Name":
-            tapePartition.Name = parseNullableString(child.Content)
-        case "Quiesced":
-            parseEnum(child.Content, &tapePartition.Quiesced, aggErr)
-        case "SerialNumber":
-            tapePartition.SerialNumber = parseNullableString(child.Content)
-        case "State":
-            parseEnum(child.Content, &tapePartition.State, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartition.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AutoCompactionEnabled":
+			tapePartition.AutoCompactionEnabled = parseBool(child.Content, aggErr)
+		case "AutoQuiesceEnabled":
+			tapePartition.AutoQuiesceEnabled = parseBool(child.Content, aggErr)
+		case "DriveIdleTimeoutInMinutes":
+			tapePartition.DriveIdleTimeoutInMinutes = parseNullableInt(child.Content, aggErr)
+		case "DriveType":
+			tapePartition.DriveType = newTapeDriveTypeFromContent(child.Content, aggErr)
+		case "ErrorMessage":
+			tapePartition.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			tapePartition.Id = parseString(child.Content)
+		case "ImportExportConfiguration":
+			parseEnum(child.Content, &tapePartition.ImportExportConfiguration, aggErr)
+		case "LibraryId":
+			tapePartition.LibraryId = parseString(child.Content)
+		case "MinimumReadReservedDrives":
+			tapePartition.MinimumReadReservedDrives = parseInt(child.Content, aggErr)
+		case "MinimumWriteReservedDrives":
+			tapePartition.MinimumWriteReservedDrives = parseInt(child.Content, aggErr)
+		case "Name":
+			tapePartition.Name = parseNullableString(child.Content)
+		case "Quiesced":
+			parseEnum(child.Content, &tapePartition.Quiesced, aggErr)
+		case "SerialNumber":
+			tapePartition.SerialNumber = parseNullableString(child.Content)
+		case "State":
+			parseEnum(child.Content, &tapePartition.State, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartition.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapePartitionFailure struct {
-    Date string
-    ErrorMessage *string
-    Id string
-    PartitionId string
-    Type TapePartitionFailureType
+	Date         string
+	ErrorMessage *string
+	Id           string
+	PartitionId  string
+	Type         TapePartitionFailureType
 }
 
 func (tapePartitionFailure *TapePartitionFailure) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Date":
-            tapePartitionFailure.Date = parseString(child.Content)
-        case "ErrorMessage":
-            tapePartitionFailure.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            tapePartitionFailure.Id = parseString(child.Content)
-        case "PartitionId":
-            tapePartitionFailure.PartitionId = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &tapePartitionFailure.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartitionFailure.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Date":
+			tapePartitionFailure.Date = parseString(child.Content)
+		case "ErrorMessage":
+			tapePartitionFailure.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			tapePartitionFailure.Id = parseString(child.Content)
+		case "PartitionId":
+			tapePartitionFailure.PartitionId = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &tapePartitionFailure.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartitionFailure.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapePartitionFailureType Enum
 
 const (
-    TAPE_PARTITION_FAILURE_TYPE_AUTO_QUIESCED TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_CLEANING_TAPE_REQUIRED TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_DUPLICATE_TAPE_BAR_CODES_DETECTED TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_EJECT_STALLED_DUE_TO_OFFLINE_TAPES TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_MINIMUM_DRIVE_COUNT_NOT_MET TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED_DUE_TO_PREPARE_TAPE_FOR_REMOVAL_FAILURE TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_NO_USABLE_DRIVES TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_ONLINE_STALLED_DUE_TO_NO_STORAGE_SLOTS TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_IN_ERROR TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_MISSING TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_NOT_CLEANED TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_QUIESCED TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_TYPE_MISMATCH TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_TAPE_EJECTION_BY_OPERATOR_REQUIRED TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_TAPE_MEDIA_TYPE_INCOMPATIBLE TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_TAPE_REMOVAL_UNEXPECTED TapePartitionFailureType = 1 + iota
-    TAPE_PARTITION_FAILURE_TYPE_TAPE_IN_INVALID_PARTITION TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_AUTO_QUIESCED                                       TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_CLEANING_TAPE_REQUIRED                              TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_DUPLICATE_TAPE_BAR_CODES_DETECTED                   TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_EJECT_STALLED_DUE_TO_OFFLINE_TAPES                  TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_MINIMUM_DRIVE_COUNT_NOT_MET                         TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED                                         TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED_DUE_TO_PREPARE_TAPE_FOR_REMOVAL_FAILURE TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_NO_USABLE_DRIVES                                    TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_ONLINE_STALLED_DUE_TO_NO_STORAGE_SLOTS              TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_IN_ERROR                                 TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_MISSING                                  TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_NOT_CLEANED                              TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_QUIESCED                                 TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_TYPE_MISMATCH                            TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_TAPE_EJECTION_BY_OPERATOR_REQUIRED                  TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_TAPE_MEDIA_TYPE_INCOMPATIBLE                        TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_TAPE_REMOVAL_UNEXPECTED                             TapePartitionFailureType = 1 + iota
+	TAPE_PARTITION_FAILURE_TYPE_TAPE_IN_INVALID_PARTITION                           TapePartitionFailureType = 1 + iota
 )
 
 func (tapePartitionFailureType *TapePartitionFailureType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *tapePartitionFailureType = UNDEFINED
-        case "AUTO_QUIESCED": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_AUTO_QUIESCED
-        case "CLEANING_TAPE_REQUIRED": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_CLEANING_TAPE_REQUIRED
-        case "DUPLICATE_TAPE_BAR_CODES_DETECTED": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_DUPLICATE_TAPE_BAR_CODES_DETECTED
-        case "EJECT_STALLED_DUE_TO_OFFLINE_TAPES": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_EJECT_STALLED_DUE_TO_OFFLINE_TAPES
-        case "MINIMUM_DRIVE_COUNT_NOT_MET": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_MINIMUM_DRIVE_COUNT_NOT_MET
-        case "MOVE_FAILED": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED
-        case "MOVE_FAILED_DUE_TO_PREPARE_TAPE_FOR_REMOVAL_FAILURE": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED_DUE_TO_PREPARE_TAPE_FOR_REMOVAL_FAILURE
-        case "NO_USABLE_DRIVES": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_NO_USABLE_DRIVES
-        case "ONLINE_STALLED_DUE_TO_NO_STORAGE_SLOTS": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_ONLINE_STALLED_DUE_TO_NO_STORAGE_SLOTS
-        case "TAPE_DRIVE_IN_ERROR": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_IN_ERROR
-        case "TAPE_DRIVE_MISSING": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_MISSING
-        case "TAPE_DRIVE_NOT_CLEANED": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_NOT_CLEANED
-        case "TAPE_DRIVE_QUIESCED": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_QUIESCED
-        case "TAPE_DRIVE_TYPE_MISMATCH": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_TYPE_MISMATCH
-        case "TAPE_EJECTION_BY_OPERATOR_REQUIRED": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_EJECTION_BY_OPERATOR_REQUIRED
-        case "TAPE_MEDIA_TYPE_INCOMPATIBLE": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_MEDIA_TYPE_INCOMPATIBLE
-        case "TAPE_REMOVAL_UNEXPECTED": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_REMOVAL_UNEXPECTED
-        case "TAPE_IN_INVALID_PARTITION": *tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_IN_INVALID_PARTITION
-        default:
-            *tapePartitionFailureType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapePartitionFailureType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*tapePartitionFailureType = UNDEFINED
+	case "AUTO_QUIESCED":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_AUTO_QUIESCED
+	case "CLEANING_TAPE_REQUIRED":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_CLEANING_TAPE_REQUIRED
+	case "DUPLICATE_TAPE_BAR_CODES_DETECTED":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_DUPLICATE_TAPE_BAR_CODES_DETECTED
+	case "EJECT_STALLED_DUE_TO_OFFLINE_TAPES":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_EJECT_STALLED_DUE_TO_OFFLINE_TAPES
+	case "MINIMUM_DRIVE_COUNT_NOT_MET":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_MINIMUM_DRIVE_COUNT_NOT_MET
+	case "MOVE_FAILED":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED
+	case "MOVE_FAILED_DUE_TO_PREPARE_TAPE_FOR_REMOVAL_FAILURE":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED_DUE_TO_PREPARE_TAPE_FOR_REMOVAL_FAILURE
+	case "NO_USABLE_DRIVES":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_NO_USABLE_DRIVES
+	case "ONLINE_STALLED_DUE_TO_NO_STORAGE_SLOTS":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_ONLINE_STALLED_DUE_TO_NO_STORAGE_SLOTS
+	case "TAPE_DRIVE_IN_ERROR":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_IN_ERROR
+	case "TAPE_DRIVE_MISSING":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_MISSING
+	case "TAPE_DRIVE_NOT_CLEANED":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_NOT_CLEANED
+	case "TAPE_DRIVE_QUIESCED":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_QUIESCED
+	case "TAPE_DRIVE_TYPE_MISMATCH":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_TYPE_MISMATCH
+	case "TAPE_EJECTION_BY_OPERATOR_REQUIRED":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_EJECTION_BY_OPERATOR_REQUIRED
+	case "TAPE_MEDIA_TYPE_INCOMPATIBLE":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_MEDIA_TYPE_INCOMPATIBLE
+	case "TAPE_REMOVAL_UNEXPECTED":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_REMOVAL_UNEXPECTED
+	case "TAPE_IN_INVALID_PARTITION":
+		*tapePartitionFailureType = TAPE_PARTITION_FAILURE_TYPE_TAPE_IN_INVALID_PARTITION
+	default:
+		*tapePartitionFailureType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapePartitionFailureType", str))
+	}
+	return nil
 }
 
 func (tapePartitionFailureType TapePartitionFailureType) String() string {
-    switch tapePartitionFailureType {
-        case TAPE_PARTITION_FAILURE_TYPE_AUTO_QUIESCED: return "AUTO_QUIESCED"
-        case TAPE_PARTITION_FAILURE_TYPE_CLEANING_TAPE_REQUIRED: return "CLEANING_TAPE_REQUIRED"
-        case TAPE_PARTITION_FAILURE_TYPE_DUPLICATE_TAPE_BAR_CODES_DETECTED: return "DUPLICATE_TAPE_BAR_CODES_DETECTED"
-        case TAPE_PARTITION_FAILURE_TYPE_EJECT_STALLED_DUE_TO_OFFLINE_TAPES: return "EJECT_STALLED_DUE_TO_OFFLINE_TAPES"
-        case TAPE_PARTITION_FAILURE_TYPE_MINIMUM_DRIVE_COUNT_NOT_MET: return "MINIMUM_DRIVE_COUNT_NOT_MET"
-        case TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED: return "MOVE_FAILED"
-        case TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED_DUE_TO_PREPARE_TAPE_FOR_REMOVAL_FAILURE: return "MOVE_FAILED_DUE_TO_PREPARE_TAPE_FOR_REMOVAL_FAILURE"
-        case TAPE_PARTITION_FAILURE_TYPE_NO_USABLE_DRIVES: return "NO_USABLE_DRIVES"
-        case TAPE_PARTITION_FAILURE_TYPE_ONLINE_STALLED_DUE_TO_NO_STORAGE_SLOTS: return "ONLINE_STALLED_DUE_TO_NO_STORAGE_SLOTS"
-        case TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_IN_ERROR: return "TAPE_DRIVE_IN_ERROR"
-        case TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_MISSING: return "TAPE_DRIVE_MISSING"
-        case TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_NOT_CLEANED: return "TAPE_DRIVE_NOT_CLEANED"
-        case TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_QUIESCED: return "TAPE_DRIVE_QUIESCED"
-        case TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_TYPE_MISMATCH: return "TAPE_DRIVE_TYPE_MISMATCH"
-        case TAPE_PARTITION_FAILURE_TYPE_TAPE_EJECTION_BY_OPERATOR_REQUIRED: return "TAPE_EJECTION_BY_OPERATOR_REQUIRED"
-        case TAPE_PARTITION_FAILURE_TYPE_TAPE_MEDIA_TYPE_INCOMPATIBLE: return "TAPE_MEDIA_TYPE_INCOMPATIBLE"
-        case TAPE_PARTITION_FAILURE_TYPE_TAPE_REMOVAL_UNEXPECTED: return "TAPE_REMOVAL_UNEXPECTED"
-        case TAPE_PARTITION_FAILURE_TYPE_TAPE_IN_INVALID_PARTITION: return "TAPE_IN_INVALID_PARTITION"
-        default:
-            log.Printf("Error: invalid TapePartitionFailureType represented by '%d'", tapePartitionFailureType)
-            return ""
-    }
+	switch tapePartitionFailureType {
+	case TAPE_PARTITION_FAILURE_TYPE_AUTO_QUIESCED:
+		return "AUTO_QUIESCED"
+	case TAPE_PARTITION_FAILURE_TYPE_CLEANING_TAPE_REQUIRED:
+		return "CLEANING_TAPE_REQUIRED"
+	case TAPE_PARTITION_FAILURE_TYPE_DUPLICATE_TAPE_BAR_CODES_DETECTED:
+		return "DUPLICATE_TAPE_BAR_CODES_DETECTED"
+	case TAPE_PARTITION_FAILURE_TYPE_EJECT_STALLED_DUE_TO_OFFLINE_TAPES:
+		return "EJECT_STALLED_DUE_TO_OFFLINE_TAPES"
+	case TAPE_PARTITION_FAILURE_TYPE_MINIMUM_DRIVE_COUNT_NOT_MET:
+		return "MINIMUM_DRIVE_COUNT_NOT_MET"
+	case TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED:
+		return "MOVE_FAILED"
+	case TAPE_PARTITION_FAILURE_TYPE_MOVE_FAILED_DUE_TO_PREPARE_TAPE_FOR_REMOVAL_FAILURE:
+		return "MOVE_FAILED_DUE_TO_PREPARE_TAPE_FOR_REMOVAL_FAILURE"
+	case TAPE_PARTITION_FAILURE_TYPE_NO_USABLE_DRIVES:
+		return "NO_USABLE_DRIVES"
+	case TAPE_PARTITION_FAILURE_TYPE_ONLINE_STALLED_DUE_TO_NO_STORAGE_SLOTS:
+		return "ONLINE_STALLED_DUE_TO_NO_STORAGE_SLOTS"
+	case TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_IN_ERROR:
+		return "TAPE_DRIVE_IN_ERROR"
+	case TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_MISSING:
+		return "TAPE_DRIVE_MISSING"
+	case TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_NOT_CLEANED:
+		return "TAPE_DRIVE_NOT_CLEANED"
+	case TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_QUIESCED:
+		return "TAPE_DRIVE_QUIESCED"
+	case TAPE_PARTITION_FAILURE_TYPE_TAPE_DRIVE_TYPE_MISMATCH:
+		return "TAPE_DRIVE_TYPE_MISMATCH"
+	case TAPE_PARTITION_FAILURE_TYPE_TAPE_EJECTION_BY_OPERATOR_REQUIRED:
+		return "TAPE_EJECTION_BY_OPERATOR_REQUIRED"
+	case TAPE_PARTITION_FAILURE_TYPE_TAPE_MEDIA_TYPE_INCOMPATIBLE:
+		return "TAPE_MEDIA_TYPE_INCOMPATIBLE"
+	case TAPE_PARTITION_FAILURE_TYPE_TAPE_REMOVAL_UNEXPECTED:
+		return "TAPE_REMOVAL_UNEXPECTED"
+	case TAPE_PARTITION_FAILURE_TYPE_TAPE_IN_INVALID_PARTITION:
+		return "TAPE_IN_INVALID_PARTITION"
+	default:
+		log.Printf("Error: invalid TapePartitionFailureType represented by '%d'", tapePartitionFailureType)
+		return ""
+	}
 }
 
 func (tapePartitionFailureType TapePartitionFailureType) StringPtr() *string {
-    if tapePartitionFailureType == UNDEFINED {
-        return nil
-    }
-    result := tapePartitionFailureType.String()
-    return &result
+	if tapePartitionFailureType == UNDEFINED {
+		return nil
+	}
+	result := tapePartitionFailureType.String()
+	return &result
 }
 
 func newTapePartitionFailureTypeFromContent(content []byte, aggErr *AggregateError) *TapePartitionFailureType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(TapePartitionFailureType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(TapePartitionFailureType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type TapePartitionState Enum
 
 const (
-    TAPE_PARTITION_STATE_ONLINE TapePartitionState = 1 + iota
-    TAPE_PARTITION_STATE_OFFLINE TapePartitionState = 1 + iota
-    TAPE_PARTITION_STATE_ERROR TapePartitionState = 1 + iota
+	TAPE_PARTITION_STATE_ONLINE  TapePartitionState = 1 + iota
+	TAPE_PARTITION_STATE_OFFLINE TapePartitionState = 1 + iota
+	TAPE_PARTITION_STATE_ERROR   TapePartitionState = 1 + iota
 )
 
 func (tapePartitionState *TapePartitionState) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *tapePartitionState = UNDEFINED
-        case "ONLINE": *tapePartitionState = TAPE_PARTITION_STATE_ONLINE
-        case "OFFLINE": *tapePartitionState = TAPE_PARTITION_STATE_OFFLINE
-        case "ERROR": *tapePartitionState = TAPE_PARTITION_STATE_ERROR
-        default:
-            *tapePartitionState = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapePartitionState", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*tapePartitionState = UNDEFINED
+	case "ONLINE":
+		*tapePartitionState = TAPE_PARTITION_STATE_ONLINE
+	case "OFFLINE":
+		*tapePartitionState = TAPE_PARTITION_STATE_OFFLINE
+	case "ERROR":
+		*tapePartitionState = TAPE_PARTITION_STATE_ERROR
+	default:
+		*tapePartitionState = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapePartitionState", str))
+	}
+	return nil
 }
 
 func (tapePartitionState TapePartitionState) String() string {
-    switch tapePartitionState {
-        case TAPE_PARTITION_STATE_ONLINE: return "ONLINE"
-        case TAPE_PARTITION_STATE_OFFLINE: return "OFFLINE"
-        case TAPE_PARTITION_STATE_ERROR: return "ERROR"
-        default:
-            log.Printf("Error: invalid TapePartitionState represented by '%d'", tapePartitionState)
-            return ""
-    }
+	switch tapePartitionState {
+	case TAPE_PARTITION_STATE_ONLINE:
+		return "ONLINE"
+	case TAPE_PARTITION_STATE_OFFLINE:
+		return "OFFLINE"
+	case TAPE_PARTITION_STATE_ERROR:
+		return "ERROR"
+	default:
+		log.Printf("Error: invalid TapePartitionState represented by '%d'", tapePartitionState)
+		return ""
+	}
 }
 
 func (tapePartitionState TapePartitionState) StringPtr() *string {
-    if tapePartitionState == UNDEFINED {
-        return nil
-    }
-    result := tapePartitionState.String()
-    return &result
+	if tapePartitionState == UNDEFINED {
+		return nil
+	}
+	result := tapePartitionState.String()
+	return &result
 }
 
 func newTapePartitionStateFromContent(content []byte, aggErr *AggregateError) *TapePartitionState {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(TapePartitionState)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(TapePartitionState)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type TapeRole Enum
 
 const (
-    TAPE_ROLE_NORMAL TapeRole = 1 + iota
-    TAPE_ROLE_TEST TapeRole = 1 + iota
+	TAPE_ROLE_NORMAL TapeRole = 1 + iota
+	TAPE_ROLE_TEST   TapeRole = 1 + iota
 )
 
 func (tapeRole *TapeRole) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *tapeRole = UNDEFINED
-        case "NORMAL": *tapeRole = TAPE_ROLE_NORMAL
-        case "TEST": *tapeRole = TAPE_ROLE_TEST
-        default:
-            *tapeRole = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapeRole", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*tapeRole = UNDEFINED
+	case "NORMAL":
+		*tapeRole = TAPE_ROLE_NORMAL
+	case "TEST":
+		*tapeRole = TAPE_ROLE_TEST
+	default:
+		*tapeRole = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapeRole", str))
+	}
+	return nil
 }
 
 func (tapeRole TapeRole) String() string {
-    switch tapeRole {
-        case TAPE_ROLE_NORMAL: return "NORMAL"
-        case TAPE_ROLE_TEST: return "TEST"
-        default:
-            log.Printf("Error: invalid TapeRole represented by '%d'", tapeRole)
-            return ""
-    }
+	switch tapeRole {
+	case TAPE_ROLE_NORMAL:
+		return "NORMAL"
+	case TAPE_ROLE_TEST:
+		return "TEST"
+	default:
+		log.Printf("Error: invalid TapeRole represented by '%d'", tapeRole)
+		return ""
+	}
 }
 
 func (tapeRole TapeRole) StringPtr() *string {
-    if tapeRole == UNDEFINED {
-        return nil
-    }
-    result := tapeRole.String()
-    return &result
+	if tapeRole == UNDEFINED {
+		return nil
+	}
+	result := tapeRole.String()
+	return &result
 }
 
 func newTapeRoleFromContent(content []byte, aggErr *AggregateError) *TapeRole {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(TapeRole)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(TapeRole)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type TapeState Enum
 
 const (
-    TAPE_STATE_NORMAL TapeState = 1 + iota
-    TAPE_STATE_OFFLINE TapeState = 1 + iota
-    TAPE_STATE_ONLINE_PENDING TapeState = 1 + iota
-    TAPE_STATE_ONLINE_IN_PROGRESS TapeState = 1 + iota
-    TAPE_STATE_PENDING_INSPECTION TapeState = 1 + iota
-    TAPE_STATE_UNKNOWN TapeState = 1 + iota
-    TAPE_STATE_DATA_CHECKPOINT_FAILURE TapeState = 1 + iota
-    TAPE_STATE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY TapeState = 1 + iota
-    TAPE_STATE_DATA_CHECKPOINT_MISSING TapeState = 1 + iota
-    TAPE_STATE_LTFS_WITH_FOREIGN_DATA TapeState = 1 + iota
-    TAPE_STATE_RAW_IMPORT_PENDING TapeState = 1 + iota
-    TAPE_STATE_RAW_IMPORT_IN_PROGRESS TapeState = 1 + iota
-    TAPE_STATE_FOREIGN TapeState = 1 + iota
-    TAPE_STATE_IMPORT_PENDING TapeState = 1 + iota
-    TAPE_STATE_IMPORT_IN_PROGRESS TapeState = 1 + iota
-    TAPE_STATE_INCOMPATIBLE TapeState = 1 + iota
-    TAPE_STATE_LOST TapeState = 1 + iota
-    TAPE_STATE_BAD TapeState = 1 + iota
-    TAPE_STATE_CANNOT_FORMAT_DUE_TO_WRITE_PROTECTION TapeState = 1 + iota
-    TAPE_STATE_SERIAL_NUMBER_MISMATCH TapeState = 1 + iota
-    TAPE_STATE_BAR_CODE_MISSING TapeState = 1 + iota
-    TAPE_STATE_AUTO_COMPACTION_IN_PROGRESS TapeState = 1 + iota
-    TAPE_STATE_FORMAT_PENDING TapeState = 1 + iota
-    TAPE_STATE_FORMAT_IN_PROGRESS TapeState = 1 + iota
-    TAPE_STATE_EJECT_TO_EE_IN_PROGRESS TapeState = 1 + iota
-    TAPE_STATE_EJECT_FROM_EE_PENDING TapeState = 1 + iota
-    TAPE_STATE_EJECTED TapeState = 1 + iota
+	TAPE_STATE_NORMAL                                   TapeState = 1 + iota
+	TAPE_STATE_OFFLINE                                  TapeState = 1 + iota
+	TAPE_STATE_ONLINE_PENDING                           TapeState = 1 + iota
+	TAPE_STATE_ONLINE_IN_PROGRESS                       TapeState = 1 + iota
+	TAPE_STATE_PENDING_INSPECTION                       TapeState = 1 + iota
+	TAPE_STATE_UNKNOWN                                  TapeState = 1 + iota
+	TAPE_STATE_DATA_CHECKPOINT_FAILURE                  TapeState = 1 + iota
+	TAPE_STATE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY TapeState = 1 + iota
+	TAPE_STATE_DATA_CHECKPOINT_MISSING                  TapeState = 1 + iota
+	TAPE_STATE_LTFS_WITH_FOREIGN_DATA                   TapeState = 1 + iota
+	TAPE_STATE_RAW_IMPORT_PENDING                       TapeState = 1 + iota
+	TAPE_STATE_RAW_IMPORT_IN_PROGRESS                   TapeState = 1 + iota
+	TAPE_STATE_FOREIGN                                  TapeState = 1 + iota
+	TAPE_STATE_IMPORT_PENDING                           TapeState = 1 + iota
+	TAPE_STATE_IMPORT_IN_PROGRESS                       TapeState = 1 + iota
+	TAPE_STATE_INCOMPATIBLE                             TapeState = 1 + iota
+	TAPE_STATE_LOST                                     TapeState = 1 + iota
+	TAPE_STATE_BAD                                      TapeState = 1 + iota
+	TAPE_STATE_CANNOT_FORMAT_DUE_TO_WRITE_PROTECTION    TapeState = 1 + iota
+	TAPE_STATE_SERIAL_NUMBER_MISMATCH                   TapeState = 1 + iota
+	TAPE_STATE_BAR_CODE_MISSING                         TapeState = 1 + iota
+	TAPE_STATE_AUTO_COMPACTION_IN_PROGRESS              TapeState = 1 + iota
+	TAPE_STATE_FORMAT_PENDING                           TapeState = 1 + iota
+	TAPE_STATE_FORMAT_IN_PROGRESS                       TapeState = 1 + iota
+	TAPE_STATE_EJECT_TO_EE_IN_PROGRESS                  TapeState = 1 + iota
+	TAPE_STATE_EJECT_FROM_EE_PENDING                    TapeState = 1 + iota
+	TAPE_STATE_EJECTED                                  TapeState = 1 + iota
 )
 
 func (tapeState *TapeState) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *tapeState = UNDEFINED
-        case "NORMAL": *tapeState = TAPE_STATE_NORMAL
-        case "OFFLINE": *tapeState = TAPE_STATE_OFFLINE
-        case "ONLINE_PENDING": *tapeState = TAPE_STATE_ONLINE_PENDING
-        case "ONLINE_IN_PROGRESS": *tapeState = TAPE_STATE_ONLINE_IN_PROGRESS
-        case "PENDING_INSPECTION": *tapeState = TAPE_STATE_PENDING_INSPECTION
-        case "UNKNOWN": *tapeState = TAPE_STATE_UNKNOWN
-        case "DATA_CHECKPOINT_FAILURE": *tapeState = TAPE_STATE_DATA_CHECKPOINT_FAILURE
-        case "DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY": *tapeState = TAPE_STATE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY
-        case "DATA_CHECKPOINT_MISSING": *tapeState = TAPE_STATE_DATA_CHECKPOINT_MISSING
-        case "LTFS_WITH_FOREIGN_DATA": *tapeState = TAPE_STATE_LTFS_WITH_FOREIGN_DATA
-        case "RAW_IMPORT_PENDING": *tapeState = TAPE_STATE_RAW_IMPORT_PENDING
-        case "RAW_IMPORT_IN_PROGRESS": *tapeState = TAPE_STATE_RAW_IMPORT_IN_PROGRESS
-        case "FOREIGN": *tapeState = TAPE_STATE_FOREIGN
-        case "IMPORT_PENDING": *tapeState = TAPE_STATE_IMPORT_PENDING
-        case "IMPORT_IN_PROGRESS": *tapeState = TAPE_STATE_IMPORT_IN_PROGRESS
-        case "INCOMPATIBLE": *tapeState = TAPE_STATE_INCOMPATIBLE
-        case "LOST": *tapeState = TAPE_STATE_LOST
-        case "BAD": *tapeState = TAPE_STATE_BAD
-        case "CANNOT_FORMAT_DUE_TO_WRITE_PROTECTION": *tapeState = TAPE_STATE_CANNOT_FORMAT_DUE_TO_WRITE_PROTECTION
-        case "SERIAL_NUMBER_MISMATCH": *tapeState = TAPE_STATE_SERIAL_NUMBER_MISMATCH
-        case "BAR_CODE_MISSING": *tapeState = TAPE_STATE_BAR_CODE_MISSING
-        case "AUTO_COMPACTION_IN_PROGRESS": *tapeState = TAPE_STATE_AUTO_COMPACTION_IN_PROGRESS
-        case "FORMAT_PENDING": *tapeState = TAPE_STATE_FORMAT_PENDING
-        case "FORMAT_IN_PROGRESS": *tapeState = TAPE_STATE_FORMAT_IN_PROGRESS
-        case "EJECT_TO_EE_IN_PROGRESS": *tapeState = TAPE_STATE_EJECT_TO_EE_IN_PROGRESS
-        case "EJECT_FROM_EE_PENDING": *tapeState = TAPE_STATE_EJECT_FROM_EE_PENDING
-        case "EJECTED": *tapeState = TAPE_STATE_EJECTED
-        default:
-            *tapeState = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapeState", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*tapeState = UNDEFINED
+	case "NORMAL":
+		*tapeState = TAPE_STATE_NORMAL
+	case "OFFLINE":
+		*tapeState = TAPE_STATE_OFFLINE
+	case "ONLINE_PENDING":
+		*tapeState = TAPE_STATE_ONLINE_PENDING
+	case "ONLINE_IN_PROGRESS":
+		*tapeState = TAPE_STATE_ONLINE_IN_PROGRESS
+	case "PENDING_INSPECTION":
+		*tapeState = TAPE_STATE_PENDING_INSPECTION
+	case "UNKNOWN":
+		*tapeState = TAPE_STATE_UNKNOWN
+	case "DATA_CHECKPOINT_FAILURE":
+		*tapeState = TAPE_STATE_DATA_CHECKPOINT_FAILURE
+	case "DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY":
+		*tapeState = TAPE_STATE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY
+	case "DATA_CHECKPOINT_MISSING":
+		*tapeState = TAPE_STATE_DATA_CHECKPOINT_MISSING
+	case "LTFS_WITH_FOREIGN_DATA":
+		*tapeState = TAPE_STATE_LTFS_WITH_FOREIGN_DATA
+	case "RAW_IMPORT_PENDING":
+		*tapeState = TAPE_STATE_RAW_IMPORT_PENDING
+	case "RAW_IMPORT_IN_PROGRESS":
+		*tapeState = TAPE_STATE_RAW_IMPORT_IN_PROGRESS
+	case "FOREIGN":
+		*tapeState = TAPE_STATE_FOREIGN
+	case "IMPORT_PENDING":
+		*tapeState = TAPE_STATE_IMPORT_PENDING
+	case "IMPORT_IN_PROGRESS":
+		*tapeState = TAPE_STATE_IMPORT_IN_PROGRESS
+	case "INCOMPATIBLE":
+		*tapeState = TAPE_STATE_INCOMPATIBLE
+	case "LOST":
+		*tapeState = TAPE_STATE_LOST
+	case "BAD":
+		*tapeState = TAPE_STATE_BAD
+	case "CANNOT_FORMAT_DUE_TO_WRITE_PROTECTION":
+		*tapeState = TAPE_STATE_CANNOT_FORMAT_DUE_TO_WRITE_PROTECTION
+	case "SERIAL_NUMBER_MISMATCH":
+		*tapeState = TAPE_STATE_SERIAL_NUMBER_MISMATCH
+	case "BAR_CODE_MISSING":
+		*tapeState = TAPE_STATE_BAR_CODE_MISSING
+	case "AUTO_COMPACTION_IN_PROGRESS":
+		*tapeState = TAPE_STATE_AUTO_COMPACTION_IN_PROGRESS
+	case "FORMAT_PENDING":
+		*tapeState = TAPE_STATE_FORMAT_PENDING
+	case "FORMAT_IN_PROGRESS":
+		*tapeState = TAPE_STATE_FORMAT_IN_PROGRESS
+	case "EJECT_TO_EE_IN_PROGRESS":
+		*tapeState = TAPE_STATE_EJECT_TO_EE_IN_PROGRESS
+	case "EJECT_FROM_EE_PENDING":
+		*tapeState = TAPE_STATE_EJECT_FROM_EE_PENDING
+	case "EJECTED":
+		*tapeState = TAPE_STATE_EJECTED
+	default:
+		*tapeState = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into TapeState", str))
+	}
+	return nil
 }
 
 func (tapeState TapeState) String() string {
-    switch tapeState {
-        case TAPE_STATE_NORMAL: return "NORMAL"
-        case TAPE_STATE_OFFLINE: return "OFFLINE"
-        case TAPE_STATE_ONLINE_PENDING: return "ONLINE_PENDING"
-        case TAPE_STATE_ONLINE_IN_PROGRESS: return "ONLINE_IN_PROGRESS"
-        case TAPE_STATE_PENDING_INSPECTION: return "PENDING_INSPECTION"
-        case TAPE_STATE_UNKNOWN: return "UNKNOWN"
-        case TAPE_STATE_DATA_CHECKPOINT_FAILURE: return "DATA_CHECKPOINT_FAILURE"
-        case TAPE_STATE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY: return "DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY"
-        case TAPE_STATE_DATA_CHECKPOINT_MISSING: return "DATA_CHECKPOINT_MISSING"
-        case TAPE_STATE_LTFS_WITH_FOREIGN_DATA: return "LTFS_WITH_FOREIGN_DATA"
-        case TAPE_STATE_RAW_IMPORT_PENDING: return "RAW_IMPORT_PENDING"
-        case TAPE_STATE_RAW_IMPORT_IN_PROGRESS: return "RAW_IMPORT_IN_PROGRESS"
-        case TAPE_STATE_FOREIGN: return "FOREIGN"
-        case TAPE_STATE_IMPORT_PENDING: return "IMPORT_PENDING"
-        case TAPE_STATE_IMPORT_IN_PROGRESS: return "IMPORT_IN_PROGRESS"
-        case TAPE_STATE_INCOMPATIBLE: return "INCOMPATIBLE"
-        case TAPE_STATE_LOST: return "LOST"
-        case TAPE_STATE_BAD: return "BAD"
-        case TAPE_STATE_CANNOT_FORMAT_DUE_TO_WRITE_PROTECTION: return "CANNOT_FORMAT_DUE_TO_WRITE_PROTECTION"
-        case TAPE_STATE_SERIAL_NUMBER_MISMATCH: return "SERIAL_NUMBER_MISMATCH"
-        case TAPE_STATE_BAR_CODE_MISSING: return "BAR_CODE_MISSING"
-        case TAPE_STATE_AUTO_COMPACTION_IN_PROGRESS: return "AUTO_COMPACTION_IN_PROGRESS"
-        case TAPE_STATE_FORMAT_PENDING: return "FORMAT_PENDING"
-        case TAPE_STATE_FORMAT_IN_PROGRESS: return "FORMAT_IN_PROGRESS"
-        case TAPE_STATE_EJECT_TO_EE_IN_PROGRESS: return "EJECT_TO_EE_IN_PROGRESS"
-        case TAPE_STATE_EJECT_FROM_EE_PENDING: return "EJECT_FROM_EE_PENDING"
-        case TAPE_STATE_EJECTED: return "EJECTED"
-        default:
-            log.Printf("Error: invalid TapeState represented by '%d'", tapeState)
-            return ""
-    }
+	switch tapeState {
+	case TAPE_STATE_NORMAL:
+		return "NORMAL"
+	case TAPE_STATE_OFFLINE:
+		return "OFFLINE"
+	case TAPE_STATE_ONLINE_PENDING:
+		return "ONLINE_PENDING"
+	case TAPE_STATE_ONLINE_IN_PROGRESS:
+		return "ONLINE_IN_PROGRESS"
+	case TAPE_STATE_PENDING_INSPECTION:
+		return "PENDING_INSPECTION"
+	case TAPE_STATE_UNKNOWN:
+		return "UNKNOWN"
+	case TAPE_STATE_DATA_CHECKPOINT_FAILURE:
+		return "DATA_CHECKPOINT_FAILURE"
+	case TAPE_STATE_DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY:
+		return "DATA_CHECKPOINT_FAILURE_DUE_TO_READ_ONLY"
+	case TAPE_STATE_DATA_CHECKPOINT_MISSING:
+		return "DATA_CHECKPOINT_MISSING"
+	case TAPE_STATE_LTFS_WITH_FOREIGN_DATA:
+		return "LTFS_WITH_FOREIGN_DATA"
+	case TAPE_STATE_RAW_IMPORT_PENDING:
+		return "RAW_IMPORT_PENDING"
+	case TAPE_STATE_RAW_IMPORT_IN_PROGRESS:
+		return "RAW_IMPORT_IN_PROGRESS"
+	case TAPE_STATE_FOREIGN:
+		return "FOREIGN"
+	case TAPE_STATE_IMPORT_PENDING:
+		return "IMPORT_PENDING"
+	case TAPE_STATE_IMPORT_IN_PROGRESS:
+		return "IMPORT_IN_PROGRESS"
+	case TAPE_STATE_INCOMPATIBLE:
+		return "INCOMPATIBLE"
+	case TAPE_STATE_LOST:
+		return "LOST"
+	case TAPE_STATE_BAD:
+		return "BAD"
+	case TAPE_STATE_CANNOT_FORMAT_DUE_TO_WRITE_PROTECTION:
+		return "CANNOT_FORMAT_DUE_TO_WRITE_PROTECTION"
+	case TAPE_STATE_SERIAL_NUMBER_MISMATCH:
+		return "SERIAL_NUMBER_MISMATCH"
+	case TAPE_STATE_BAR_CODE_MISSING:
+		return "BAR_CODE_MISSING"
+	case TAPE_STATE_AUTO_COMPACTION_IN_PROGRESS:
+		return "AUTO_COMPACTION_IN_PROGRESS"
+	case TAPE_STATE_FORMAT_PENDING:
+		return "FORMAT_PENDING"
+	case TAPE_STATE_FORMAT_IN_PROGRESS:
+		return "FORMAT_IN_PROGRESS"
+	case TAPE_STATE_EJECT_TO_EE_IN_PROGRESS:
+		return "EJECT_TO_EE_IN_PROGRESS"
+	case TAPE_STATE_EJECT_FROM_EE_PENDING:
+		return "EJECT_FROM_EE_PENDING"
+	case TAPE_STATE_EJECTED:
+		return "EJECTED"
+	default:
+		log.Printf("Error: invalid TapeState represented by '%d'", tapeState)
+		return ""
+	}
 }
 
 func (tapeState TapeState) StringPtr() *string {
-    if tapeState == UNDEFINED {
-        return nil
-    }
-    result := tapeState.String()
-    return &result
+	if tapeState == UNDEFINED {
+		return nil
+	}
+	result := tapeState.String()
+	return &result
 }
 
 func newTapeStateFromContent(content []byte, aggErr *AggregateError) *TapeState {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(TapeState)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(TapeState)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type AzureTarget struct {
-    AccountKey *string
-    AccountName *string
-    AutoVerifyFrequencyInDays *int
-    CloudBucketPrefix *string
-    CloudBucketSuffix *string
-    DefaultReadPreference TargetReadPreferenceType
-    Https bool
-    Id string
-    LastFullyVerified *string
-    Name *string
-    NamingMode CloudNamingMode
-    PermitGoingOutOfSync bool
-    Quiesced Quiesced
-    State TargetState
+	AccountKey                *string
+	AccountName               *string
+	AutoVerifyFrequencyInDays *int
+	CloudBucketPrefix         *string
+	CloudBucketSuffix         *string
+	DefaultReadPreference     TargetReadPreferenceType
+	Https                     bool
+	Id                        string
+	LastFullyVerified         *string
+	Name                      *string
+	NamingMode                CloudNamingMode
+	PermitGoingOutOfSync      bool
+	Quiesced                  Quiesced
+	State                     TargetState
 }
 
 func (azureTarget *AzureTarget) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AccountKey":
-            azureTarget.AccountKey = parseNullableString(child.Content)
-        case "AccountName":
-            azureTarget.AccountName = parseNullableString(child.Content)
-        case "AutoVerifyFrequencyInDays":
-            azureTarget.AutoVerifyFrequencyInDays = parseNullableInt(child.Content, aggErr)
-        case "CloudBucketPrefix":
-            azureTarget.CloudBucketPrefix = parseNullableString(child.Content)
-        case "CloudBucketSuffix":
-            azureTarget.CloudBucketSuffix = parseNullableString(child.Content)
-        case "DefaultReadPreference":
-            parseEnum(child.Content, &azureTarget.DefaultReadPreference, aggErr)
-        case "Https":
-            azureTarget.Https = parseBool(child.Content, aggErr)
-        case "Id":
-            azureTarget.Id = parseString(child.Content)
-        case "LastFullyVerified":
-            azureTarget.LastFullyVerified = parseNullableString(child.Content)
-        case "Name":
-            azureTarget.Name = parseNullableString(child.Content)
-        case "NamingMode":
-            parseEnum(child.Content, &azureTarget.NamingMode, aggErr)
-        case "PermitGoingOutOfSync":
-            azureTarget.PermitGoingOutOfSync = parseBool(child.Content, aggErr)
-        case "Quiesced":
-            parseEnum(child.Content, &azureTarget.Quiesced, aggErr)
-        case "State":
-            parseEnum(child.Content, &azureTarget.State, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTarget.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AccountKey":
+			azureTarget.AccountKey = parseNullableString(child.Content)
+		case "AccountName":
+			azureTarget.AccountName = parseNullableString(child.Content)
+		case "AutoVerifyFrequencyInDays":
+			azureTarget.AutoVerifyFrequencyInDays = parseNullableInt(child.Content, aggErr)
+		case "CloudBucketPrefix":
+			azureTarget.CloudBucketPrefix = parseNullableString(child.Content)
+		case "CloudBucketSuffix":
+			azureTarget.CloudBucketSuffix = parseNullableString(child.Content)
+		case "DefaultReadPreference":
+			parseEnum(child.Content, &azureTarget.DefaultReadPreference, aggErr)
+		case "Https":
+			azureTarget.Https = parseBool(child.Content, aggErr)
+		case "Id":
+			azureTarget.Id = parseString(child.Content)
+		case "LastFullyVerified":
+			azureTarget.LastFullyVerified = parseNullableString(child.Content)
+		case "Name":
+			azureTarget.Name = parseNullableString(child.Content)
+		case "NamingMode":
+			parseEnum(child.Content, &azureTarget.NamingMode, aggErr)
+		case "PermitGoingOutOfSync":
+			azureTarget.PermitGoingOutOfSync = parseBool(child.Content, aggErr)
+		case "Quiesced":
+			parseEnum(child.Content, &azureTarget.Quiesced, aggErr)
+		case "State":
+			parseEnum(child.Content, &azureTarget.State, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTarget.", child.XMLName.Local)
+		}
+	}
 }
 
-
 func parseAzureTargetSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []AzureTarget {
-    var result []AzureTarget
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult AzureTarget
-            curResult.parse(&curXmlNode, aggErr)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing AzureTarget struct.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []AzureTarget
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult AzureTarget
+			curResult.parse(&curXmlNode, aggErr)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing AzureTarget struct.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }
 
 type AzureTargetBucketName struct {
-    BucketId string
-    Id string
-    Name *string
-    TargetId string
+	BucketId string
+	Id       string
+	Name     *string
+	TargetId string
 }
 
 func (azureTargetBucketName *AzureTargetBucketName) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketId":
-            azureTargetBucketName.BucketId = parseString(child.Content)
-        case "Id":
-            azureTargetBucketName.Id = parseString(child.Content)
-        case "Name":
-            azureTargetBucketName.Name = parseNullableString(child.Content)
-        case "TargetId":
-            azureTargetBucketName.TargetId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetBucketName.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketId":
+			azureTargetBucketName.BucketId = parseString(child.Content)
+		case "Id":
+			azureTargetBucketName.Id = parseString(child.Content)
+		case "Name":
+			azureTargetBucketName.Name = parseNullableString(child.Content)
+		case "TargetId":
+			azureTargetBucketName.TargetId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetBucketName.", child.XMLName.Local)
+		}
+	}
 }
 
 type AzureTargetFailure struct {
-    Date string
-    ErrorMessage *string
-    Id string
-    TargetId string
-    Type TargetFailureType
+	Date         string
+	ErrorMessage *string
+	Id           string
+	TargetId     string
+	Type         TargetFailureType
 }
 
 func (azureTargetFailure *AzureTargetFailure) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Date":
-            azureTargetFailure.Date = parseString(child.Content)
-        case "ErrorMessage":
-            azureTargetFailure.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            azureTargetFailure.Id = parseString(child.Content)
-        case "TargetId":
-            azureTargetFailure.TargetId = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &azureTargetFailure.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetFailure.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Date":
+			azureTargetFailure.Date = parseString(child.Content)
+		case "ErrorMessage":
+			azureTargetFailure.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			azureTargetFailure.Id = parseString(child.Content)
+		case "TargetId":
+			azureTargetFailure.TargetId = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &azureTargetFailure.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetFailure.", child.XMLName.Local)
+		}
+	}
 }
 
 type AzureTargetReadPreference struct {
-    BucketId string
-    Id string
-    ReadPreference TargetReadPreferenceType
-    TargetId string
+	BucketId       string
+	Id             string
+	ReadPreference TargetReadPreferenceType
+	TargetId       string
 }
 
 func (azureTargetReadPreference *AzureTargetReadPreference) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketId":
-            azureTargetReadPreference.BucketId = parseString(child.Content)
-        case "Id":
-            azureTargetReadPreference.Id = parseString(child.Content)
-        case "ReadPreference":
-            parseEnum(child.Content, &azureTargetReadPreference.ReadPreference, aggErr)
-        case "TargetId":
-            azureTargetReadPreference.TargetId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetReadPreference.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketId":
+			azureTargetReadPreference.BucketId = parseString(child.Content)
+		case "Id":
+			azureTargetReadPreference.Id = parseString(child.Content)
+		case "ReadPreference":
+			parseEnum(child.Content, &azureTargetReadPreference.ReadPreference, aggErr)
+		case "TargetId":
+			azureTargetReadPreference.TargetId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetReadPreference.", child.XMLName.Local)
+		}
+	}
 }
 
 type Ds3Target struct {
-    AccessControlReplication Ds3TargetAccessControlReplication
-    AdminAuthId *string
-    AdminSecretKey *string
-    DataPathEndPoint *string
-    DataPathHttps bool
-    DataPathPort *int
-    DataPathProxy *string
-    DataPathVerifyCertificate bool
-    DefaultReadPreference TargetReadPreferenceType
-    Id string
-    Name *string
-    PermitGoingOutOfSync bool
-    Quiesced Quiesced
-    ReplicatedUserDefaultDataPolicy *string
-    State TargetState
+	AccessControlReplication        Ds3TargetAccessControlReplication
+	AdminAuthId                     *string
+	AdminSecretKey                  *string
+	DataPathEndPoint                *string
+	DataPathHttps                   bool
+	DataPathPort                    *int
+	DataPathProxy                   *string
+	DataPathVerifyCertificate       bool
+	DefaultReadPreference           TargetReadPreferenceType
+	Id                              string
+	Name                            *string
+	PermitGoingOutOfSync            bool
+	Quiesced                        Quiesced
+	ReplicatedUserDefaultDataPolicy *string
+	State                           TargetState
 }
 
 func (ds3Target *Ds3Target) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AccessControlReplication":
-            parseEnum(child.Content, &ds3Target.AccessControlReplication, aggErr)
-        case "AdminAuthId":
-            ds3Target.AdminAuthId = parseNullableString(child.Content)
-        case "AdminSecretKey":
-            ds3Target.AdminSecretKey = parseNullableString(child.Content)
-        case "DataPathEndPoint":
-            ds3Target.DataPathEndPoint = parseNullableString(child.Content)
-        case "DataPathHttps":
-            ds3Target.DataPathHttps = parseBool(child.Content, aggErr)
-        case "DataPathPort":
-            ds3Target.DataPathPort = parseNullableInt(child.Content, aggErr)
-        case "DataPathProxy":
-            ds3Target.DataPathProxy = parseNullableString(child.Content)
-        case "DataPathVerifyCertificate":
-            ds3Target.DataPathVerifyCertificate = parseBool(child.Content, aggErr)
-        case "DefaultReadPreference":
-            parseEnum(child.Content, &ds3Target.DefaultReadPreference, aggErr)
-        case "Id":
-            ds3Target.Id = parseString(child.Content)
-        case "Name":
-            ds3Target.Name = parseNullableString(child.Content)
-        case "PermitGoingOutOfSync":
-            ds3Target.PermitGoingOutOfSync = parseBool(child.Content, aggErr)
-        case "Quiesced":
-            parseEnum(child.Content, &ds3Target.Quiesced, aggErr)
-        case "ReplicatedUserDefaultDataPolicy":
-            ds3Target.ReplicatedUserDefaultDataPolicy = parseNullableString(child.Content)
-        case "State":
-            parseEnum(child.Content, &ds3Target.State, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3Target.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AccessControlReplication":
+			parseEnum(child.Content, &ds3Target.AccessControlReplication, aggErr)
+		case "AdminAuthId":
+			ds3Target.AdminAuthId = parseNullableString(child.Content)
+		case "AdminSecretKey":
+			ds3Target.AdminSecretKey = parseNullableString(child.Content)
+		case "DataPathEndPoint":
+			ds3Target.DataPathEndPoint = parseNullableString(child.Content)
+		case "DataPathHttps":
+			ds3Target.DataPathHttps = parseBool(child.Content, aggErr)
+		case "DataPathPort":
+			ds3Target.DataPathPort = parseNullableInt(child.Content, aggErr)
+		case "DataPathProxy":
+			ds3Target.DataPathProxy = parseNullableString(child.Content)
+		case "DataPathVerifyCertificate":
+			ds3Target.DataPathVerifyCertificate = parseBool(child.Content, aggErr)
+		case "DefaultReadPreference":
+			parseEnum(child.Content, &ds3Target.DefaultReadPreference, aggErr)
+		case "Id":
+			ds3Target.Id = parseString(child.Content)
+		case "Name":
+			ds3Target.Name = parseNullableString(child.Content)
+		case "PermitGoingOutOfSync":
+			ds3Target.PermitGoingOutOfSync = parseBool(child.Content, aggErr)
+		case "Quiesced":
+			parseEnum(child.Content, &ds3Target.Quiesced, aggErr)
+		case "ReplicatedUserDefaultDataPolicy":
+			ds3Target.ReplicatedUserDefaultDataPolicy = parseNullableString(child.Content)
+		case "State":
+			parseEnum(child.Content, &ds3Target.State, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3Target.", child.XMLName.Local)
+		}
+	}
 }
 
-
 func parseDs3TargetSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []Ds3Target {
-    var result []Ds3Target
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult Ds3Target
-            curResult.parse(&curXmlNode, aggErr)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing Ds3Target struct.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []Ds3Target
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult Ds3Target
+			curResult.parse(&curXmlNode, aggErr)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing Ds3Target struct.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }
 
 type Ds3TargetAccessControlReplication Enum
 
 const (
-    DS3_TARGET_ACCESS_CONTROL_REPLICATION_NONE Ds3TargetAccessControlReplication = 1 + iota
-    DS3_TARGET_ACCESS_CONTROL_REPLICATION_USERS Ds3TargetAccessControlReplication = 1 + iota
+	DS3_TARGET_ACCESS_CONTROL_REPLICATION_NONE  Ds3TargetAccessControlReplication = 1 + iota
+	DS3_TARGET_ACCESS_CONTROL_REPLICATION_USERS Ds3TargetAccessControlReplication = 1 + iota
 )
 
 func (ds3TargetAccessControlReplication *Ds3TargetAccessControlReplication) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *ds3TargetAccessControlReplication = UNDEFINED
-        case "NONE": *ds3TargetAccessControlReplication = DS3_TARGET_ACCESS_CONTROL_REPLICATION_NONE
-        case "USERS": *ds3TargetAccessControlReplication = DS3_TARGET_ACCESS_CONTROL_REPLICATION_USERS
-        default:
-            *ds3TargetAccessControlReplication = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into Ds3TargetAccessControlReplication", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*ds3TargetAccessControlReplication = UNDEFINED
+	case "NONE":
+		*ds3TargetAccessControlReplication = DS3_TARGET_ACCESS_CONTROL_REPLICATION_NONE
+	case "USERS":
+		*ds3TargetAccessControlReplication = DS3_TARGET_ACCESS_CONTROL_REPLICATION_USERS
+	default:
+		*ds3TargetAccessControlReplication = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into Ds3TargetAccessControlReplication", str))
+	}
+	return nil
 }
 
 func (ds3TargetAccessControlReplication Ds3TargetAccessControlReplication) String() string {
-    switch ds3TargetAccessControlReplication {
-        case DS3_TARGET_ACCESS_CONTROL_REPLICATION_NONE: return "NONE"
-        case DS3_TARGET_ACCESS_CONTROL_REPLICATION_USERS: return "USERS"
-        default:
-            log.Printf("Error: invalid Ds3TargetAccessControlReplication represented by '%d'", ds3TargetAccessControlReplication)
-            return ""
-    }
+	switch ds3TargetAccessControlReplication {
+	case DS3_TARGET_ACCESS_CONTROL_REPLICATION_NONE:
+		return "NONE"
+	case DS3_TARGET_ACCESS_CONTROL_REPLICATION_USERS:
+		return "USERS"
+	default:
+		log.Printf("Error: invalid Ds3TargetAccessControlReplication represented by '%d'", ds3TargetAccessControlReplication)
+		return ""
+	}
 }
 
 func (ds3TargetAccessControlReplication Ds3TargetAccessControlReplication) StringPtr() *string {
-    if ds3TargetAccessControlReplication == UNDEFINED {
-        return nil
-    }
-    result := ds3TargetAccessControlReplication.String()
-    return &result
+	if ds3TargetAccessControlReplication == UNDEFINED {
+		return nil
+	}
+	result := ds3TargetAccessControlReplication.String()
+	return &result
 }
 
 func newDs3TargetAccessControlReplicationFromContent(content []byte, aggErr *AggregateError) *Ds3TargetAccessControlReplication {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(Ds3TargetAccessControlReplication)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(Ds3TargetAccessControlReplication)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type Ds3TargetFailure struct {
-    Date string
-    ErrorMessage *string
-    Id string
-    TargetId string
-    Type TargetFailureType
+	Date         string
+	ErrorMessage *string
+	Id           string
+	TargetId     string
+	Type         TargetFailureType
 }
 
 func (ds3TargetFailure *Ds3TargetFailure) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Date":
-            ds3TargetFailure.Date = parseString(child.Content)
-        case "ErrorMessage":
-            ds3TargetFailure.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            ds3TargetFailure.Id = parseString(child.Content)
-        case "TargetId":
-            ds3TargetFailure.TargetId = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &ds3TargetFailure.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetFailure.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Date":
+			ds3TargetFailure.Date = parseString(child.Content)
+		case "ErrorMessage":
+			ds3TargetFailure.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			ds3TargetFailure.Id = parseString(child.Content)
+		case "TargetId":
+			ds3TargetFailure.TargetId = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &ds3TargetFailure.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetFailure.", child.XMLName.Local)
+		}
+	}
 }
 
 type Ds3TargetReadPreference struct {
-    BucketId string
-    Id string
-    ReadPreference TargetReadPreferenceType
-    TargetId string
+	BucketId       string
+	Id             string
+	ReadPreference TargetReadPreferenceType
+	TargetId       string
 }
 
 func (ds3TargetReadPreference *Ds3TargetReadPreference) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketId":
-            ds3TargetReadPreference.BucketId = parseString(child.Content)
-        case "Id":
-            ds3TargetReadPreference.Id = parseString(child.Content)
-        case "ReadPreference":
-            parseEnum(child.Content, &ds3TargetReadPreference.ReadPreference, aggErr)
-        case "TargetId":
-            ds3TargetReadPreference.TargetId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetReadPreference.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketId":
+			ds3TargetReadPreference.BucketId = parseString(child.Content)
+		case "Id":
+			ds3TargetReadPreference.Id = parseString(child.Content)
+		case "ReadPreference":
+			parseEnum(child.Content, &ds3TargetReadPreference.ReadPreference, aggErr)
+		case "TargetId":
+			ds3TargetReadPreference.TargetId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetReadPreference.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3Target struct {
-    AccessKey *string
-    AutoVerifyFrequencyInDays *int
-    CloudBucketPrefix *string
-    CloudBucketSuffix *string
-    DataPathEndPoint *string
-    DefaultReadPreference TargetReadPreferenceType
-    Https bool
-    Id string
-    LastFullyVerified *string
-    Name *string
-    NamingMode CloudNamingMode
-    OfflineDataStagingWindowInTb int
-    PermitGoingOutOfSync bool
-    ProxyDomain *string
-    ProxyHost *string
-    ProxyPassword *string
-    ProxyPort *int
-    ProxyUsername *string
-    Quiesced Quiesced
-    Region *S3Region
-    RestrictedAccess bool
-    SecretKey *string
-    StagedDataExpirationInDays int
-    State TargetState
+	AccessKey                    *string
+	AutoVerifyFrequencyInDays    *int
+	CloudBucketPrefix            *string
+	CloudBucketSuffix            *string
+	DataPathEndPoint             *string
+	DefaultReadPreference        TargetReadPreferenceType
+	Https                        bool
+	Id                           string
+	LastFullyVerified            *string
+	Name                         *string
+	NamingMode                   CloudNamingMode
+	OfflineDataStagingWindowInTb int
+	PermitGoingOutOfSync         bool
+	ProxyDomain                  *string
+	ProxyHost                    *string
+	ProxyPassword                *string
+	ProxyPort                    *int
+	ProxyUsername                *string
+	Quiesced                     Quiesced
+	Region                       *S3Region
+	RestrictedAccess             bool
+	SecretKey                    *string
+	StagedDataExpirationInDays   int
+	State                        TargetState
 }
 
 func (s3Target *S3Target) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AccessKey":
-            s3Target.AccessKey = parseNullableString(child.Content)
-        case "AutoVerifyFrequencyInDays":
-            s3Target.AutoVerifyFrequencyInDays = parseNullableInt(child.Content, aggErr)
-        case "CloudBucketPrefix":
-            s3Target.CloudBucketPrefix = parseNullableString(child.Content)
-        case "CloudBucketSuffix":
-            s3Target.CloudBucketSuffix = parseNullableString(child.Content)
-        case "DataPathEndPoint":
-            s3Target.DataPathEndPoint = parseNullableString(child.Content)
-        case "DefaultReadPreference":
-            parseEnum(child.Content, &s3Target.DefaultReadPreference, aggErr)
-        case "Https":
-            s3Target.Https = parseBool(child.Content, aggErr)
-        case "Id":
-            s3Target.Id = parseString(child.Content)
-        case "LastFullyVerified":
-            s3Target.LastFullyVerified = parseNullableString(child.Content)
-        case "Name":
-            s3Target.Name = parseNullableString(child.Content)
-        case "NamingMode":
-            parseEnum(child.Content, &s3Target.NamingMode, aggErr)
-        case "OfflineDataStagingWindowInTb":
-            s3Target.OfflineDataStagingWindowInTb = parseInt(child.Content, aggErr)
-        case "PermitGoingOutOfSync":
-            s3Target.PermitGoingOutOfSync = parseBool(child.Content, aggErr)
-        case "ProxyDomain":
-            s3Target.ProxyDomain = parseNullableString(child.Content)
-        case "ProxyHost":
-            s3Target.ProxyHost = parseNullableString(child.Content)
-        case "ProxyPassword":
-            s3Target.ProxyPassword = parseNullableString(child.Content)
-        case "ProxyPort":
-            s3Target.ProxyPort = parseNullableInt(child.Content, aggErr)
-        case "ProxyUsername":
-            s3Target.ProxyUsername = parseNullableString(child.Content)
-        case "Quiesced":
-            parseEnum(child.Content, &s3Target.Quiesced, aggErr)
-        case "Region":
-            s3Target.Region = newS3RegionFromContent(child.Content, aggErr)
-        case "RestrictedAccess":
-            s3Target.RestrictedAccess = parseBool(child.Content, aggErr)
-        case "SecretKey":
-            s3Target.SecretKey = parseNullableString(child.Content)
-        case "StagedDataExpirationInDays":
-            s3Target.StagedDataExpirationInDays = parseInt(child.Content, aggErr)
-        case "State":
-            parseEnum(child.Content, &s3Target.State, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3Target.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AccessKey":
+			s3Target.AccessKey = parseNullableString(child.Content)
+		case "AutoVerifyFrequencyInDays":
+			s3Target.AutoVerifyFrequencyInDays = parseNullableInt(child.Content, aggErr)
+		case "CloudBucketPrefix":
+			s3Target.CloudBucketPrefix = parseNullableString(child.Content)
+		case "CloudBucketSuffix":
+			s3Target.CloudBucketSuffix = parseNullableString(child.Content)
+		case "DataPathEndPoint":
+			s3Target.DataPathEndPoint = parseNullableString(child.Content)
+		case "DefaultReadPreference":
+			parseEnum(child.Content, &s3Target.DefaultReadPreference, aggErr)
+		case "Https":
+			s3Target.Https = parseBool(child.Content, aggErr)
+		case "Id":
+			s3Target.Id = parseString(child.Content)
+		case "LastFullyVerified":
+			s3Target.LastFullyVerified = parseNullableString(child.Content)
+		case "Name":
+			s3Target.Name = parseNullableString(child.Content)
+		case "NamingMode":
+			parseEnum(child.Content, &s3Target.NamingMode, aggErr)
+		case "OfflineDataStagingWindowInTb":
+			s3Target.OfflineDataStagingWindowInTb = parseInt(child.Content, aggErr)
+		case "PermitGoingOutOfSync":
+			s3Target.PermitGoingOutOfSync = parseBool(child.Content, aggErr)
+		case "ProxyDomain":
+			s3Target.ProxyDomain = parseNullableString(child.Content)
+		case "ProxyHost":
+			s3Target.ProxyHost = parseNullableString(child.Content)
+		case "ProxyPassword":
+			s3Target.ProxyPassword = parseNullableString(child.Content)
+		case "ProxyPort":
+			s3Target.ProxyPort = parseNullableInt(child.Content, aggErr)
+		case "ProxyUsername":
+			s3Target.ProxyUsername = parseNullableString(child.Content)
+		case "Quiesced":
+			parseEnum(child.Content, &s3Target.Quiesced, aggErr)
+		case "Region":
+			s3Target.Region = newS3RegionFromContent(child.Content, aggErr)
+		case "RestrictedAccess":
+			s3Target.RestrictedAccess = parseBool(child.Content, aggErr)
+		case "SecretKey":
+			s3Target.SecretKey = parseNullableString(child.Content)
+		case "StagedDataExpirationInDays":
+			s3Target.StagedDataExpirationInDays = parseInt(child.Content, aggErr)
+		case "State":
+			parseEnum(child.Content, &s3Target.State, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3Target.", child.XMLName.Local)
+		}
+	}
 }
 
-
 func parseS3TargetSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []S3Target {
-    var result []S3Target
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult S3Target
-            curResult.parse(&curXmlNode, aggErr)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing S3Target struct.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []S3Target
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult S3Target
+			curResult.parse(&curXmlNode, aggErr)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing S3Target struct.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }
 
 type S3TargetBucketName struct {
-    BucketId string
-    Id string
-    Name *string
-    TargetId string
+	BucketId string
+	Id       string
+	Name     *string
+	TargetId string
 }
 
 func (s3TargetBucketName *S3TargetBucketName) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketId":
-            s3TargetBucketName.BucketId = parseString(child.Content)
-        case "Id":
-            s3TargetBucketName.Id = parseString(child.Content)
-        case "Name":
-            s3TargetBucketName.Name = parseNullableString(child.Content)
-        case "TargetId":
-            s3TargetBucketName.TargetId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetBucketName.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketId":
+			s3TargetBucketName.BucketId = parseString(child.Content)
+		case "Id":
+			s3TargetBucketName.Id = parseString(child.Content)
+		case "Name":
+			s3TargetBucketName.Name = parseNullableString(child.Content)
+		case "TargetId":
+			s3TargetBucketName.TargetId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetBucketName.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3TargetFailure struct {
-    Date string
-    ErrorMessage *string
-    Id string
-    TargetId string
-    Type TargetFailureType
+	Date         string
+	ErrorMessage *string
+	Id           string
+	TargetId     string
+	Type         TargetFailureType
 }
 
 func (s3TargetFailure *S3TargetFailure) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Date":
-            s3TargetFailure.Date = parseString(child.Content)
-        case "ErrorMessage":
-            s3TargetFailure.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            s3TargetFailure.Id = parseString(child.Content)
-        case "TargetId":
-            s3TargetFailure.TargetId = parseString(child.Content)
-        case "Type":
-            parseEnum(child.Content, &s3TargetFailure.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetFailure.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Date":
+			s3TargetFailure.Date = parseString(child.Content)
+		case "ErrorMessage":
+			s3TargetFailure.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			s3TargetFailure.Id = parseString(child.Content)
+		case "TargetId":
+			s3TargetFailure.TargetId = parseString(child.Content)
+		case "Type":
+			parseEnum(child.Content, &s3TargetFailure.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetFailure.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3TargetReadPreference struct {
-    BucketId string
-    Id string
-    ReadPreference TargetReadPreferenceType
-    TargetId string
+	BucketId       string
+	Id             string
+	ReadPreference TargetReadPreferenceType
+	TargetId       string
 }
 
 func (s3TargetReadPreference *S3TargetReadPreference) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketId":
-            s3TargetReadPreference.BucketId = parseString(child.Content)
-        case "Id":
-            s3TargetReadPreference.Id = parseString(child.Content)
-        case "ReadPreference":
-            parseEnum(child.Content, &s3TargetReadPreference.ReadPreference, aggErr)
-        case "TargetId":
-            s3TargetReadPreference.TargetId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetReadPreference.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketId":
+			s3TargetReadPreference.BucketId = parseString(child.Content)
+		case "Id":
+			s3TargetReadPreference.Id = parseString(child.Content)
+		case "ReadPreference":
+			parseEnum(child.Content, &s3TargetReadPreference.ReadPreference, aggErr)
+		case "TargetId":
+			s3TargetReadPreference.TargetId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetReadPreference.", child.XMLName.Local)
+		}
+	}
 }
 
 type SuspectBlobAzureTarget struct {
-    BlobId string
-    Id string
-    TargetId string
+	BlobId   string
+	Id       string
+	TargetId string
 }
 
 func (suspectBlobAzureTarget *SuspectBlobAzureTarget) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BlobId":
-            suspectBlobAzureTarget.BlobId = parseString(child.Content)
-        case "Id":
-            suspectBlobAzureTarget.Id = parseString(child.Content)
-        case "TargetId":
-            suspectBlobAzureTarget.TargetId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobAzureTarget.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BlobId":
+			suspectBlobAzureTarget.BlobId = parseString(child.Content)
+		case "Id":
+			suspectBlobAzureTarget.Id = parseString(child.Content)
+		case "TargetId":
+			suspectBlobAzureTarget.TargetId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobAzureTarget.", child.XMLName.Local)
+		}
+	}
 }
 
 type SuspectBlobDs3Target struct {
-    BlobId string
-    Id string
-    TargetId string
+	BlobId   string
+	Id       string
+	TargetId string
 }
 
 func (suspectBlobDs3Target *SuspectBlobDs3Target) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BlobId":
-            suspectBlobDs3Target.BlobId = parseString(child.Content)
-        case "Id":
-            suspectBlobDs3Target.Id = parseString(child.Content)
-        case "TargetId":
-            suspectBlobDs3Target.TargetId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobDs3Target.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BlobId":
+			suspectBlobDs3Target.BlobId = parseString(child.Content)
+		case "Id":
+			suspectBlobDs3Target.Id = parseString(child.Content)
+		case "TargetId":
+			suspectBlobDs3Target.TargetId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobDs3Target.", child.XMLName.Local)
+		}
+	}
 }
 
 type SuspectBlobS3Target struct {
-    BlobId string
-    Id string
-    TargetId string
+	BlobId   string
+	Id       string
+	TargetId string
 }
 
 func (suspectBlobS3Target *SuspectBlobS3Target) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BlobId":
-            suspectBlobS3Target.BlobId = parseString(child.Content)
-        case "Id":
-            suspectBlobS3Target.Id = parseString(child.Content)
-        case "TargetId":
-            suspectBlobS3Target.TargetId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobS3Target.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BlobId":
+			suspectBlobS3Target.BlobId = parseString(child.Content)
+		case "Id":
+			suspectBlobS3Target.Id = parseString(child.Content)
+		case "TargetId":
+			suspectBlobS3Target.TargetId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobS3Target.", child.XMLName.Local)
+		}
+	}
 }
 
 type TargetFailureType Enum
 
 const (
-    TARGET_FAILURE_TYPE_IMPORT_FAILED TargetFailureType = 1 + iota
-    TARGET_FAILURE_TYPE_IMPORT_INCOMPLETE TargetFailureType = 1 + iota
-    TARGET_FAILURE_TYPE_NOT_ONLINE TargetFailureType = 1 + iota
-    TARGET_FAILURE_TYPE_WRITE_FAILED TargetFailureType = 1 + iota
-    TARGET_FAILURE_TYPE_WRITE_INITIATE_FAILED TargetFailureType = 1 + iota
-    TARGET_FAILURE_TYPE_READ_FAILED TargetFailureType = 1 + iota
-    TARGET_FAILURE_TYPE_READ_INITIATE_FAILED TargetFailureType = 1 + iota
-    TARGET_FAILURE_TYPE_VERIFY_FAILED TargetFailureType = 1 + iota
-    TARGET_FAILURE_TYPE_VERIFY_COMPLETE TargetFailureType = 1 + iota
+	TARGET_FAILURE_TYPE_IMPORT_FAILED         TargetFailureType = 1 + iota
+	TARGET_FAILURE_TYPE_IMPORT_INCOMPLETE     TargetFailureType = 1 + iota
+	TARGET_FAILURE_TYPE_NOT_ONLINE            TargetFailureType = 1 + iota
+	TARGET_FAILURE_TYPE_WRITE_FAILED          TargetFailureType = 1 + iota
+	TARGET_FAILURE_TYPE_WRITE_INITIATE_FAILED TargetFailureType = 1 + iota
+	TARGET_FAILURE_TYPE_READ_FAILED           TargetFailureType = 1 + iota
+	TARGET_FAILURE_TYPE_READ_INITIATE_FAILED  TargetFailureType = 1 + iota
+	TARGET_FAILURE_TYPE_VERIFY_FAILED         TargetFailureType = 1 + iota
+	TARGET_FAILURE_TYPE_VERIFY_COMPLETE       TargetFailureType = 1 + iota
 )
 
 func (targetFailureType *TargetFailureType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *targetFailureType = UNDEFINED
-        case "IMPORT_FAILED": *targetFailureType = TARGET_FAILURE_TYPE_IMPORT_FAILED
-        case "IMPORT_INCOMPLETE": *targetFailureType = TARGET_FAILURE_TYPE_IMPORT_INCOMPLETE
-        case "NOT_ONLINE": *targetFailureType = TARGET_FAILURE_TYPE_NOT_ONLINE
-        case "WRITE_FAILED": *targetFailureType = TARGET_FAILURE_TYPE_WRITE_FAILED
-        case "WRITE_INITIATE_FAILED": *targetFailureType = TARGET_FAILURE_TYPE_WRITE_INITIATE_FAILED
-        case "READ_FAILED": *targetFailureType = TARGET_FAILURE_TYPE_READ_FAILED
-        case "READ_INITIATE_FAILED": *targetFailureType = TARGET_FAILURE_TYPE_READ_INITIATE_FAILED
-        case "VERIFY_FAILED": *targetFailureType = TARGET_FAILURE_TYPE_VERIFY_FAILED
-        case "VERIFY_COMPLETE": *targetFailureType = TARGET_FAILURE_TYPE_VERIFY_COMPLETE
-        default:
-            *targetFailureType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into TargetFailureType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*targetFailureType = UNDEFINED
+	case "IMPORT_FAILED":
+		*targetFailureType = TARGET_FAILURE_TYPE_IMPORT_FAILED
+	case "IMPORT_INCOMPLETE":
+		*targetFailureType = TARGET_FAILURE_TYPE_IMPORT_INCOMPLETE
+	case "NOT_ONLINE":
+		*targetFailureType = TARGET_FAILURE_TYPE_NOT_ONLINE
+	case "WRITE_FAILED":
+		*targetFailureType = TARGET_FAILURE_TYPE_WRITE_FAILED
+	case "WRITE_INITIATE_FAILED":
+		*targetFailureType = TARGET_FAILURE_TYPE_WRITE_INITIATE_FAILED
+	case "READ_FAILED":
+		*targetFailureType = TARGET_FAILURE_TYPE_READ_FAILED
+	case "READ_INITIATE_FAILED":
+		*targetFailureType = TARGET_FAILURE_TYPE_READ_INITIATE_FAILED
+	case "VERIFY_FAILED":
+		*targetFailureType = TARGET_FAILURE_TYPE_VERIFY_FAILED
+	case "VERIFY_COMPLETE":
+		*targetFailureType = TARGET_FAILURE_TYPE_VERIFY_COMPLETE
+	default:
+		*targetFailureType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into TargetFailureType", str))
+	}
+	return nil
 }
 
 func (targetFailureType TargetFailureType) String() string {
-    switch targetFailureType {
-        case TARGET_FAILURE_TYPE_IMPORT_FAILED: return "IMPORT_FAILED"
-        case TARGET_FAILURE_TYPE_IMPORT_INCOMPLETE: return "IMPORT_INCOMPLETE"
-        case TARGET_FAILURE_TYPE_NOT_ONLINE: return "NOT_ONLINE"
-        case TARGET_FAILURE_TYPE_WRITE_FAILED: return "WRITE_FAILED"
-        case TARGET_FAILURE_TYPE_WRITE_INITIATE_FAILED: return "WRITE_INITIATE_FAILED"
-        case TARGET_FAILURE_TYPE_READ_FAILED: return "READ_FAILED"
-        case TARGET_FAILURE_TYPE_READ_INITIATE_FAILED: return "READ_INITIATE_FAILED"
-        case TARGET_FAILURE_TYPE_VERIFY_FAILED: return "VERIFY_FAILED"
-        case TARGET_FAILURE_TYPE_VERIFY_COMPLETE: return "VERIFY_COMPLETE"
-        default:
-            log.Printf("Error: invalid TargetFailureType represented by '%d'", targetFailureType)
-            return ""
-    }
+	switch targetFailureType {
+	case TARGET_FAILURE_TYPE_IMPORT_FAILED:
+		return "IMPORT_FAILED"
+	case TARGET_FAILURE_TYPE_IMPORT_INCOMPLETE:
+		return "IMPORT_INCOMPLETE"
+	case TARGET_FAILURE_TYPE_NOT_ONLINE:
+		return "NOT_ONLINE"
+	case TARGET_FAILURE_TYPE_WRITE_FAILED:
+		return "WRITE_FAILED"
+	case TARGET_FAILURE_TYPE_WRITE_INITIATE_FAILED:
+		return "WRITE_INITIATE_FAILED"
+	case TARGET_FAILURE_TYPE_READ_FAILED:
+		return "READ_FAILED"
+	case TARGET_FAILURE_TYPE_READ_INITIATE_FAILED:
+		return "READ_INITIATE_FAILED"
+	case TARGET_FAILURE_TYPE_VERIFY_FAILED:
+		return "VERIFY_FAILED"
+	case TARGET_FAILURE_TYPE_VERIFY_COMPLETE:
+		return "VERIFY_COMPLETE"
+	default:
+		log.Printf("Error: invalid TargetFailureType represented by '%d'", targetFailureType)
+		return ""
+	}
 }
 
 func (targetFailureType TargetFailureType) StringPtr() *string {
-    if targetFailureType == UNDEFINED {
-        return nil
-    }
-    result := targetFailureType.String()
-    return &result
+	if targetFailureType == UNDEFINED {
+		return nil
+	}
+	result := targetFailureType.String()
+	return &result
 }
 
 func newTargetFailureTypeFromContent(content []byte, aggErr *AggregateError) *TargetFailureType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(TargetFailureType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(TargetFailureType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type TargetReadPreferenceType Enum
 
 const (
-    TARGET_READ_PREFERENCE_TYPE_MINIMUM_LATENCY TargetReadPreferenceType = 1 + iota
-    TARGET_READ_PREFERENCE_TYPE_AFTER_ONLINE_POOL TargetReadPreferenceType = 1 + iota
-    TARGET_READ_PREFERENCE_TYPE_AFTER_NEARLINE_POOL TargetReadPreferenceType = 1 + iota
-    TARGET_READ_PREFERENCE_TYPE_AFTER_NON_EJECTABLE_TAPE TargetReadPreferenceType = 1 + iota
-    TARGET_READ_PREFERENCE_TYPE_LAST_RESORT TargetReadPreferenceType = 1 + iota
-    TARGET_READ_PREFERENCE_TYPE_NEVER TargetReadPreferenceType = 1 + iota
+	TARGET_READ_PREFERENCE_TYPE_MINIMUM_LATENCY          TargetReadPreferenceType = 1 + iota
+	TARGET_READ_PREFERENCE_TYPE_AFTER_ONLINE_POOL        TargetReadPreferenceType = 1 + iota
+	TARGET_READ_PREFERENCE_TYPE_AFTER_NEARLINE_POOL      TargetReadPreferenceType = 1 + iota
+	TARGET_READ_PREFERENCE_TYPE_AFTER_NON_EJECTABLE_TAPE TargetReadPreferenceType = 1 + iota
+	TARGET_READ_PREFERENCE_TYPE_LAST_RESORT              TargetReadPreferenceType = 1 + iota
+	TARGET_READ_PREFERENCE_TYPE_NEVER                    TargetReadPreferenceType = 1 + iota
 )
 
 func (targetReadPreferenceType *TargetReadPreferenceType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *targetReadPreferenceType = UNDEFINED
-        case "MINIMUM_LATENCY": *targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_MINIMUM_LATENCY
-        case "AFTER_ONLINE_POOL": *targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_AFTER_ONLINE_POOL
-        case "AFTER_NEARLINE_POOL": *targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_AFTER_NEARLINE_POOL
-        case "AFTER_NON_EJECTABLE_TAPE": *targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_AFTER_NON_EJECTABLE_TAPE
-        case "LAST_RESORT": *targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_LAST_RESORT
-        case "NEVER": *targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_NEVER
-        default:
-            *targetReadPreferenceType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into TargetReadPreferenceType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*targetReadPreferenceType = UNDEFINED
+	case "MINIMUM_LATENCY":
+		*targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_MINIMUM_LATENCY
+	case "AFTER_ONLINE_POOL":
+		*targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_AFTER_ONLINE_POOL
+	case "AFTER_NEARLINE_POOL":
+		*targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_AFTER_NEARLINE_POOL
+	case "AFTER_NON_EJECTABLE_TAPE":
+		*targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_AFTER_NON_EJECTABLE_TAPE
+	case "LAST_RESORT":
+		*targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_LAST_RESORT
+	case "NEVER":
+		*targetReadPreferenceType = TARGET_READ_PREFERENCE_TYPE_NEVER
+	default:
+		*targetReadPreferenceType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into TargetReadPreferenceType", str))
+	}
+	return nil
 }
 
 func (targetReadPreferenceType TargetReadPreferenceType) String() string {
-    switch targetReadPreferenceType {
-        case TARGET_READ_PREFERENCE_TYPE_MINIMUM_LATENCY: return "MINIMUM_LATENCY"
-        case TARGET_READ_PREFERENCE_TYPE_AFTER_ONLINE_POOL: return "AFTER_ONLINE_POOL"
-        case TARGET_READ_PREFERENCE_TYPE_AFTER_NEARLINE_POOL: return "AFTER_NEARLINE_POOL"
-        case TARGET_READ_PREFERENCE_TYPE_AFTER_NON_EJECTABLE_TAPE: return "AFTER_NON_EJECTABLE_TAPE"
-        case TARGET_READ_PREFERENCE_TYPE_LAST_RESORT: return "LAST_RESORT"
-        case TARGET_READ_PREFERENCE_TYPE_NEVER: return "NEVER"
-        default:
-            log.Printf("Error: invalid TargetReadPreferenceType represented by '%d'", targetReadPreferenceType)
-            return ""
-    }
+	switch targetReadPreferenceType {
+	case TARGET_READ_PREFERENCE_TYPE_MINIMUM_LATENCY:
+		return "MINIMUM_LATENCY"
+	case TARGET_READ_PREFERENCE_TYPE_AFTER_ONLINE_POOL:
+		return "AFTER_ONLINE_POOL"
+	case TARGET_READ_PREFERENCE_TYPE_AFTER_NEARLINE_POOL:
+		return "AFTER_NEARLINE_POOL"
+	case TARGET_READ_PREFERENCE_TYPE_AFTER_NON_EJECTABLE_TAPE:
+		return "AFTER_NON_EJECTABLE_TAPE"
+	case TARGET_READ_PREFERENCE_TYPE_LAST_RESORT:
+		return "LAST_RESORT"
+	case TARGET_READ_PREFERENCE_TYPE_NEVER:
+		return "NEVER"
+	default:
+		log.Printf("Error: invalid TargetReadPreferenceType represented by '%d'", targetReadPreferenceType)
+		return ""
+	}
 }
 
 func (targetReadPreferenceType TargetReadPreferenceType) StringPtr() *string {
-    if targetReadPreferenceType == UNDEFINED {
-        return nil
-    }
-    result := targetReadPreferenceType.String()
-    return &result
+	if targetReadPreferenceType == UNDEFINED {
+		return nil
+	}
+	result := targetReadPreferenceType.String()
+	return &result
 }
 
 func newTargetReadPreferenceTypeFromContent(content []byte, aggErr *AggregateError) *TargetReadPreferenceType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(TargetReadPreferenceType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(TargetReadPreferenceType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type TargetState Enum
 
 const (
-    TARGET_STATE_ONLINE TargetState = 1 + iota
-    TARGET_STATE_OFFLINE TargetState = 1 + iota
+	TARGET_STATE_ONLINE  TargetState = 1 + iota
+	TARGET_STATE_OFFLINE TargetState = 1 + iota
 )
 
 func (targetState *TargetState) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *targetState = UNDEFINED
-        case "ONLINE": *targetState = TARGET_STATE_ONLINE
-        case "OFFLINE": *targetState = TARGET_STATE_OFFLINE
-        default:
-            *targetState = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into TargetState", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*targetState = UNDEFINED
+	case "ONLINE":
+		*targetState = TARGET_STATE_ONLINE
+	case "OFFLINE":
+		*targetState = TARGET_STATE_OFFLINE
+	default:
+		*targetState = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into TargetState", str))
+	}
+	return nil
 }
 
 func (targetState TargetState) String() string {
-    switch targetState {
-        case TARGET_STATE_ONLINE: return "ONLINE"
-        case TARGET_STATE_OFFLINE: return "OFFLINE"
-        default:
-            log.Printf("Error: invalid TargetState represented by '%d'", targetState)
-            return ""
-    }
+	switch targetState {
+	case TARGET_STATE_ONLINE:
+		return "ONLINE"
+	case TARGET_STATE_OFFLINE:
+		return "OFFLINE"
+	default:
+		log.Printf("Error: invalid TargetState represented by '%d'", targetState)
+		return ""
+	}
 }
 
 func (targetState TargetState) StringPtr() *string {
-    if targetState == UNDEFINED {
-        return nil
-    }
-    result := targetState.String()
-    return &result
+	if targetState == UNDEFINED {
+		return nil
+	}
+	result := targetState.String()
+	return &result
 }
 
 func newTargetStateFromContent(content []byte, aggErr *AggregateError) *TargetState {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(TargetState)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(TargetState)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type BulkObject struct {
-    Bucket *string
-    Id *string
-    InCache *bool
-    Latest bool
-    Length int64
-    Name *string
-    Offset int64
-    PhysicalPlacement *PhysicalPlacement
-    VersionId string
+	Bucket            *string
+	Id                *string
+	InCache           *bool
+	Latest            bool
+	Length            int64
+	Name              *string
+	Offset            int64
+	PhysicalPlacement *PhysicalPlacement
+	VersionId         string
 }
 
 func (bulkObject *BulkObject) parse(xmlNode *XmlNode, aggErr *AggregateError) {
-    // Parse Attributes
-    for _, attr := range xmlNode.Attrs {
-        switch attr.Name.Local {
-        case "Bucket":
-            bulkObject.Bucket = parseNullableStringFromString(attr.Value)
-        case "Id":
-            bulkObject.Id = parseNullableStringFromString(attr.Value)
-        case "InCache":
-            bulkObject.InCache = parseNullableBoolFromString(attr.Value, aggErr)
-        case "Latest":
-            bulkObject.Latest = parseBoolFromString(attr.Value, aggErr)
-        case "Length":
-            bulkObject.Length = parseInt64FromString(attr.Value, aggErr)
-        case "Name":
-            bulkObject.Name = parseNullableStringFromString(attr.Value)
-        case "Offset":
-            bulkObject.Offset = parseInt64FromString(attr.Value, aggErr)
-        case "VersionId":
-            bulkObject.VersionId = attr.Value
-        default:
-            log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing BulkObject.", attr.Name.Local)
-        }
-    }
+	// Parse Attributes
+	for _, attr := range xmlNode.Attrs {
+		switch attr.Name.Local {
+		case "Bucket":
+			bulkObject.Bucket = parseNullableStringFromString(attr.Value)
+		case "Id":
+			bulkObject.Id = parseNullableStringFromString(attr.Value)
+		case "InCache":
+			bulkObject.InCache = parseNullableBoolFromString(attr.Value, aggErr)
+		case "Latest":
+			bulkObject.Latest = parseBoolFromString(attr.Value, aggErr)
+		case "Length":
+			bulkObject.Length = parseInt64FromString(attr.Value, aggErr)
+		case "Name":
+			bulkObject.Name = parseNullableStringFromString(attr.Value)
+		case "Offset":
+			bulkObject.Offset = parseInt64FromString(attr.Value, aggErr)
+		case "VersionId":
+			bulkObject.VersionId = attr.Value
+		default:
+			log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing BulkObject.", attr.Name.Local)
+		}
+	}
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "PhysicalPlacement":
-            var model PhysicalPlacement
-            model.parse(&child, aggErr)
-            bulkObject.PhysicalPlacement = &model
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BulkObject.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "PhysicalPlacement":
+			var model PhysicalPlacement
+			model.parse(&child, aggErr)
+			bulkObject.PhysicalPlacement = &model
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BulkObject.", child.XMLName.Local)
+		}
+	}
 }
 
 type BulkObjectList struct {
-    Objects []BulkObject
+	Objects []BulkObject
 }
 
 func (bulkObjectList *BulkObjectList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Object":
-            var model BulkObject
-            model.parse(&child, aggErr)
-            bulkObjectList.Objects = append(bulkObjectList.Objects, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BulkObjectList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Object":
+			var model BulkObject
+			model.parse(&child, aggErr)
+			bulkObjectList.Objects = append(bulkObjectList.Objects, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BulkObjectList.", child.XMLName.Local)
+		}
+	}
 }
 
 type BuildInformation struct {
-    Branch *string
-    Revision *string
-    Version *string
+	Branch   *string
+	Revision *string
+	Version  *string
 }
 
 func (buildInformation *BuildInformation) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Branch":
-            buildInformation.Branch = parseNullableString(child.Content)
-        case "Revision":
-            buildInformation.Revision = parseNullableString(child.Content)
-        case "Version":
-            buildInformation.Version = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BuildInformation.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Branch":
+			buildInformation.Branch = parseNullableString(child.Content)
+		case "Revision":
+			buildInformation.Revision = parseNullableString(child.Content)
+		case "Version":
+			buildInformation.Version = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BuildInformation.", child.XMLName.Local)
+		}
+	}
 }
 
 type BlobStoreTaskInformation struct {
-    DateScheduled string
-    DateStarted *string
-    Description *string
-    DriveId *string
-    Id int64
-    Name *string
-    PoolId *string
-    Priority Priority
-    State BlobStoreTaskState
-    TapeId *string
-    TargetId *string
-    TargetType *string
+	DateScheduled string
+	DateStarted   *string
+	Description   *string
+	DriveId       *string
+	Id            int64
+	Name          *string
+	PoolId        *string
+	Priority      Priority
+	State         BlobStoreTaskState
+	TapeId        *string
+	TargetId      *string
+	TargetType    *string
 }
 
 func (blobStoreTaskInformation *BlobStoreTaskInformation) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DateScheduled":
-            blobStoreTaskInformation.DateScheduled = parseString(child.Content)
-        case "DateStarted":
-            blobStoreTaskInformation.DateStarted = parseNullableString(child.Content)
-        case "Description":
-            blobStoreTaskInformation.Description = parseNullableString(child.Content)
-        case "DriveId":
-            blobStoreTaskInformation.DriveId = parseNullableString(child.Content)
-        case "Id":
-            blobStoreTaskInformation.Id = parseInt64(child.Content, aggErr)
-        case "Name":
-            blobStoreTaskInformation.Name = parseNullableString(child.Content)
-        case "PoolId":
-            blobStoreTaskInformation.PoolId = parseNullableString(child.Content)
-        case "Priority":
-            parseEnum(child.Content, &blobStoreTaskInformation.Priority, aggErr)
-        case "State":
-            parseEnum(child.Content, &blobStoreTaskInformation.State, aggErr)
-        case "TapeId":
-            blobStoreTaskInformation.TapeId = parseNullableString(child.Content)
-        case "TargetId":
-            blobStoreTaskInformation.TargetId = parseNullableString(child.Content)
-        case "TargetType":
-            blobStoreTaskInformation.TargetType = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BlobStoreTaskInformation.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DateScheduled":
+			blobStoreTaskInformation.DateScheduled = parseString(child.Content)
+		case "DateStarted":
+			blobStoreTaskInformation.DateStarted = parseNullableString(child.Content)
+		case "Description":
+			blobStoreTaskInformation.Description = parseNullableString(child.Content)
+		case "DriveId":
+			blobStoreTaskInformation.DriveId = parseNullableString(child.Content)
+		case "Id":
+			blobStoreTaskInformation.Id = parseInt64(child.Content, aggErr)
+		case "Name":
+			blobStoreTaskInformation.Name = parseNullableString(child.Content)
+		case "PoolId":
+			blobStoreTaskInformation.PoolId = parseNullableString(child.Content)
+		case "Priority":
+			parseEnum(child.Content, &blobStoreTaskInformation.Priority, aggErr)
+		case "State":
+			parseEnum(child.Content, &blobStoreTaskInformation.State, aggErr)
+		case "TapeId":
+			blobStoreTaskInformation.TapeId = parseNullableString(child.Content)
+		case "TargetId":
+			blobStoreTaskInformation.TargetId = parseNullableString(child.Content)
+		case "TargetType":
+			blobStoreTaskInformation.TargetType = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BlobStoreTaskInformation.", child.XMLName.Local)
+		}
+	}
 }
 
 type BlobStoreTaskState Enum
 
 const (
-    BLOB_STORE_TASK_STATE_NOT_READY BlobStoreTaskState = 1 + iota
-    BLOB_STORE_TASK_STATE_READY BlobStoreTaskState = 1 + iota
-    BLOB_STORE_TASK_STATE_PENDING_EXECUTION BlobStoreTaskState = 1 + iota
-    BLOB_STORE_TASK_STATE_IN_PROGRESS BlobStoreTaskState = 1 + iota
-    BLOB_STORE_TASK_STATE_COMPLETED BlobStoreTaskState = 1 + iota
+	BLOB_STORE_TASK_STATE_NOT_READY         BlobStoreTaskState = 1 + iota
+	BLOB_STORE_TASK_STATE_READY             BlobStoreTaskState = 1 + iota
+	BLOB_STORE_TASK_STATE_PENDING_EXECUTION BlobStoreTaskState = 1 + iota
+	BLOB_STORE_TASK_STATE_IN_PROGRESS       BlobStoreTaskState = 1 + iota
+	BLOB_STORE_TASK_STATE_COMPLETED         BlobStoreTaskState = 1 + iota
 )
 
 func (blobStoreTaskState *BlobStoreTaskState) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *blobStoreTaskState = UNDEFINED
-        case "NOT_READY": *blobStoreTaskState = BLOB_STORE_TASK_STATE_NOT_READY
-        case "READY": *blobStoreTaskState = BLOB_STORE_TASK_STATE_READY
-        case "PENDING_EXECUTION": *blobStoreTaskState = BLOB_STORE_TASK_STATE_PENDING_EXECUTION
-        case "IN_PROGRESS": *blobStoreTaskState = BLOB_STORE_TASK_STATE_IN_PROGRESS
-        case "COMPLETED": *blobStoreTaskState = BLOB_STORE_TASK_STATE_COMPLETED
-        default:
-            *blobStoreTaskState = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into BlobStoreTaskState", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*blobStoreTaskState = UNDEFINED
+	case "NOT_READY":
+		*blobStoreTaskState = BLOB_STORE_TASK_STATE_NOT_READY
+	case "READY":
+		*blobStoreTaskState = BLOB_STORE_TASK_STATE_READY
+	case "PENDING_EXECUTION":
+		*blobStoreTaskState = BLOB_STORE_TASK_STATE_PENDING_EXECUTION
+	case "IN_PROGRESS":
+		*blobStoreTaskState = BLOB_STORE_TASK_STATE_IN_PROGRESS
+	case "COMPLETED":
+		*blobStoreTaskState = BLOB_STORE_TASK_STATE_COMPLETED
+	default:
+		*blobStoreTaskState = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into BlobStoreTaskState", str))
+	}
+	return nil
 }
 
 func (blobStoreTaskState BlobStoreTaskState) String() string {
-    switch blobStoreTaskState {
-        case BLOB_STORE_TASK_STATE_NOT_READY: return "NOT_READY"
-        case BLOB_STORE_TASK_STATE_READY: return "READY"
-        case BLOB_STORE_TASK_STATE_PENDING_EXECUTION: return "PENDING_EXECUTION"
-        case BLOB_STORE_TASK_STATE_IN_PROGRESS: return "IN_PROGRESS"
-        case BLOB_STORE_TASK_STATE_COMPLETED: return "COMPLETED"
-        default:
-            log.Printf("Error: invalid BlobStoreTaskState represented by '%d'", blobStoreTaskState)
-            return ""
-    }
+	switch blobStoreTaskState {
+	case BLOB_STORE_TASK_STATE_NOT_READY:
+		return "NOT_READY"
+	case BLOB_STORE_TASK_STATE_READY:
+		return "READY"
+	case BLOB_STORE_TASK_STATE_PENDING_EXECUTION:
+		return "PENDING_EXECUTION"
+	case BLOB_STORE_TASK_STATE_IN_PROGRESS:
+		return "IN_PROGRESS"
+	case BLOB_STORE_TASK_STATE_COMPLETED:
+		return "COMPLETED"
+	default:
+		log.Printf("Error: invalid BlobStoreTaskState represented by '%d'", blobStoreTaskState)
+		return ""
+	}
 }
 
 func (blobStoreTaskState BlobStoreTaskState) StringPtr() *string {
-    if blobStoreTaskState == UNDEFINED {
-        return nil
-    }
-    result := blobStoreTaskState.String()
-    return &result
+	if blobStoreTaskState == UNDEFINED {
+		return nil
+	}
+	result := blobStoreTaskState.String()
+	return &result
 }
 
 func newBlobStoreTaskStateFromContent(content []byte, aggErr *AggregateError) *BlobStoreTaskState {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(BlobStoreTaskState)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(BlobStoreTaskState)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type BlobStoreTasksInformation struct {
-    Tasks []BlobStoreTaskInformation
+	Tasks []BlobStoreTaskInformation
 }
 
 func (blobStoreTasksInformation *BlobStoreTasksInformation) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Tasks":
-            var model BlobStoreTaskInformation
-            model.parse(&child, aggErr)
-            blobStoreTasksInformation.Tasks = append(blobStoreTasksInformation.Tasks, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BlobStoreTasksInformation.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Tasks":
+			var model BlobStoreTaskInformation
+			model.parse(&child, aggErr)
+			blobStoreTasksInformation.Tasks = append(blobStoreTasksInformation.Tasks, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BlobStoreTasksInformation.", child.XMLName.Local)
+		}
+	}
 }
 
 type CacheEntryInformation struct {
-    Blob *Blob
-    State CacheEntryState
+	Blob  *Blob
+	State CacheEntryState
 }
 
 func (cacheEntryInformation *CacheEntryInformation) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Blob":
-            var model Blob
-            model.parse(&child, aggErr)
-            cacheEntryInformation.Blob = &model
-        case "State":
-            parseEnum(child.Content, &cacheEntryInformation.State, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CacheEntryInformation.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Blob":
+			var model Blob
+			model.parse(&child, aggErr)
+			cacheEntryInformation.Blob = &model
+		case "State":
+			parseEnum(child.Content, &cacheEntryInformation.State, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CacheEntryInformation.", child.XMLName.Local)
+		}
+	}
 }
 
 type CacheFilesystemInformation struct {
-    AvailableCapacityInBytes int64
-    CacheFilesystem CacheFilesystem
-    Entries []CacheEntryInformation
-    JobLockedCacheInBytes int64
-    Summary *string
-    TotalCapacityInBytes int64
-    UnavailableCapacityInBytes int64
-    UsedCapacityInBytes int64
+	AvailableCapacityInBytes   int64
+	CacheFilesystem            CacheFilesystem
+	Entries                    []CacheEntryInformation
+	JobLockedCacheInBytes      int64
+	Summary                    *string
+	TotalCapacityInBytes       int64
+	UnavailableCapacityInBytes int64
+	UsedCapacityInBytes        int64
 }
 
 func (cacheFilesystemInformation *CacheFilesystemInformation) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AvailableCapacityInBytes":
-            cacheFilesystemInformation.AvailableCapacityInBytes = parseInt64(child.Content, aggErr)
-        case "CacheFilesystem":
-            cacheFilesystemInformation.CacheFilesystem.parse(&child, aggErr)
-        case "Entries":
-            var model CacheEntryInformation
-            model.parse(&child, aggErr)
-            cacheFilesystemInformation.Entries = append(cacheFilesystemInformation.Entries, model)
-        case "JobLockedCacheInBytes":
-            cacheFilesystemInformation.JobLockedCacheInBytes = parseInt64(child.Content, aggErr)
-        case "Summary":
-            cacheFilesystemInformation.Summary = parseNullableString(child.Content)
-        case "TotalCapacityInBytes":
-            cacheFilesystemInformation.TotalCapacityInBytes = parseInt64(child.Content, aggErr)
-        case "UnavailableCapacityInBytes":
-            cacheFilesystemInformation.UnavailableCapacityInBytes = parseInt64(child.Content, aggErr)
-        case "UsedCapacityInBytes":
-            cacheFilesystemInformation.UsedCapacityInBytes = parseInt64(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CacheFilesystemInformation.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AvailableCapacityInBytes":
+			cacheFilesystemInformation.AvailableCapacityInBytes = parseInt64(child.Content, aggErr)
+		case "CacheFilesystem":
+			cacheFilesystemInformation.CacheFilesystem.parse(&child, aggErr)
+		case "Entries":
+			var model CacheEntryInformation
+			model.parse(&child, aggErr)
+			cacheFilesystemInformation.Entries = append(cacheFilesystemInformation.Entries, model)
+		case "JobLockedCacheInBytes":
+			cacheFilesystemInformation.JobLockedCacheInBytes = parseInt64(child.Content, aggErr)
+		case "Summary":
+			cacheFilesystemInformation.Summary = parseNullableString(child.Content)
+		case "TotalCapacityInBytes":
+			cacheFilesystemInformation.TotalCapacityInBytes = parseInt64(child.Content, aggErr)
+		case "UnavailableCapacityInBytes":
+			cacheFilesystemInformation.UnavailableCapacityInBytes = parseInt64(child.Content, aggErr)
+		case "UsedCapacityInBytes":
+			cacheFilesystemInformation.UsedCapacityInBytes = parseInt64(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CacheFilesystemInformation.", child.XMLName.Local)
+		}
+	}
 }
 
 type CacheInformation struct {
-    Filesystems []CacheFilesystemInformation
+	Filesystems []CacheFilesystemInformation
 }
 
 func (cacheInformation *CacheInformation) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Filesystems":
-            var model CacheFilesystemInformation
-            model.parse(&child, aggErr)
-            cacheInformation.Filesystems = append(cacheInformation.Filesystems, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CacheInformation.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Filesystems":
+			var model CacheFilesystemInformation
+			model.parse(&child, aggErr)
+			cacheInformation.Filesystems = append(cacheInformation.Filesystems, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CacheInformation.", child.XMLName.Local)
+		}
+	}
 }
 
 type BucketDetails struct {
-    CreationDate *string
-    Name *string
+	CreationDate *string
+	Name         *string
 }
 
 func (bucketDetails *BucketDetails) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CreationDate":
-            bucketDetails.CreationDate = parseNullableString(child.Content)
-        case "Name":
-            bucketDetails.Name = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketDetails.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CreationDate":
+			bucketDetails.CreationDate = parseNullableString(child.Content)
+		case "Name":
+			bucketDetails.Name = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketDetails.", child.XMLName.Local)
+		}
+	}
 }
 
-
 func parseBucketDetailsSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []BucketDetails {
-    var result []BucketDetails
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult BucketDetails
-            curResult.parse(&curXmlNode, aggErr)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing BucketDetails struct.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []BucketDetails
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult BucketDetails
+			curResult.parse(&curXmlNode, aggErr)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing BucketDetails struct.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }
 
 type ListBucketResult struct {
-    CommonPrefixes []string
-    CreationDate *string
-    Delimiter *string
-    Marker *string
-    MaxKeys int
-    Name *string
-    NextMarker *string
-    Objects []Contents
-    Prefix *string
-    Truncated bool
-    VersionedObjects []Contents
+	CommonPrefixes   []string
+	CreationDate     *string
+	Delimiter        *string
+	Marker           *string
+	MaxKeys          int
+	Name             *string
+	NextMarker       *string
+	Objects          []Contents
+	Prefix           *string
+	Truncated        bool
+	VersionedObjects []Contents
 }
 
 func (listBucketResult *ListBucketResult) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CommonPrefixes":
-            var prefixes []string
-            prefixes = parseStringSlice("Prefix", child.Children, aggErr)
-            listBucketResult.CommonPrefixes = append(listBucketResult.CommonPrefixes, prefixes...)
-        case "CreationDate":
-            listBucketResult.CreationDate = parseNullableString(child.Content)
-        case "Delimiter":
-            listBucketResult.Delimiter = parseNullableString(child.Content)
-        case "Marker":
-            listBucketResult.Marker = parseNullableString(child.Content)
-        case "MaxKeys":
-            listBucketResult.MaxKeys = parseInt(child.Content, aggErr)
-        case "Name":
-            listBucketResult.Name = parseNullableString(child.Content)
-        case "NextMarker":
-            listBucketResult.NextMarker = parseNullableString(child.Content)
-        case "Contents":
-            var model Contents
-            model.parse(&child, aggErr)
-            listBucketResult.Objects = append(listBucketResult.Objects, model)
-        case "Prefix":
-            listBucketResult.Prefix = parseNullableString(child.Content)
-        case "IsTruncated":
-            listBucketResult.Truncated = parseBool(child.Content, aggErr)
-        case "Version":
-            var model Contents
-            model.parse(&child, aggErr)
-            listBucketResult.VersionedObjects = append(listBucketResult.VersionedObjects, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ListBucketResult.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CommonPrefixes":
+			var prefixes []string
+			prefixes = parseStringSlice("Prefix", child.Children, aggErr)
+			listBucketResult.CommonPrefixes = append(listBucketResult.CommonPrefixes, prefixes...)
+		case "CreationDate":
+			listBucketResult.CreationDate = parseNullableString(child.Content)
+		case "Delimiter":
+			listBucketResult.Delimiter = parseNullableString(child.Content)
+		case "Marker":
+			listBucketResult.Marker = parseNullableString(child.Content)
+		case "MaxKeys":
+			listBucketResult.MaxKeys = parseInt(child.Content, aggErr)
+		case "Name":
+			listBucketResult.Name = parseNullableString(child.Content)
+		case "NextMarker":
+			listBucketResult.NextMarker = parseNullableString(child.Content)
+		case "Contents":
+			var model Contents
+			model.parse(&child, aggErr)
+			listBucketResult.Objects = append(listBucketResult.Objects, model)
+		case "Prefix":
+			listBucketResult.Prefix = parseNullableString(child.Content)
+		case "IsTruncated":
+			listBucketResult.Truncated = parseBool(child.Content, aggErr)
+		case "Version":
+			var model Contents
+			model.parse(&child, aggErr)
+			listBucketResult.VersionedObjects = append(listBucketResult.VersionedObjects, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ListBucketResult.", child.XMLName.Local)
+		}
+	}
 }
 
 type ListAllMyBucketsResult struct {
-    Buckets []BucketDetails
-    Owner User
+	Buckets []BucketDetails
+	Owner   User
 }
 
 func (listAllMyBucketsResult *ListAllMyBucketsResult) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Buckets":
-            listAllMyBucketsResult.Buckets = parseBucketDetailsSlice("Bucket", child.Children, aggErr)
-        case "Owner":
-            listAllMyBucketsResult.Owner.parse(&child, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ListAllMyBucketsResult.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Buckets":
+			listAllMyBucketsResult.Buckets = parseBucketDetailsSlice("Bucket", child.Children, aggErr)
+		case "Owner":
+			listAllMyBucketsResult.Owner.parse(&child, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ListAllMyBucketsResult.", child.XMLName.Local)
+		}
+	}
 }
 
 type CompleteMultipartUploadResult struct {
-    Bucket *string
-    ETag *string
-    Key *string
-    Location *string
+	Bucket   *string
+	ETag     *string
+	Key      *string
+	Location *string
 }
 
 func (completeMultipartUploadResult *CompleteMultipartUploadResult) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Bucket":
-            completeMultipartUploadResult.Bucket = parseNullableString(child.Content)
-        case "ETag":
-            completeMultipartUploadResult.ETag = parseNullableString(child.Content)
-        case "Key":
-            completeMultipartUploadResult.Key = parseNullableString(child.Content)
-        case "Location":
-            completeMultipartUploadResult.Location = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CompleteMultipartUploadResult.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Bucket":
+			completeMultipartUploadResult.Bucket = parseNullableString(child.Content)
+		case "ETag":
+			completeMultipartUploadResult.ETag = parseNullableString(child.Content)
+		case "Key":
+			completeMultipartUploadResult.Key = parseNullableString(child.Content)
+		case "Location":
+			completeMultipartUploadResult.Location = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CompleteMultipartUploadResult.", child.XMLName.Local)
+		}
+	}
 }
 
 type DeleteObjectError struct {
-    Code *string
-    Key *string
-    Message *string
-    VersionId *string
+	Code      *string
+	Key       *string
+	Message   *string
+	VersionId *string
 }
 
 func (deleteObjectError *DeleteObjectError) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Code":
-            deleteObjectError.Code = parseNullableString(child.Content)
-        case "Key":
-            deleteObjectError.Key = parseNullableString(child.Content)
-        case "Message":
-            deleteObjectError.Message = parseNullableString(child.Content)
-        case "VersionId":
-            deleteObjectError.VersionId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DeleteObjectError.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Code":
+			deleteObjectError.Code = parseNullableString(child.Content)
+		case "Key":
+			deleteObjectError.Key = parseNullableString(child.Content)
+		case "Message":
+			deleteObjectError.Message = parseNullableString(child.Content)
+		case "VersionId":
+			deleteObjectError.VersionId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DeleteObjectError.", child.XMLName.Local)
+		}
+	}
 }
 
 type DeleteResult struct {
-    DeletedObjects []S3ObjectToDelete
-    Errors []DeleteObjectError
+	DeletedObjects []S3ObjectToDelete
+	Errors         []DeleteObjectError
 }
 
 func (deleteResult *DeleteResult) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Deleted":
-            var model S3ObjectToDelete
-            model.parse(&child, aggErr)
-            deleteResult.DeletedObjects = append(deleteResult.DeletedObjects, model)
-        case "Error":
-            var model DeleteObjectError
-            model.parse(&child, aggErr)
-            deleteResult.Errors = append(deleteResult.Errors, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DeleteResult.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Deleted":
+			var model S3ObjectToDelete
+			model.parse(&child, aggErr)
+			deleteResult.DeletedObjects = append(deleteResult.DeletedObjects, model)
+		case "Error":
+			var model DeleteObjectError
+			model.parse(&child, aggErr)
+			deleteResult.Errors = append(deleteResult.Errors, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DeleteResult.", child.XMLName.Local)
+		}
+	}
 }
 
 type DetailedTapePartition struct {
-    AutoCompactionEnabled bool
-    AutoQuiesceEnabled bool
-    AvailableStorageCapacity int64
-    DriveIdleTimeoutInMinutes *int
-    DriveType *TapeDriveType
-    DriveTypes []TapeDriveType
-    ErrorMessage *string
-    Id string
-    ImportExportConfiguration ImportExportConfiguration
-    LibraryId string
-    MinimumReadReservedDrives int
-    MinimumWriteReservedDrives int
-    Name *string
-    Quiesced Quiesced
-    SerialNumber *string
-    State TapePartitionState
-    TapeCount int
-    TapeStateSummaries []TapeStateSummaryApiBean
-    TapeTypeSummaries []TapeTypeSummaryApiBean
-    TapeTypes []string
-    TotalStorageCapacity int64
-    UsedStorageCapacity int64
+	AutoCompactionEnabled      bool
+	AutoQuiesceEnabled         bool
+	AvailableStorageCapacity   int64
+	DriveIdleTimeoutInMinutes  *int
+	DriveType                  *TapeDriveType
+	DriveTypes                 []TapeDriveType
+	ErrorMessage               *string
+	Id                         string
+	ImportExportConfiguration  ImportExportConfiguration
+	LibraryId                  string
+	MinimumReadReservedDrives  int
+	MinimumWriteReservedDrives int
+	Name                       *string
+	Quiesced                   Quiesced
+	SerialNumber               *string
+	State                      TapePartitionState
+	TapeCount                  int
+	TapeStateSummaries         []TapeStateSummaryApiBean
+	TapeTypeSummaries          []TapeTypeSummaryApiBean
+	TapeTypes                  []string
+	TotalStorageCapacity       int64
+	UsedStorageCapacity        int64
 }
 
 func (detailedTapePartition *DetailedTapePartition) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AutoCompactionEnabled":
-            detailedTapePartition.AutoCompactionEnabled = parseBool(child.Content, aggErr)
-        case "AutoQuiesceEnabled":
-            detailedTapePartition.AutoQuiesceEnabled = parseBool(child.Content, aggErr)
-        case "AvailableStorageCapacity":
-            detailedTapePartition.AvailableStorageCapacity = parseInt64(child.Content, aggErr)
-        case "DriveIdleTimeoutInMinutes":
-            detailedTapePartition.DriveIdleTimeoutInMinutes = parseNullableInt(child.Content, aggErr)
-        case "DriveType":
-            detailedTapePartition.DriveType = newTapeDriveTypeFromContent(child.Content, aggErr)
-        case "DriveTypes":
-            var model TapeDriveType
-            parseEnum(child.Content, &model, aggErr)
-            detailedTapePartition.DriveTypes = append(detailedTapePartition.DriveTypes, model)
-        case "ErrorMessage":
-            detailedTapePartition.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            detailedTapePartition.Id = parseString(child.Content)
-        case "ImportExportConfiguration":
-            parseEnum(child.Content, &detailedTapePartition.ImportExportConfiguration, aggErr)
-        case "LibraryId":
-            detailedTapePartition.LibraryId = parseString(child.Content)
-        case "MinimumReadReservedDrives":
-            detailedTapePartition.MinimumReadReservedDrives = parseInt(child.Content, aggErr)
-        case "MinimumWriteReservedDrives":
-            detailedTapePartition.MinimumWriteReservedDrives = parseInt(child.Content, aggErr)
-        case "Name":
-            detailedTapePartition.Name = parseNullableString(child.Content)
-        case "Quiesced":
-            parseEnum(child.Content, &detailedTapePartition.Quiesced, aggErr)
-        case "SerialNumber":
-            detailedTapePartition.SerialNumber = parseNullableString(child.Content)
-        case "State":
-            parseEnum(child.Content, &detailedTapePartition.State, aggErr)
-        case "TapeCount":
-            detailedTapePartition.TapeCount = parseInt(child.Content, aggErr)
-        case "TapeStateSummaries":
-            detailedTapePartition.TapeStateSummaries = parseTapeStateSummaryApiBeanSlice("TapeStateSummary", child.Children, aggErr)
-        case "TapeTypeSummaries":
-            detailedTapePartition.TapeTypeSummaries = parseTapeTypeSummaryApiBeanSlice("TapeTypeSummary", child.Children, aggErr)
-        case "TapeTypes":
-            var str = parseString(child.Content)
-            detailedTapePartition.TapeTypes = append(detailedTapePartition.TapeTypes, str)
-        case "TotalStorageCapacity":
-            detailedTapePartition.TotalStorageCapacity = parseInt64(child.Content, aggErr)
-        case "UsedStorageCapacity":
-            detailedTapePartition.UsedStorageCapacity = parseInt64(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DetailedTapePartition.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AutoCompactionEnabled":
+			detailedTapePartition.AutoCompactionEnabled = parseBool(child.Content, aggErr)
+		case "AutoQuiesceEnabled":
+			detailedTapePartition.AutoQuiesceEnabled = parseBool(child.Content, aggErr)
+		case "AvailableStorageCapacity":
+			detailedTapePartition.AvailableStorageCapacity = parseInt64(child.Content, aggErr)
+		case "DriveIdleTimeoutInMinutes":
+			detailedTapePartition.DriveIdleTimeoutInMinutes = parseNullableInt(child.Content, aggErr)
+		case "DriveType":
+			detailedTapePartition.DriveType = newTapeDriveTypeFromContent(child.Content, aggErr)
+		case "DriveTypes":
+			var model TapeDriveType
+			parseEnum(child.Content, &model, aggErr)
+			detailedTapePartition.DriveTypes = append(detailedTapePartition.DriveTypes, model)
+		case "ErrorMessage":
+			detailedTapePartition.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			detailedTapePartition.Id = parseString(child.Content)
+		case "ImportExportConfiguration":
+			parseEnum(child.Content, &detailedTapePartition.ImportExportConfiguration, aggErr)
+		case "LibraryId":
+			detailedTapePartition.LibraryId = parseString(child.Content)
+		case "MinimumReadReservedDrives":
+			detailedTapePartition.MinimumReadReservedDrives = parseInt(child.Content, aggErr)
+		case "MinimumWriteReservedDrives":
+			detailedTapePartition.MinimumWriteReservedDrives = parseInt(child.Content, aggErr)
+		case "Name":
+			detailedTapePartition.Name = parseNullableString(child.Content)
+		case "Quiesced":
+			parseEnum(child.Content, &detailedTapePartition.Quiesced, aggErr)
+		case "SerialNumber":
+			detailedTapePartition.SerialNumber = parseNullableString(child.Content)
+		case "State":
+			parseEnum(child.Content, &detailedTapePartition.State, aggErr)
+		case "TapeCount":
+			detailedTapePartition.TapeCount = parseInt(child.Content, aggErr)
+		case "TapeStateSummaries":
+			detailedTapePartition.TapeStateSummaries = parseTapeStateSummaryApiBeanSlice("TapeStateSummary", child.Children, aggErr)
+		case "TapeTypeSummaries":
+			detailedTapePartition.TapeTypeSummaries = parseTapeTypeSummaryApiBeanSlice("TapeTypeSummary", child.Children, aggErr)
+		case "TapeTypes":
+			var str = parseString(child.Content)
+			detailedTapePartition.TapeTypes = append(detailedTapePartition.TapeTypes, str)
+		case "TotalStorageCapacity":
+			detailedTapePartition.TotalStorageCapacity = parseInt64(child.Content, aggErr)
+		case "UsedStorageCapacity":
+			detailedTapePartition.UsedStorageCapacity = parseInt64(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DetailedTapePartition.", child.XMLName.Local)
+		}
+	}
 }
 
 type Error struct {
-    Code *string
-    HttpErrorCode int
-    Message *string
-    Resource *string
-    ResourceId int64
+	Code          *string
+	HttpErrorCode int
+	Message       *string
+	Resource      *string
+	ResourceId    int64
 }
 
 func (error *Error) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Code":
-            error.Code = parseNullableString(child.Content)
-        case "HttpErrorCode":
-            error.HttpErrorCode = parseInt(child.Content, aggErr)
-        case "Message":
-            error.Message = parseNullableString(child.Content)
-        case "Resource":
-            error.Resource = parseNullableString(child.Content)
-        case "ResourceId":
-            error.ResourceId = parseInt64(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Error.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Code":
+			error.Code = parseNullableString(child.Content)
+		case "HttpErrorCode":
+			error.HttpErrorCode = parseInt(child.Content, aggErr)
+		case "Message":
+			error.Message = parseNullableString(child.Content)
+		case "Resource":
+			error.Resource = parseNullableString(child.Content)
+		case "ResourceId":
+			error.ResourceId = parseInt64(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Error.", child.XMLName.Local)
+		}
+	}
 }
 
 type InitiateMultipartUploadResult struct {
-    Bucket *string
-    Key *string
-    UploadId *string
+	Bucket   *string
+	Key      *string
+	UploadId *string
 }
 
 func (initiateMultipartUploadResult *InitiateMultipartUploadResult) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Bucket":
-            initiateMultipartUploadResult.Bucket = parseNullableString(child.Content)
-        case "Key":
-            initiateMultipartUploadResult.Key = parseNullableString(child.Content)
-        case "UploadId":
-            initiateMultipartUploadResult.UploadId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing InitiateMultipartUploadResult.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Bucket":
+			initiateMultipartUploadResult.Bucket = parseNullableString(child.Content)
+		case "Key":
+			initiateMultipartUploadResult.Key = parseNullableString(child.Content)
+		case "UploadId":
+			initiateMultipartUploadResult.UploadId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing InitiateMultipartUploadResult.", child.XMLName.Local)
+		}
+	}
 }
 
 type Job struct {
-    Aggregating bool
-    BucketName *string
-    CachedSizeInBytes int64
-    ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
-    CompletedSizeInBytes int64
-    EntirelyInCache *bool
-    JobId string
-    Naked bool
-    Name *string
-    Nodes []JobNode
-    OriginalSizeInBytes int64
-    Priority Priority
-    RequestType JobRequestType
-    StartDate string
-    Status JobStatus
-    UserId string
-    UserName *string
+	Aggregating                         bool
+	BucketName                          *string
+	CachedSizeInBytes                   int64
+	ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
+	CompletedSizeInBytes                int64
+	EntirelyInCache                     *bool
+	JobId                               string
+	Naked                               bool
+	Name                                *string
+	Nodes                               []JobNode
+	OriginalSizeInBytes                 int64
+	Priority                            Priority
+	RequestType                         JobRequestType
+	StartDate                           string
+	Status                              JobStatus
+	UserId                              string
+	UserName                            *string
 }
 
 func (job *Job) parse(xmlNode *XmlNode, aggErr *AggregateError) {
-    // Parse Attributes
-    for _, attr := range xmlNode.Attrs {
-        switch attr.Name.Local {
-        case "Aggregating":
-            job.Aggregating = parseBoolFromString(attr.Value, aggErr)
-        case "BucketName":
-            job.BucketName = parseNullableStringFromString(attr.Value)
-        case "CachedSizeInBytes":
-            job.CachedSizeInBytes = parseInt64FromString(attr.Value, aggErr)
-        case "ChunkClientProcessingOrderGuarantee":
-            parseEnumFromString(attr.Value, &job.ChunkClientProcessingOrderGuarantee, aggErr)
-        case "CompletedSizeInBytes":
-            job.CompletedSizeInBytes = parseInt64FromString(attr.Value, aggErr)
-        case "EntirelyInCache":
-            job.EntirelyInCache = parseNullableBoolFromString(attr.Value, aggErr)
-        case "JobId":
-            job.JobId = attr.Value
-        case "Naked":
-            job.Naked = parseBoolFromString(attr.Value, aggErr)
-        case "Name":
-            job.Name = parseNullableStringFromString(attr.Value)
-        case "OriginalSizeInBytes":
-            job.OriginalSizeInBytes = parseInt64FromString(attr.Value, aggErr)
-        case "Priority":
-            parseEnumFromString(attr.Value, &job.Priority, aggErr)
-        case "RequestType":
-            parseEnumFromString(attr.Value, &job.RequestType, aggErr)
-        case "StartDate":
-            job.StartDate = attr.Value
-        case "Status":
-            parseEnumFromString(attr.Value, &job.Status, aggErr)
-        case "UserId":
-            job.UserId = attr.Value
-        case "UserName":
-            job.UserName = parseNullableStringFromString(attr.Value)
-        default:
-            log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing Job.", attr.Name.Local)
-        }
-    }
+	// Parse Attributes
+	for _, attr := range xmlNode.Attrs {
+		switch attr.Name.Local {
+		case "Aggregating":
+			job.Aggregating = parseBoolFromString(attr.Value, aggErr)
+		case "BucketName":
+			job.BucketName = parseNullableStringFromString(attr.Value)
+		case "CachedSizeInBytes":
+			job.CachedSizeInBytes = parseInt64FromString(attr.Value, aggErr)
+		case "ChunkClientProcessingOrderGuarantee":
+			parseEnumFromString(attr.Value, &job.ChunkClientProcessingOrderGuarantee, aggErr)
+		case "CompletedSizeInBytes":
+			job.CompletedSizeInBytes = parseInt64FromString(attr.Value, aggErr)
+		case "EntirelyInCache":
+			job.EntirelyInCache = parseNullableBoolFromString(attr.Value, aggErr)
+		case "JobId":
+			job.JobId = attr.Value
+		case "Naked":
+			job.Naked = parseBoolFromString(attr.Value, aggErr)
+		case "Name":
+			job.Name = parseNullableStringFromString(attr.Value)
+		case "OriginalSizeInBytes":
+			job.OriginalSizeInBytes = parseInt64FromString(attr.Value, aggErr)
+		case "Priority":
+			parseEnumFromString(attr.Value, &job.Priority, aggErr)
+		case "RequestType":
+			parseEnumFromString(attr.Value, &job.RequestType, aggErr)
+		case "StartDate":
+			job.StartDate = attr.Value
+		case "Status":
+			parseEnumFromString(attr.Value, &job.Status, aggErr)
+		case "UserId":
+			job.UserId = attr.Value
+		case "UserName":
+			job.UserName = parseNullableStringFromString(attr.Value)
+		default:
+			log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing Job.", attr.Name.Local)
+		}
+	}
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Nodes":
-            job.Nodes = parseJobNodeSlice("Node", child.Children, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Job.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Nodes":
+			job.Nodes = parseJobNodeSlice("Node", child.Children, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Job.", child.XMLName.Local)
+		}
+	}
 }
 
-
 func parseJobSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []Job {
-    var result []Job
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult Job
-            curResult.parse(&curXmlNode, aggErr)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing Job struct.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []Job
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult Job
+			curResult.parse(&curXmlNode, aggErr)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing Job struct.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }
 
 type Objects struct {
-    ChunkId string
-    ChunkNumber int
-    NodeId *string
-    Objects []BulkObject
+	ChunkId     string
+	ChunkNumber int
+	NodeId      *string
+	Objects     []BulkObject
 }
 
 func (objects *Objects) parse(xmlNode *XmlNode, aggErr *AggregateError) {
-    // Parse Attributes
-    for _, attr := range xmlNode.Attrs {
-        switch attr.Name.Local {
-        case "ChunkId":
-            objects.ChunkId = attr.Value
-        case "ChunkNumber":
-            objects.ChunkNumber = parseIntFromString(attr.Value, aggErr)
-        case "NodeId":
-            objects.NodeId = parseNullableStringFromString(attr.Value)
-        default:
-            log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing Objects.", attr.Name.Local)
-        }
-    }
+	// Parse Attributes
+	for _, attr := range xmlNode.Attrs {
+		switch attr.Name.Local {
+		case "ChunkId":
+			objects.ChunkId = attr.Value
+		case "ChunkNumber":
+			objects.ChunkNumber = parseIntFromString(attr.Value, aggErr)
+		case "NodeId":
+			objects.NodeId = parseNullableStringFromString(attr.Value)
+		default:
+			log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing Objects.", attr.Name.Local)
+		}
+	}
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Object":
-            var model BulkObject
-            model.parse(&child, aggErr)
-            objects.Objects = append(objects.Objects, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Objects.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Object":
+			var model BulkObject
+			model.parse(&child, aggErr)
+			objects.Objects = append(objects.Objects, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Objects.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobStatus Enum
 
 const (
-    JOB_STATUS_IN_PROGRESS JobStatus = 1 + iota
-    JOB_STATUS_COMPLETED JobStatus = 1 + iota
-    JOB_STATUS_CANCELED JobStatus = 1 + iota
+	JOB_STATUS_IN_PROGRESS JobStatus = 1 + iota
+	JOB_STATUS_COMPLETED   JobStatus = 1 + iota
+	JOB_STATUS_CANCELED    JobStatus = 1 + iota
 )
 
 func (jobStatus *JobStatus) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *jobStatus = UNDEFINED
-        case "IN_PROGRESS": *jobStatus = JOB_STATUS_IN_PROGRESS
-        case "COMPLETED": *jobStatus = JOB_STATUS_COMPLETED
-        case "CANCELED": *jobStatus = JOB_STATUS_CANCELED
-        default:
-            *jobStatus = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobStatus", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*jobStatus = UNDEFINED
+	case "IN_PROGRESS":
+		*jobStatus = JOB_STATUS_IN_PROGRESS
+	case "COMPLETED":
+		*jobStatus = JOB_STATUS_COMPLETED
+	case "CANCELED":
+		*jobStatus = JOB_STATUS_CANCELED
+	default:
+		*jobStatus = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into JobStatus", str))
+	}
+	return nil
 }
 
 func (jobStatus JobStatus) String() string {
-    switch jobStatus {
-        case JOB_STATUS_IN_PROGRESS: return "IN_PROGRESS"
-        case JOB_STATUS_COMPLETED: return "COMPLETED"
-        case JOB_STATUS_CANCELED: return "CANCELED"
-        default:
-            log.Printf("Error: invalid JobStatus represented by '%d'", jobStatus)
-            return ""
-    }
+	switch jobStatus {
+	case JOB_STATUS_IN_PROGRESS:
+		return "IN_PROGRESS"
+	case JOB_STATUS_COMPLETED:
+		return "COMPLETED"
+	case JOB_STATUS_CANCELED:
+		return "CANCELED"
+	default:
+		log.Printf("Error: invalid JobStatus represented by '%d'", jobStatus)
+		return ""
+	}
 }
 
 func (jobStatus JobStatus) StringPtr() *string {
-    if jobStatus == UNDEFINED {
-        return nil
-    }
-    result := jobStatus.String()
-    return &result
+	if jobStatus == UNDEFINED {
+		return nil
+	}
+	result := jobStatus.String()
+	return &result
 }
 
 func newJobStatusFromContent(content []byte, aggErr *AggregateError) *JobStatus {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(JobStatus)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(JobStatus)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type MasterObjectList struct {
-    Aggregating bool
-    BucketName *string
-    CachedSizeInBytes int64
-    ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
-    CompletedSizeInBytes int64
-    EntirelyInCache *bool
-    JobId string
-    Naked bool
-    Name *string
-    Nodes []JobNode
-    Objects []Objects
-    OriginalSizeInBytes int64
-    Priority Priority
-    RequestType JobRequestType
-    StartDate string
-    Status JobStatus
-    UserId string
-    UserName *string
+	Aggregating                         bool
+	BucketName                          *string
+	CachedSizeInBytes                   int64
+	ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee
+	CompletedSizeInBytes                int64
+	EntirelyInCache                     *bool
+	JobId                               string
+	Naked                               bool
+	Name                                *string
+	Nodes                               []JobNode
+	Objects                             []Objects
+	OriginalSizeInBytes                 int64
+	Priority                            Priority
+	RequestType                         JobRequestType
+	StartDate                           string
+	Status                              JobStatus
+	UserId                              string
+	UserName                            *string
 }
 
 func (masterObjectList *MasterObjectList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
-    // Parse Attributes
-    for _, attr := range xmlNode.Attrs {
-        switch attr.Name.Local {
-        case "Aggregating":
-            masterObjectList.Aggregating = parseBoolFromString(attr.Value, aggErr)
-        case "BucketName":
-            masterObjectList.BucketName = parseNullableStringFromString(attr.Value)
-        case "CachedSizeInBytes":
-            masterObjectList.CachedSizeInBytes = parseInt64FromString(attr.Value, aggErr)
-        case "ChunkClientProcessingOrderGuarantee":
-            parseEnumFromString(attr.Value, &masterObjectList.ChunkClientProcessingOrderGuarantee, aggErr)
-        case "CompletedSizeInBytes":
-            masterObjectList.CompletedSizeInBytes = parseInt64FromString(attr.Value, aggErr)
-        case "EntirelyInCache":
-            masterObjectList.EntirelyInCache = parseNullableBoolFromString(attr.Value, aggErr)
-        case "JobId":
-            masterObjectList.JobId = attr.Value
-        case "Naked":
-            masterObjectList.Naked = parseBoolFromString(attr.Value, aggErr)
-        case "Name":
-            masterObjectList.Name = parseNullableStringFromString(attr.Value)
-        case "OriginalSizeInBytes":
-            masterObjectList.OriginalSizeInBytes = parseInt64FromString(attr.Value, aggErr)
-        case "Priority":
-            parseEnumFromString(attr.Value, &masterObjectList.Priority, aggErr)
-        case "RequestType":
-            parseEnumFromString(attr.Value, &masterObjectList.RequestType, aggErr)
-        case "StartDate":
-            masterObjectList.StartDate = attr.Value
-        case "Status":
-            parseEnumFromString(attr.Value, &masterObjectList.Status, aggErr)
-        case "UserId":
-            masterObjectList.UserId = attr.Value
-        case "UserName":
-            masterObjectList.UserName = parseNullableStringFromString(attr.Value)
-        default:
-            log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing MasterObjectList.", attr.Name.Local)
-        }
-    }
+	// Parse Attributes
+	for _, attr := range xmlNode.Attrs {
+		switch attr.Name.Local {
+		case "Aggregating":
+			masterObjectList.Aggregating = parseBoolFromString(attr.Value, aggErr)
+		case "BucketName":
+			masterObjectList.BucketName = parseNullableStringFromString(attr.Value)
+		case "CachedSizeInBytes":
+			masterObjectList.CachedSizeInBytes = parseInt64FromString(attr.Value, aggErr)
+		case "ChunkClientProcessingOrderGuarantee":
+			parseEnumFromString(attr.Value, &masterObjectList.ChunkClientProcessingOrderGuarantee, aggErr)
+		case "CompletedSizeInBytes":
+			masterObjectList.CompletedSizeInBytes = parseInt64FromString(attr.Value, aggErr)
+		case "EntirelyInCache":
+			masterObjectList.EntirelyInCache = parseNullableBoolFromString(attr.Value, aggErr)
+		case "JobId":
+			masterObjectList.JobId = attr.Value
+		case "Naked":
+			masterObjectList.Naked = parseBoolFromString(attr.Value, aggErr)
+		case "Name":
+			masterObjectList.Name = parseNullableStringFromString(attr.Value)
+		case "OriginalSizeInBytes":
+			masterObjectList.OriginalSizeInBytes = parseInt64FromString(attr.Value, aggErr)
+		case "Priority":
+			parseEnumFromString(attr.Value, &masterObjectList.Priority, aggErr)
+		case "RequestType":
+			parseEnumFromString(attr.Value, &masterObjectList.RequestType, aggErr)
+		case "StartDate":
+			masterObjectList.StartDate = attr.Value
+		case "Status":
+			parseEnumFromString(attr.Value, &masterObjectList.Status, aggErr)
+		case "UserId":
+			masterObjectList.UserId = attr.Value
+		case "UserName":
+			masterObjectList.UserName = parseNullableStringFromString(attr.Value)
+		default:
+			log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing MasterObjectList.", attr.Name.Local)
+		}
+	}
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Nodes":
-            masterObjectList.Nodes = parseJobNodeSlice("Node", child.Children, aggErr)
-        case "Objects":
-            var model Objects
-            model.parse(&child, aggErr)
-            masterObjectList.Objects = append(masterObjectList.Objects, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing MasterObjectList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Nodes":
+			masterObjectList.Nodes = parseJobNodeSlice("Node", child.Children, aggErr)
+		case "Objects":
+			var model Objects
+			model.parse(&child, aggErr)
+			masterObjectList.Objects = append(masterObjectList.Objects, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing MasterObjectList.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobList struct {
-    Jobs []Job
+	Jobs []Job
 }
 
 func (jobList *JobList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Job":
-            var model Job
-            model.parse(&child, aggErr)
-            jobList.Jobs = append(jobList.Jobs, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Job":
+			var model Job
+			model.parse(&child, aggErr)
+			jobList.Jobs = append(jobList.Jobs, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobList.", child.XMLName.Local)
+		}
+	}
 }
 
 type ListPartsResult struct {
-    Bucket *string
-    Key *string
-    MaxParts int
-    NextPartNumberMarker int
-    Owner User
-    PartNumberMarker *int
-    Parts []MultiPartUploadPart
-    Truncated bool
-    UploadId string
+	Bucket               *string
+	Key                  *string
+	MaxParts             int
+	NextPartNumberMarker int
+	Owner                User
+	PartNumberMarker     *int
+	Parts                []MultiPartUploadPart
+	Truncated            bool
+	UploadId             string
 }
 
 func (listPartsResult *ListPartsResult) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Bucket":
-            listPartsResult.Bucket = parseNullableString(child.Content)
-        case "Key":
-            listPartsResult.Key = parseNullableString(child.Content)
-        case "MaxParts":
-            listPartsResult.MaxParts = parseInt(child.Content, aggErr)
-        case "NextPartNumberMarker":
-            listPartsResult.NextPartNumberMarker = parseInt(child.Content, aggErr)
-        case "Owner":
-            listPartsResult.Owner.parse(&child, aggErr)
-        case "PartNumberMarker":
-            listPartsResult.PartNumberMarker = parseNullableInt(child.Content, aggErr)
-        case "Part":
-            var model MultiPartUploadPart
-            model.parse(&child, aggErr)
-            listPartsResult.Parts = append(listPartsResult.Parts, model)
-        case "IsTruncated":
-            listPartsResult.Truncated = parseBool(child.Content, aggErr)
-        case "UploadId":
-            listPartsResult.UploadId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ListPartsResult.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Bucket":
+			listPartsResult.Bucket = parseNullableString(child.Content)
+		case "Key":
+			listPartsResult.Key = parseNullableString(child.Content)
+		case "MaxParts":
+			listPartsResult.MaxParts = parseInt(child.Content, aggErr)
+		case "NextPartNumberMarker":
+			listPartsResult.NextPartNumberMarker = parseInt(child.Content, aggErr)
+		case "Owner":
+			listPartsResult.Owner.parse(&child, aggErr)
+		case "PartNumberMarker":
+			listPartsResult.PartNumberMarker = parseNullableInt(child.Content, aggErr)
+		case "Part":
+			var model MultiPartUploadPart
+			model.parse(&child, aggErr)
+			listPartsResult.Parts = append(listPartsResult.Parts, model)
+		case "IsTruncated":
+			listPartsResult.Truncated = parseBool(child.Content, aggErr)
+		case "UploadId":
+			listPartsResult.UploadId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ListPartsResult.", child.XMLName.Local)
+		}
+	}
 }
 
 type ListMultiPartUploadsResult struct {
-    Bucket *string
-    CommonPrefixes []string
-    Delimiter *string
-    KeyMarker *string
-    MaxUploads int
-    NextKeyMarker *string
-    NextUploadIdMarker *string
-    Prefix *string
-    Truncated bool
-    UploadIdMarker *string
-    Uploads []MultiPartUpload
+	Bucket             *string
+	CommonPrefixes     []string
+	Delimiter          *string
+	KeyMarker          *string
+	MaxUploads         int
+	NextKeyMarker      *string
+	NextUploadIdMarker *string
+	Prefix             *string
+	Truncated          bool
+	UploadIdMarker     *string
+	Uploads            []MultiPartUpload
 }
 
 func (listMultiPartUploadsResult *ListMultiPartUploadsResult) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Bucket":
-            listMultiPartUploadsResult.Bucket = parseNullableString(child.Content)
-        case "CommonPrefixes":
-            var prefixes []string
-            prefixes = parseStringSlice("Prefix", child.Children, aggErr)
-            listMultiPartUploadsResult.CommonPrefixes = append(listMultiPartUploadsResult.CommonPrefixes, prefixes...)
-        case "Delimiter":
-            listMultiPartUploadsResult.Delimiter = parseNullableString(child.Content)
-        case "KeyMarker":
-            listMultiPartUploadsResult.KeyMarker = parseNullableString(child.Content)
-        case "MaxUploads":
-            listMultiPartUploadsResult.MaxUploads = parseInt(child.Content, aggErr)
-        case "NextKeyMarker":
-            listMultiPartUploadsResult.NextKeyMarker = parseNullableString(child.Content)
-        case "NextUploadIdMarker":
-            listMultiPartUploadsResult.NextUploadIdMarker = parseNullableString(child.Content)
-        case "Prefix":
-            listMultiPartUploadsResult.Prefix = parseNullableString(child.Content)
-        case "IsTruncated":
-            listMultiPartUploadsResult.Truncated = parseBool(child.Content, aggErr)
-        case "UploadIdMarker":
-            listMultiPartUploadsResult.UploadIdMarker = parseNullableString(child.Content)
-        case "Upload":
-            var model MultiPartUpload
-            model.parse(&child, aggErr)
-            listMultiPartUploadsResult.Uploads = append(listMultiPartUploadsResult.Uploads, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ListMultiPartUploadsResult.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Bucket":
+			listMultiPartUploadsResult.Bucket = parseNullableString(child.Content)
+		case "CommonPrefixes":
+			var prefixes []string
+			prefixes = parseStringSlice("Prefix", child.Children, aggErr)
+			listMultiPartUploadsResult.CommonPrefixes = append(listMultiPartUploadsResult.CommonPrefixes, prefixes...)
+		case "Delimiter":
+			listMultiPartUploadsResult.Delimiter = parseNullableString(child.Content)
+		case "KeyMarker":
+			listMultiPartUploadsResult.KeyMarker = parseNullableString(child.Content)
+		case "MaxUploads":
+			listMultiPartUploadsResult.MaxUploads = parseInt(child.Content, aggErr)
+		case "NextKeyMarker":
+			listMultiPartUploadsResult.NextKeyMarker = parseNullableString(child.Content)
+		case "NextUploadIdMarker":
+			listMultiPartUploadsResult.NextUploadIdMarker = parseNullableString(child.Content)
+		case "Prefix":
+			listMultiPartUploadsResult.Prefix = parseNullableString(child.Content)
+		case "IsTruncated":
+			listMultiPartUploadsResult.Truncated = parseBool(child.Content, aggErr)
+		case "UploadIdMarker":
+			listMultiPartUploadsResult.UploadIdMarker = parseNullableString(child.Content)
+		case "Upload":
+			var model MultiPartUpload
+			model.parse(&child, aggErr)
+			listMultiPartUploadsResult.Uploads = append(listMultiPartUploadsResult.Uploads, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ListMultiPartUploadsResult.", child.XMLName.Local)
+		}
+	}
 }
 
 type MultiPartUpload struct {
-    Initiated string
-    Key *string
-    Owner User
-    UploadId string
+	Initiated string
+	Key       *string
+	Owner     User
+	UploadId  string
 }
 
 func (multiPartUpload *MultiPartUpload) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Initiated":
-            multiPartUpload.Initiated = parseString(child.Content)
-        case "Key":
-            multiPartUpload.Key = parseNullableString(child.Content)
-        case "Owner":
-            multiPartUpload.Owner.parse(&child, aggErr)
-        case "UploadId":
-            multiPartUpload.UploadId = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing MultiPartUpload.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Initiated":
+			multiPartUpload.Initiated = parseString(child.Content)
+		case "Key":
+			multiPartUpload.Key = parseNullableString(child.Content)
+		case "Owner":
+			multiPartUpload.Owner.parse(&child, aggErr)
+		case "UploadId":
+			multiPartUpload.UploadId = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing MultiPartUpload.", child.XMLName.Local)
+		}
+	}
 }
 
 type MultiPartUploadPart struct {
-    ETag *string
-    LastModified string
-    PartNumber int
+	ETag         *string
+	LastModified string
+	PartNumber   int
 }
 
 func (multiPartUploadPart *MultiPartUploadPart) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "ETag":
-            multiPartUploadPart.ETag = parseNullableString(child.Content)
-        case "LastModified":
-            multiPartUploadPart.LastModified = parseString(child.Content)
-        case "PartNumber":
-            multiPartUploadPart.PartNumber = parseInt(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing MultiPartUploadPart.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "ETag":
+			multiPartUploadPart.ETag = parseNullableString(child.Content)
+		case "LastModified":
+			multiPartUploadPart.LastModified = parseString(child.Content)
+		case "PartNumber":
+			multiPartUploadPart.PartNumber = parseInt(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing MultiPartUploadPart.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobNode struct {
-    EndPoint *string
-    HttpPort *int
-    HttpsPort *int
-    Id string
+	EndPoint  *string
+	HttpPort  *int
+	HttpsPort *int
+	Id        string
 }
 
 func (jobNode *JobNode) parse(xmlNode *XmlNode, aggErr *AggregateError) {
-    // Parse Attributes
-    for _, attr := range xmlNode.Attrs {
-        switch attr.Name.Local {
-        case "EndPoint":
-            jobNode.EndPoint = parseNullableStringFromString(attr.Value)
-        case "HttpPort":
-            jobNode.HttpPort = parseNullableIntFromString(attr.Value, aggErr)
-        case "HttpsPort":
-            jobNode.HttpsPort = parseNullableIntFromString(attr.Value, aggErr)
-        case "Id":
-            jobNode.Id = attr.Value
-        default:
-            log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing JobNode.", attr.Name.Local)
-        }
-    }
+	// Parse Attributes
+	for _, attr := range xmlNode.Attrs {
+		switch attr.Name.Local {
+		case "EndPoint":
+			jobNode.EndPoint = parseNullableStringFromString(attr.Value)
+		case "HttpPort":
+			jobNode.HttpPort = parseNullableIntFromString(attr.Value, aggErr)
+		case "HttpsPort":
+			jobNode.HttpsPort = parseNullableIntFromString(attr.Value, aggErr)
+		case "Id":
+			jobNode.Id = attr.Value
+		default:
+			log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing JobNode.", attr.Name.Local)
+		}
+	}
 
 }
 
-
 func parseJobNodeSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []JobNode {
-    var result []JobNode
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult JobNode
-            curResult.parse(&curXmlNode, aggErr)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing JobNode struct.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []JobNode
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult JobNode
+			curResult.parse(&curXmlNode, aggErr)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing JobNode struct.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }
 
 type Contents struct {
-    ETag *string
-    IsLatest *bool
-    Key *string
-    LastModified *string
-    Owner User
-    Size int64
-    StorageClass *string
-    VersionId *string
+	ETag         *string
+	IsLatest     *bool
+	Key          *string
+	LastModified *string
+	Owner        User
+	Size         int64
+	StorageClass *string
+	VersionId    *string
 }
 
 func (contents *Contents) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "ETag":
-            contents.ETag = parseNullableString(child.Content)
-        case "IsLatest":
-            contents.IsLatest = parseNullableBool(child.Content, aggErr)
-        case "Key":
-            contents.Key = parseNullableString(child.Content)
-        case "LastModified":
-            contents.LastModified = parseNullableString(child.Content)
-        case "Owner":
-            contents.Owner.parse(&child, aggErr)
-        case "Size":
-            contents.Size = parseInt64(child.Content, aggErr)
-        case "StorageClass":
-            contents.StorageClass = parseNullableString(child.Content)
-        case "VersionId":
-            contents.VersionId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Contents.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "ETag":
+			contents.ETag = parseNullableString(child.Content)
+		case "IsLatest":
+			contents.IsLatest = parseNullableBool(child.Content, aggErr)
+		case "Key":
+			contents.Key = parseNullableString(child.Content)
+		case "LastModified":
+			contents.LastModified = parseNullableString(child.Content)
+		case "Owner":
+			contents.Owner.parse(&child, aggErr)
+		case "Size":
+			contents.Size = parseInt64(child.Content, aggErr)
+		case "StorageClass":
+			contents.StorageClass = parseNullableString(child.Content)
+		case "VersionId":
+			contents.VersionId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Contents.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3ObjectToDelete struct {
-    Key *string
-    VersionId *string
+	Key       *string
+	VersionId *string
 }
 
 func (s3ObjectToDelete *S3ObjectToDelete) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Key":
-            s3ObjectToDelete.Key = parseNullableString(child.Content)
-        case "VersionId":
-            s3ObjectToDelete.VersionId = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectToDelete.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Key":
+			s3ObjectToDelete.Key = parseNullableString(child.Content)
+		case "VersionId":
+			s3ObjectToDelete.VersionId = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectToDelete.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeStateSummaryApiBean struct {
-    Count int
-    FullOfData int
-    TapeState TapeState
-    TypeCounts []TypeTypeCountApiBean
+	Count      int
+	FullOfData int
+	TapeState  TapeState
+	TypeCounts []TypeTypeCountApiBean
 }
 
 func (tapeStateSummaryApiBean *TapeStateSummaryApiBean) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Count":
-            tapeStateSummaryApiBean.Count = parseInt(child.Content, aggErr)
-        case "FullOfData":
-            tapeStateSummaryApiBean.FullOfData = parseInt(child.Content, aggErr)
-        case "TapeState":
-            parseEnum(child.Content, &tapeStateSummaryApiBean.TapeState, aggErr)
-        case "TypeCounts":
-            var model TypeTypeCountApiBean
-            model.parse(&child, aggErr)
-            tapeStateSummaryApiBean.TypeCounts = append(tapeStateSummaryApiBean.TypeCounts, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeStateSummaryApiBean.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Count":
+			tapeStateSummaryApiBean.Count = parseInt(child.Content, aggErr)
+		case "FullOfData":
+			tapeStateSummaryApiBean.FullOfData = parseInt(child.Content, aggErr)
+		case "TapeState":
+			parseEnum(child.Content, &tapeStateSummaryApiBean.TapeState, aggErr)
+		case "TypeCounts":
+			var model TypeTypeCountApiBean
+			model.parse(&child, aggErr)
+			tapeStateSummaryApiBean.TypeCounts = append(tapeStateSummaryApiBean.TypeCounts, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeStateSummaryApiBean.", child.XMLName.Local)
+		}
+	}
 }
 
-
 func parseTapeStateSummaryApiBeanSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []TapeStateSummaryApiBean {
-    var result []TapeStateSummaryApiBean
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult TapeStateSummaryApiBean
-            curResult.parse(&curXmlNode, aggErr)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing TapeStateSummaryApiBean struct.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []TapeStateSummaryApiBean
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult TapeStateSummaryApiBean
+			curResult.parse(&curXmlNode, aggErr)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing TapeStateSummaryApiBean struct.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }
 
 type TapeTypeSummaryApiBean struct {
-    AvailableStorageCapacity int64
-    Count int
-    TotalStorageCapacity int64
-    Type string
-    UsedStorageCapacity int64
+	AvailableStorageCapacity int64
+	Count                    int
+	TotalStorageCapacity     int64
+	Type                     string
+	UsedStorageCapacity      int64
 }
 
 func (tapeTypeSummaryApiBean *TapeTypeSummaryApiBean) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AvailableStorageCapacity":
-            tapeTypeSummaryApiBean.AvailableStorageCapacity = parseInt64(child.Content, aggErr)
-        case "Count":
-            tapeTypeSummaryApiBean.Count = parseInt(child.Content, aggErr)
-        case "TotalStorageCapacity":
-            tapeTypeSummaryApiBean.TotalStorageCapacity = parseInt64(child.Content, aggErr)
-        case "Type":
-            tapeTypeSummaryApiBean.Type = parseString(child.Content)
-        case "UsedStorageCapacity":
-            tapeTypeSummaryApiBean.UsedStorageCapacity = parseInt64(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeTypeSummaryApiBean.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AvailableStorageCapacity":
+			tapeTypeSummaryApiBean.AvailableStorageCapacity = parseInt64(child.Content, aggErr)
+		case "Count":
+			tapeTypeSummaryApiBean.Count = parseInt(child.Content, aggErr)
+		case "TotalStorageCapacity":
+			tapeTypeSummaryApiBean.TotalStorageCapacity = parseInt64(child.Content, aggErr)
+		case "Type":
+			tapeTypeSummaryApiBean.Type = parseString(child.Content)
+		case "UsedStorageCapacity":
+			tapeTypeSummaryApiBean.UsedStorageCapacity = parseInt64(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeTypeSummaryApiBean.", child.XMLName.Local)
+		}
+	}
 }
 
-
 func parseTapeTypeSummaryApiBeanSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []TapeTypeSummaryApiBean {
-    var result []TapeTypeSummaryApiBean
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult TapeTypeSummaryApiBean
-            curResult.parse(&curXmlNode, aggErr)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing TapeTypeSummaryApiBean struct.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []TapeTypeSummaryApiBean
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult TapeTypeSummaryApiBean
+			curResult.parse(&curXmlNode, aggErr)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing TapeTypeSummaryApiBean struct.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }
 
 type TypeTypeCountApiBean struct {
-    Count int
-    FullOfData int
-    Type string
+	Count      int
+	FullOfData int
+	Type       string
 }
 
 func (typeTypeCountApiBean *TypeTypeCountApiBean) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Count":
-            typeTypeCountApiBean.Count = parseInt(child.Content, aggErr)
-        case "FullOfData":
-            typeTypeCountApiBean.FullOfData = parseInt(child.Content, aggErr)
-        case "Type":
-            typeTypeCountApiBean.Type = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TypeTypeCountApiBean.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Count":
+			typeTypeCountApiBean.Count = parseInt(child.Content, aggErr)
+		case "FullOfData":
+			typeTypeCountApiBean.FullOfData = parseInt(child.Content, aggErr)
+		case "Type":
+			typeTypeCountApiBean.Type = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TypeTypeCountApiBean.", child.XMLName.Local)
+		}
+	}
 }
 
 type User struct {
-    DisplayName *string
-    Id string
+	DisplayName *string
+	Id          string
 }
 
 func (user *User) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DisplayName":
-            user.DisplayName = parseNullableString(child.Content)
-        case "ID":
-            user.Id = parseString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing User.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DisplayName":
+			user.DisplayName = parseNullableString(child.Content)
+		case "ID":
+			user.Id = parseString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing User.", child.XMLName.Local)
+		}
+	}
 }
 
 type DetailedS3Object struct {
-    Blobs *BulkObjectList
-    BlobsBeingPersisted *int
-    BlobsDegraded *int
-    BlobsInCache *int
-    BlobsTotal *int
-    BucketId string
-    CreationDate *string
-    ETag *string
-    Id string
-    Latest bool
-    Name *string
-    Owner *string
-    Size int64
-    Type S3ObjectType
+	Blobs               *BulkObjectList
+	BlobsBeingPersisted *int
+	BlobsDegraded       *int
+	BlobsInCache        *int
+	BlobsTotal          *int
+	BucketId            string
+	CreationDate        *string
+	ETag                *string
+	Id                  string
+	Latest              bool
+	Name                *string
+	Owner               *string
+	Size                int64
+	Type                S3ObjectType
 }
 
 func (detailedS3Object *DetailedS3Object) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Blobs":
-            var model BulkObjectList
-            model.parse(&child, aggErr)
-            detailedS3Object.Blobs = &model
-        case "BlobsBeingPersisted":
-            detailedS3Object.BlobsBeingPersisted = parseNullableInt(child.Content, aggErr)
-        case "BlobsDegraded":
-            detailedS3Object.BlobsDegraded = parseNullableInt(child.Content, aggErr)
-        case "BlobsInCache":
-            detailedS3Object.BlobsInCache = parseNullableInt(child.Content, aggErr)
-        case "BlobsTotal":
-            detailedS3Object.BlobsTotal = parseNullableInt(child.Content, aggErr)
-        case "BucketId":
-            detailedS3Object.BucketId = parseString(child.Content)
-        case "CreationDate":
-            detailedS3Object.CreationDate = parseNullableString(child.Content)
-        case "ETag":
-            detailedS3Object.ETag = parseNullableString(child.Content)
-        case "Id":
-            detailedS3Object.Id = parseString(child.Content)
-        case "Latest":
-            detailedS3Object.Latest = parseBool(child.Content, aggErr)
-        case "Name":
-            detailedS3Object.Name = parseNullableString(child.Content)
-        case "Owner":
-            detailedS3Object.Owner = parseNullableString(child.Content)
-        case "Size":
-            detailedS3Object.Size = parseInt64(child.Content, aggErr)
-        case "Type":
-            parseEnum(child.Content, &detailedS3Object.Type, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DetailedS3Object.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Blobs":
+			var model BulkObjectList
+			model.parse(&child, aggErr)
+			detailedS3Object.Blobs = &model
+		case "BlobsBeingPersisted":
+			detailedS3Object.BlobsBeingPersisted = parseNullableInt(child.Content, aggErr)
+		case "BlobsDegraded":
+			detailedS3Object.BlobsDegraded = parseNullableInt(child.Content, aggErr)
+		case "BlobsInCache":
+			detailedS3Object.BlobsInCache = parseNullableInt(child.Content, aggErr)
+		case "BlobsTotal":
+			detailedS3Object.BlobsTotal = parseNullableInt(child.Content, aggErr)
+		case "BucketId":
+			detailedS3Object.BucketId = parseString(child.Content)
+		case "CreationDate":
+			detailedS3Object.CreationDate = parseNullableString(child.Content)
+		case "ETag":
+			detailedS3Object.ETag = parseNullableString(child.Content)
+		case "Id":
+			detailedS3Object.Id = parseString(child.Content)
+		case "Latest":
+			detailedS3Object.Latest = parseBool(child.Content, aggErr)
+		case "Name":
+			detailedS3Object.Name = parseNullableString(child.Content)
+		case "Owner":
+			detailedS3Object.Owner = parseNullableString(child.Content)
+		case "Size":
+			detailedS3Object.Size = parseInt64(child.Content, aggErr)
+		case "Type":
+			parseEnum(child.Content, &detailedS3Object.Type, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DetailedS3Object.", child.XMLName.Local)
+		}
+	}
 }
 
 type SystemInformation struct {
-    ApiVersion *string
-    BackendActivated bool
-    BuildInformation BuildInformation
-    InstanceId string
-    Now int64
-    SerialNumber *string
+	ApiVersion       *string
+	BackendActivated bool
+	BuildInformation BuildInformation
+	InstanceId       string
+	Now              int64
+	SerialNumber     *string
 }
 
 func (systemInformation *SystemInformation) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "ApiVersion":
-            systemInformation.ApiVersion = parseNullableString(child.Content)
-        case "BackendActivated":
-            systemInformation.BackendActivated = parseBool(child.Content, aggErr)
-        case "BuildInformation":
-            systemInformation.BuildInformation.parse(&child, aggErr)
-        case "InstanceId":
-            systemInformation.InstanceId = parseString(child.Content)
-        case "Now":
-            systemInformation.Now = parseInt64(child.Content, aggErr)
-        case "SerialNumber":
-            systemInformation.SerialNumber = parseNullableString(child.Content)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SystemInformation.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "ApiVersion":
+			systemInformation.ApiVersion = parseNullableString(child.Content)
+		case "BackendActivated":
+			systemInformation.BackendActivated = parseBool(child.Content, aggErr)
+		case "BuildInformation":
+			systemInformation.BuildInformation.parse(&child, aggErr)
+		case "InstanceId":
+			systemInformation.InstanceId = parseString(child.Content)
+		case "Now":
+			systemInformation.Now = parseInt64(child.Content, aggErr)
+		case "SerialNumber":
+			systemInformation.SerialNumber = parseNullableString(child.Content)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SystemInformation.", child.XMLName.Local)
+		}
+	}
 }
 
 type HealthVerificationResult struct {
-    DatabaseFilesystemFreeSpace DatabasePhysicalSpaceState
-    MsRequiredToVerifyDataPlannerHealth int64
+	DatabaseFilesystemFreeSpace         DatabasePhysicalSpaceState
+	MsRequiredToVerifyDataPlannerHealth int64
 }
 
 func (healthVerificationResult *HealthVerificationResult) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DatabaseFilesystemFreeSpace":
-            parseEnum(child.Content, &healthVerificationResult.DatabaseFilesystemFreeSpace, aggErr)
-        case "MsRequiredToVerifyDataPlannerHealth":
-            healthVerificationResult.MsRequiredToVerifyDataPlannerHealth = parseInt64(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing HealthVerificationResult.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DatabaseFilesystemFreeSpace":
+			parseEnum(child.Content, &healthVerificationResult.DatabaseFilesystemFreeSpace, aggErr)
+		case "MsRequiredToVerifyDataPlannerHealth":
+			healthVerificationResult.MsRequiredToVerifyDataPlannerHealth = parseInt64(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing HealthVerificationResult.", child.XMLName.Local)
+		}
+	}
 }
 
 type NamedDetailedTapePartition struct {
-    AutoCompactionEnabled bool
-    AutoQuiesceEnabled bool
-    AvailableStorageCapacity int64
-    DriveIdleTimeoutInMinutes *int
-    DriveType *TapeDriveType
-    DriveTypes []TapeDriveType
-    ErrorMessage *string
-    Id string
-    ImportExportConfiguration ImportExportConfiguration
-    LibraryId string
-    MinimumReadReservedDrives int
-    MinimumWriteReservedDrives int
-    Name *string
-    Quiesced Quiesced
-    SerialNumber *string
-    State TapePartitionState
-    TapeCount int
-    TapeStateSummaries []TapeStateSummaryApiBean
-    TapeTypeSummaries []TapeTypeSummaryApiBean
-    TapeTypes []string
-    TotalStorageCapacity int64
-    UsedStorageCapacity int64
+	AutoCompactionEnabled      bool
+	AutoQuiesceEnabled         bool
+	AvailableStorageCapacity   int64
+	DriveIdleTimeoutInMinutes  *int
+	DriveType                  *TapeDriveType
+	DriveTypes                 []TapeDriveType
+	ErrorMessage               *string
+	Id                         string
+	ImportExportConfiguration  ImportExportConfiguration
+	LibraryId                  string
+	MinimumReadReservedDrives  int
+	MinimumWriteReservedDrives int
+	Name                       *string
+	Quiesced                   Quiesced
+	SerialNumber               *string
+	State                      TapePartitionState
+	TapeCount                  int
+	TapeStateSummaries         []TapeStateSummaryApiBean
+	TapeTypeSummaries          []TapeTypeSummaryApiBean
+	TapeTypes                  []string
+	TotalStorageCapacity       int64
+	UsedStorageCapacity        int64
 }
 
 func (namedDetailedTapePartition *NamedDetailedTapePartition) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AutoCompactionEnabled":
-            namedDetailedTapePartition.AutoCompactionEnabled = parseBool(child.Content, aggErr)
-        case "AutoQuiesceEnabled":
-            namedDetailedTapePartition.AutoQuiesceEnabled = parseBool(child.Content, aggErr)
-        case "AvailableStorageCapacity":
-            namedDetailedTapePartition.AvailableStorageCapacity = parseInt64(child.Content, aggErr)
-        case "DriveIdleTimeoutInMinutes":
-            namedDetailedTapePartition.DriveIdleTimeoutInMinutes = parseNullableInt(child.Content, aggErr)
-        case "DriveType":
-            namedDetailedTapePartition.DriveType = newTapeDriveTypeFromContent(child.Content, aggErr)
-        case "DriveTypes":
-            var model TapeDriveType
-            parseEnum(child.Content, &model, aggErr)
-            namedDetailedTapePartition.DriveTypes = append(namedDetailedTapePartition.DriveTypes, model)
-        case "ErrorMessage":
-            namedDetailedTapePartition.ErrorMessage = parseNullableString(child.Content)
-        case "Id":
-            namedDetailedTapePartition.Id = parseString(child.Content)
-        case "ImportExportConfiguration":
-            parseEnum(child.Content, &namedDetailedTapePartition.ImportExportConfiguration, aggErr)
-        case "LibraryId":
-            namedDetailedTapePartition.LibraryId = parseString(child.Content)
-        case "MinimumReadReservedDrives":
-            namedDetailedTapePartition.MinimumReadReservedDrives = parseInt(child.Content, aggErr)
-        case "MinimumWriteReservedDrives":
-            namedDetailedTapePartition.MinimumWriteReservedDrives = parseInt(child.Content, aggErr)
-        case "Name":
-            namedDetailedTapePartition.Name = parseNullableString(child.Content)
-        case "Quiesced":
-            parseEnum(child.Content, &namedDetailedTapePartition.Quiesced, aggErr)
-        case "SerialNumber":
-            namedDetailedTapePartition.SerialNumber = parseNullableString(child.Content)
-        case "State":
-            parseEnum(child.Content, &namedDetailedTapePartition.State, aggErr)
-        case "TapeCount":
-            namedDetailedTapePartition.TapeCount = parseInt(child.Content, aggErr)
-        case "TapeStateSummaries":
-            namedDetailedTapePartition.TapeStateSummaries = parseTapeStateSummaryApiBeanSlice("TapeStateSummary", child.Children, aggErr)
-        case "TapeTypeSummaries":
-            namedDetailedTapePartition.TapeTypeSummaries = parseTapeTypeSummaryApiBeanSlice("TapeTypeSummary", child.Children, aggErr)
-        case "TapeTypes":
-            var str = parseString(child.Content)
-            namedDetailedTapePartition.TapeTypes = append(namedDetailedTapePartition.TapeTypes, str)
-        case "TotalStorageCapacity":
-            namedDetailedTapePartition.TotalStorageCapacity = parseInt64(child.Content, aggErr)
-        case "UsedStorageCapacity":
-            namedDetailedTapePartition.UsedStorageCapacity = parseInt64(child.Content, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing NamedDetailedTapePartition.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AutoCompactionEnabled":
+			namedDetailedTapePartition.AutoCompactionEnabled = parseBool(child.Content, aggErr)
+		case "AutoQuiesceEnabled":
+			namedDetailedTapePartition.AutoQuiesceEnabled = parseBool(child.Content, aggErr)
+		case "AvailableStorageCapacity":
+			namedDetailedTapePartition.AvailableStorageCapacity = parseInt64(child.Content, aggErr)
+		case "DriveIdleTimeoutInMinutes":
+			namedDetailedTapePartition.DriveIdleTimeoutInMinutes = parseNullableInt(child.Content, aggErr)
+		case "DriveType":
+			namedDetailedTapePartition.DriveType = newTapeDriveTypeFromContent(child.Content, aggErr)
+		case "DriveTypes":
+			var model TapeDriveType
+			parseEnum(child.Content, &model, aggErr)
+			namedDetailedTapePartition.DriveTypes = append(namedDetailedTapePartition.DriveTypes, model)
+		case "ErrorMessage":
+			namedDetailedTapePartition.ErrorMessage = parseNullableString(child.Content)
+		case "Id":
+			namedDetailedTapePartition.Id = parseString(child.Content)
+		case "ImportExportConfiguration":
+			parseEnum(child.Content, &namedDetailedTapePartition.ImportExportConfiguration, aggErr)
+		case "LibraryId":
+			namedDetailedTapePartition.LibraryId = parseString(child.Content)
+		case "MinimumReadReservedDrives":
+			namedDetailedTapePartition.MinimumReadReservedDrives = parseInt(child.Content, aggErr)
+		case "MinimumWriteReservedDrives":
+			namedDetailedTapePartition.MinimumWriteReservedDrives = parseInt(child.Content, aggErr)
+		case "Name":
+			namedDetailedTapePartition.Name = parseNullableString(child.Content)
+		case "Quiesced":
+			parseEnum(child.Content, &namedDetailedTapePartition.Quiesced, aggErr)
+		case "SerialNumber":
+			namedDetailedTapePartition.SerialNumber = parseNullableString(child.Content)
+		case "State":
+			parseEnum(child.Content, &namedDetailedTapePartition.State, aggErr)
+		case "TapeCount":
+			namedDetailedTapePartition.TapeCount = parseInt(child.Content, aggErr)
+		case "TapeStateSummaries":
+			namedDetailedTapePartition.TapeStateSummaries = parseTapeStateSummaryApiBeanSlice("TapeStateSummary", child.Children, aggErr)
+		case "TapeTypeSummaries":
+			namedDetailedTapePartition.TapeTypeSummaries = parseTapeTypeSummaryApiBeanSlice("TapeTypeSummary", child.Children, aggErr)
+		case "TapeTypes":
+			var str = parseString(child.Content)
+			namedDetailedTapePartition.TapeTypes = append(namedDetailedTapePartition.TapeTypes, str)
+		case "TotalStorageCapacity":
+			namedDetailedTapePartition.TotalStorageCapacity = parseInt64(child.Content, aggErr)
+		case "UsedStorageCapacity":
+			namedDetailedTapePartition.UsedStorageCapacity = parseInt64(child.Content, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing NamedDetailedTapePartition.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeFailure struct {
-    Cause *string
-    Tape Tape
+	Cause *string
+	Tape  Tape
 }
 
 func (tapeFailure *TapeFailure) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Cause":
-            tapeFailure.Cause = parseNullableString(child.Content)
-        case "Tape":
-            tapeFailure.Tape.parse(&child, aggErr)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeFailure.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Cause":
+			tapeFailure.Cause = parseNullableString(child.Content)
+		case "Tape":
+			tapeFailure.Tape.parse(&child, aggErr)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeFailure.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeFailureList struct {
-    Failures []TapeFailure
+	Failures []TapeFailure
 }
 
 func (tapeFailureList *TapeFailureList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Failure":
-            var model TapeFailure
-            model.parse(&child, aggErr)
-            tapeFailureList.Failures = append(tapeFailureList.Failures, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeFailureList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Failure":
+			var model TapeFailure
+			model.parse(&child, aggErr)
+			tapeFailureList.Failures = append(tapeFailureList.Failures, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeFailureList.", child.XMLName.Local)
+		}
+	}
 }
 
 type RestOperationType Enum
 
 const (
-    REST_OPERATION_TYPE_ALLOCATE RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_CANCEL_EJECT RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_CANCEL_FORMAT RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_CANCEL_IMPORT RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_CANCEL_ONLINE RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_CANCEL_TEST RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_CANCEL_VERIFY RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_CLEAN RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_COMPACT RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_DEALLOCATE RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_DUMP RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_EJECT RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_FORMAT RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_GET_PHYSICAL_PLACEMENT RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_IMPORT RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_INSPECT RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_MARK_FOR_COMPACTION RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_ONLINE RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_PAIR_BACK RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_REGENERATE_SECRET_KEY RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_START_BULK_GET RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_START_BULK_PUT RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_START_BULK_STAGE RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_START_BULK_VERIFY RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_TEST RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_VERIFY RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_VERIFY_SAFE_TO_START_BULK_PUT RestOperationType = 1 + iota
-    REST_OPERATION_TYPE_VERIFY_PHYSICAL_PLACEMENT RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_ALLOCATE                      RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_CANCEL_EJECT                  RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_CANCEL_FORMAT                 RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_CANCEL_IMPORT                 RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_CANCEL_ONLINE                 RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_CANCEL_TEST                   RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_CANCEL_VERIFY                 RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_CLEAN                         RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_COMPACT                       RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_DEALLOCATE                    RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_DUMP                          RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_EJECT                         RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_FORMAT                        RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_GET_PHYSICAL_PLACEMENT        RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_IMPORT                        RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_INSPECT                       RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_MARK_FOR_COMPACTION           RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_ONLINE                        RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_PAIR_BACK                     RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_REGENERATE_SECRET_KEY         RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_START_BULK_GET                RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_START_BULK_PUT                RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_START_BULK_STAGE              RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_START_BULK_VERIFY             RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_TEST                          RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_VERIFY                        RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_VERIFY_SAFE_TO_START_BULK_PUT RestOperationType = 1 + iota
+	REST_OPERATION_TYPE_VERIFY_PHYSICAL_PLACEMENT     RestOperationType = 1 + iota
 )
 
 func (restOperationType *RestOperationType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *restOperationType = UNDEFINED
-        case "ALLOCATE": *restOperationType = REST_OPERATION_TYPE_ALLOCATE
-        case "CANCEL_EJECT": *restOperationType = REST_OPERATION_TYPE_CANCEL_EJECT
-        case "CANCEL_FORMAT": *restOperationType = REST_OPERATION_TYPE_CANCEL_FORMAT
-        case "CANCEL_IMPORT": *restOperationType = REST_OPERATION_TYPE_CANCEL_IMPORT
-        case "CANCEL_ONLINE": *restOperationType = REST_OPERATION_TYPE_CANCEL_ONLINE
-        case "CANCEL_TEST": *restOperationType = REST_OPERATION_TYPE_CANCEL_TEST
-        case "CANCEL_VERIFY": *restOperationType = REST_OPERATION_TYPE_CANCEL_VERIFY
-        case "CLEAN": *restOperationType = REST_OPERATION_TYPE_CLEAN
-        case "COMPACT": *restOperationType = REST_OPERATION_TYPE_COMPACT
-        case "DEALLOCATE": *restOperationType = REST_OPERATION_TYPE_DEALLOCATE
-        case "DUMP": *restOperationType = REST_OPERATION_TYPE_DUMP
-        case "EJECT": *restOperationType = REST_OPERATION_TYPE_EJECT
-        case "FORMAT": *restOperationType = REST_OPERATION_TYPE_FORMAT
-        case "GET_PHYSICAL_PLACEMENT": *restOperationType = REST_OPERATION_TYPE_GET_PHYSICAL_PLACEMENT
-        case "IMPORT": *restOperationType = REST_OPERATION_TYPE_IMPORT
-        case "INSPECT": *restOperationType = REST_OPERATION_TYPE_INSPECT
-        case "MARK_FOR_COMPACTION": *restOperationType = REST_OPERATION_TYPE_MARK_FOR_COMPACTION
-        case "ONLINE": *restOperationType = REST_OPERATION_TYPE_ONLINE
-        case "PAIR_BACK": *restOperationType = REST_OPERATION_TYPE_PAIR_BACK
-        case "REGENERATE_SECRET_KEY": *restOperationType = REST_OPERATION_TYPE_REGENERATE_SECRET_KEY
-        case "START_BULK_GET": *restOperationType = REST_OPERATION_TYPE_START_BULK_GET
-        case "START_BULK_PUT": *restOperationType = REST_OPERATION_TYPE_START_BULK_PUT
-        case "START_BULK_STAGE": *restOperationType = REST_OPERATION_TYPE_START_BULK_STAGE
-        case "START_BULK_VERIFY": *restOperationType = REST_OPERATION_TYPE_START_BULK_VERIFY
-        case "TEST": *restOperationType = REST_OPERATION_TYPE_TEST
-        case "VERIFY": *restOperationType = REST_OPERATION_TYPE_VERIFY
-        case "VERIFY_SAFE_TO_START_BULK_PUT": *restOperationType = REST_OPERATION_TYPE_VERIFY_SAFE_TO_START_BULK_PUT
-        case "VERIFY_PHYSICAL_PLACEMENT": *restOperationType = REST_OPERATION_TYPE_VERIFY_PHYSICAL_PLACEMENT
-        default:
-            *restOperationType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into RestOperationType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*restOperationType = UNDEFINED
+	case "ALLOCATE":
+		*restOperationType = REST_OPERATION_TYPE_ALLOCATE
+	case "CANCEL_EJECT":
+		*restOperationType = REST_OPERATION_TYPE_CANCEL_EJECT
+	case "CANCEL_FORMAT":
+		*restOperationType = REST_OPERATION_TYPE_CANCEL_FORMAT
+	case "CANCEL_IMPORT":
+		*restOperationType = REST_OPERATION_TYPE_CANCEL_IMPORT
+	case "CANCEL_ONLINE":
+		*restOperationType = REST_OPERATION_TYPE_CANCEL_ONLINE
+	case "CANCEL_TEST":
+		*restOperationType = REST_OPERATION_TYPE_CANCEL_TEST
+	case "CANCEL_VERIFY":
+		*restOperationType = REST_OPERATION_TYPE_CANCEL_VERIFY
+	case "CLEAN":
+		*restOperationType = REST_OPERATION_TYPE_CLEAN
+	case "COMPACT":
+		*restOperationType = REST_OPERATION_TYPE_COMPACT
+	case "DEALLOCATE":
+		*restOperationType = REST_OPERATION_TYPE_DEALLOCATE
+	case "DUMP":
+		*restOperationType = REST_OPERATION_TYPE_DUMP
+	case "EJECT":
+		*restOperationType = REST_OPERATION_TYPE_EJECT
+	case "FORMAT":
+		*restOperationType = REST_OPERATION_TYPE_FORMAT
+	case "GET_PHYSICAL_PLACEMENT":
+		*restOperationType = REST_OPERATION_TYPE_GET_PHYSICAL_PLACEMENT
+	case "IMPORT":
+		*restOperationType = REST_OPERATION_TYPE_IMPORT
+	case "INSPECT":
+		*restOperationType = REST_OPERATION_TYPE_INSPECT
+	case "MARK_FOR_COMPACTION":
+		*restOperationType = REST_OPERATION_TYPE_MARK_FOR_COMPACTION
+	case "ONLINE":
+		*restOperationType = REST_OPERATION_TYPE_ONLINE
+	case "PAIR_BACK":
+		*restOperationType = REST_OPERATION_TYPE_PAIR_BACK
+	case "REGENERATE_SECRET_KEY":
+		*restOperationType = REST_OPERATION_TYPE_REGENERATE_SECRET_KEY
+	case "START_BULK_GET":
+		*restOperationType = REST_OPERATION_TYPE_START_BULK_GET
+	case "START_BULK_PUT":
+		*restOperationType = REST_OPERATION_TYPE_START_BULK_PUT
+	case "START_BULK_STAGE":
+		*restOperationType = REST_OPERATION_TYPE_START_BULK_STAGE
+	case "START_BULK_VERIFY":
+		*restOperationType = REST_OPERATION_TYPE_START_BULK_VERIFY
+	case "TEST":
+		*restOperationType = REST_OPERATION_TYPE_TEST
+	case "VERIFY":
+		*restOperationType = REST_OPERATION_TYPE_VERIFY
+	case "VERIFY_SAFE_TO_START_BULK_PUT":
+		*restOperationType = REST_OPERATION_TYPE_VERIFY_SAFE_TO_START_BULK_PUT
+	case "VERIFY_PHYSICAL_PLACEMENT":
+		*restOperationType = REST_OPERATION_TYPE_VERIFY_PHYSICAL_PLACEMENT
+	default:
+		*restOperationType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into RestOperationType", str))
+	}
+	return nil
 }
 
 func (restOperationType RestOperationType) String() string {
-    switch restOperationType {
-        case REST_OPERATION_TYPE_ALLOCATE: return "ALLOCATE"
-        case REST_OPERATION_TYPE_CANCEL_EJECT: return "CANCEL_EJECT"
-        case REST_OPERATION_TYPE_CANCEL_FORMAT: return "CANCEL_FORMAT"
-        case REST_OPERATION_TYPE_CANCEL_IMPORT: return "CANCEL_IMPORT"
-        case REST_OPERATION_TYPE_CANCEL_ONLINE: return "CANCEL_ONLINE"
-        case REST_OPERATION_TYPE_CANCEL_TEST: return "CANCEL_TEST"
-        case REST_OPERATION_TYPE_CANCEL_VERIFY: return "CANCEL_VERIFY"
-        case REST_OPERATION_TYPE_CLEAN: return "CLEAN"
-        case REST_OPERATION_TYPE_COMPACT: return "COMPACT"
-        case REST_OPERATION_TYPE_DEALLOCATE: return "DEALLOCATE"
-        case REST_OPERATION_TYPE_DUMP: return "DUMP"
-        case REST_OPERATION_TYPE_EJECT: return "EJECT"
-        case REST_OPERATION_TYPE_FORMAT: return "FORMAT"
-        case REST_OPERATION_TYPE_GET_PHYSICAL_PLACEMENT: return "GET_PHYSICAL_PLACEMENT"
-        case REST_OPERATION_TYPE_IMPORT: return "IMPORT"
-        case REST_OPERATION_TYPE_INSPECT: return "INSPECT"
-        case REST_OPERATION_TYPE_MARK_FOR_COMPACTION: return "MARK_FOR_COMPACTION"
-        case REST_OPERATION_TYPE_ONLINE: return "ONLINE"
-        case REST_OPERATION_TYPE_PAIR_BACK: return "PAIR_BACK"
-        case REST_OPERATION_TYPE_REGENERATE_SECRET_KEY: return "REGENERATE_SECRET_KEY"
-        case REST_OPERATION_TYPE_START_BULK_GET: return "START_BULK_GET"
-        case REST_OPERATION_TYPE_START_BULK_PUT: return "START_BULK_PUT"
-        case REST_OPERATION_TYPE_START_BULK_STAGE: return "START_BULK_STAGE"
-        case REST_OPERATION_TYPE_START_BULK_VERIFY: return "START_BULK_VERIFY"
-        case REST_OPERATION_TYPE_TEST: return "TEST"
-        case REST_OPERATION_TYPE_VERIFY: return "VERIFY"
-        case REST_OPERATION_TYPE_VERIFY_SAFE_TO_START_BULK_PUT: return "VERIFY_SAFE_TO_START_BULK_PUT"
-        case REST_OPERATION_TYPE_VERIFY_PHYSICAL_PLACEMENT: return "VERIFY_PHYSICAL_PLACEMENT"
-        default:
-            log.Printf("Error: invalid RestOperationType represented by '%d'", restOperationType)
-            return ""
-    }
+	switch restOperationType {
+	case REST_OPERATION_TYPE_ALLOCATE:
+		return "ALLOCATE"
+	case REST_OPERATION_TYPE_CANCEL_EJECT:
+		return "CANCEL_EJECT"
+	case REST_OPERATION_TYPE_CANCEL_FORMAT:
+		return "CANCEL_FORMAT"
+	case REST_OPERATION_TYPE_CANCEL_IMPORT:
+		return "CANCEL_IMPORT"
+	case REST_OPERATION_TYPE_CANCEL_ONLINE:
+		return "CANCEL_ONLINE"
+	case REST_OPERATION_TYPE_CANCEL_TEST:
+		return "CANCEL_TEST"
+	case REST_OPERATION_TYPE_CANCEL_VERIFY:
+		return "CANCEL_VERIFY"
+	case REST_OPERATION_TYPE_CLEAN:
+		return "CLEAN"
+	case REST_OPERATION_TYPE_COMPACT:
+		return "COMPACT"
+	case REST_OPERATION_TYPE_DEALLOCATE:
+		return "DEALLOCATE"
+	case REST_OPERATION_TYPE_DUMP:
+		return "DUMP"
+	case REST_OPERATION_TYPE_EJECT:
+		return "EJECT"
+	case REST_OPERATION_TYPE_FORMAT:
+		return "FORMAT"
+	case REST_OPERATION_TYPE_GET_PHYSICAL_PLACEMENT:
+		return "GET_PHYSICAL_PLACEMENT"
+	case REST_OPERATION_TYPE_IMPORT:
+		return "IMPORT"
+	case REST_OPERATION_TYPE_INSPECT:
+		return "INSPECT"
+	case REST_OPERATION_TYPE_MARK_FOR_COMPACTION:
+		return "MARK_FOR_COMPACTION"
+	case REST_OPERATION_TYPE_ONLINE:
+		return "ONLINE"
+	case REST_OPERATION_TYPE_PAIR_BACK:
+		return "PAIR_BACK"
+	case REST_OPERATION_TYPE_REGENERATE_SECRET_KEY:
+		return "REGENERATE_SECRET_KEY"
+	case REST_OPERATION_TYPE_START_BULK_GET:
+		return "START_BULK_GET"
+	case REST_OPERATION_TYPE_START_BULK_PUT:
+		return "START_BULK_PUT"
+	case REST_OPERATION_TYPE_START_BULK_STAGE:
+		return "START_BULK_STAGE"
+	case REST_OPERATION_TYPE_START_BULK_VERIFY:
+		return "START_BULK_VERIFY"
+	case REST_OPERATION_TYPE_TEST:
+		return "TEST"
+	case REST_OPERATION_TYPE_VERIFY:
+		return "VERIFY"
+	case REST_OPERATION_TYPE_VERIFY_SAFE_TO_START_BULK_PUT:
+		return "VERIFY_SAFE_TO_START_BULK_PUT"
+	case REST_OPERATION_TYPE_VERIFY_PHYSICAL_PLACEMENT:
+		return "VERIFY_PHYSICAL_PLACEMENT"
+	default:
+		log.Printf("Error: invalid RestOperationType represented by '%d'", restOperationType)
+		return ""
+	}
 }
 
 func (restOperationType RestOperationType) StringPtr() *string {
-    if restOperationType == UNDEFINED {
-        return nil
-    }
-    result := restOperationType.String()
-    return &result
+	if restOperationType == UNDEFINED {
+		return nil
+	}
+	result := restOperationType.String()
+	return &result
 }
 
 func newRestOperationTypeFromContent(content []byte, aggErr *AggregateError) *RestOperationType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(RestOperationType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(RestOperationType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type DatabasePhysicalSpaceState Enum
 
 const (
-    DATABASE_PHYSICAL_SPACE_STATE_CRITICAL DatabasePhysicalSpaceState = 1 + iota
-    DATABASE_PHYSICAL_SPACE_STATE_LOW DatabasePhysicalSpaceState = 1 + iota
-    DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW DatabasePhysicalSpaceState = 1 + iota
-    DATABASE_PHYSICAL_SPACE_STATE_NORMAL DatabasePhysicalSpaceState = 1 + iota
+	DATABASE_PHYSICAL_SPACE_STATE_CRITICAL DatabasePhysicalSpaceState = 1 + iota
+	DATABASE_PHYSICAL_SPACE_STATE_LOW      DatabasePhysicalSpaceState = 1 + iota
+	DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW DatabasePhysicalSpaceState = 1 + iota
+	DATABASE_PHYSICAL_SPACE_STATE_NORMAL   DatabasePhysicalSpaceState = 1 + iota
 )
 
 func (databasePhysicalSpaceState *DatabasePhysicalSpaceState) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *databasePhysicalSpaceState = UNDEFINED
-        case "CRITICAL": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_CRITICAL
-        case "LOW": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_LOW
-        case "NEAR_LOW": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW
-        case "NORMAL": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NORMAL
-        default:
-            *databasePhysicalSpaceState = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into DatabasePhysicalSpaceState", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*databasePhysicalSpaceState = UNDEFINED
+	case "CRITICAL":
+		*databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_CRITICAL
+	case "LOW":
+		*databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_LOW
+	case "NEAR_LOW":
+		*databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW
+	case "NORMAL":
+		*databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NORMAL
+	default:
+		*databasePhysicalSpaceState = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into DatabasePhysicalSpaceState", str))
+	}
+	return nil
 }
 
 func (databasePhysicalSpaceState DatabasePhysicalSpaceState) String() string {
-    switch databasePhysicalSpaceState {
-        case DATABASE_PHYSICAL_SPACE_STATE_CRITICAL: return "CRITICAL"
-        case DATABASE_PHYSICAL_SPACE_STATE_LOW: return "LOW"
-        case DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW: return "NEAR_LOW"
-        case DATABASE_PHYSICAL_SPACE_STATE_NORMAL: return "NORMAL"
-        default:
-            log.Printf("Error: invalid DatabasePhysicalSpaceState represented by '%d'", databasePhysicalSpaceState)
-            return ""
-    }
+	switch databasePhysicalSpaceState {
+	case DATABASE_PHYSICAL_SPACE_STATE_CRITICAL:
+		return "CRITICAL"
+	case DATABASE_PHYSICAL_SPACE_STATE_LOW:
+		return "LOW"
+	case DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW:
+		return "NEAR_LOW"
+	case DATABASE_PHYSICAL_SPACE_STATE_NORMAL:
+		return "NORMAL"
+	default:
+		log.Printf("Error: invalid DatabasePhysicalSpaceState represented by '%d'", databasePhysicalSpaceState)
+		return ""
+	}
 }
 
 func (databasePhysicalSpaceState DatabasePhysicalSpaceState) StringPtr() *string {
-    if databasePhysicalSpaceState == UNDEFINED {
-        return nil
-    }
-    result := databasePhysicalSpaceState.String()
-    return &result
+	if databasePhysicalSpaceState == UNDEFINED {
+		return nil
+	}
+	result := databasePhysicalSpaceState.String()
+	return &result
 }
 
 func newDatabasePhysicalSpaceStateFromContent(content []byte, aggErr *AggregateError) *DatabasePhysicalSpaceState {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(DatabasePhysicalSpaceState)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(DatabasePhysicalSpaceState)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type HttpResponseFormatType Enum
 
 const (
-    HTTP_RESPONSE_FORMAT_TYPE_DEFAULT HttpResponseFormatType = 1 + iota
-    HTTP_RESPONSE_FORMAT_TYPE_JSON HttpResponseFormatType = 1 + iota
-    HTTP_RESPONSE_FORMAT_TYPE_XML HttpResponseFormatType = 1 + iota
+	HTTP_RESPONSE_FORMAT_TYPE_DEFAULT HttpResponseFormatType = 1 + iota
+	HTTP_RESPONSE_FORMAT_TYPE_JSON    HttpResponseFormatType = 1 + iota
+	HTTP_RESPONSE_FORMAT_TYPE_XML     HttpResponseFormatType = 1 + iota
 )
 
 func (httpResponseFormatType *HttpResponseFormatType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *httpResponseFormatType = UNDEFINED
-        case "DEFAULT": *httpResponseFormatType = HTTP_RESPONSE_FORMAT_TYPE_DEFAULT
-        case "JSON": *httpResponseFormatType = HTTP_RESPONSE_FORMAT_TYPE_JSON
-        case "XML": *httpResponseFormatType = HTTP_RESPONSE_FORMAT_TYPE_XML
-        default:
-            *httpResponseFormatType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into HttpResponseFormatType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*httpResponseFormatType = UNDEFINED
+	case "DEFAULT":
+		*httpResponseFormatType = HTTP_RESPONSE_FORMAT_TYPE_DEFAULT
+	case "JSON":
+		*httpResponseFormatType = HTTP_RESPONSE_FORMAT_TYPE_JSON
+	case "XML":
+		*httpResponseFormatType = HTTP_RESPONSE_FORMAT_TYPE_XML
+	default:
+		*httpResponseFormatType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into HttpResponseFormatType", str))
+	}
+	return nil
 }
 
 func (httpResponseFormatType HttpResponseFormatType) String() string {
-    switch httpResponseFormatType {
-        case HTTP_RESPONSE_FORMAT_TYPE_DEFAULT: return "DEFAULT"
-        case HTTP_RESPONSE_FORMAT_TYPE_JSON: return "JSON"
-        case HTTP_RESPONSE_FORMAT_TYPE_XML: return "XML"
-        default:
-            log.Printf("Error: invalid HttpResponseFormatType represented by '%d'", httpResponseFormatType)
-            return ""
-    }
+	switch httpResponseFormatType {
+	case HTTP_RESPONSE_FORMAT_TYPE_DEFAULT:
+		return "DEFAULT"
+	case HTTP_RESPONSE_FORMAT_TYPE_JSON:
+		return "JSON"
+	case HTTP_RESPONSE_FORMAT_TYPE_XML:
+		return "XML"
+	default:
+		log.Printf("Error: invalid HttpResponseFormatType represented by '%d'", httpResponseFormatType)
+		return ""
+	}
 }
 
 func (httpResponseFormatType HttpResponseFormatType) StringPtr() *string {
-    if httpResponseFormatType == UNDEFINED {
-        return nil
-    }
-    result := httpResponseFormatType.String()
-    return &result
+	if httpResponseFormatType == UNDEFINED {
+		return nil
+	}
+	result := httpResponseFormatType.String()
+	return &result
 }
 
 func newHttpResponseFormatTypeFromContent(content []byte, aggErr *AggregateError) *HttpResponseFormatType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(HttpResponseFormatType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(HttpResponseFormatType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type RequestType Enum
 
 const (
-    REQUEST_TYPE_DELETE RequestType = 1 + iota
-    REQUEST_TYPE_GET RequestType = 1 + iota
-    REQUEST_TYPE_HEAD RequestType = 1 + iota
-    REQUEST_TYPE_POST RequestType = 1 + iota
-    REQUEST_TYPE_PUT RequestType = 1 + iota
+	REQUEST_TYPE_DELETE RequestType = 1 + iota
+	REQUEST_TYPE_GET    RequestType = 1 + iota
+	REQUEST_TYPE_HEAD   RequestType = 1 + iota
+	REQUEST_TYPE_POST   RequestType = 1 + iota
+	REQUEST_TYPE_PUT    RequestType = 1 + iota
 )
 
 func (requestType *RequestType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *requestType = UNDEFINED
-        case "DELETE": *requestType = REQUEST_TYPE_DELETE
-        case "GET": *requestType = REQUEST_TYPE_GET
-        case "HEAD": *requestType = REQUEST_TYPE_HEAD
-        case "POST": *requestType = REQUEST_TYPE_POST
-        case "PUT": *requestType = REQUEST_TYPE_PUT
-        default:
-            *requestType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into RequestType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*requestType = UNDEFINED
+	case "DELETE":
+		*requestType = REQUEST_TYPE_DELETE
+	case "GET":
+		*requestType = REQUEST_TYPE_GET
+	case "HEAD":
+		*requestType = REQUEST_TYPE_HEAD
+	case "POST":
+		*requestType = REQUEST_TYPE_POST
+	case "PUT":
+		*requestType = REQUEST_TYPE_PUT
+	default:
+		*requestType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into RequestType", str))
+	}
+	return nil
 }
 
 func (requestType RequestType) String() string {
-    switch requestType {
-        case REQUEST_TYPE_DELETE: return "DELETE"
-        case REQUEST_TYPE_GET: return "GET"
-        case REQUEST_TYPE_HEAD: return "HEAD"
-        case REQUEST_TYPE_POST: return "POST"
-        case REQUEST_TYPE_PUT: return "PUT"
-        default:
-            log.Printf("Error: invalid RequestType represented by '%d'", requestType)
-            return ""
-    }
+	switch requestType {
+	case REQUEST_TYPE_DELETE:
+		return "DELETE"
+	case REQUEST_TYPE_GET:
+		return "GET"
+	case REQUEST_TYPE_HEAD:
+		return "HEAD"
+	case REQUEST_TYPE_POST:
+		return "POST"
+	case REQUEST_TYPE_PUT:
+		return "PUT"
+	default:
+		log.Printf("Error: invalid RequestType represented by '%d'", requestType)
+		return ""
+	}
 }
 
 func (requestType RequestType) StringPtr() *string {
-    if requestType == UNDEFINED {
-        return nil
-    }
-    result := requestType.String()
-    return &result
+	if requestType == UNDEFINED {
+		return nil
+	}
+	result := requestType.String()
+	return &result
 }
 
 func newRequestTypeFromContent(content []byte, aggErr *AggregateError) *RequestType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(RequestType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(RequestType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type NamingConventionType Enum
 
 const (
-    NAMING_CONVENTION_TYPE_CONCAT_LOWERCASE NamingConventionType = 1 + iota
-    NAMING_CONVENTION_TYPE_CONSTANT NamingConventionType = 1 + iota
-    NAMING_CONVENTION_TYPE_UNDERSCORED NamingConventionType = 1 + iota
-    NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_UPPERCASE NamingConventionType = 1 + iota
-    NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_LOWERCASE NamingConventionType = 1 + iota
+	NAMING_CONVENTION_TYPE_CONCAT_LOWERCASE                       NamingConventionType = 1 + iota
+	NAMING_CONVENTION_TYPE_CONSTANT                               NamingConventionType = 1 + iota
+	NAMING_CONVENTION_TYPE_UNDERSCORED                            NamingConventionType = 1 + iota
+	NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_UPPERCASE NamingConventionType = 1 + iota
+	NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_LOWERCASE NamingConventionType = 1 + iota
 )
 
 func (namingConventionType *NamingConventionType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *namingConventionType = UNDEFINED
-        case "CONCAT_LOWERCASE": *namingConventionType = NAMING_CONVENTION_TYPE_CONCAT_LOWERCASE
-        case "CONSTANT": *namingConventionType = NAMING_CONVENTION_TYPE_CONSTANT
-        case "UNDERSCORED": *namingConventionType = NAMING_CONVENTION_TYPE_UNDERSCORED
-        case "CAMEL_CASE_WITH_FIRST_LETTER_UPPERCASE": *namingConventionType = NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_UPPERCASE
-        case "CAMEL_CASE_WITH_FIRST_LETTER_LOWERCASE": *namingConventionType = NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_LOWERCASE
-        default:
-            *namingConventionType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into NamingConventionType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*namingConventionType = UNDEFINED
+	case "CONCAT_LOWERCASE":
+		*namingConventionType = NAMING_CONVENTION_TYPE_CONCAT_LOWERCASE
+	case "CONSTANT":
+		*namingConventionType = NAMING_CONVENTION_TYPE_CONSTANT
+	case "UNDERSCORED":
+		*namingConventionType = NAMING_CONVENTION_TYPE_UNDERSCORED
+	case "CAMEL_CASE_WITH_FIRST_LETTER_UPPERCASE":
+		*namingConventionType = NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_UPPERCASE
+	case "CAMEL_CASE_WITH_FIRST_LETTER_LOWERCASE":
+		*namingConventionType = NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_LOWERCASE
+	default:
+		*namingConventionType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into NamingConventionType", str))
+	}
+	return nil
 }
 
 func (namingConventionType NamingConventionType) String() string {
-    switch namingConventionType {
-        case NAMING_CONVENTION_TYPE_CONCAT_LOWERCASE: return "CONCAT_LOWERCASE"
-        case NAMING_CONVENTION_TYPE_CONSTANT: return "CONSTANT"
-        case NAMING_CONVENTION_TYPE_UNDERSCORED: return "UNDERSCORED"
-        case NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_UPPERCASE: return "CAMEL_CASE_WITH_FIRST_LETTER_UPPERCASE"
-        case NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_LOWERCASE: return "CAMEL_CASE_WITH_FIRST_LETTER_LOWERCASE"
-        default:
-            log.Printf("Error: invalid NamingConventionType represented by '%d'", namingConventionType)
-            return ""
-    }
+	switch namingConventionType {
+	case NAMING_CONVENTION_TYPE_CONCAT_LOWERCASE:
+		return "CONCAT_LOWERCASE"
+	case NAMING_CONVENTION_TYPE_CONSTANT:
+		return "CONSTANT"
+	case NAMING_CONVENTION_TYPE_UNDERSCORED:
+		return "UNDERSCORED"
+	case NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_UPPERCASE:
+		return "CAMEL_CASE_WITH_FIRST_LETTER_UPPERCASE"
+	case NAMING_CONVENTION_TYPE_CAMEL_CASE_WITH_FIRST_LETTER_LOWERCASE:
+		return "CAMEL_CASE_WITH_FIRST_LETTER_LOWERCASE"
+	default:
+		log.Printf("Error: invalid NamingConventionType represented by '%d'", namingConventionType)
+		return ""
+	}
 }
 
 func (namingConventionType NamingConventionType) StringPtr() *string {
-    if namingConventionType == UNDEFINED {
-        return nil
-    }
-    result := namingConventionType.String()
-    return &result
+	if namingConventionType == UNDEFINED {
+		return nil
+	}
+	result := namingConventionType.String()
+	return &result
 }
 
 func newNamingConventionTypeFromContent(content []byte, aggErr *AggregateError) *NamingConventionType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(NamingConventionType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(NamingConventionType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type ChecksumType Enum
 
 const (
-    CHECKSUM_TYPE_CRC_32 ChecksumType = 1 + iota
-    CHECKSUM_TYPE_CRC_32C ChecksumType = 1 + iota
-    CHECKSUM_TYPE_MD5 ChecksumType = 1 + iota
-    CHECKSUM_TYPE_SHA_256 ChecksumType = 1 + iota
-    CHECKSUM_TYPE_SHA_512 ChecksumType = 1 + iota
-    NONE ChecksumType = 1 + iota
+	CHECKSUM_TYPE_CRC_32  ChecksumType = 1 + iota
+	CHECKSUM_TYPE_CRC_32C ChecksumType = 1 + iota
+	CHECKSUM_TYPE_MD5     ChecksumType = 1 + iota
+	CHECKSUM_TYPE_SHA_256 ChecksumType = 1 + iota
+	CHECKSUM_TYPE_SHA_512 ChecksumType = 1 + iota
+	NONE                  ChecksumType = 1 + iota
 )
 
 func (checksumType *ChecksumType) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *checksumType = UNDEFINED
-        case "CRC_32": *checksumType = CHECKSUM_TYPE_CRC_32
-        case "CRC_32C": *checksumType = CHECKSUM_TYPE_CRC_32C
-        case "MD5": *checksumType = CHECKSUM_TYPE_MD5
-        case "SHA_256": *checksumType = CHECKSUM_TYPE_SHA_256
-        case "SHA_512": *checksumType = CHECKSUM_TYPE_SHA_512
-        default:
-            *checksumType = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into ChecksumType", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*checksumType = UNDEFINED
+	case "CRC_32":
+		*checksumType = CHECKSUM_TYPE_CRC_32
+	case "CRC_32C":
+		*checksumType = CHECKSUM_TYPE_CRC_32C
+	case "MD5":
+		*checksumType = CHECKSUM_TYPE_MD5
+	case "SHA_256":
+		*checksumType = CHECKSUM_TYPE_SHA_256
+	case "SHA_512":
+		*checksumType = CHECKSUM_TYPE_SHA_512
+	default:
+		*checksumType = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into ChecksumType", str))
+	}
+	return nil
 }
 
 func (checksumType ChecksumType) String() string {
-    switch checksumType {
-        case CHECKSUM_TYPE_CRC_32: return "CRC_32"
-        case CHECKSUM_TYPE_CRC_32C: return "CRC_32C"
-        case CHECKSUM_TYPE_MD5: return "MD5"
-        case CHECKSUM_TYPE_SHA_256: return "SHA_256"
-        case CHECKSUM_TYPE_SHA_512: return "SHA_512"
-        default:
-            log.Printf("Error: invalid ChecksumType represented by '%d'", checksumType)
-            return ""
-    }
+	switch checksumType {
+	case CHECKSUM_TYPE_CRC_32:
+		return "CRC_32"
+	case CHECKSUM_TYPE_CRC_32C:
+		return "CRC_32C"
+	case CHECKSUM_TYPE_MD5:
+		return "MD5"
+	case CHECKSUM_TYPE_SHA_256:
+		return "SHA_256"
+	case CHECKSUM_TYPE_SHA_512:
+		return "SHA_512"
+	default:
+		log.Printf("Error: invalid ChecksumType represented by '%d'", checksumType)
+		return ""
+	}
 }
 
 func (checksumType ChecksumType) StringPtr() *string {
-    if checksumType == UNDEFINED {
-        return nil
-    }
-    result := checksumType.String()
-    return &result
+	if checksumType == UNDEFINED {
+		return nil
+	}
+	result := checksumType.String()
+	return &result
 }
 
 func newChecksumTypeFromContent(content []byte, aggErr *AggregateError) *ChecksumType {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(ChecksumType)
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(ChecksumType)
+	parseEnum(content, result, aggErr)
+	return result
 }
+
 type BucketAclList struct {
-    BucketAcls []BucketAcl
+	BucketAcls []BucketAcl
 }
 
 func (bucketAclList *BucketAclList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketAcl":
-            var model BucketAcl
-            model.parse(&child, aggErr)
-            bucketAclList.BucketAcls = append(bucketAclList.BucketAcls, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketAclList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketAcl":
+			var model BucketAcl
+			model.parse(&child, aggErr)
+			bucketAclList.BucketAcls = append(bucketAclList.BucketAcls, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketAclList.", child.XMLName.Local)
+		}
+	}
 }
 
 type DataPolicyAclList struct {
-    DataPolicyAcls []DataPolicyAcl
+	DataPolicyAcls []DataPolicyAcl
 }
 
 func (dataPolicyAclList *DataPolicyAclList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DataPolicyAcl":
-            var model DataPolicyAcl
-            model.parse(&child, aggErr)
-            dataPolicyAclList.DataPolicyAcls = append(dataPolicyAclList.DataPolicyAcls, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPolicyAclList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DataPolicyAcl":
+			var model DataPolicyAcl
+			model.parse(&child, aggErr)
+			dataPolicyAclList.DataPolicyAcls = append(dataPolicyAclList.DataPolicyAcls, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPolicyAclList.", child.XMLName.Local)
+		}
+	}
 }
 
 type BucketList struct {
-    Buckets []Bucket
+	Buckets []Bucket
 }
 
 func (bucketList *BucketList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Bucket":
-            var model Bucket
-            model.parse(&child, aggErr)
-            bucketList.Buckets = append(bucketList.Buckets, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Bucket":
+			var model Bucket
+			model.parse(&child, aggErr)
+			bucketList.Buckets = append(bucketList.Buckets, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketList.", child.XMLName.Local)
+		}
+	}
 }
 
 type CacheFilesystemList struct {
-    CacheFilesystems []CacheFilesystem
+	CacheFilesystems []CacheFilesystem
 }
 
 func (cacheFilesystemList *CacheFilesystemList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CacheFilesystem":
-            var model CacheFilesystem
-            model.parse(&child, aggErr)
-            cacheFilesystemList.CacheFilesystems = append(cacheFilesystemList.CacheFilesystems, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CacheFilesystemList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CacheFilesystem":
+			var model CacheFilesystem
+			model.parse(&child, aggErr)
+			cacheFilesystemList.CacheFilesystems = append(cacheFilesystemList.CacheFilesystems, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CacheFilesystemList.", child.XMLName.Local)
+		}
+	}
 }
 
 type AzureDataReplicationRuleList struct {
-    AzureDataReplicationRules []AzureDataReplicationRule
+	AzureDataReplicationRules []AzureDataReplicationRule
 }
 
 func (azureDataReplicationRuleList *AzureDataReplicationRuleList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AzureDataReplicationRule":
-            var model AzureDataReplicationRule
-            model.parse(&child, aggErr)
-            azureDataReplicationRuleList.AzureDataReplicationRules = append(azureDataReplicationRuleList.AzureDataReplicationRules, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureDataReplicationRuleList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AzureDataReplicationRule":
+			var model AzureDataReplicationRule
+			model.parse(&child, aggErr)
+			azureDataReplicationRuleList.AzureDataReplicationRules = append(azureDataReplicationRuleList.AzureDataReplicationRules, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureDataReplicationRuleList.", child.XMLName.Local)
+		}
+	}
 }
 
 type DataPersistenceRuleList struct {
-    DataPersistenceRules []DataPersistenceRule
+	DataPersistenceRules []DataPersistenceRule
 }
 
 func (dataPersistenceRuleList *DataPersistenceRuleList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DataPersistenceRule":
-            var model DataPersistenceRule
-            model.parse(&child, aggErr)
-            dataPersistenceRuleList.DataPersistenceRules = append(dataPersistenceRuleList.DataPersistenceRules, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPersistenceRuleList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DataPersistenceRule":
+			var model DataPersistenceRule
+			model.parse(&child, aggErr)
+			dataPersistenceRuleList.DataPersistenceRules = append(dataPersistenceRuleList.DataPersistenceRules, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPersistenceRuleList.", child.XMLName.Local)
+		}
+	}
 }
 
 type DataPolicyList struct {
-    DataPolicies []DataPolicy
+	DataPolicies []DataPolicy
 }
 
 func (dataPolicyList *DataPolicyList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DataPolicy":
-            var model DataPolicy
-            model.parse(&child, aggErr)
-            dataPolicyList.DataPolicies = append(dataPolicyList.DataPolicies, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPolicyList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DataPolicy":
+			var model DataPolicy
+			model.parse(&child, aggErr)
+			dataPolicyList.DataPolicies = append(dataPolicyList.DataPolicies, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DataPolicyList.", child.XMLName.Local)
+		}
+	}
 }
 
 type Ds3DataReplicationRuleList struct {
-    Ds3DataReplicationRules []Ds3DataReplicationRule
+	Ds3DataReplicationRules []Ds3DataReplicationRule
 }
 
 func (ds3DataReplicationRuleList *Ds3DataReplicationRuleList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Ds3DataReplicationRule":
-            var model Ds3DataReplicationRule
-            model.parse(&child, aggErr)
-            ds3DataReplicationRuleList.Ds3DataReplicationRules = append(ds3DataReplicationRuleList.Ds3DataReplicationRules, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3DataReplicationRuleList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Ds3DataReplicationRule":
+			var model Ds3DataReplicationRule
+			model.parse(&child, aggErr)
+			ds3DataReplicationRuleList.Ds3DataReplicationRules = append(ds3DataReplicationRuleList.Ds3DataReplicationRules, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3DataReplicationRuleList.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3DataReplicationRuleList struct {
-    S3DataReplicationRules []S3DataReplicationRule
+	S3DataReplicationRules []S3DataReplicationRule
 }
 
 func (s3DataReplicationRuleList *S3DataReplicationRuleList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "S3DataReplicationRule":
-            var model S3DataReplicationRule
-            model.parse(&child, aggErr)
-            s3DataReplicationRuleList.S3DataReplicationRules = append(s3DataReplicationRuleList.S3DataReplicationRules, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3DataReplicationRuleList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "S3DataReplicationRule":
+			var model S3DataReplicationRule
+			model.parse(&child, aggErr)
+			s3DataReplicationRuleList.S3DataReplicationRules = append(s3DataReplicationRuleList.S3DataReplicationRules, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3DataReplicationRuleList.", child.XMLName.Local)
+		}
+	}
 }
 
 type DegradedBlobList struct {
-    DegradedBlobs []DegradedBlob
+	DegradedBlobs []DegradedBlob
 }
 
 func (degradedBlobList *DegradedBlobList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "DegradedBlob":
-            var model DegradedBlob
-            model.parse(&child, aggErr)
-            degradedBlobList.DegradedBlobs = append(degradedBlobList.DegradedBlobs, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DegradedBlobList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "DegradedBlob":
+			var model DegradedBlob
+			model.parse(&child, aggErr)
+			degradedBlobList.DegradedBlobs = append(degradedBlobList.DegradedBlobs, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DegradedBlobList.", child.XMLName.Local)
+		}
+	}
 }
 
 type SuspectBlobAzureTargetList struct {
-    SuspectBlobAzureTargets []SuspectBlobAzureTarget
+	SuspectBlobAzureTargets []SuspectBlobAzureTarget
 }
 
 func (suspectBlobAzureTargetList *SuspectBlobAzureTargetList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "SuspectBlobAzureTarget":
-            var model SuspectBlobAzureTarget
-            model.parse(&child, aggErr)
-            suspectBlobAzureTargetList.SuspectBlobAzureTargets = append(suspectBlobAzureTargetList.SuspectBlobAzureTargets, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobAzureTargetList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "SuspectBlobAzureTarget":
+			var model SuspectBlobAzureTarget
+			model.parse(&child, aggErr)
+			suspectBlobAzureTargetList.SuspectBlobAzureTargets = append(suspectBlobAzureTargetList.SuspectBlobAzureTargets, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobAzureTargetList.", child.XMLName.Local)
+		}
+	}
 }
 
 type SuspectBlobDs3TargetList struct {
-    SuspectBlobDs3Targets []SuspectBlobDs3Target
+	SuspectBlobDs3Targets []SuspectBlobDs3Target
 }
 
 func (suspectBlobDs3TargetList *SuspectBlobDs3TargetList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "SuspectBlobDs3Target":
-            var model SuspectBlobDs3Target
-            model.parse(&child, aggErr)
-            suspectBlobDs3TargetList.SuspectBlobDs3Targets = append(suspectBlobDs3TargetList.SuspectBlobDs3Targets, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobDs3TargetList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "SuspectBlobDs3Target":
+			var model SuspectBlobDs3Target
+			model.parse(&child, aggErr)
+			suspectBlobDs3TargetList.SuspectBlobDs3Targets = append(suspectBlobDs3TargetList.SuspectBlobDs3Targets, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobDs3TargetList.", child.XMLName.Local)
+		}
+	}
 }
 
 type SuspectBlobPoolList struct {
-    SuspectBlobPools []SuspectBlobPool
+	SuspectBlobPools []SuspectBlobPool
 }
 
 func (suspectBlobPoolList *SuspectBlobPoolList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "SuspectBlobPool":
-            var model SuspectBlobPool
-            model.parse(&child, aggErr)
-            suspectBlobPoolList.SuspectBlobPools = append(suspectBlobPoolList.SuspectBlobPools, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobPoolList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "SuspectBlobPool":
+			var model SuspectBlobPool
+			model.parse(&child, aggErr)
+			suspectBlobPoolList.SuspectBlobPools = append(suspectBlobPoolList.SuspectBlobPools, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobPoolList.", child.XMLName.Local)
+		}
+	}
 }
 
 type SuspectBlobS3TargetList struct {
-    SuspectBlobS3Targets []SuspectBlobS3Target
+	SuspectBlobS3Targets []SuspectBlobS3Target
 }
 
 func (suspectBlobS3TargetList *SuspectBlobS3TargetList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "SuspectBlobS3Target":
-            var model SuspectBlobS3Target
-            model.parse(&child, aggErr)
-            suspectBlobS3TargetList.SuspectBlobS3Targets = append(suspectBlobS3TargetList.SuspectBlobS3Targets, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobS3TargetList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "SuspectBlobS3Target":
+			var model SuspectBlobS3Target
+			model.parse(&child, aggErr)
+			suspectBlobS3TargetList.SuspectBlobS3Targets = append(suspectBlobS3TargetList.SuspectBlobS3Targets, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobS3TargetList.", child.XMLName.Local)
+		}
+	}
 }
 
 type SuspectBlobTapeList struct {
-    SuspectBlobTapes []SuspectBlobTape
+	SuspectBlobTapes []SuspectBlobTape
 }
 
 func (suspectBlobTapeList *SuspectBlobTapeList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "SuspectBlobTape":
-            var model SuspectBlobTape
-            model.parse(&child, aggErr)
-            suspectBlobTapeList.SuspectBlobTapes = append(suspectBlobTapeList.SuspectBlobTapes, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobTapeList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "SuspectBlobTape":
+			var model SuspectBlobTape
+			model.parse(&child, aggErr)
+			suspectBlobTapeList.SuspectBlobTapes = append(suspectBlobTapeList.SuspectBlobTapes, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SuspectBlobTapeList.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3ObjectList struct {
-    S3Objects []S3Object
+	S3Objects []S3Object
 }
 
 func (s3ObjectList *S3ObjectList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "S3Object":
-            var model S3Object
-            model.parse(&child, aggErr)
-            s3ObjectList.S3Objects = append(s3ObjectList.S3Objects, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "S3Object":
+			var model S3Object
+			model.parse(&child, aggErr)
+			s3ObjectList.S3Objects = append(s3ObjectList.S3Objects, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectList.", child.XMLName.Local)
+		}
+	}
 }
 
 type GroupMemberList struct {
-    GroupMembers []GroupMember
+	GroupMembers []GroupMember
 }
 
 func (groupMemberList *GroupMemberList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "GroupMember":
-            var model GroupMember
-            model.parse(&child, aggErr)
-            groupMemberList.GroupMembers = append(groupMemberList.GroupMembers, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing GroupMemberList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "GroupMember":
+			var model GroupMember
+			model.parse(&child, aggErr)
+			groupMemberList.GroupMembers = append(groupMemberList.GroupMembers, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing GroupMemberList.", child.XMLName.Local)
+		}
+	}
 }
 
 type GroupList struct {
-    Groups []Group
+	Groups []Group
 }
 
 func (groupList *GroupList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Group":
-            var model Group
-            model.parse(&child, aggErr)
-            groupList.Groups = append(groupList.Groups, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing GroupList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Group":
+			var model Group
+			model.parse(&child, aggErr)
+			groupList.Groups = append(groupList.Groups, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing GroupList.", child.XMLName.Local)
+		}
+	}
 }
 
 type ActiveJobList struct {
-    ActiveJobs []ActiveJob
+	ActiveJobs []ActiveJob
 }
 
 func (activeJobList *ActiveJobList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Job":
-            var model ActiveJob
-            model.parse(&child, aggErr)
-            activeJobList.ActiveJobs = append(activeJobList.ActiveJobs, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ActiveJobList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Job":
+			var model ActiveJob
+			model.parse(&child, aggErr)
+			activeJobList.ActiveJobs = append(activeJobList.ActiveJobs, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ActiveJobList.", child.XMLName.Local)
+		}
+	}
 }
 
 type CanceledJobList struct {
-    CanceledJobs []CanceledJob
+	CanceledJobs []CanceledJob
 }
 
 func (canceledJobList *CanceledJobList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CanceledJob":
-            var model CanceledJob
-            model.parse(&child, aggErr)
-            canceledJobList.CanceledJobs = append(canceledJobList.CanceledJobs, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CanceledJobList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CanceledJob":
+			var model CanceledJob
+			model.parse(&child, aggErr)
+			canceledJobList.CanceledJobs = append(canceledJobList.CanceledJobs, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CanceledJobList.", child.XMLName.Local)
+		}
+	}
 }
 
 type CompletedJobList struct {
-    CompletedJobs []CompletedJob
+	CompletedJobs []CompletedJob
 }
 
 func (completedJobList *CompletedJobList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "CompletedJob":
-            var model CompletedJob
-            model.parse(&child, aggErr)
-            completedJobList.CompletedJobs = append(completedJobList.CompletedJobs, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CompletedJobList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "CompletedJob":
+			var model CompletedJob
+			model.parse(&child, aggErr)
+			completedJobList.CompletedJobs = append(completedJobList.CompletedJobs, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing CompletedJobList.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobCreationFailedList struct {
-    JobCreationFaileds []JobCreationFailed
+	JobCreationFaileds []JobCreationFailed
 }
 
 func (jobCreationFailedList *JobCreationFailedList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "JobCreationFailed":
-            var model JobCreationFailed
-            model.parse(&child, aggErr)
-            jobCreationFailedList.JobCreationFaileds = append(jobCreationFailedList.JobCreationFaileds, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreationFailedList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "JobCreationFailed":
+			var model JobCreationFailed
+			model.parse(&child, aggErr)
+			jobCreationFailedList.JobCreationFaileds = append(jobCreationFailedList.JobCreationFaileds, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreationFailedList.", child.XMLName.Local)
+		}
+	}
 }
 
 type NodeList struct {
-    Nodes []Node
+	Nodes []Node
 }
 
 func (nodeList *NodeList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Node":
-            var model Node
-            model.parse(&child, aggErr)
-            nodeList.Nodes = append(nodeList.Nodes, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing NodeList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Node":
+			var model Node
+			model.parse(&child, aggErr)
+			nodeList.Nodes = append(nodeList.Nodes, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing NodeList.", child.XMLName.Local)
+		}
+	}
 }
 
 type AzureTargetFailureNotificationRegistrationList struct {
-    AzureTargetFailureNotificationRegistrations []AzureTargetFailureNotificationRegistration
+	AzureTargetFailureNotificationRegistrations []AzureTargetFailureNotificationRegistration
 }
 
 func (azureTargetFailureNotificationRegistrationList *AzureTargetFailureNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AzureTargetFailureNotificationRegistration":
-            var model AzureTargetFailureNotificationRegistration
-            model.parse(&child, aggErr)
-            azureTargetFailureNotificationRegistrationList.AzureTargetFailureNotificationRegistrations = append(azureTargetFailureNotificationRegistrationList.AzureTargetFailureNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetFailureNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AzureTargetFailureNotificationRegistration":
+			var model AzureTargetFailureNotificationRegistration
+			model.parse(&child, aggErr)
+			azureTargetFailureNotificationRegistrationList.AzureTargetFailureNotificationRegistrations = append(azureTargetFailureNotificationRegistrationList.AzureTargetFailureNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetFailureNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type BucketChangesNotificationRegistrationList struct {
-    BucketChangesNotificationRegistrations []BucketChangesNotificationRegistration
+	BucketChangesNotificationRegistrations []BucketChangesNotificationRegistration
 }
 
 func (bucketChangesNotificationRegistrationList *BucketChangesNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketChangesNotificationRegistration":
-            var model BucketChangesNotificationRegistration
-            model.parse(&child, aggErr)
-            bucketChangesNotificationRegistrationList.BucketChangesNotificationRegistrations = append(bucketChangesNotificationRegistrationList.BucketChangesNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketChangesNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketChangesNotificationRegistration":
+			var model BucketChangesNotificationRegistration
+			model.parse(&child, aggErr)
+			bucketChangesNotificationRegistrationList.BucketChangesNotificationRegistrations = append(bucketChangesNotificationRegistrationList.BucketChangesNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketChangesNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type BucketHistoryEventList struct {
-    BucketHistoryEvents []BucketHistoryEvent
+	BucketHistoryEvents []BucketHistoryEvent
 }
 
 func (bucketHistoryEventList *BucketHistoryEventList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "BucketHistoryEvent":
-            var model BucketHistoryEvent
-            model.parse(&child, aggErr)
-            bucketHistoryEventList.BucketHistoryEvents = append(bucketHistoryEventList.BucketHistoryEvents, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketHistoryEventList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "BucketHistoryEvent":
+			var model BucketHistoryEvent
+			model.parse(&child, aggErr)
+			bucketHistoryEventList.BucketHistoryEvents = append(bucketHistoryEventList.BucketHistoryEvents, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing BucketHistoryEventList.", child.XMLName.Local)
+		}
+	}
 }
 
 type Ds3TargetFailureNotificationRegistrationList struct {
-    Ds3TargetFailureNotificationRegistrations []Ds3TargetFailureNotificationRegistration
+	Ds3TargetFailureNotificationRegistrations []Ds3TargetFailureNotificationRegistration
 }
 
 func (ds3TargetFailureNotificationRegistrationList *Ds3TargetFailureNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Ds3TargetFailureNotificationRegistration":
-            var model Ds3TargetFailureNotificationRegistration
-            model.parse(&child, aggErr)
-            ds3TargetFailureNotificationRegistrationList.Ds3TargetFailureNotificationRegistrations = append(ds3TargetFailureNotificationRegistrationList.Ds3TargetFailureNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetFailureNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Ds3TargetFailureNotificationRegistration":
+			var model Ds3TargetFailureNotificationRegistration
+			model.parse(&child, aggErr)
+			ds3TargetFailureNotificationRegistrationList.Ds3TargetFailureNotificationRegistrations = append(ds3TargetFailureNotificationRegistrationList.Ds3TargetFailureNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetFailureNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobCompletedNotificationRegistrationList struct {
-    JobCompletedNotificationRegistrations []JobCompletedNotificationRegistration
+	JobCompletedNotificationRegistrations []JobCompletedNotificationRegistration
 }
 
 func (jobCompletedNotificationRegistrationList *JobCompletedNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "JobCompletedNotificationRegistration":
-            var model JobCompletedNotificationRegistration
-            model.parse(&child, aggErr)
-            jobCompletedNotificationRegistrationList.JobCompletedNotificationRegistrations = append(jobCompletedNotificationRegistrationList.JobCompletedNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCompletedNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "JobCompletedNotificationRegistration":
+			var model JobCompletedNotificationRegistration
+			model.parse(&child, aggErr)
+			jobCompletedNotificationRegistrationList.JobCompletedNotificationRegistrations = append(jobCompletedNotificationRegistrationList.JobCompletedNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCompletedNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobCreatedNotificationRegistrationList struct {
-    JobCreatedNotificationRegistrations []JobCreatedNotificationRegistration
+	JobCreatedNotificationRegistrations []JobCreatedNotificationRegistration
 }
 
 func (jobCreatedNotificationRegistrationList *JobCreatedNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "JobCreatedNotificationRegistration":
-            var model JobCreatedNotificationRegistration
-            model.parse(&child, aggErr)
-            jobCreatedNotificationRegistrationList.JobCreatedNotificationRegistrations = append(jobCreatedNotificationRegistrationList.JobCreatedNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreatedNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "JobCreatedNotificationRegistration":
+			var model JobCreatedNotificationRegistration
+			model.parse(&child, aggErr)
+			jobCreatedNotificationRegistrationList.JobCreatedNotificationRegistrations = append(jobCreatedNotificationRegistrationList.JobCreatedNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreatedNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type JobCreationFailedNotificationRegistrationList struct {
-    JobCreationFailedNotificationRegistrations []JobCreationFailedNotificationRegistration
+	JobCreationFailedNotificationRegistrations []JobCreationFailedNotificationRegistration
 }
 
 func (jobCreationFailedNotificationRegistrationList *JobCreationFailedNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "JobCreationFailedNotificationRegistration":
-            var model JobCreationFailedNotificationRegistration
-            model.parse(&child, aggErr)
-            jobCreationFailedNotificationRegistrationList.JobCreationFailedNotificationRegistrations = append(jobCreationFailedNotificationRegistrationList.JobCreationFailedNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreationFailedNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "JobCreationFailedNotificationRegistration":
+			var model JobCreationFailedNotificationRegistration
+			model.parse(&child, aggErr)
+			jobCreationFailedNotificationRegistrationList.JobCreationFailedNotificationRegistrations = append(jobCreationFailedNotificationRegistrationList.JobCreationFailedNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing JobCreationFailedNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3ObjectCachedNotificationRegistrationList struct {
-    S3ObjectCachedNotificationRegistrations []S3ObjectCachedNotificationRegistration
+	S3ObjectCachedNotificationRegistrations []S3ObjectCachedNotificationRegistration
 }
 
 func (s3ObjectCachedNotificationRegistrationList *S3ObjectCachedNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "S3ObjectCachedNotificationRegistration":
-            var model S3ObjectCachedNotificationRegistration
-            model.parse(&child, aggErr)
-            s3ObjectCachedNotificationRegistrationList.S3ObjectCachedNotificationRegistrations = append(s3ObjectCachedNotificationRegistrationList.S3ObjectCachedNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectCachedNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "S3ObjectCachedNotificationRegistration":
+			var model S3ObjectCachedNotificationRegistration
+			model.parse(&child, aggErr)
+			s3ObjectCachedNotificationRegistrationList.S3ObjectCachedNotificationRegistrations = append(s3ObjectCachedNotificationRegistrationList.S3ObjectCachedNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectCachedNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3ObjectLostNotificationRegistrationList struct {
-    S3ObjectLostNotificationRegistrations []S3ObjectLostNotificationRegistration
+	S3ObjectLostNotificationRegistrations []S3ObjectLostNotificationRegistration
 }
 
 func (s3ObjectLostNotificationRegistrationList *S3ObjectLostNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "S3ObjectLostNotificationRegistration":
-            var model S3ObjectLostNotificationRegistration
-            model.parse(&child, aggErr)
-            s3ObjectLostNotificationRegistrationList.S3ObjectLostNotificationRegistrations = append(s3ObjectLostNotificationRegistrationList.S3ObjectLostNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectLostNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "S3ObjectLostNotificationRegistration":
+			var model S3ObjectLostNotificationRegistration
+			model.parse(&child, aggErr)
+			s3ObjectLostNotificationRegistrationList.S3ObjectLostNotificationRegistrations = append(s3ObjectLostNotificationRegistrationList.S3ObjectLostNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectLostNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3ObjectPersistedNotificationRegistrationList struct {
-    S3ObjectPersistedNotificationRegistrations []S3ObjectPersistedNotificationRegistration
+	S3ObjectPersistedNotificationRegistrations []S3ObjectPersistedNotificationRegistration
 }
 
 func (s3ObjectPersistedNotificationRegistrationList *S3ObjectPersistedNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "S3ObjectPersistedNotificationRegistration":
-            var model S3ObjectPersistedNotificationRegistration
-            model.parse(&child, aggErr)
-            s3ObjectPersistedNotificationRegistrationList.S3ObjectPersistedNotificationRegistrations = append(s3ObjectPersistedNotificationRegistrationList.S3ObjectPersistedNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectPersistedNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "S3ObjectPersistedNotificationRegistration":
+			var model S3ObjectPersistedNotificationRegistration
+			model.parse(&child, aggErr)
+			s3ObjectPersistedNotificationRegistrationList.S3ObjectPersistedNotificationRegistrations = append(s3ObjectPersistedNotificationRegistrationList.S3ObjectPersistedNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3ObjectPersistedNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type PoolFailureNotificationRegistrationList struct {
-    PoolFailureNotificationRegistrations []PoolFailureNotificationRegistration
+	PoolFailureNotificationRegistrations []PoolFailureNotificationRegistration
 }
 
 func (poolFailureNotificationRegistrationList *PoolFailureNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "PoolFailureNotificationRegistration":
-            var model PoolFailureNotificationRegistration
-            model.parse(&child, aggErr)
-            poolFailureNotificationRegistrationList.PoolFailureNotificationRegistrations = append(poolFailureNotificationRegistrationList.PoolFailureNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolFailureNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "PoolFailureNotificationRegistration":
+			var model PoolFailureNotificationRegistration
+			model.parse(&child, aggErr)
+			poolFailureNotificationRegistrationList.PoolFailureNotificationRegistrations = append(poolFailureNotificationRegistrationList.PoolFailureNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolFailureNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3TargetFailureNotificationRegistrationList struct {
-    S3TargetFailureNotificationRegistrations []S3TargetFailureNotificationRegistration
+	S3TargetFailureNotificationRegistrations []S3TargetFailureNotificationRegistration
 }
 
 func (s3TargetFailureNotificationRegistrationList *S3TargetFailureNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "S3TargetFailureNotificationRegistration":
-            var model S3TargetFailureNotificationRegistration
-            model.parse(&child, aggErr)
-            s3TargetFailureNotificationRegistrationList.S3TargetFailureNotificationRegistrations = append(s3TargetFailureNotificationRegistrationList.S3TargetFailureNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetFailureNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "S3TargetFailureNotificationRegistration":
+			var model S3TargetFailureNotificationRegistration
+			model.parse(&child, aggErr)
+			s3TargetFailureNotificationRegistrationList.S3TargetFailureNotificationRegistrations = append(s3TargetFailureNotificationRegistrationList.S3TargetFailureNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetFailureNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type StorageDomainFailureNotificationRegistrationList struct {
-    StorageDomainFailureNotificationRegistrations []StorageDomainFailureNotificationRegistration
+	StorageDomainFailureNotificationRegistrations []StorageDomainFailureNotificationRegistration
 }
 
 func (storageDomainFailureNotificationRegistrationList *StorageDomainFailureNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "StorageDomainFailureNotificationRegistration":
-            var model StorageDomainFailureNotificationRegistration
-            model.parse(&child, aggErr)
-            storageDomainFailureNotificationRegistrationList.StorageDomainFailureNotificationRegistrations = append(storageDomainFailureNotificationRegistrationList.StorageDomainFailureNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainFailureNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "StorageDomainFailureNotificationRegistration":
+			var model StorageDomainFailureNotificationRegistration
+			model.parse(&child, aggErr)
+			storageDomainFailureNotificationRegistrationList.StorageDomainFailureNotificationRegistrations = append(storageDomainFailureNotificationRegistrationList.StorageDomainFailureNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainFailureNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type SystemFailureNotificationRegistrationList struct {
-    SystemFailureNotificationRegistrations []SystemFailureNotificationRegistration
+	SystemFailureNotificationRegistrations []SystemFailureNotificationRegistration
 }
 
 func (systemFailureNotificationRegistrationList *SystemFailureNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "SystemFailureNotificationRegistration":
-            var model SystemFailureNotificationRegistration
-            model.parse(&child, aggErr)
-            systemFailureNotificationRegistrationList.SystemFailureNotificationRegistrations = append(systemFailureNotificationRegistrationList.SystemFailureNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SystemFailureNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "SystemFailureNotificationRegistration":
+			var model SystemFailureNotificationRegistration
+			model.parse(&child, aggErr)
+			systemFailureNotificationRegistrationList.SystemFailureNotificationRegistrations = append(systemFailureNotificationRegistrationList.SystemFailureNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SystemFailureNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeFailureNotificationRegistrationList struct {
-    TapeFailureNotificationRegistrations []TapeFailureNotificationRegistration
+	TapeFailureNotificationRegistrations []TapeFailureNotificationRegistration
 }
 
 func (tapeFailureNotificationRegistrationList *TapeFailureNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "TapeFailureNotificationRegistration":
-            var model TapeFailureNotificationRegistration
-            model.parse(&child, aggErr)
-            tapeFailureNotificationRegistrationList.TapeFailureNotificationRegistrations = append(tapeFailureNotificationRegistrationList.TapeFailureNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeFailureNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "TapeFailureNotificationRegistration":
+			var model TapeFailureNotificationRegistration
+			model.parse(&child, aggErr)
+			tapeFailureNotificationRegistrationList.TapeFailureNotificationRegistrations = append(tapeFailureNotificationRegistrationList.TapeFailureNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeFailureNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapePartitionFailureNotificationRegistrationList struct {
-    TapePartitionFailureNotificationRegistrations []TapePartitionFailureNotificationRegistration
+	TapePartitionFailureNotificationRegistrations []TapePartitionFailureNotificationRegistration
 }
 
 func (tapePartitionFailureNotificationRegistrationList *TapePartitionFailureNotificationRegistrationList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "TapePartitionFailureNotificationRegistration":
-            var model TapePartitionFailureNotificationRegistration
-            model.parse(&child, aggErr)
-            tapePartitionFailureNotificationRegistrationList.TapePartitionFailureNotificationRegistrations = append(tapePartitionFailureNotificationRegistrationList.TapePartitionFailureNotificationRegistrations, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartitionFailureNotificationRegistrationList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "TapePartitionFailureNotificationRegistration":
+			var model TapePartitionFailureNotificationRegistration
+			model.parse(&child, aggErr)
+			tapePartitionFailureNotificationRegistrationList.TapePartitionFailureNotificationRegistrations = append(tapePartitionFailureNotificationRegistrationList.TapePartitionFailureNotificationRegistrations, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartitionFailureNotificationRegistrationList.", child.XMLName.Local)
+		}
+	}
 }
 
 type DetailedS3ObjectList struct {
-    DetailedS3Objects []DetailedS3Object
+	DetailedS3Objects []DetailedS3Object
 }
 
 func (detailedS3ObjectList *DetailedS3ObjectList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Object":
-            var model DetailedS3Object
-            model.parse(&child, aggErr)
-            detailedS3ObjectList.DetailedS3Objects = append(detailedS3ObjectList.DetailedS3Objects, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DetailedS3ObjectList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Object":
+			var model DetailedS3Object
+			model.parse(&child, aggErr)
+			detailedS3ObjectList.DetailedS3Objects = append(detailedS3ObjectList.DetailedS3Objects, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DetailedS3ObjectList.", child.XMLName.Local)
+		}
+	}
 }
 
 type PoolFailureList struct {
-    PoolFailures []PoolFailure
+	PoolFailures []PoolFailure
 }
 
 func (poolFailureList *PoolFailureList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "PoolFailure":
-            var model PoolFailure
-            model.parse(&child, aggErr)
-            poolFailureList.PoolFailures = append(poolFailureList.PoolFailures, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolFailureList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "PoolFailure":
+			var model PoolFailure
+			model.parse(&child, aggErr)
+			poolFailureList.PoolFailures = append(poolFailureList.PoolFailures, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolFailureList.", child.XMLName.Local)
+		}
+	}
 }
 
 type PoolPartitionList struct {
-    PoolPartitions []PoolPartition
+	PoolPartitions []PoolPartition
 }
 
 func (poolPartitionList *PoolPartitionList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "PoolPartition":
-            var model PoolPartition
-            model.parse(&child, aggErr)
-            poolPartitionList.PoolPartitions = append(poolPartitionList.PoolPartitions, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolPartitionList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "PoolPartition":
+			var model PoolPartition
+			model.parse(&child, aggErr)
+			poolPartitionList.PoolPartitions = append(poolPartitionList.PoolPartitions, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolPartitionList.", child.XMLName.Local)
+		}
+	}
 }
 
 type PoolList struct {
-    Pools []Pool
+	Pools []Pool
 }
 
 func (poolList *PoolList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Pool":
-            var model Pool
-            model.parse(&child, aggErr)
-            poolList.Pools = append(poolList.Pools, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Pool":
+			var model Pool
+			model.parse(&child, aggErr)
+			poolList.Pools = append(poolList.Pools, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing PoolList.", child.XMLName.Local)
+		}
+	}
 }
 
 type StorageDomainFailureList struct {
-    StorageDomainFailures []StorageDomainFailure
+	StorageDomainFailures []StorageDomainFailure
 }
 
 func (storageDomainFailureList *StorageDomainFailureList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "StorageDomainFailure":
-            var model StorageDomainFailure
-            model.parse(&child, aggErr)
-            storageDomainFailureList.StorageDomainFailures = append(storageDomainFailureList.StorageDomainFailures, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainFailureList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "StorageDomainFailure":
+			var model StorageDomainFailure
+			model.parse(&child, aggErr)
+			storageDomainFailureList.StorageDomainFailures = append(storageDomainFailureList.StorageDomainFailures, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainFailureList.", child.XMLName.Local)
+		}
+	}
 }
 
 type StorageDomainMemberList struct {
-    StorageDomainMembers []StorageDomainMember
+	StorageDomainMembers []StorageDomainMember
 }
 
 func (storageDomainMemberList *StorageDomainMemberList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "StorageDomainMember":
-            var model StorageDomainMember
-            model.parse(&child, aggErr)
-            storageDomainMemberList.StorageDomainMembers = append(storageDomainMemberList.StorageDomainMembers, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainMemberList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "StorageDomainMember":
+			var model StorageDomainMember
+			model.parse(&child, aggErr)
+			storageDomainMemberList.StorageDomainMembers = append(storageDomainMemberList.StorageDomainMembers, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainMemberList.", child.XMLName.Local)
+		}
+	}
 }
 
 type StorageDomainList struct {
-    StorageDomains []StorageDomain
+	StorageDomains []StorageDomain
 }
 
 func (storageDomainList *StorageDomainList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "StorageDomain":
-            var model StorageDomain
-            model.parse(&child, aggErr)
-            storageDomainList.StorageDomains = append(storageDomainList.StorageDomains, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "StorageDomain":
+			var model StorageDomain
+			model.parse(&child, aggErr)
+			storageDomainList.StorageDomains = append(storageDomainList.StorageDomains, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing StorageDomainList.", child.XMLName.Local)
+		}
+	}
 }
 
 type FeatureKeyList struct {
-    FeatureKeys []FeatureKey
+	FeatureKeys []FeatureKey
 }
 
 func (featureKeyList *FeatureKeyList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "FeatureKey":
-            var model FeatureKey
-            model.parse(&child, aggErr)
-            featureKeyList.FeatureKeys = append(featureKeyList.FeatureKeys, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing FeatureKeyList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "FeatureKey":
+			var model FeatureKey
+			model.parse(&child, aggErr)
+			featureKeyList.FeatureKeys = append(featureKeyList.FeatureKeys, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing FeatureKeyList.", child.XMLName.Local)
+		}
+	}
 }
 
 type SystemFailureList struct {
-    SystemFailures []SystemFailure
+	SystemFailures []SystemFailure
 }
 
 func (systemFailureList *SystemFailureList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "SystemFailure":
-            var model SystemFailure
-            model.parse(&child, aggErr)
-            systemFailureList.SystemFailures = append(systemFailureList.SystemFailures, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SystemFailureList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "SystemFailure":
+			var model SystemFailure
+			model.parse(&child, aggErr)
+			systemFailureList.SystemFailures = append(systemFailureList.SystemFailures, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SystemFailureList.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeDensityDirectiveList struct {
-    TapeDensityDirectives []TapeDensityDirective
+	TapeDensityDirectives []TapeDensityDirective
 }
 
 func (tapeDensityDirectiveList *TapeDensityDirectiveList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "TapeDensityDirective":
-            var model TapeDensityDirective
-            model.parse(&child, aggErr)
-            tapeDensityDirectiveList.TapeDensityDirectives = append(tapeDensityDirectiveList.TapeDensityDirectives, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeDensityDirectiveList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "TapeDensityDirective":
+			var model TapeDensityDirective
+			model.parse(&child, aggErr)
+			tapeDensityDirectiveList.TapeDensityDirectives = append(tapeDensityDirectiveList.TapeDensityDirectives, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeDensityDirectiveList.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeDriveList struct {
-    TapeDrives []TapeDrive
+	TapeDrives []TapeDrive
 }
 
 func (tapeDriveList *TapeDriveList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "TapeDrive":
-            var model TapeDrive
-            model.parse(&child, aggErr)
-            tapeDriveList.TapeDrives = append(tapeDriveList.TapeDrives, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeDriveList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "TapeDrive":
+			var model TapeDrive
+			model.parse(&child, aggErr)
+			tapeDriveList.TapeDrives = append(tapeDriveList.TapeDrives, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeDriveList.", child.XMLName.Local)
+		}
+	}
 }
 
 type DetailedTapeFailureList struct {
-    DetailedTapeFailures []DetailedTapeFailure
+	DetailedTapeFailures []DetailedTapeFailure
 }
 
 func (detailedTapeFailureList *DetailedTapeFailureList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "TapeFailure":
-            var model DetailedTapeFailure
-            model.parse(&child, aggErr)
-            detailedTapeFailureList.DetailedTapeFailures = append(detailedTapeFailureList.DetailedTapeFailures, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DetailedTapeFailureList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "TapeFailure":
+			var model DetailedTapeFailure
+			model.parse(&child, aggErr)
+			detailedTapeFailureList.DetailedTapeFailures = append(detailedTapeFailureList.DetailedTapeFailures, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing DetailedTapeFailureList.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeLibraryList struct {
-    TapeLibraries []TapeLibrary
+	TapeLibraries []TapeLibrary
 }
 
 func (tapeLibraryList *TapeLibraryList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "TapeLibrary":
-            var model TapeLibrary
-            model.parse(&child, aggErr)
-            tapeLibraryList.TapeLibraries = append(tapeLibraryList.TapeLibraries, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeLibraryList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "TapeLibrary":
+			var model TapeLibrary
+			model.parse(&child, aggErr)
+			tapeLibraryList.TapeLibraries = append(tapeLibraryList.TapeLibraries, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeLibraryList.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapePartitionFailureList struct {
-    TapePartitionFailures []TapePartitionFailure
+	TapePartitionFailures []TapePartitionFailure
 }
 
 func (tapePartitionFailureList *TapePartitionFailureList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "TapePartitionFailure":
-            var model TapePartitionFailure
-            model.parse(&child, aggErr)
-            tapePartitionFailureList.TapePartitionFailures = append(tapePartitionFailureList.TapePartitionFailures, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartitionFailureList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "TapePartitionFailure":
+			var model TapePartitionFailure
+			model.parse(&child, aggErr)
+			tapePartitionFailureList.TapePartitionFailures = append(tapePartitionFailureList.TapePartitionFailures, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartitionFailureList.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapePartitionList struct {
-    TapePartitions []TapePartition
+	TapePartitions []TapePartition
 }
 
 func (tapePartitionList *TapePartitionList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "TapePartition":
-            var model TapePartition
-            model.parse(&child, aggErr)
-            tapePartitionList.TapePartitions = append(tapePartitionList.TapePartitions, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartitionList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "TapePartition":
+			var model TapePartition
+			model.parse(&child, aggErr)
+			tapePartitionList.TapePartitions = append(tapePartitionList.TapePartitions, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapePartitionList.", child.XMLName.Local)
+		}
+	}
 }
 
 type NamedDetailedTapePartitionList struct {
-    NamedDetailedTapePartitions []NamedDetailedTapePartition
+	NamedDetailedTapePartitions []NamedDetailedTapePartition
 }
 
 func (namedDetailedTapePartitionList *NamedDetailedTapePartitionList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "TapePartition":
-            var model NamedDetailedTapePartition
-            model.parse(&child, aggErr)
-            namedDetailedTapePartitionList.NamedDetailedTapePartitions = append(namedDetailedTapePartitionList.NamedDetailedTapePartitions, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing NamedDetailedTapePartitionList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "TapePartition":
+			var model NamedDetailedTapePartition
+			model.parse(&child, aggErr)
+			namedDetailedTapePartitionList.NamedDetailedTapePartitions = append(namedDetailedTapePartitionList.NamedDetailedTapePartitions, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing NamedDetailedTapePartitionList.", child.XMLName.Local)
+		}
+	}
 }
 
 type TapeList struct {
-    Tapes []Tape
+	Tapes []Tape
 }
 
 func (tapeList *TapeList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Tape":
-            var model Tape
-            model.parse(&child, aggErr)
-            tapeList.Tapes = append(tapeList.Tapes, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Tape":
+			var model Tape
+			model.parse(&child, aggErr)
+			tapeList.Tapes = append(tapeList.Tapes, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing TapeList.", child.XMLName.Local)
+		}
+	}
 }
 
 type AzureTargetBucketNameList struct {
-    AzureTargetBucketNames []AzureTargetBucketName
+	AzureTargetBucketNames []AzureTargetBucketName
 }
 
 func (azureTargetBucketNameList *AzureTargetBucketNameList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AzureTargetBucketName":
-            var model AzureTargetBucketName
-            model.parse(&child, aggErr)
-            azureTargetBucketNameList.AzureTargetBucketNames = append(azureTargetBucketNameList.AzureTargetBucketNames, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetBucketNameList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AzureTargetBucketName":
+			var model AzureTargetBucketName
+			model.parse(&child, aggErr)
+			azureTargetBucketNameList.AzureTargetBucketNames = append(azureTargetBucketNameList.AzureTargetBucketNames, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetBucketNameList.", child.XMLName.Local)
+		}
+	}
 }
 
 type AzureTargetFailureList struct {
-    AzureTargetFailures []AzureTargetFailure
+	AzureTargetFailures []AzureTargetFailure
 }
 
 func (azureTargetFailureList *AzureTargetFailureList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AzureTargetFailure":
-            var model AzureTargetFailure
-            model.parse(&child, aggErr)
-            azureTargetFailureList.AzureTargetFailures = append(azureTargetFailureList.AzureTargetFailures, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetFailureList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AzureTargetFailure":
+			var model AzureTargetFailure
+			model.parse(&child, aggErr)
+			azureTargetFailureList.AzureTargetFailures = append(azureTargetFailureList.AzureTargetFailures, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetFailureList.", child.XMLName.Local)
+		}
+	}
 }
 
 type AzureTargetReadPreferenceList struct {
-    AzureTargetReadPreferences []AzureTargetReadPreference
+	AzureTargetReadPreferences []AzureTargetReadPreference
 }
 
 func (azureTargetReadPreferenceList *AzureTargetReadPreferenceList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AzureTargetReadPreference":
-            var model AzureTargetReadPreference
-            model.parse(&child, aggErr)
-            azureTargetReadPreferenceList.AzureTargetReadPreferences = append(azureTargetReadPreferenceList.AzureTargetReadPreferences, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetReadPreferenceList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AzureTargetReadPreference":
+			var model AzureTargetReadPreference
+			model.parse(&child, aggErr)
+			azureTargetReadPreferenceList.AzureTargetReadPreferences = append(azureTargetReadPreferenceList.AzureTargetReadPreferences, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetReadPreferenceList.", child.XMLName.Local)
+		}
+	}
 }
 
 type AzureTargetList struct {
-    AzureTargets []AzureTarget
+	AzureTargets []AzureTarget
 }
 
 func (azureTargetList *AzureTargetList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "AzureTarget":
-            var model AzureTarget
-            model.parse(&child, aggErr)
-            azureTargetList.AzureTargets = append(azureTargetList.AzureTargets, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "AzureTarget":
+			var model AzureTarget
+			model.parse(&child, aggErr)
+			azureTargetList.AzureTargets = append(azureTargetList.AzureTargets, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing AzureTargetList.", child.XMLName.Local)
+		}
+	}
 }
 
 type Ds3TargetFailureList struct {
-    Ds3TargetFailures []Ds3TargetFailure
+	Ds3TargetFailures []Ds3TargetFailure
 }
 
 func (ds3TargetFailureList *Ds3TargetFailureList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Ds3TargetFailure":
-            var model Ds3TargetFailure
-            model.parse(&child, aggErr)
-            ds3TargetFailureList.Ds3TargetFailures = append(ds3TargetFailureList.Ds3TargetFailures, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetFailureList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Ds3TargetFailure":
+			var model Ds3TargetFailure
+			model.parse(&child, aggErr)
+			ds3TargetFailureList.Ds3TargetFailures = append(ds3TargetFailureList.Ds3TargetFailures, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetFailureList.", child.XMLName.Local)
+		}
+	}
 }
 
 type Ds3TargetReadPreferenceList struct {
-    Ds3TargetReadPreferences []Ds3TargetReadPreference
+	Ds3TargetReadPreferences []Ds3TargetReadPreference
 }
 
 func (ds3TargetReadPreferenceList *Ds3TargetReadPreferenceList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Ds3TargetReadPreference":
-            var model Ds3TargetReadPreference
-            model.parse(&child, aggErr)
-            ds3TargetReadPreferenceList.Ds3TargetReadPreferences = append(ds3TargetReadPreferenceList.Ds3TargetReadPreferences, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetReadPreferenceList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Ds3TargetReadPreference":
+			var model Ds3TargetReadPreference
+			model.parse(&child, aggErr)
+			ds3TargetReadPreferenceList.Ds3TargetReadPreferences = append(ds3TargetReadPreferenceList.Ds3TargetReadPreferences, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetReadPreferenceList.", child.XMLName.Local)
+		}
+	}
 }
 
 type Ds3TargetList struct {
-    Ds3Targets []Ds3Target
+	Ds3Targets []Ds3Target
 }
 
 func (ds3TargetList *Ds3TargetList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "Ds3Target":
-            var model Ds3Target
-            model.parse(&child, aggErr)
-            ds3TargetList.Ds3Targets = append(ds3TargetList.Ds3Targets, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "Ds3Target":
+			var model Ds3Target
+			model.parse(&child, aggErr)
+			ds3TargetList.Ds3Targets = append(ds3TargetList.Ds3Targets, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing Ds3TargetList.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3TargetBucketNameList struct {
-    S3TargetBucketNames []S3TargetBucketName
+	S3TargetBucketNames []S3TargetBucketName
 }
 
 func (s3TargetBucketNameList *S3TargetBucketNameList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "S3TargetBucketName":
-            var model S3TargetBucketName
-            model.parse(&child, aggErr)
-            s3TargetBucketNameList.S3TargetBucketNames = append(s3TargetBucketNameList.S3TargetBucketNames, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetBucketNameList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "S3TargetBucketName":
+			var model S3TargetBucketName
+			model.parse(&child, aggErr)
+			s3TargetBucketNameList.S3TargetBucketNames = append(s3TargetBucketNameList.S3TargetBucketNames, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetBucketNameList.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3TargetFailureList struct {
-    S3TargetFailures []S3TargetFailure
+	S3TargetFailures []S3TargetFailure
 }
 
 func (s3TargetFailureList *S3TargetFailureList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "S3TargetFailure":
-            var model S3TargetFailure
-            model.parse(&child, aggErr)
-            s3TargetFailureList.S3TargetFailures = append(s3TargetFailureList.S3TargetFailures, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetFailureList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "S3TargetFailure":
+			var model S3TargetFailure
+			model.parse(&child, aggErr)
+			s3TargetFailureList.S3TargetFailures = append(s3TargetFailureList.S3TargetFailures, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetFailureList.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3TargetReadPreferenceList struct {
-    S3TargetReadPreferences []S3TargetReadPreference
+	S3TargetReadPreferences []S3TargetReadPreference
 }
 
 func (s3TargetReadPreferenceList *S3TargetReadPreferenceList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "S3TargetReadPreference":
-            var model S3TargetReadPreference
-            model.parse(&child, aggErr)
-            s3TargetReadPreferenceList.S3TargetReadPreferences = append(s3TargetReadPreferenceList.S3TargetReadPreferences, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetReadPreferenceList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "S3TargetReadPreference":
+			var model S3TargetReadPreference
+			model.parse(&child, aggErr)
+			s3TargetReadPreferenceList.S3TargetReadPreferences = append(s3TargetReadPreferenceList.S3TargetReadPreferences, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetReadPreferenceList.", child.XMLName.Local)
+		}
+	}
 }
 
 type S3TargetList struct {
-    S3Targets []S3Target
+	S3Targets []S3Target
 }
 
 func (s3TargetList *S3TargetList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "S3Target":
-            var model S3Target
-            model.parse(&child, aggErr)
-            s3TargetList.S3Targets = append(s3TargetList.S3Targets, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "S3Target":
+			var model S3Target
+			model.parse(&child, aggErr)
+			s3TargetList.S3Targets = append(s3TargetList.S3Targets, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing S3TargetList.", child.XMLName.Local)
+		}
+	}
 }
 
 type SpectraUserList struct {
-    SpectraUsers []SpectraUser
+	SpectraUsers []SpectraUser
 }
 
 func (spectraUserList *SpectraUserList) parse(xmlNode *XmlNode, aggErr *AggregateError) {
 
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        case "User":
-            var model SpectraUser
-            model.parse(&child, aggErr)
-            spectraUserList.SpectraUsers = append(spectraUserList.SpectraUsers, model)
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SpectraUserList.", child.XMLName.Local)
-        }
-    }
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+		case "User":
+			var model SpectraUser
+			model.parse(&child, aggErr)
+			spectraUserList.SpectraUsers = append(spectraUserList.SpectraUsers, model)
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing SpectraUserList.", child.XMLName.Local)
+		}
+	}
 }
-

--- a/ds3/models/responseModels_test.go
+++ b/ds3/models/responseModels_test.go
@@ -1,103 +1,103 @@
 package models
 
 import (
-    "io"
-    "strings"
-    "testing"
+	"io"
+	"strings"
+	"testing"
 )
 
 type nopCloser struct {
-    io.Reader
+	io.Reader
 }
 
 func (readCloser *nopCloser) Close() error {
-    return nil
+	return nil
 }
 
 // GOSDK-25 unmarshaling optional enums in response payloads causes panic.
 // This test is for validating the above jira is fixed and to catch future regressions.
 func TestUnmarshalingTapeWithPreviousState(t *testing.T) {
-    responseContent := "<Data><Tape><AssignedToStorageDomain>false</AssignedToStorageDomain>" +
-        "<AvailableRawCapacity>10000</AvailableRawCapacity><BarCode>2f8f0dd0-c1db-4c72-9edc-cd23f7cccd2a</BarCode>" +
-        "<BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/>" +
-        "<FullOfData>false</FullOfData><Id>069ad1fb-8c46-4834-a8b1-f92bc9e66059</Id><LastAccessed/>" +
-        "<LastCheckpoint>new</LastCheckpoint><LastModified/><LastVerified/><PartiallyVerifiedEndOfTape/>" +
-        "<PartitionId>d6245cbe-b6ea-46e3-a974-87663016733c</PartitionId>" +
-        "<PreviousState>eject_from_ee_pending</PreviousState><SerialNumber/><State>NORMAL</State>" +
-        "<TakeOwnershipPending>false</TakeOwnershipPending><TotalRawCapacity>20000</TotalRawCapacity><Type>LTO5</Type>" +
-        "<VerifyPending/><WriteProtected>false</WriteProtected></Tape></Data>"
+	responseContent := "<Data><Tape><AssignedToStorageDomain>false</AssignedToStorageDomain>" +
+		"<AvailableRawCapacity>10000</AvailableRawCapacity><BarCode>2f8f0dd0-c1db-4c72-9edc-cd23f7cccd2a</BarCode>" +
+		"<BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/>" +
+		"<FullOfData>false</FullOfData><Id>069ad1fb-8c46-4834-a8b1-f92bc9e66059</Id><LastAccessed/>" +
+		"<LastCheckpoint>new</LastCheckpoint><LastModified/><LastVerified/><PartiallyVerifiedEndOfTape/>" +
+		"<PartitionId>d6245cbe-b6ea-46e3-a974-87663016733c</PartitionId>" +
+		"<PreviousState>eject_from_ee_pending</PreviousState><SerialNumber/><State>NORMAL</State>" +
+		"<TakeOwnershipPending>false</TakeOwnershipPending><TotalRawCapacity>20000</TotalRawCapacity><Type>LTO5</Type>" +
+		"<VerifyPending/><WriteProtected>false</WriteProtected></Tape></Data>"
 
-    responseReadCloser := &nopCloser{Reader: strings.NewReader(responseContent)}
+	responseReadCloser := &nopCloser{Reader: strings.NewReader(responseContent)}
 
-    // create the xml tree
-    root, err := parseXmlTree(responseReadCloser)
-    if err != nil {
-        t.Fatalf("expected not to error when parsing xml tree: %v", err)
-    }
+	// create the xml tree
+	root, err := parseXmlTree(responseReadCloser)
+	if err != nil {
+		t.Fatalf("expected not to error when parsing xml tree: %v", err)
+	}
 
-    // parse the response
-    var aggErr AggregateError
-    var tapeResponse GetTapesSpectraS3Response
-    tapeResponse.TapeList.parse(root, &aggErr)
+	// parse the response
+	var aggErr AggregateError
+	var tapeResponse GetTapesSpectraS3Response
+	tapeResponse.TapeList.parse(root, &aggErr)
 
-    if len(aggErr.Errors) > 0 {
-        t.Fatalf("expected no errors when marshaling, but got %d", len(aggErr.Errors))
-    }
+	if len(aggErr.Errors) > 0 {
+		t.Fatalf("expected no errors when marshaling, but got %d", len(aggErr.Errors))
+	}
 
-    if len(tapeResponse.TapeList.Tapes) != 1 {
-        t.Fatalf("expected to unmarshal one tape, but got %d", len(tapeResponse.TapeList.Tapes))
-    }
+	if len(tapeResponse.TapeList.Tapes) != 1 {
+		t.Fatalf("expected to unmarshal one tape, but got %d", len(tapeResponse.TapeList.Tapes))
+	}
 
-    for _, err := range aggErr.Errors {
-        t.Logf(err.Error())
-    }
+	for _, err := range aggErr.Errors {
+		t.Logf(err.Error())
+	}
 
-    tapeState := tapeResponse.TapeList.Tapes[0].PreviousState
-    if tapeState == nil || *tapeState != TAPE_STATE_EJECT_FROM_EE_PENDING {
-        t.Fatalf("expected tape state to be TAPE_STATE_EJECT_FROM_EE_PENDING, but was '%v'", tapeState)
-    }
+	tapeState := tapeResponse.TapeList.Tapes[0].PreviousState
+	if tapeState == nil || *tapeState != TAPE_STATE_EJECT_FROM_EE_PENDING {
+		t.Fatalf("expected tape state to be TAPE_STATE_EJECT_FROM_EE_PENDING, but was '%v'", tapeState)
+	}
 }
 
 // GOSDK-25 unmarshaling optional enums in response payloads causes panic.
 // This test is for validating the above jira is fixed and to catch future regressions.
 func TestUnmarshalingTapeWithoutPreviousState(t *testing.T) {
-    responseContent := "<Data><Tape><AssignedToStorageDomain>false</AssignedToStorageDomain>" +
-        "<AvailableRawCapacity>10000</AvailableRawCapacity><BarCode>2f8f0dd0-c1db-4c72-9edc-cd23f7cccd2a</BarCode>" +
-        "<BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/>" +
-        "<FullOfData>false</FullOfData><Id>069ad1fb-8c46-4834-a8b1-f92bc9e66059</Id><LastAccessed/>" +
-        "<LastCheckpoint>new</LastCheckpoint><LastModified/><LastVerified/><PartiallyVerifiedEndOfTape/>" +
-        "<PartitionId>d6245cbe-b6ea-46e3-a974-87663016733c</PartitionId>" +
-        "<PreviousState/><SerialNumber/><State>NORMAL</State>" +
-        "<TakeOwnershipPending>false</TakeOwnershipPending><TotalRawCapacity>20000</TotalRawCapacity><Type>LTO5</Type>" +
-        "<VerifyPending/><WriteProtected>false</WriteProtected></Tape></Data>"
+	responseContent := "<Data><Tape><AssignedToStorageDomain>false</AssignedToStorageDomain>" +
+		"<AvailableRawCapacity>10000</AvailableRawCapacity><BarCode>2f8f0dd0-c1db-4c72-9edc-cd23f7cccd2a</BarCode>" +
+		"<BucketId/><DescriptionForIdentification/><EjectDate/><EjectLabel/><EjectLocation/><EjectPending/>" +
+		"<FullOfData>false</FullOfData><Id>069ad1fb-8c46-4834-a8b1-f92bc9e66059</Id><LastAccessed/>" +
+		"<LastCheckpoint>new</LastCheckpoint><LastModified/><LastVerified/><PartiallyVerifiedEndOfTape/>" +
+		"<PartitionId>d6245cbe-b6ea-46e3-a974-87663016733c</PartitionId>" +
+		"<PreviousState/><SerialNumber/><State>NORMAL</State>" +
+		"<TakeOwnershipPending>false</TakeOwnershipPending><TotalRawCapacity>20000</TotalRawCapacity><Type>LTO5</Type>" +
+		"<VerifyPending/><WriteProtected>false</WriteProtected></Tape></Data>"
 
-    responseReadCloser := &nopCloser{Reader: strings.NewReader(responseContent)}
+	responseReadCloser := &nopCloser{Reader: strings.NewReader(responseContent)}
 
-    // create the xml tree
-    root, err := parseXmlTree(responseReadCloser)
-    if err != nil {
-        t.Fatalf("expected not to error when parsing xml tree: %v", err)
-    }
+	// create the xml tree
+	root, err := parseXmlTree(responseReadCloser)
+	if err != nil {
+		t.Fatalf("expected not to error when parsing xml tree: %v", err)
+	}
 
-    // parse the response
-    var aggErr AggregateError
-    var tapeResponse GetTapesSpectraS3Response
-    tapeResponse.TapeList.parse(root, &aggErr)
+	// parse the response
+	var aggErr AggregateError
+	var tapeResponse GetTapesSpectraS3Response
+	tapeResponse.TapeList.parse(root, &aggErr)
 
-    if len(aggErr.Errors) > 0 {
-        t.Fatalf("expected no errors when marshaling, but got %d", len(aggErr.Errors))
-    }
+	if len(aggErr.Errors) > 0 {
+		t.Fatalf("expected no errors when marshaling, but got %d", len(aggErr.Errors))
+	}
 
-    if len(tapeResponse.TapeList.Tapes) != 1 {
-        t.Fatalf("expected to unmarshal one tape, but got %d", len(tapeResponse.TapeList.Tapes))
-    }
+	if len(tapeResponse.TapeList.Tapes) != 1 {
+		t.Fatalf("expected to unmarshal one tape, but got %d", len(tapeResponse.TapeList.Tapes))
+	}
 
-    for _, err := range aggErr.Errors {
-        t.Logf(err.Error())
-    }
+	for _, err := range aggErr.Errors {
+		t.Logf(err.Error())
+	}
 
-    tapeState := tapeResponse.TapeList.Tapes[0].PreviousState
-    if tapeState != nil {
-        t.Fatalf("expected tape state to be nil, but was '%v'", tapeState)
-    }
+	tapeState := tapeResponse.TapeList.Tapes[0].PreviousState
+	if tapeState != nil {
+		t.Fatalf("expected tape state to be nil, but was '%v'", tapeState)
+	}
 }

--- a/ds3/models/responseParsingUtil.go
+++ b/ds3/models/responseParsingUtil.go
@@ -12,10 +12,10 @@
 package models
 
 import (
-    "log"
-    "net/http"
-    "strconv"
-    "strings"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
 )
 
 // Contains utils used by model parsers to parse response payloads.
@@ -25,282 +25,282 @@ const BLOB_CHECKSUM_HEADER string = "ds3-blob-checksum-offset-"
 
 // Parses blob checksum header if exists. This is used by HeadObjectResponse.
 func getBlobChecksumType(headers *http.Header) (ChecksumType, error) {
-    checksumStr := headers.Get(BLOB_CHECKSUM_TYPE_HEADER)
-    if len(checksumStr) == 0 {
-        return NONE, nil
-    }
-    var checksumEnum ChecksumType
-    err := checksumEnum.UnmarshalText([]byte(checksumStr))
-    if err != nil {
-        return UNDEFINED, err
-    }
-    return checksumEnum, nil
+	checksumStr := headers.Get(BLOB_CHECKSUM_TYPE_HEADER)
+	if len(checksumStr) == 0 {
+		return NONE, nil
+	}
+	var checksumEnum ChecksumType
+	err := checksumEnum.UnmarshalText([]byte(checksumStr))
+	if err != nil {
+		return UNDEFINED, err
+	}
+	return checksumEnum, nil
 }
 
 // Parses response headers and creates a map of blob offset to blob checksum
 // for all occurrences of headers with prefix defined in BLOB_CHECKSUM_HEADER.
 // This is used by HeadObjectResponse.
 func getBlobChecksumMap(headers *http.Header) (map[int64]string, error) {
-    blobChecksumMap := make(map[int64]string)
+	blobChecksumMap := make(map[int64]string)
 
-    if headers == nil || len(*headers) == 0 {
-        return blobChecksumMap, nil
-    }
+	if headers == nil || len(*headers) == 0 {
+		return blobChecksumMap, nil
+	}
 
-    for key := range *headers {
-        if strings.HasPrefix(strings.ToLower(key), strings.ToLower(BLOB_CHECKSUM_HEADER)) {
-            offsetStr := strings.TrimPrefix(strings.ToLower(key), strings.ToLower(BLOB_CHECKSUM_HEADER))
-            offset, err := strconv.ParseInt(offsetStr, 10, 64)
-            if err != nil {
-                return blobChecksumMap, err
-            }
-            blobChecksumMap[offset] = headers.Get(key)
-        }
-    }
+	for key := range *headers {
+		if strings.HasPrefix(strings.ToLower(key), strings.ToLower(BLOB_CHECKSUM_HEADER)) {
+			offsetStr := strings.TrimPrefix(strings.ToLower(key), strings.ToLower(BLOB_CHECKSUM_HEADER))
+			offset, err := strconv.ParseInt(offsetStr, 10, 64)
+			if err != nil {
+				return blobChecksumMap, err
+			}
+			blobChecksumMap[offset] = headers.Get(key)
+		}
+	}
 
-    return blobChecksumMap, nil
+	return blobChecksumMap, nil
 }
 
 // Interface defined for spectra defined enums.
 // Used for generic parsing of enums.
 type Ds3Enum interface {
-    UnmarshalText(text []byte) error
+	UnmarshalText(text []byte) error
 }
 
 // Parses a byte slice into an enum value. Assumes that a valid enum value is
 // contained within the byte slice.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseEnum(content []byte, param Ds3Enum, aggErr *AggregateError) {
-    err := param.UnmarshalText(content)
-    if err != nil {
-        aggErr.Append(err)
-    }
+	err := param.UnmarshalText(content)
+	if err != nil {
+		aggErr.Append(err)
+	}
 }
 
 // Parses a byte slice into an enum value. An empty slice is converted into a nil value.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseNullableEnum(content []byte, param Ds3Enum, aggErr *AggregateError) {
-    if len(content) > 0 {
-        parseEnum(content, param, aggErr)
-    }
+	if len(content) > 0 {
+		parseEnum(content, param, aggErr)
+	}
 }
 
 // Converts a byte slice into a string value.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseString(content []byte) string {
-    return string(content)
+	return string(content)
 }
 
 // Converts a byte slice into a string value. An empty slice is converted into a nil value.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseNullableString(content []byte) *string {
-    if len(content) == 0 {
-        return nil
-    }
-    result := parseString(content)
-    return &result
+	if len(content) == 0 {
+		return nil
+	}
+	result := parseString(content)
+	return &result
 }
 
 // Converts a byte slice into an int value. Assumes that a valid int value is
 // contained within the byte slice.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseInt(content []byte, aggErr *AggregateError) int {
-    result, err :=  strconv.Atoi(string(content))
-    if err != nil {
-        aggErr.Append(err)
-    }
-    return result
+	result, err := strconv.Atoi(string(content))
+	if err != nil {
+		aggErr.Append(err)
+	}
+	return result
 }
 
 // Converts a byte slice into an int value. An empty slice is converted into a nil value.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseNullableInt(content []byte, aggErr *AggregateError) *int {
-    if len(content) == 0 {
-        return nil
-    }
-    result := parseInt(content, aggErr)
-    return &result
+	if len(content) == 0 {
+		return nil
+	}
+	result := parseInt(content, aggErr)
+	return &result
 }
 
 // Converts a byte slice into an int64 value. Assumes that a valid int64 value is
 // contained within the byte slice.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseInt64(content []byte, aggErr *AggregateError) int64 {
-    result, err := strconv.ParseInt(string(content), 10, 64)
-    if err != nil {
-        aggErr.Append(err)
-    }
-    return result
+	result, err := strconv.ParseInt(string(content), 10, 64)
+	if err != nil {
+		aggErr.Append(err)
+	}
+	return result
 }
 
 // Converts a byte slice into an int64 value. An empty slice is converted into a nil value.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseNullableInt64(content []byte, aggErr *AggregateError) *int64 {
-    if len(content) == 0 {
-        return nil
-    }
-    result := parseInt64(content, aggErr)
-    return &result
+	if len(content) == 0 {
+		return nil
+	}
+	result := parseInt64(content, aggErr)
+	return &result
 }
 
 // Converts a byte slice into an float64 value. Assumes that a valid float64 value is
 // contained within the byte slice.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseFloat64(content []byte, aggErr *AggregateError) float64 {
-    result, err := strconv.ParseFloat(string(content), 64)
-    if err != nil {
-        aggErr.Append(err)
-    }
-    return result
+	result, err := strconv.ParseFloat(string(content), 64)
+	if err != nil {
+		aggErr.Append(err)
+	}
+	return result
 }
 
 // Converts a byte slice into an float64 value. An empty slice is converted into a nil value.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseNullableFloat64(content []byte, aggErr *AggregateError) *float64 {
-    if len(content) == 0 {
-        return nil
-    }
-    result := parseFloat64(content, aggErr)
-    return &result
+	if len(content) == 0 {
+		return nil
+	}
+	result := parseFloat64(content, aggErr)
+	return &result
 }
 
 // Converts a byte slice into a boolean value. Assumes that a valid boolean value is
 // contained within the byte slice.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseBool(content []byte, aggErr *AggregateError) bool {
-    result, err := strconv.ParseBool(string(content))
-    if err != nil {
-        aggErr.Append(err)
-    }
-    return result
+	result, err := strconv.ParseBool(string(content))
+	if err != nil {
+		aggErr.Append(err)
+	}
+	return result
 }
 
 // Converts a byte slice into a boolean value. An empty slice is converted into a nil value.
 // Used in response payload parsing to convert xml node content into expected types.
 func parseNullableBool(content []byte, aggErr *AggregateError) *bool {
-    if len(content) == 0 {
-        return nil
-    }
-    result := parseBool(content, aggErr)
-    return &result
+	if len(content) == 0 {
+		return nil
+	}
+	result := parseBool(content, aggErr)
+	return &result
 }
 
 // Parses an enum value from a string and expects a valid value to exist.
 // Used for parsing response payload attributes into expected types.
 func parseEnumFromString(content string, param Ds3Enum, aggErr *AggregateError) {
-    err := param.UnmarshalText([]byte(content))
-    if err != nil {
-        aggErr.Append(err)
-    }
+	err := param.UnmarshalText([]byte(content))
+	if err != nil {
+		aggErr.Append(err)
+	}
 }
 
 // Parse nullable enum from string, where empty content represents a nil enum result.
 // Used for parsing response payload attributes into expected types.
 func parseNullableEnumFromString(content string, param Ds3Enum, aggErr *AggregateError) {
-    if len(content) > 0 {
-        parseEnumFromString(content, param, aggErr)
-    }
+	if len(content) > 0 {
+		parseEnumFromString(content, param, aggErr)
+	}
 }
 
 // Parses a nullable string, where empty content represents a nil string result.
 // Used for parsing response payload attributes into expected types.
 func parseNullableStringFromString(content string) *string {
-    if len(content) == 0 {
-        return nil
-    }
-    result := content
-    return &result
+	if len(content) == 0 {
+		return nil
+	}
+	result := content
+	return &result
 }
 
 // Parses an int value from a string and expects a value to exist.
 // Used for parsing response payload attributes into expected types.
 func parseIntFromString(content string, aggErr *AggregateError) int {
-    result, err :=  strconv.Atoi(content)
-    if err != nil {
-        aggErr.Append(err)
-    }
-    return result
+	result, err := strconv.Atoi(content)
+	if err != nil {
+		aggErr.Append(err)
+	}
+	return result
 }
 
 // Parses a nullable int from string, where empty content represents a nil int result.
 // Used for parsing response payload attributes into expected types.
 func parseNullableIntFromString(content string, aggErr *AggregateError) *int {
-    if len(content) == 0 {
-        return nil
-    }
-    result := parseIntFromString(content, aggErr)
-    return &result
+	if len(content) == 0 {
+		return nil
+	}
+	result := parseIntFromString(content, aggErr)
+	return &result
 }
 
 // Parses an int64 value from a string and expects a value to exist.
 // Used for parsing response payload attributes into expected types.
 func parseInt64FromString(content string, aggErr *AggregateError) int64 {
-    result, err := strconv.ParseInt(content, 10, 64)
-    if err != nil {
-        aggErr.Append(err)
-    }
-    return result
+	result, err := strconv.ParseInt(content, 10, 64)
+	if err != nil {
+		aggErr.Append(err)
+	}
+	return result
 }
 
 // Parses a nullable int64 from string, where an empty string represents a nil int64 result.
 // Used for parsing response payload attributes into expected types.
 func parseNullableInt64FromString(content string, aggErr *AggregateError) *int64 {
-    if len(content) == 0 {
-        return nil
-    }
-    result := parseInt64FromString(content, aggErr)
-    return &result
+	if len(content) == 0 {
+		return nil
+	}
+	result := parseInt64FromString(content, aggErr)
+	return &result
 }
 
 // Parses an float64 value from a string and expects a value to exist.
 // Used for parsing response payload attributes into expected types.
 func parseFloat64FromString(content string, aggErr *AggregateError) float64 {
-    result, err := strconv.ParseFloat(content, 64)
-    if err != nil {
-        aggErr.Append(err)
-    }
-    return result
+	result, err := strconv.ParseFloat(content, 64)
+	if err != nil {
+		aggErr.Append(err)
+	}
+	return result
 }
 
 // Parses a nullable float64 from string, where an empty string represents a nil float64 result.
 // Used for parsing response payload attributes into expected types.
 func parseNullableFloat64FromString(content string, aggErr *AggregateError) *float64 {
-    if len(content) == 0 {
-        return nil
-    }
-    result := parseFloat64FromString(content, aggErr)
-    return &result
+	if len(content) == 0 {
+		return nil
+	}
+	result := parseFloat64FromString(content, aggErr)
+	return &result
 }
 
 // Parses a boolean value from a string and expects a valid boolean value to exist.
 // Used for parsing response payload attributes into expected types.
 func parseBoolFromString(content string, aggErr *AggregateError) bool {
-    result, err := strconv.ParseBool(content)
-    if err != nil {
-        aggErr.Append(err)
-    }
-    return result
+	result, err := strconv.ParseBool(content)
+	if err != nil {
+		aggErr.Append(err)
+	}
+	return result
 }
 
 // Parses a nullable boolean value from a string, where an empty string represents a nil boolean result.
 // Used for parsing response payload attributes into expected types.
 func parseNullableBoolFromString(content string, aggErr *AggregateError) *bool {
-    if len(content) == 0 {
-        return nil
-    }
-    result := parseBoolFromString(content, aggErr)
-    return &result
+	if len(content) == 0 {
+		return nil
+	}
+	result := parseBoolFromString(content, aggErr)
+	return &result
 }
 
 func parseStringSlice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []string {
-    var result []string
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult string = string(curXmlNode.Content)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing string slice.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []string
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult string = string(curXmlNode.Content)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing string slice.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }

--- a/ds3/models/responses.go
+++ b/ds3/models/responses.go
@@ -14,9150 +14,8829 @@
 package models
 
 import (
-    "net/http"
-    "io"
+	"io"
+	"net/http"
 )
 
 type AbortMultiPartUploadResponse struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewAbortMultiPartUploadResponse(webResponse WebResponse) (*AbortMultiPartUploadResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &AbortMultiPartUploadResponse{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &AbortMultiPartUploadResponse{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CompleteBlobResponse struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewCompleteBlobResponse(webResponse WebResponse) (*CompleteBlobResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        return &CompleteBlobResponse{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		return &CompleteBlobResponse{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CompleteMultiPartUploadResponse struct {
-    CompleteMultipartUploadResult CompleteMultipartUploadResult
-    Headers *http.Header
+	CompleteMultipartUploadResult CompleteMultipartUploadResult
+	Headers                       *http.Header
 }
 
 func (completeMultiPartUploadResponse *CompleteMultiPartUploadResponse) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &completeMultiPartUploadResponse.CompleteMultipartUploadResult)
+	return parseResponsePayload(webResponse, &completeMultiPartUploadResponse.CompleteMultipartUploadResult)
 }
 
 func NewCompleteMultiPartUploadResponse(webResponse WebResponse) (*CompleteMultiPartUploadResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CompleteMultiPartUploadResponse
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CompleteMultiPartUploadResponse
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutBucketResponse struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewPutBucketResponse(webResponse WebResponse) (*PutBucketResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        return &PutBucketResponse{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		return &PutBucketResponse{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutMultiPartUploadPartResponse struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewPutMultiPartUploadPartResponse(webResponse WebResponse) (*PutMultiPartUploadPartResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        return &PutMultiPartUploadPartResponse{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		return &PutMultiPartUploadPartResponse{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutObjectResponse struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewPutObjectResponse(webResponse WebResponse) (*PutObjectResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        return &PutObjectResponse{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		return &PutObjectResponse{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteBucketResponse struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteBucketResponse(webResponse WebResponse) (*DeleteBucketResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteBucketResponse{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteBucketResponse{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteObjectResponse struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteObjectResponse(webResponse WebResponse) (*DeleteObjectResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteObjectResponse{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteObjectResponse{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteObjectsResponse struct {
-    DeleteResult DeleteResult
-    Headers *http.Header
+	DeleteResult DeleteResult
+	Headers      *http.Header
 }
 
 func (deleteObjectsResponse *DeleteObjectsResponse) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &deleteObjectsResponse.DeleteResult)
+	return parseResponsePayload(webResponse, &deleteObjectsResponse.DeleteResult)
 }
 
 func NewDeleteObjectsResponse(webResponse WebResponse) (*DeleteObjectsResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body DeleteObjectsResponse
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body DeleteObjectsResponse
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBucketResponse struct {
-    ListBucketResult ListBucketResult
-    Headers *http.Header
+	ListBucketResult ListBucketResult
+	Headers          *http.Header
 }
 
 func (getBucketResponse *GetBucketResponse) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBucketResponse.ListBucketResult)
+	return parseResponsePayload(webResponse, &getBucketResponse.ListBucketResult)
 }
 
 func NewGetBucketResponse(webResponse WebResponse) (*GetBucketResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBucketResponse
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBucketResponse
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetServiceResponse struct {
-    ListAllMyBucketsResult ListAllMyBucketsResult
-    Headers *http.Header
+	ListAllMyBucketsResult ListAllMyBucketsResult
+	Headers                *http.Header
 }
 
 func (getServiceResponse *GetServiceResponse) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getServiceResponse.ListAllMyBucketsResult)
+	return parseResponsePayload(webResponse, &getServiceResponse.ListAllMyBucketsResult)
 }
 
 func NewGetServiceResponse(webResponse WebResponse) (*GetServiceResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetServiceResponse
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetServiceResponse
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetObjectResponse struct {
-    Content io.ReadCloser
-    Headers *http.Header
+	Content io.ReadCloser
+	Headers *http.Header
 }
 
-
-
 func NewGetObjectResponse(webResponse WebResponse) (*GetObjectResponse, error) {
-    expectedStatusCodes := []int { 200, 206 }
+	expectedStatusCodes := []int{200, 206}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        return &GetObjectResponse{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil
-    case 206:
-        return &GetObjectResponse{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil
-    default:
-        defer webResponse.Body().Close()
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		return &GetObjectResponse{Content: webResponse.Body(), Headers: webResponse.Header()}, nil
+	case 206:
+		return &GetObjectResponse{Content: webResponse.Body(), Headers: webResponse.Header()}, nil
+	default:
+		defer webResponse.Body().Close()
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type HeadBucketResponse struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewHeadBucketResponse(webResponse WebResponse) (*HeadBucketResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        return &HeadBucketResponse{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		return &HeadBucketResponse{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type HeadObjectResponse struct {
-    BlobChecksumType ChecksumType
-    BlobChecksums map[int64]string
-    Headers *http.Header
+	BlobChecksumType ChecksumType
+	BlobChecksums    map[int64]string
+	Headers          *http.Header
 }
 
-
-
 func NewHeadObjectResponse(webResponse WebResponse) (*HeadObjectResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        checksumType, err := getBlobChecksumType(webResponse.Header())
-        if err != nil {
-            return nil, err
-        }
-        checksumMap, err := getBlobChecksumMap(webResponse.Header())
-        if err != nil {
-            return nil, err
-        }
-        return &HeadObjectResponse{BlobChecksumType: checksumType, BlobChecksums: checksumMap, Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		checksumType, err := getBlobChecksumType(webResponse.Header())
+		if err != nil {
+			return nil, err
+		}
+		checksumMap, err := getBlobChecksumMap(webResponse.Header())
+		if err != nil {
+			return nil, err
+		}
+		return &HeadObjectResponse{BlobChecksumType: checksumType, BlobChecksums: checksumMap, Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type InitiateMultiPartUploadResponse struct {
-    InitiateMultipartUploadResult InitiateMultipartUploadResult
-    Headers *http.Header
+	InitiateMultipartUploadResult InitiateMultipartUploadResult
+	Headers                       *http.Header
 }
 
 func (initiateMultiPartUploadResponse *InitiateMultiPartUploadResponse) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &initiateMultiPartUploadResponse.InitiateMultipartUploadResult)
+	return parseResponsePayload(webResponse, &initiateMultiPartUploadResponse.InitiateMultipartUploadResult)
 }
 
 func NewInitiateMultiPartUploadResponse(webResponse WebResponse) (*InitiateMultiPartUploadResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body InitiateMultiPartUploadResponse
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body InitiateMultiPartUploadResponse
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ListMultiPartUploadPartsResponse struct {
-    ListPartsResult ListPartsResult
-    Headers *http.Header
+	ListPartsResult ListPartsResult
+	Headers         *http.Header
 }
 
 func (listMultiPartUploadPartsResponse *ListMultiPartUploadPartsResponse) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &listMultiPartUploadPartsResponse.ListPartsResult)
+	return parseResponsePayload(webResponse, &listMultiPartUploadPartsResponse.ListPartsResult)
 }
 
 func NewListMultiPartUploadPartsResponse(webResponse WebResponse) (*ListMultiPartUploadPartsResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ListMultiPartUploadPartsResponse
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ListMultiPartUploadPartsResponse
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ListMultiPartUploadsResponse struct {
-    ListMultiPartUploadsResult ListMultiPartUploadsResult
-    Headers *http.Header
+	ListMultiPartUploadsResult ListMultiPartUploadsResult
+	Headers                    *http.Header
 }
 
 func (listMultiPartUploadsResponse *ListMultiPartUploadsResponse) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &listMultiPartUploadsResponse.ListMultiPartUploadsResult)
+	return parseResponsePayload(webResponse, &listMultiPartUploadsResponse.ListMultiPartUploadsResult)
 }
 
 func NewListMultiPartUploadsResponse(webResponse WebResponse) (*ListMultiPartUploadsResponse, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ListMultiPartUploadsResponse
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ListMultiPartUploadsResponse
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutBucketAclForGroupSpectraS3Response struct {
-    BucketAcl BucketAcl
-    Headers *http.Header
+	BucketAcl BucketAcl
+	Headers   *http.Header
 }
 
 func (putBucketAclForGroupSpectraS3Response *PutBucketAclForGroupSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putBucketAclForGroupSpectraS3Response.BucketAcl)
+	return parseResponsePayload(webResponse, &putBucketAclForGroupSpectraS3Response.BucketAcl)
 }
 
 func NewPutBucketAclForGroupSpectraS3Response(webResponse WebResponse) (*PutBucketAclForGroupSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutBucketAclForGroupSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutBucketAclForGroupSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutBucketAclForUserSpectraS3Response struct {
-    BucketAcl BucketAcl
-    Headers *http.Header
+	BucketAcl BucketAcl
+	Headers   *http.Header
 }
 
 func (putBucketAclForUserSpectraS3Response *PutBucketAclForUserSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putBucketAclForUserSpectraS3Response.BucketAcl)
+	return parseResponsePayload(webResponse, &putBucketAclForUserSpectraS3Response.BucketAcl)
 }
 
 func NewPutBucketAclForUserSpectraS3Response(webResponse WebResponse) (*PutBucketAclForUserSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutBucketAclForUserSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutBucketAclForUserSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutDataPolicyAclForGroupSpectraS3Response struct {
-    DataPolicyAcl DataPolicyAcl
-    Headers *http.Header
+	DataPolicyAcl DataPolicyAcl
+	Headers       *http.Header
 }
 
 func (putDataPolicyAclForGroupSpectraS3Response *PutDataPolicyAclForGroupSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putDataPolicyAclForGroupSpectraS3Response.DataPolicyAcl)
+	return parseResponsePayload(webResponse, &putDataPolicyAclForGroupSpectraS3Response.DataPolicyAcl)
 }
 
 func NewPutDataPolicyAclForGroupSpectraS3Response(webResponse WebResponse) (*PutDataPolicyAclForGroupSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutDataPolicyAclForGroupSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutDataPolicyAclForGroupSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutDataPolicyAclForUserSpectraS3Response struct {
-    DataPolicyAcl DataPolicyAcl
-    Headers *http.Header
+	DataPolicyAcl DataPolicyAcl
+	Headers       *http.Header
 }
 
 func (putDataPolicyAclForUserSpectraS3Response *PutDataPolicyAclForUserSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putDataPolicyAclForUserSpectraS3Response.DataPolicyAcl)
+	return parseResponsePayload(webResponse, &putDataPolicyAclForUserSpectraS3Response.DataPolicyAcl)
 }
 
 func NewPutDataPolicyAclForUserSpectraS3Response(webResponse WebResponse) (*PutDataPolicyAclForUserSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutDataPolicyAclForUserSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutDataPolicyAclForUserSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutGlobalBucketAclForGroupSpectraS3Response struct {
-    BucketAcl BucketAcl
-    Headers *http.Header
+	BucketAcl BucketAcl
+	Headers   *http.Header
 }
 
 func (putGlobalBucketAclForGroupSpectraS3Response *PutGlobalBucketAclForGroupSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putGlobalBucketAclForGroupSpectraS3Response.BucketAcl)
+	return parseResponsePayload(webResponse, &putGlobalBucketAclForGroupSpectraS3Response.BucketAcl)
 }
 
 func NewPutGlobalBucketAclForGroupSpectraS3Response(webResponse WebResponse) (*PutGlobalBucketAclForGroupSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutGlobalBucketAclForGroupSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutGlobalBucketAclForGroupSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutGlobalBucketAclForUserSpectraS3Response struct {
-    BucketAcl BucketAcl
-    Headers *http.Header
+	BucketAcl BucketAcl
+	Headers   *http.Header
 }
 
 func (putGlobalBucketAclForUserSpectraS3Response *PutGlobalBucketAclForUserSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putGlobalBucketAclForUserSpectraS3Response.BucketAcl)
+	return parseResponsePayload(webResponse, &putGlobalBucketAclForUserSpectraS3Response.BucketAcl)
 }
 
 func NewPutGlobalBucketAclForUserSpectraS3Response(webResponse WebResponse) (*PutGlobalBucketAclForUserSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutGlobalBucketAclForUserSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutGlobalBucketAclForUserSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutGlobalDataPolicyAclForGroupSpectraS3Response struct {
-    DataPolicyAcl DataPolicyAcl
-    Headers *http.Header
+	DataPolicyAcl DataPolicyAcl
+	Headers       *http.Header
 }
 
 func (putGlobalDataPolicyAclForGroupSpectraS3Response *PutGlobalDataPolicyAclForGroupSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putGlobalDataPolicyAclForGroupSpectraS3Response.DataPolicyAcl)
+	return parseResponsePayload(webResponse, &putGlobalDataPolicyAclForGroupSpectraS3Response.DataPolicyAcl)
 }
 
 func NewPutGlobalDataPolicyAclForGroupSpectraS3Response(webResponse WebResponse) (*PutGlobalDataPolicyAclForGroupSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutGlobalDataPolicyAclForGroupSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutGlobalDataPolicyAclForGroupSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutGlobalDataPolicyAclForUserSpectraS3Response struct {
-    DataPolicyAcl DataPolicyAcl
-    Headers *http.Header
+	DataPolicyAcl DataPolicyAcl
+	Headers       *http.Header
 }
 
 func (putGlobalDataPolicyAclForUserSpectraS3Response *PutGlobalDataPolicyAclForUserSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putGlobalDataPolicyAclForUserSpectraS3Response.DataPolicyAcl)
+	return parseResponsePayload(webResponse, &putGlobalDataPolicyAclForUserSpectraS3Response.DataPolicyAcl)
 }
 
 func NewPutGlobalDataPolicyAclForUserSpectraS3Response(webResponse WebResponse) (*PutGlobalDataPolicyAclForUserSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutGlobalDataPolicyAclForUserSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutGlobalDataPolicyAclForUserSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteBucketAclSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteBucketAclSpectraS3Response(webResponse WebResponse) (*DeleteBucketAclSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteBucketAclSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteBucketAclSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteDataPolicyAclSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteDataPolicyAclSpectraS3Response(webResponse WebResponse) (*DeleteDataPolicyAclSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteDataPolicyAclSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteDataPolicyAclSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBucketAclSpectraS3Response struct {
-    BucketAcl BucketAcl
-    Headers *http.Header
+	BucketAcl BucketAcl
+	Headers   *http.Header
 }
 
 func (getBucketAclSpectraS3Response *GetBucketAclSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBucketAclSpectraS3Response.BucketAcl)
+	return parseResponsePayload(webResponse, &getBucketAclSpectraS3Response.BucketAcl)
 }
 
 func NewGetBucketAclSpectraS3Response(webResponse WebResponse) (*GetBucketAclSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBucketAclSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBucketAclSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBucketAclsSpectraS3Response struct {
-    BucketAclList BucketAclList
-    Headers *http.Header
+	BucketAclList BucketAclList
+	Headers       *http.Header
 }
 
 func (getBucketAclsSpectraS3Response *GetBucketAclsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBucketAclsSpectraS3Response.BucketAclList)
+	return parseResponsePayload(webResponse, &getBucketAclsSpectraS3Response.BucketAclList)
 }
 
 func NewGetBucketAclsSpectraS3Response(webResponse WebResponse) (*GetBucketAclsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBucketAclsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBucketAclsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDataPolicyAclSpectraS3Response struct {
-    DataPolicyAcl DataPolicyAcl
-    Headers *http.Header
+	DataPolicyAcl DataPolicyAcl
+	Headers       *http.Header
 }
 
 func (getDataPolicyAclSpectraS3Response *GetDataPolicyAclSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDataPolicyAclSpectraS3Response.DataPolicyAcl)
+	return parseResponsePayload(webResponse, &getDataPolicyAclSpectraS3Response.DataPolicyAcl)
 }
 
 func NewGetDataPolicyAclSpectraS3Response(webResponse WebResponse) (*GetDataPolicyAclSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDataPolicyAclSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDataPolicyAclSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDataPolicyAclsSpectraS3Response struct {
-    DataPolicyAclList DataPolicyAclList
-    Headers *http.Header
+	DataPolicyAclList DataPolicyAclList
+	Headers           *http.Header
 }
 
 func (getDataPolicyAclsSpectraS3Response *GetDataPolicyAclsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDataPolicyAclsSpectraS3Response.DataPolicyAclList)
+	return parseResponsePayload(webResponse, &getDataPolicyAclsSpectraS3Response.DataPolicyAclList)
 }
 
 func NewGetDataPolicyAclsSpectraS3Response(webResponse WebResponse) (*GetDataPolicyAclsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDataPolicyAclsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDataPolicyAclsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutBucketSpectraS3Response struct {
-    Bucket Bucket
-    Headers *http.Header
+	Bucket  Bucket
+	Headers *http.Header
 }
 
 func (putBucketSpectraS3Response *PutBucketSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putBucketSpectraS3Response.Bucket)
+	return parseResponsePayload(webResponse, &putBucketSpectraS3Response.Bucket)
 }
 
 func NewPutBucketSpectraS3Response(webResponse WebResponse) (*PutBucketSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutBucketSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutBucketSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteBucketSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteBucketSpectraS3Response(webResponse WebResponse) (*DeleteBucketSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteBucketSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteBucketSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBucketSpectraS3Response struct {
-    Bucket Bucket
-    Headers *http.Header
+	Bucket  Bucket
+	Headers *http.Header
 }
 
 func (getBucketSpectraS3Response *GetBucketSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBucketSpectraS3Response.Bucket)
+	return parseResponsePayload(webResponse, &getBucketSpectraS3Response.Bucket)
 }
 
 func NewGetBucketSpectraS3Response(webResponse WebResponse) (*GetBucketSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBucketSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBucketSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBucketsSpectraS3Response struct {
-    BucketList BucketList
-    Headers *http.Header
+	BucketList BucketList
+	Headers    *http.Header
 }
 
 func (getBucketsSpectraS3Response *GetBucketsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBucketsSpectraS3Response.BucketList)
+	return parseResponsePayload(webResponse, &getBucketsSpectraS3Response.BucketList)
 }
 
 func NewGetBucketsSpectraS3Response(webResponse WebResponse) (*GetBucketsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBucketsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBucketsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyBucketSpectraS3Response struct {
-    Bucket Bucket
-    Headers *http.Header
+	Bucket  Bucket
+	Headers *http.Header
 }
 
 func (modifyBucketSpectraS3Response *ModifyBucketSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyBucketSpectraS3Response.Bucket)
+	return parseResponsePayload(webResponse, &modifyBucketSpectraS3Response.Bucket)
 }
 
 func NewModifyBucketSpectraS3Response(webResponse WebResponse) (*ModifyBucketSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyBucketSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyBucketSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ForceFullCacheReclaimSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewForceFullCacheReclaimSpectraS3Response(webResponse WebResponse) (*ForceFullCacheReclaimSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ForceFullCacheReclaimSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ForceFullCacheReclaimSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetCacheFilesystemSpectraS3Response struct {
-    CacheFilesystem CacheFilesystem
-    Headers *http.Header
+	CacheFilesystem CacheFilesystem
+	Headers         *http.Header
 }
 
 func (getCacheFilesystemSpectraS3Response *GetCacheFilesystemSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getCacheFilesystemSpectraS3Response.CacheFilesystem)
+	return parseResponsePayload(webResponse, &getCacheFilesystemSpectraS3Response.CacheFilesystem)
 }
 
 func NewGetCacheFilesystemSpectraS3Response(webResponse WebResponse) (*GetCacheFilesystemSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetCacheFilesystemSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetCacheFilesystemSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetCacheFilesystemsSpectraS3Response struct {
-    CacheFilesystemList CacheFilesystemList
-    Headers *http.Header
+	CacheFilesystemList CacheFilesystemList
+	Headers             *http.Header
 }
 
 func (getCacheFilesystemsSpectraS3Response *GetCacheFilesystemsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getCacheFilesystemsSpectraS3Response.CacheFilesystemList)
+	return parseResponsePayload(webResponse, &getCacheFilesystemsSpectraS3Response.CacheFilesystemList)
 }
 
 func NewGetCacheFilesystemsSpectraS3Response(webResponse WebResponse) (*GetCacheFilesystemsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetCacheFilesystemsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetCacheFilesystemsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetCacheStateSpectraS3Response struct {
-    CacheInformation CacheInformation
-    Headers *http.Header
+	CacheInformation CacheInformation
+	Headers          *http.Header
 }
 
 func (getCacheStateSpectraS3Response *GetCacheStateSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getCacheStateSpectraS3Response.CacheInformation)
+	return parseResponsePayload(webResponse, &getCacheStateSpectraS3Response.CacheInformation)
 }
 
 func NewGetCacheStateSpectraS3Response(webResponse WebResponse) (*GetCacheStateSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetCacheStateSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetCacheStateSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyCacheFilesystemSpectraS3Response struct {
-    CacheFilesystem CacheFilesystem
-    Headers *http.Header
+	CacheFilesystem CacheFilesystem
+	Headers         *http.Header
 }
 
 func (modifyCacheFilesystemSpectraS3Response *ModifyCacheFilesystemSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyCacheFilesystemSpectraS3Response.CacheFilesystem)
+	return parseResponsePayload(webResponse, &modifyCacheFilesystemSpectraS3Response.CacheFilesystem)
 }
 
 func NewModifyCacheFilesystemSpectraS3Response(webResponse WebResponse) (*ModifyCacheFilesystemSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyCacheFilesystemSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyCacheFilesystemSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBucketCapacitySummarySpectraS3Response struct {
-    CapacitySummaryContainer CapacitySummaryContainer
-    Headers *http.Header
+	CapacitySummaryContainer CapacitySummaryContainer
+	Headers                  *http.Header
 }
 
 func (getBucketCapacitySummarySpectraS3Response *GetBucketCapacitySummarySpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBucketCapacitySummarySpectraS3Response.CapacitySummaryContainer)
+	return parseResponsePayload(webResponse, &getBucketCapacitySummarySpectraS3Response.CapacitySummaryContainer)
 }
 
 func NewGetBucketCapacitySummarySpectraS3Response(webResponse WebResponse) (*GetBucketCapacitySummarySpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBucketCapacitySummarySpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBucketCapacitySummarySpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetStorageDomainCapacitySummarySpectraS3Response struct {
-    CapacitySummaryContainer CapacitySummaryContainer
-    Headers *http.Header
+	CapacitySummaryContainer CapacitySummaryContainer
+	Headers                  *http.Header
 }
 
 func (getStorageDomainCapacitySummarySpectraS3Response *GetStorageDomainCapacitySummarySpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getStorageDomainCapacitySummarySpectraS3Response.CapacitySummaryContainer)
+	return parseResponsePayload(webResponse, &getStorageDomainCapacitySummarySpectraS3Response.CapacitySummaryContainer)
 }
 
 func NewGetStorageDomainCapacitySummarySpectraS3Response(webResponse WebResponse) (*GetStorageDomainCapacitySummarySpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetStorageDomainCapacitySummarySpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetStorageDomainCapacitySummarySpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSystemCapacitySummarySpectraS3Response struct {
-    CapacitySummaryContainer CapacitySummaryContainer
-    Headers *http.Header
+	CapacitySummaryContainer CapacitySummaryContainer
+	Headers                  *http.Header
 }
 
 func (getSystemCapacitySummarySpectraS3Response *GetSystemCapacitySummarySpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSystemCapacitySummarySpectraS3Response.CapacitySummaryContainer)
+	return parseResponsePayload(webResponse, &getSystemCapacitySummarySpectraS3Response.CapacitySummaryContainer)
 }
 
 func NewGetSystemCapacitySummarySpectraS3Response(webResponse WebResponse) (*GetSystemCapacitySummarySpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSystemCapacitySummarySpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSystemCapacitySummarySpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDataPathBackendSpectraS3Response struct {
-    DataPathBackend DataPathBackend
-    Headers *http.Header
+	DataPathBackend DataPathBackend
+	Headers         *http.Header
 }
 
 func (getDataPathBackendSpectraS3Response *GetDataPathBackendSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDataPathBackendSpectraS3Response.DataPathBackend)
+	return parseResponsePayload(webResponse, &getDataPathBackendSpectraS3Response.DataPathBackend)
 }
 
 func NewGetDataPathBackendSpectraS3Response(webResponse WebResponse) (*GetDataPathBackendSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDataPathBackendSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDataPathBackendSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDataPlannerBlobStoreTasksSpectraS3Response struct {
-    BlobStoreTasksInformation BlobStoreTasksInformation
-    Headers *http.Header
+	BlobStoreTasksInformation BlobStoreTasksInformation
+	Headers                   *http.Header
 }
 
 func (getDataPlannerBlobStoreTasksSpectraS3Response *GetDataPlannerBlobStoreTasksSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDataPlannerBlobStoreTasksSpectraS3Response.BlobStoreTasksInformation)
+	return parseResponsePayload(webResponse, &getDataPlannerBlobStoreTasksSpectraS3Response.BlobStoreTasksInformation)
 }
 
 func NewGetDataPlannerBlobStoreTasksSpectraS3Response(webResponse WebResponse) (*GetDataPlannerBlobStoreTasksSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDataPlannerBlobStoreTasksSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDataPlannerBlobStoreTasksSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyDataPathBackendSpectraS3Response struct {
-    DataPathBackend DataPathBackend
-    Headers *http.Header
+	DataPathBackend DataPathBackend
+	Headers         *http.Header
 }
 
 func (modifyDataPathBackendSpectraS3Response *ModifyDataPathBackendSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyDataPathBackendSpectraS3Response.DataPathBackend)
+	return parseResponsePayload(webResponse, &modifyDataPathBackendSpectraS3Response.DataPathBackend)
 }
 
 func NewModifyDataPathBackendSpectraS3Response(webResponse WebResponse) (*ModifyDataPathBackendSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyDataPathBackendSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyDataPathBackendSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutAzureDataReplicationRuleSpectraS3Response struct {
-    AzureDataReplicationRule AzureDataReplicationRule
-    Headers *http.Header
+	AzureDataReplicationRule AzureDataReplicationRule
+	Headers                  *http.Header
 }
 
 func (putAzureDataReplicationRuleSpectraS3Response *PutAzureDataReplicationRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putAzureDataReplicationRuleSpectraS3Response.AzureDataReplicationRule)
+	return parseResponsePayload(webResponse, &putAzureDataReplicationRuleSpectraS3Response.AzureDataReplicationRule)
 }
 
 func NewPutAzureDataReplicationRuleSpectraS3Response(webResponse WebResponse) (*PutAzureDataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutAzureDataReplicationRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutAzureDataReplicationRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutDataPersistenceRuleSpectraS3Response struct {
-    DataPersistenceRule DataPersistenceRule
-    Headers *http.Header
+	DataPersistenceRule DataPersistenceRule
+	Headers             *http.Header
 }
 
 func (putDataPersistenceRuleSpectraS3Response *PutDataPersistenceRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putDataPersistenceRuleSpectraS3Response.DataPersistenceRule)
+	return parseResponsePayload(webResponse, &putDataPersistenceRuleSpectraS3Response.DataPersistenceRule)
 }
 
 func NewPutDataPersistenceRuleSpectraS3Response(webResponse WebResponse) (*PutDataPersistenceRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutDataPersistenceRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutDataPersistenceRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutDataPolicySpectraS3Response struct {
-    DataPolicy DataPolicy
-    Headers *http.Header
+	DataPolicy DataPolicy
+	Headers    *http.Header
 }
 
 func (putDataPolicySpectraS3Response *PutDataPolicySpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putDataPolicySpectraS3Response.DataPolicy)
+	return parseResponsePayload(webResponse, &putDataPolicySpectraS3Response.DataPolicy)
 }
 
 func NewPutDataPolicySpectraS3Response(webResponse WebResponse) (*PutDataPolicySpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutDataPolicySpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutDataPolicySpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutDs3DataReplicationRuleSpectraS3Response struct {
-    Ds3DataReplicationRule Ds3DataReplicationRule
-    Headers *http.Header
+	Ds3DataReplicationRule Ds3DataReplicationRule
+	Headers                *http.Header
 }
 
 func (putDs3DataReplicationRuleSpectraS3Response *PutDs3DataReplicationRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putDs3DataReplicationRuleSpectraS3Response.Ds3DataReplicationRule)
+	return parseResponsePayload(webResponse, &putDs3DataReplicationRuleSpectraS3Response.Ds3DataReplicationRule)
 }
 
 func NewPutDs3DataReplicationRuleSpectraS3Response(webResponse WebResponse) (*PutDs3DataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutDs3DataReplicationRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutDs3DataReplicationRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutS3DataReplicationRuleSpectraS3Response struct {
-    S3DataReplicationRule S3DataReplicationRule
-    Headers *http.Header
+	S3DataReplicationRule S3DataReplicationRule
+	Headers               *http.Header
 }
 
 func (putS3DataReplicationRuleSpectraS3Response *PutS3DataReplicationRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putS3DataReplicationRuleSpectraS3Response.S3DataReplicationRule)
+	return parseResponsePayload(webResponse, &putS3DataReplicationRuleSpectraS3Response.S3DataReplicationRule)
 }
 
 func NewPutS3DataReplicationRuleSpectraS3Response(webResponse WebResponse) (*PutS3DataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutS3DataReplicationRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutS3DataReplicationRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteAzureDataReplicationRuleSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteAzureDataReplicationRuleSpectraS3Response(webResponse WebResponse) (*DeleteAzureDataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteAzureDataReplicationRuleSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteAzureDataReplicationRuleSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteDataPersistenceRuleSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteDataPersistenceRuleSpectraS3Response(webResponse WebResponse) (*DeleteDataPersistenceRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteDataPersistenceRuleSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteDataPersistenceRuleSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteDataPolicySpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteDataPolicySpectraS3Response(webResponse WebResponse) (*DeleteDataPolicySpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteDataPolicySpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteDataPolicySpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteDs3DataReplicationRuleSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteDs3DataReplicationRuleSpectraS3Response(webResponse WebResponse) (*DeleteDs3DataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteDs3DataReplicationRuleSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteDs3DataReplicationRuleSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteS3DataReplicationRuleSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteS3DataReplicationRuleSpectraS3Response(webResponse WebResponse) (*DeleteS3DataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteS3DataReplicationRuleSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteS3DataReplicationRuleSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetAzureDataReplicationRuleSpectraS3Response struct {
-    AzureDataReplicationRule AzureDataReplicationRule
-    Headers *http.Header
+	AzureDataReplicationRule AzureDataReplicationRule
+	Headers                  *http.Header
 }
 
 func (getAzureDataReplicationRuleSpectraS3Response *GetAzureDataReplicationRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getAzureDataReplicationRuleSpectraS3Response.AzureDataReplicationRule)
+	return parseResponsePayload(webResponse, &getAzureDataReplicationRuleSpectraS3Response.AzureDataReplicationRule)
 }
 
 func NewGetAzureDataReplicationRuleSpectraS3Response(webResponse WebResponse) (*GetAzureDataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetAzureDataReplicationRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetAzureDataReplicationRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetAzureDataReplicationRulesSpectraS3Response struct {
-    AzureDataReplicationRuleList AzureDataReplicationRuleList
-    Headers *http.Header
+	AzureDataReplicationRuleList AzureDataReplicationRuleList
+	Headers                      *http.Header
 }
 
 func (getAzureDataReplicationRulesSpectraS3Response *GetAzureDataReplicationRulesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getAzureDataReplicationRulesSpectraS3Response.AzureDataReplicationRuleList)
+	return parseResponsePayload(webResponse, &getAzureDataReplicationRulesSpectraS3Response.AzureDataReplicationRuleList)
 }
 
 func NewGetAzureDataReplicationRulesSpectraS3Response(webResponse WebResponse) (*GetAzureDataReplicationRulesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetAzureDataReplicationRulesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetAzureDataReplicationRulesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDataPersistenceRuleSpectraS3Response struct {
-    DataPersistenceRule DataPersistenceRule
-    Headers *http.Header
+	DataPersistenceRule DataPersistenceRule
+	Headers             *http.Header
 }
 
 func (getDataPersistenceRuleSpectraS3Response *GetDataPersistenceRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDataPersistenceRuleSpectraS3Response.DataPersistenceRule)
+	return parseResponsePayload(webResponse, &getDataPersistenceRuleSpectraS3Response.DataPersistenceRule)
 }
 
 func NewGetDataPersistenceRuleSpectraS3Response(webResponse WebResponse) (*GetDataPersistenceRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDataPersistenceRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDataPersistenceRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDataPersistenceRulesSpectraS3Response struct {
-    DataPersistenceRuleList DataPersistenceRuleList
-    Headers *http.Header
+	DataPersistenceRuleList DataPersistenceRuleList
+	Headers                 *http.Header
 }
 
 func (getDataPersistenceRulesSpectraS3Response *GetDataPersistenceRulesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDataPersistenceRulesSpectraS3Response.DataPersistenceRuleList)
+	return parseResponsePayload(webResponse, &getDataPersistenceRulesSpectraS3Response.DataPersistenceRuleList)
 }
 
 func NewGetDataPersistenceRulesSpectraS3Response(webResponse WebResponse) (*GetDataPersistenceRulesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDataPersistenceRulesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDataPersistenceRulesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDataPoliciesSpectraS3Response struct {
-    DataPolicyList DataPolicyList
-    Headers *http.Header
+	DataPolicyList DataPolicyList
+	Headers        *http.Header
 }
 
 func (getDataPoliciesSpectraS3Response *GetDataPoliciesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDataPoliciesSpectraS3Response.DataPolicyList)
+	return parseResponsePayload(webResponse, &getDataPoliciesSpectraS3Response.DataPolicyList)
 }
 
 func NewGetDataPoliciesSpectraS3Response(webResponse WebResponse) (*GetDataPoliciesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDataPoliciesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDataPoliciesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDataPolicySpectraS3Response struct {
-    DataPolicy DataPolicy
-    Headers *http.Header
+	DataPolicy DataPolicy
+	Headers    *http.Header
 }
 
 func (getDataPolicySpectraS3Response *GetDataPolicySpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDataPolicySpectraS3Response.DataPolicy)
+	return parseResponsePayload(webResponse, &getDataPolicySpectraS3Response.DataPolicy)
 }
 
 func NewGetDataPolicySpectraS3Response(webResponse WebResponse) (*GetDataPolicySpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDataPolicySpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDataPolicySpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDs3DataReplicationRuleSpectraS3Response struct {
-    Ds3DataReplicationRule Ds3DataReplicationRule
-    Headers *http.Header
+	Ds3DataReplicationRule Ds3DataReplicationRule
+	Headers                *http.Header
 }
 
 func (getDs3DataReplicationRuleSpectraS3Response *GetDs3DataReplicationRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDs3DataReplicationRuleSpectraS3Response.Ds3DataReplicationRule)
+	return parseResponsePayload(webResponse, &getDs3DataReplicationRuleSpectraS3Response.Ds3DataReplicationRule)
 }
 
 func NewGetDs3DataReplicationRuleSpectraS3Response(webResponse WebResponse) (*GetDs3DataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDs3DataReplicationRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDs3DataReplicationRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDs3DataReplicationRulesSpectraS3Response struct {
-    Ds3DataReplicationRuleList Ds3DataReplicationRuleList
-    Headers *http.Header
+	Ds3DataReplicationRuleList Ds3DataReplicationRuleList
+	Headers                    *http.Header
 }
 
 func (getDs3DataReplicationRulesSpectraS3Response *GetDs3DataReplicationRulesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDs3DataReplicationRulesSpectraS3Response.Ds3DataReplicationRuleList)
+	return parseResponsePayload(webResponse, &getDs3DataReplicationRulesSpectraS3Response.Ds3DataReplicationRuleList)
 }
 
 func NewGetDs3DataReplicationRulesSpectraS3Response(webResponse WebResponse) (*GetDs3DataReplicationRulesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDs3DataReplicationRulesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDs3DataReplicationRulesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetS3DataReplicationRuleSpectraS3Response struct {
-    S3DataReplicationRule S3DataReplicationRule
-    Headers *http.Header
+	S3DataReplicationRule S3DataReplicationRule
+	Headers               *http.Header
 }
 
 func (getS3DataReplicationRuleSpectraS3Response *GetS3DataReplicationRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getS3DataReplicationRuleSpectraS3Response.S3DataReplicationRule)
+	return parseResponsePayload(webResponse, &getS3DataReplicationRuleSpectraS3Response.S3DataReplicationRule)
 }
 
 func NewGetS3DataReplicationRuleSpectraS3Response(webResponse WebResponse) (*GetS3DataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetS3DataReplicationRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetS3DataReplicationRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetS3DataReplicationRulesSpectraS3Response struct {
-    S3DataReplicationRuleList S3DataReplicationRuleList
-    Headers *http.Header
+	S3DataReplicationRuleList S3DataReplicationRuleList
+	Headers                   *http.Header
 }
 
 func (getS3DataReplicationRulesSpectraS3Response *GetS3DataReplicationRulesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getS3DataReplicationRulesSpectraS3Response.S3DataReplicationRuleList)
+	return parseResponsePayload(webResponse, &getS3DataReplicationRulesSpectraS3Response.S3DataReplicationRuleList)
 }
 
 func NewGetS3DataReplicationRulesSpectraS3Response(webResponse WebResponse) (*GetS3DataReplicationRulesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetS3DataReplicationRulesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetS3DataReplicationRulesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyAzureDataReplicationRuleSpectraS3Response struct {
-    AzureDataReplicationRule AzureDataReplicationRule
-    Headers *http.Header
+	AzureDataReplicationRule AzureDataReplicationRule
+	Headers                  *http.Header
 }
 
 func (modifyAzureDataReplicationRuleSpectraS3Response *ModifyAzureDataReplicationRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyAzureDataReplicationRuleSpectraS3Response.AzureDataReplicationRule)
+	return parseResponsePayload(webResponse, &modifyAzureDataReplicationRuleSpectraS3Response.AzureDataReplicationRule)
 }
 
 func NewModifyAzureDataReplicationRuleSpectraS3Response(webResponse WebResponse) (*ModifyAzureDataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyAzureDataReplicationRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyAzureDataReplicationRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyDataPersistenceRuleSpectraS3Response struct {
-    DataPersistenceRule DataPersistenceRule
-    Headers *http.Header
+	DataPersistenceRule DataPersistenceRule
+	Headers             *http.Header
 }
 
 func (modifyDataPersistenceRuleSpectraS3Response *ModifyDataPersistenceRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyDataPersistenceRuleSpectraS3Response.DataPersistenceRule)
+	return parseResponsePayload(webResponse, &modifyDataPersistenceRuleSpectraS3Response.DataPersistenceRule)
 }
 
 func NewModifyDataPersistenceRuleSpectraS3Response(webResponse WebResponse) (*ModifyDataPersistenceRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyDataPersistenceRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyDataPersistenceRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyDataPolicySpectraS3Response struct {
-    DataPolicy DataPolicy
-    Headers *http.Header
+	DataPolicy DataPolicy
+	Headers    *http.Header
 }
 
 func (modifyDataPolicySpectraS3Response *ModifyDataPolicySpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyDataPolicySpectraS3Response.DataPolicy)
+	return parseResponsePayload(webResponse, &modifyDataPolicySpectraS3Response.DataPolicy)
 }
 
 func NewModifyDataPolicySpectraS3Response(webResponse WebResponse) (*ModifyDataPolicySpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyDataPolicySpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyDataPolicySpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyDs3DataReplicationRuleSpectraS3Response struct {
-    Ds3DataReplicationRule Ds3DataReplicationRule
-    Headers *http.Header
+	Ds3DataReplicationRule Ds3DataReplicationRule
+	Headers                *http.Header
 }
 
 func (modifyDs3DataReplicationRuleSpectraS3Response *ModifyDs3DataReplicationRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyDs3DataReplicationRuleSpectraS3Response.Ds3DataReplicationRule)
+	return parseResponsePayload(webResponse, &modifyDs3DataReplicationRuleSpectraS3Response.Ds3DataReplicationRule)
 }
 
 func NewModifyDs3DataReplicationRuleSpectraS3Response(webResponse WebResponse) (*ModifyDs3DataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyDs3DataReplicationRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyDs3DataReplicationRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyS3DataReplicationRuleSpectraS3Response struct {
-    S3DataReplicationRule S3DataReplicationRule
-    Headers *http.Header
+	S3DataReplicationRule S3DataReplicationRule
+	Headers               *http.Header
 }
 
 func (modifyS3DataReplicationRuleSpectraS3Response *ModifyS3DataReplicationRuleSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyS3DataReplicationRuleSpectraS3Response.S3DataReplicationRule)
+	return parseResponsePayload(webResponse, &modifyS3DataReplicationRuleSpectraS3Response.S3DataReplicationRule)
 }
 
 func NewModifyS3DataReplicationRuleSpectraS3Response(webResponse WebResponse) (*ModifyS3DataReplicationRuleSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyS3DataReplicationRuleSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyS3DataReplicationRuleSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ClearSuspectBlobAzureTargetsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewClearSuspectBlobAzureTargetsSpectraS3Response(webResponse WebResponse) (*ClearSuspectBlobAzureTargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ClearSuspectBlobAzureTargetsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ClearSuspectBlobAzureTargetsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ClearSuspectBlobDs3TargetsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewClearSuspectBlobDs3TargetsSpectraS3Response(webResponse WebResponse) (*ClearSuspectBlobDs3TargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ClearSuspectBlobDs3TargetsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ClearSuspectBlobDs3TargetsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ClearSuspectBlobPoolsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewClearSuspectBlobPoolsSpectraS3Response(webResponse WebResponse) (*ClearSuspectBlobPoolsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ClearSuspectBlobPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ClearSuspectBlobPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ClearSuspectBlobS3TargetsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewClearSuspectBlobS3TargetsSpectraS3Response(webResponse WebResponse) (*ClearSuspectBlobS3TargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ClearSuspectBlobS3TargetsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ClearSuspectBlobS3TargetsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ClearSuspectBlobTapesSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewClearSuspectBlobTapesSpectraS3Response(webResponse WebResponse) (*ClearSuspectBlobTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ClearSuspectBlobTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ClearSuspectBlobTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDegradedAzureDataReplicationRulesSpectraS3Response struct {
-    AzureDataReplicationRuleList AzureDataReplicationRuleList
-    Headers *http.Header
+	AzureDataReplicationRuleList AzureDataReplicationRuleList
+	Headers                      *http.Header
 }
 
 func (getDegradedAzureDataReplicationRulesSpectraS3Response *GetDegradedAzureDataReplicationRulesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDegradedAzureDataReplicationRulesSpectraS3Response.AzureDataReplicationRuleList)
+	return parseResponsePayload(webResponse, &getDegradedAzureDataReplicationRulesSpectraS3Response.AzureDataReplicationRuleList)
 }
 
 func NewGetDegradedAzureDataReplicationRulesSpectraS3Response(webResponse WebResponse) (*GetDegradedAzureDataReplicationRulesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDegradedAzureDataReplicationRulesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDegradedAzureDataReplicationRulesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDegradedBlobsSpectraS3Response struct {
-    DegradedBlobList DegradedBlobList
-    Headers *http.Header
+	DegradedBlobList DegradedBlobList
+	Headers          *http.Header
 }
 
 func (getDegradedBlobsSpectraS3Response *GetDegradedBlobsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDegradedBlobsSpectraS3Response.DegradedBlobList)
+	return parseResponsePayload(webResponse, &getDegradedBlobsSpectraS3Response.DegradedBlobList)
 }
 
 func NewGetDegradedBlobsSpectraS3Response(webResponse WebResponse) (*GetDegradedBlobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDegradedBlobsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDegradedBlobsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDegradedBucketsSpectraS3Response struct {
-    BucketList BucketList
-    Headers *http.Header
+	BucketList BucketList
+	Headers    *http.Header
 }
 
 func (getDegradedBucketsSpectraS3Response *GetDegradedBucketsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDegradedBucketsSpectraS3Response.BucketList)
+	return parseResponsePayload(webResponse, &getDegradedBucketsSpectraS3Response.BucketList)
 }
 
 func NewGetDegradedBucketsSpectraS3Response(webResponse WebResponse) (*GetDegradedBucketsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDegradedBucketsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDegradedBucketsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDegradedDataPersistenceRulesSpectraS3Response struct {
-    DataPersistenceRuleList DataPersistenceRuleList
-    Headers *http.Header
+	DataPersistenceRuleList DataPersistenceRuleList
+	Headers                 *http.Header
 }
 
 func (getDegradedDataPersistenceRulesSpectraS3Response *GetDegradedDataPersistenceRulesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDegradedDataPersistenceRulesSpectraS3Response.DataPersistenceRuleList)
+	return parseResponsePayload(webResponse, &getDegradedDataPersistenceRulesSpectraS3Response.DataPersistenceRuleList)
 }
 
 func NewGetDegradedDataPersistenceRulesSpectraS3Response(webResponse WebResponse) (*GetDegradedDataPersistenceRulesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDegradedDataPersistenceRulesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDegradedDataPersistenceRulesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDegradedDs3DataReplicationRulesSpectraS3Response struct {
-    Ds3DataReplicationRuleList Ds3DataReplicationRuleList
-    Headers *http.Header
+	Ds3DataReplicationRuleList Ds3DataReplicationRuleList
+	Headers                    *http.Header
 }
 
 func (getDegradedDs3DataReplicationRulesSpectraS3Response *GetDegradedDs3DataReplicationRulesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDegradedDs3DataReplicationRulesSpectraS3Response.Ds3DataReplicationRuleList)
+	return parseResponsePayload(webResponse, &getDegradedDs3DataReplicationRulesSpectraS3Response.Ds3DataReplicationRuleList)
 }
 
 func NewGetDegradedDs3DataReplicationRulesSpectraS3Response(webResponse WebResponse) (*GetDegradedDs3DataReplicationRulesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDegradedDs3DataReplicationRulesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDegradedDs3DataReplicationRulesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDegradedS3DataReplicationRulesSpectraS3Response struct {
-    S3DataReplicationRuleList S3DataReplicationRuleList
-    Headers *http.Header
+	S3DataReplicationRuleList S3DataReplicationRuleList
+	Headers                   *http.Header
 }
 
 func (getDegradedS3DataReplicationRulesSpectraS3Response *GetDegradedS3DataReplicationRulesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDegradedS3DataReplicationRulesSpectraS3Response.S3DataReplicationRuleList)
+	return parseResponsePayload(webResponse, &getDegradedS3DataReplicationRulesSpectraS3Response.S3DataReplicationRuleList)
 }
 
 func NewGetDegradedS3DataReplicationRulesSpectraS3Response(webResponse WebResponse) (*GetDegradedS3DataReplicationRulesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDegradedS3DataReplicationRulesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDegradedS3DataReplicationRulesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSuspectBlobAzureTargetsSpectraS3Response struct {
-    SuspectBlobAzureTargetList SuspectBlobAzureTargetList
-    Headers *http.Header
+	SuspectBlobAzureTargetList SuspectBlobAzureTargetList
+	Headers                    *http.Header
 }
 
 func (getSuspectBlobAzureTargetsSpectraS3Response *GetSuspectBlobAzureTargetsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSuspectBlobAzureTargetsSpectraS3Response.SuspectBlobAzureTargetList)
+	return parseResponsePayload(webResponse, &getSuspectBlobAzureTargetsSpectraS3Response.SuspectBlobAzureTargetList)
 }
 
 func NewGetSuspectBlobAzureTargetsSpectraS3Response(webResponse WebResponse) (*GetSuspectBlobAzureTargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSuspectBlobAzureTargetsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSuspectBlobAzureTargetsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSuspectBlobDs3TargetsSpectraS3Response struct {
-    SuspectBlobDs3TargetList SuspectBlobDs3TargetList
-    Headers *http.Header
+	SuspectBlobDs3TargetList SuspectBlobDs3TargetList
+	Headers                  *http.Header
 }
 
 func (getSuspectBlobDs3TargetsSpectraS3Response *GetSuspectBlobDs3TargetsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSuspectBlobDs3TargetsSpectraS3Response.SuspectBlobDs3TargetList)
+	return parseResponsePayload(webResponse, &getSuspectBlobDs3TargetsSpectraS3Response.SuspectBlobDs3TargetList)
 }
 
 func NewGetSuspectBlobDs3TargetsSpectraS3Response(webResponse WebResponse) (*GetSuspectBlobDs3TargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSuspectBlobDs3TargetsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSuspectBlobDs3TargetsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSuspectBlobPoolsSpectraS3Response struct {
-    SuspectBlobPoolList SuspectBlobPoolList
-    Headers *http.Header
+	SuspectBlobPoolList SuspectBlobPoolList
+	Headers             *http.Header
 }
 
 func (getSuspectBlobPoolsSpectraS3Response *GetSuspectBlobPoolsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSuspectBlobPoolsSpectraS3Response.SuspectBlobPoolList)
+	return parseResponsePayload(webResponse, &getSuspectBlobPoolsSpectraS3Response.SuspectBlobPoolList)
 }
 
 func NewGetSuspectBlobPoolsSpectraS3Response(webResponse WebResponse) (*GetSuspectBlobPoolsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSuspectBlobPoolsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSuspectBlobPoolsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSuspectBlobS3TargetsSpectraS3Response struct {
-    SuspectBlobS3TargetList SuspectBlobS3TargetList
-    Headers *http.Header
+	SuspectBlobS3TargetList SuspectBlobS3TargetList
+	Headers                 *http.Header
 }
 
 func (getSuspectBlobS3TargetsSpectraS3Response *GetSuspectBlobS3TargetsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSuspectBlobS3TargetsSpectraS3Response.SuspectBlobS3TargetList)
+	return parseResponsePayload(webResponse, &getSuspectBlobS3TargetsSpectraS3Response.SuspectBlobS3TargetList)
 }
 
 func NewGetSuspectBlobS3TargetsSpectraS3Response(webResponse WebResponse) (*GetSuspectBlobS3TargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSuspectBlobS3TargetsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSuspectBlobS3TargetsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSuspectBlobTapesSpectraS3Response struct {
-    SuspectBlobTapeList SuspectBlobTapeList
-    Headers *http.Header
+	SuspectBlobTapeList SuspectBlobTapeList
+	Headers             *http.Header
 }
 
 func (getSuspectBlobTapesSpectraS3Response *GetSuspectBlobTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSuspectBlobTapesSpectraS3Response.SuspectBlobTapeList)
+	return parseResponsePayload(webResponse, &getSuspectBlobTapesSpectraS3Response.SuspectBlobTapeList)
 }
 
 func NewGetSuspectBlobTapesSpectraS3Response(webResponse WebResponse) (*GetSuspectBlobTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSuspectBlobTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSuspectBlobTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSuspectBucketsSpectraS3Response struct {
-    BucketList BucketList
-    Headers *http.Header
+	BucketList BucketList
+	Headers    *http.Header
 }
 
 func (getSuspectBucketsSpectraS3Response *GetSuspectBucketsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSuspectBucketsSpectraS3Response.BucketList)
+	return parseResponsePayload(webResponse, &getSuspectBucketsSpectraS3Response.BucketList)
 }
 
 func NewGetSuspectBucketsSpectraS3Response(webResponse WebResponse) (*GetSuspectBucketsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSuspectBucketsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSuspectBucketsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSuspectObjectsSpectraS3Response struct {
-    S3ObjectList S3ObjectList
-    Headers *http.Header
+	S3ObjectList S3ObjectList
+	Headers      *http.Header
 }
 
 func (getSuspectObjectsSpectraS3Response *GetSuspectObjectsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSuspectObjectsSpectraS3Response.S3ObjectList)
+	return parseResponsePayload(webResponse, &getSuspectObjectsSpectraS3Response.S3ObjectList)
 }
 
 func NewGetSuspectObjectsSpectraS3Response(webResponse WebResponse) (*GetSuspectObjectsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSuspectObjectsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSuspectObjectsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSuspectObjectsWithFullDetailsSpectraS3Response struct {
-    BulkObjectList BulkObjectList
-    Headers *http.Header
+	BulkObjectList BulkObjectList
+	Headers        *http.Header
 }
 
 func (getSuspectObjectsWithFullDetailsSpectraS3Response *GetSuspectObjectsWithFullDetailsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSuspectObjectsWithFullDetailsSpectraS3Response.BulkObjectList)
+	return parseResponsePayload(webResponse, &getSuspectObjectsWithFullDetailsSpectraS3Response.BulkObjectList)
 }
 
 func NewGetSuspectObjectsWithFullDetailsSpectraS3Response(webResponse WebResponse) (*GetSuspectObjectsWithFullDetailsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSuspectObjectsWithFullDetailsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSuspectObjectsWithFullDetailsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewMarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response(webResponse WebResponse) (*MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewMarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response(webResponse WebResponse) (*MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type MarkSuspectBlobPoolsAsDegradedSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewMarkSuspectBlobPoolsAsDegradedSpectraS3Response(webResponse WebResponse) (*MarkSuspectBlobPoolsAsDegradedSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &MarkSuspectBlobPoolsAsDegradedSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &MarkSuspectBlobPoolsAsDegradedSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type MarkSuspectBlobS3TargetsAsDegradedSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewMarkSuspectBlobS3TargetsAsDegradedSpectraS3Response(webResponse WebResponse) (*MarkSuspectBlobS3TargetsAsDegradedSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &MarkSuspectBlobS3TargetsAsDegradedSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &MarkSuspectBlobS3TargetsAsDegradedSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type MarkSuspectBlobTapesAsDegradedSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewMarkSuspectBlobTapesAsDegradedSpectraS3Response(webResponse WebResponse) (*MarkSuspectBlobTapesAsDegradedSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &MarkSuspectBlobTapesAsDegradedSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &MarkSuspectBlobTapesAsDegradedSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutGroupGroupMemberSpectraS3Response struct {
-    GroupMember GroupMember
-    Headers *http.Header
+	GroupMember GroupMember
+	Headers     *http.Header
 }
 
 func (putGroupGroupMemberSpectraS3Response *PutGroupGroupMemberSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putGroupGroupMemberSpectraS3Response.GroupMember)
+	return parseResponsePayload(webResponse, &putGroupGroupMemberSpectraS3Response.GroupMember)
 }
 
 func NewPutGroupGroupMemberSpectraS3Response(webResponse WebResponse) (*PutGroupGroupMemberSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutGroupGroupMemberSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutGroupGroupMemberSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutGroupSpectraS3Response struct {
-    Group Group
-    Headers *http.Header
+	Group   Group
+	Headers *http.Header
 }
 
 func (putGroupSpectraS3Response *PutGroupSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putGroupSpectraS3Response.Group)
+	return parseResponsePayload(webResponse, &putGroupSpectraS3Response.Group)
 }
 
 func NewPutGroupSpectraS3Response(webResponse WebResponse) (*PutGroupSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutGroupSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutGroupSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutUserGroupMemberSpectraS3Response struct {
-    GroupMember GroupMember
-    Headers *http.Header
+	GroupMember GroupMember
+	Headers     *http.Header
 }
 
 func (putUserGroupMemberSpectraS3Response *PutUserGroupMemberSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putUserGroupMemberSpectraS3Response.GroupMember)
+	return parseResponsePayload(webResponse, &putUserGroupMemberSpectraS3Response.GroupMember)
 }
 
 func NewPutUserGroupMemberSpectraS3Response(webResponse WebResponse) (*PutUserGroupMemberSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutUserGroupMemberSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutUserGroupMemberSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteGroupMemberSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteGroupMemberSpectraS3Response(webResponse WebResponse) (*DeleteGroupMemberSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteGroupMemberSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteGroupMemberSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteGroupSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteGroupSpectraS3Response(webResponse WebResponse) (*DeleteGroupSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteGroupSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteGroupSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetGroupMemberSpectraS3Response struct {
-    GroupMember GroupMember
-    Headers *http.Header
+	GroupMember GroupMember
+	Headers     *http.Header
 }
 
 func (getGroupMemberSpectraS3Response *GetGroupMemberSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getGroupMemberSpectraS3Response.GroupMember)
+	return parseResponsePayload(webResponse, &getGroupMemberSpectraS3Response.GroupMember)
 }
 
 func NewGetGroupMemberSpectraS3Response(webResponse WebResponse) (*GetGroupMemberSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetGroupMemberSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetGroupMemberSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetGroupMembersSpectraS3Response struct {
-    GroupMemberList GroupMemberList
-    Headers *http.Header
+	GroupMemberList GroupMemberList
+	Headers         *http.Header
 }
 
 func (getGroupMembersSpectraS3Response *GetGroupMembersSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getGroupMembersSpectraS3Response.GroupMemberList)
+	return parseResponsePayload(webResponse, &getGroupMembersSpectraS3Response.GroupMemberList)
 }
 
 func NewGetGroupMembersSpectraS3Response(webResponse WebResponse) (*GetGroupMembersSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetGroupMembersSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetGroupMembersSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetGroupSpectraS3Response struct {
-    Group Group
-    Headers *http.Header
+	Group   Group
+	Headers *http.Header
 }
 
 func (getGroupSpectraS3Response *GetGroupSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getGroupSpectraS3Response.Group)
+	return parseResponsePayload(webResponse, &getGroupSpectraS3Response.Group)
 }
 
 func NewGetGroupSpectraS3Response(webResponse WebResponse) (*GetGroupSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetGroupSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetGroupSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetGroupsSpectraS3Response struct {
-    GroupList GroupList
-    Headers *http.Header
+	GroupList GroupList
+	Headers   *http.Header
 }
 
 func (getGroupsSpectraS3Response *GetGroupsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getGroupsSpectraS3Response.GroupList)
+	return parseResponsePayload(webResponse, &getGroupsSpectraS3Response.GroupList)
 }
 
 func NewGetGroupsSpectraS3Response(webResponse WebResponse) (*GetGroupsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetGroupsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetGroupsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyGroupSpectraS3Response struct {
-    Group Group
-    Headers *http.Header
+	Group   Group
+	Headers *http.Header
 }
 
 func (modifyGroupSpectraS3Response *ModifyGroupSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyGroupSpectraS3Response.Group)
+	return parseResponsePayload(webResponse, &modifyGroupSpectraS3Response.Group)
 }
 
 func NewModifyGroupSpectraS3Response(webResponse WebResponse) (*ModifyGroupSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyGroupSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyGroupSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifyUserIsMemberOfGroupSpectraS3Response struct {
-    Group *Group
-    Headers *http.Header
+	Group   *Group
+	Headers *http.Header
 }
 
 func (verifyUserIsMemberOfGroupSpectraS3Response *VerifyUserIsMemberOfGroupSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, verifyUserIsMemberOfGroupSpectraS3Response.Group)
+	return parseResponsePayload(webResponse, verifyUserIsMemberOfGroupSpectraS3Response.Group)
 }
 
 func NewVerifyUserIsMemberOfGroupSpectraS3Response(webResponse WebResponse) (*VerifyUserIsMemberOfGroupSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200, 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200, 204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body VerifyUserIsMemberOfGroupSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    case 204:
-        return &VerifyUserIsMemberOfGroupSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body VerifyUserIsMemberOfGroupSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	case 204:
+		return &VerifyUserIsMemberOfGroupSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type AllocateJobChunkSpectraS3Response struct {
-    Objects Objects
-    Headers *http.Header
+	Objects Objects
+	Headers *http.Header
 }
 
 func (allocateJobChunkSpectraS3Response *AllocateJobChunkSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &allocateJobChunkSpectraS3Response.Objects)
+	return parseResponsePayload(webResponse, &allocateJobChunkSpectraS3Response.Objects)
 }
 
 func NewAllocateJobChunkSpectraS3Response(webResponse WebResponse) (*AllocateJobChunkSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body AllocateJobChunkSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body AllocateJobChunkSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelActiveJobSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewCancelActiveJobSpectraS3Response(webResponse WebResponse) (*CancelActiveJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CancelActiveJobSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CancelActiveJobSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelAllActiveJobsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewCancelAllActiveJobsSpectraS3Response(webResponse WebResponse) (*CancelAllActiveJobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CancelAllActiveJobsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CancelAllActiveJobsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelAllJobsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewCancelAllJobsSpectraS3Response(webResponse WebResponse) (*CancelAllJobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CancelAllJobsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CancelAllJobsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelJobSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewCancelJobSpectraS3Response(webResponse WebResponse) (*CancelJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CancelJobSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CancelJobSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ClearAllCanceledJobsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewClearAllCanceledJobsSpectraS3Response(webResponse WebResponse) (*ClearAllCanceledJobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ClearAllCanceledJobsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ClearAllCanceledJobsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ClearAllCompletedJobsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewClearAllCompletedJobsSpectraS3Response(webResponse WebResponse) (*ClearAllCompletedJobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ClearAllCompletedJobsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ClearAllCompletedJobsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CloseAggregatingJobSpectraS3Response struct {
-    MasterObjectList MasterObjectList
-    Headers *http.Header
+	MasterObjectList MasterObjectList
+	Headers          *http.Header
 }
 
 func (closeAggregatingJobSpectraS3Response *CloseAggregatingJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &closeAggregatingJobSpectraS3Response.MasterObjectList)
+	return parseResponsePayload(webResponse, &closeAggregatingJobSpectraS3Response.MasterObjectList)
 }
 
 func NewCloseAggregatingJobSpectraS3Response(webResponse WebResponse) (*CloseAggregatingJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CloseAggregatingJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CloseAggregatingJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBulkJobSpectraS3Response struct {
-    MasterObjectList MasterObjectList
-    Headers *http.Header
+	MasterObjectList MasterObjectList
+	Headers          *http.Header
 }
 
 func (getBulkJobSpectraS3Response *GetBulkJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBulkJobSpectraS3Response.MasterObjectList)
+	return parseResponsePayload(webResponse, &getBulkJobSpectraS3Response.MasterObjectList)
 }
 
 func NewGetBulkJobSpectraS3Response(webResponse WebResponse) (*GetBulkJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBulkJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBulkJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutBulkJobSpectraS3Response struct {
-    MasterObjectList MasterObjectList
-    Headers *http.Header
+	MasterObjectList MasterObjectList
+	Headers          *http.Header
 }
 
 func (putBulkJobSpectraS3Response *PutBulkJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putBulkJobSpectraS3Response.MasterObjectList)
+	return parseResponsePayload(webResponse, &putBulkJobSpectraS3Response.MasterObjectList)
 }
 
 func NewPutBulkJobSpectraS3Response(webResponse WebResponse) (*PutBulkJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body PutBulkJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body PutBulkJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifyBulkJobSpectraS3Response struct {
-    MasterObjectList MasterObjectList
-    Headers *http.Header
+	MasterObjectList MasterObjectList
+	Headers          *http.Header
 }
 
 func (verifyBulkJobSpectraS3Response *VerifyBulkJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &verifyBulkJobSpectraS3Response.MasterObjectList)
+	return parseResponsePayload(webResponse, &verifyBulkJobSpectraS3Response.MasterObjectList)
 }
 
 func NewVerifyBulkJobSpectraS3Response(webResponse WebResponse) (*VerifyBulkJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body VerifyBulkJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body VerifyBulkJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteJobCreationFailureSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteJobCreationFailureSpectraS3Response(webResponse WebResponse) (*DeleteJobCreationFailureSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteJobCreationFailureSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteJobCreationFailureSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetActiveJobSpectraS3Response struct {
-    ActiveJob ActiveJob
-    Headers *http.Header
+	ActiveJob ActiveJob
+	Headers   *http.Header
 }
 
 func (getActiveJobSpectraS3Response *GetActiveJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getActiveJobSpectraS3Response.ActiveJob)
+	return parseResponsePayload(webResponse, &getActiveJobSpectraS3Response.ActiveJob)
 }
 
 func NewGetActiveJobSpectraS3Response(webResponse WebResponse) (*GetActiveJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetActiveJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetActiveJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetActiveJobsSpectraS3Response struct {
-    ActiveJobList ActiveJobList
-    Headers *http.Header
+	ActiveJobList ActiveJobList
+	Headers       *http.Header
 }
 
 func (getActiveJobsSpectraS3Response *GetActiveJobsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getActiveJobsSpectraS3Response.ActiveJobList)
+	return parseResponsePayload(webResponse, &getActiveJobsSpectraS3Response.ActiveJobList)
 }
 
 func NewGetActiveJobsSpectraS3Response(webResponse WebResponse) (*GetActiveJobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetActiveJobsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetActiveJobsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetCanceledJobSpectraS3Response struct {
-    CanceledJob CanceledJob
-    Headers *http.Header
+	CanceledJob CanceledJob
+	Headers     *http.Header
 }
 
 func (getCanceledJobSpectraS3Response *GetCanceledJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getCanceledJobSpectraS3Response.CanceledJob)
+	return parseResponsePayload(webResponse, &getCanceledJobSpectraS3Response.CanceledJob)
 }
 
 func NewGetCanceledJobSpectraS3Response(webResponse WebResponse) (*GetCanceledJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetCanceledJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetCanceledJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetCanceledJobsSpectraS3Response struct {
-    CanceledJobList CanceledJobList
-    Headers *http.Header
+	CanceledJobList CanceledJobList
+	Headers         *http.Header
 }
 
 func (getCanceledJobsSpectraS3Response *GetCanceledJobsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getCanceledJobsSpectraS3Response.CanceledJobList)
+	return parseResponsePayload(webResponse, &getCanceledJobsSpectraS3Response.CanceledJobList)
 }
 
 func NewGetCanceledJobsSpectraS3Response(webResponse WebResponse) (*GetCanceledJobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetCanceledJobsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetCanceledJobsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetCompletedJobSpectraS3Response struct {
-    CompletedJob CompletedJob
-    Headers *http.Header
+	CompletedJob CompletedJob
+	Headers      *http.Header
 }
 
 func (getCompletedJobSpectraS3Response *GetCompletedJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getCompletedJobSpectraS3Response.CompletedJob)
+	return parseResponsePayload(webResponse, &getCompletedJobSpectraS3Response.CompletedJob)
 }
 
 func NewGetCompletedJobSpectraS3Response(webResponse WebResponse) (*GetCompletedJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetCompletedJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetCompletedJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetCompletedJobsSpectraS3Response struct {
-    CompletedJobList CompletedJobList
-    Headers *http.Header
+	CompletedJobList CompletedJobList
+	Headers          *http.Header
 }
 
 func (getCompletedJobsSpectraS3Response *GetCompletedJobsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getCompletedJobsSpectraS3Response.CompletedJobList)
+	return parseResponsePayload(webResponse, &getCompletedJobsSpectraS3Response.CompletedJobList)
 }
 
 func NewGetCompletedJobsSpectraS3Response(webResponse WebResponse) (*GetCompletedJobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetCompletedJobsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetCompletedJobsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobChunkDaoSpectraS3Response struct {
-    JobChunk JobChunk
-    Headers *http.Header
+	JobChunk JobChunk
+	Headers  *http.Header
 }
 
 func (getJobChunkDaoSpectraS3Response *GetJobChunkDaoSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobChunkDaoSpectraS3Response.JobChunk)
+	return parseResponsePayload(webResponse, &getJobChunkDaoSpectraS3Response.JobChunk)
 }
 
 func NewGetJobChunkDaoSpectraS3Response(webResponse WebResponse) (*GetJobChunkDaoSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobChunkDaoSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobChunkDaoSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobChunkSpectraS3Response struct {
-    Objects Objects
-    Headers *http.Header
+	Objects Objects
+	Headers *http.Header
 }
 
 func (getJobChunkSpectraS3Response *GetJobChunkSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobChunkSpectraS3Response.Objects)
+	return parseResponsePayload(webResponse, &getJobChunkSpectraS3Response.Objects)
 }
 
 func NewGetJobChunkSpectraS3Response(webResponse WebResponse) (*GetJobChunkSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobChunkSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobChunkSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobChunksReadyForClientProcessingSpectraS3Response struct {
-    MasterObjectList MasterObjectList
-    Headers *http.Header
+	MasterObjectList MasterObjectList
+	Headers          *http.Header
 }
 
 func (getJobChunksReadyForClientProcessingSpectraS3Response *GetJobChunksReadyForClientProcessingSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobChunksReadyForClientProcessingSpectraS3Response.MasterObjectList)
+	return parseResponsePayload(webResponse, &getJobChunksReadyForClientProcessingSpectraS3Response.MasterObjectList)
 }
 
 func NewGetJobChunksReadyForClientProcessingSpectraS3Response(webResponse WebResponse) (*GetJobChunksReadyForClientProcessingSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobChunksReadyForClientProcessingSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobChunksReadyForClientProcessingSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobCreationFailuresSpectraS3Response struct {
-    JobCreationFailedList JobCreationFailedList
-    Headers *http.Header
+	JobCreationFailedList JobCreationFailedList
+	Headers               *http.Header
 }
 
 func (getJobCreationFailuresSpectraS3Response *GetJobCreationFailuresSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobCreationFailuresSpectraS3Response.JobCreationFailedList)
+	return parseResponsePayload(webResponse, &getJobCreationFailuresSpectraS3Response.JobCreationFailedList)
 }
 
 func NewGetJobCreationFailuresSpectraS3Response(webResponse WebResponse) (*GetJobCreationFailuresSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobCreationFailuresSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobCreationFailuresSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobSpectraS3Response struct {
-    MasterObjectList MasterObjectList
-    Headers *http.Header
+	MasterObjectList MasterObjectList
+	Headers          *http.Header
 }
 
 func (getJobSpectraS3Response *GetJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobSpectraS3Response.MasterObjectList)
+	return parseResponsePayload(webResponse, &getJobSpectraS3Response.MasterObjectList)
 }
 
 func NewGetJobSpectraS3Response(webResponse WebResponse) (*GetJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobToReplicateSpectraS3Response struct {
-    Content string
-    Headers *http.Header
+	Content string
+	Headers *http.Header
 }
 
-
-
 func NewGetJobToReplicateSpectraS3Response(webResponse WebResponse) (*GetJobToReplicateSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        content, err := getResponseBodyAsString(webResponse)
-        if err != nil {
-            return nil, err
-        }
-        return &GetJobToReplicateSpectraS3Response{Content: content, Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		content, err := getResponseBodyAsString(webResponse)
+		if err != nil {
+			return nil, err
+		}
+		return &GetJobToReplicateSpectraS3Response{Content: content, Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobsSpectraS3Response struct {
-    JobList JobList
-    Headers *http.Header
+	JobList JobList
+	Headers *http.Header
 }
 
 func (getJobsSpectraS3Response *GetJobsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobsSpectraS3Response.JobList)
+	return parseResponsePayload(webResponse, &getJobsSpectraS3Response.JobList)
 }
 
 func NewGetJobsSpectraS3Response(webResponse WebResponse) (*GetJobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyActiveJobSpectraS3Response struct {
-    MasterObjectList MasterObjectList
-    Headers *http.Header
+	MasterObjectList MasterObjectList
+	Headers          *http.Header
 }
 
 func (modifyActiveJobSpectraS3Response *ModifyActiveJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyActiveJobSpectraS3Response.MasterObjectList)
+	return parseResponsePayload(webResponse, &modifyActiveJobSpectraS3Response.MasterObjectList)
 }
 
 func NewModifyActiveJobSpectraS3Response(webResponse WebResponse) (*ModifyActiveJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyActiveJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyActiveJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyJobSpectraS3Response struct {
-    MasterObjectList MasterObjectList
-    Headers *http.Header
+	MasterObjectList MasterObjectList
+	Headers          *http.Header
 }
 
 func (modifyJobSpectraS3Response *ModifyJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyJobSpectraS3Response.MasterObjectList)
+	return parseResponsePayload(webResponse, &modifyJobSpectraS3Response.MasterObjectList)
 }
 
 func NewModifyJobSpectraS3Response(webResponse WebResponse) (*ModifyJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ReplicatePutJobSpectraS3Response struct {
-    MasterObjectList *MasterObjectList
-    Headers *http.Header
+	MasterObjectList *MasterObjectList
+	Headers          *http.Header
 }
 
 func (replicatePutJobSpectraS3Response *ReplicatePutJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, replicatePutJobSpectraS3Response.MasterObjectList)
+	return parseResponsePayload(webResponse, replicatePutJobSpectraS3Response.MasterObjectList)
 }
 
 func NewReplicatePutJobSpectraS3Response(webResponse WebResponse) (*ReplicatePutJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200, 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200, 204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ReplicatePutJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    case 204:
-        return &ReplicatePutJobSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ReplicatePutJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	case 204:
+		return &ReplicatePutJobSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type StageObjectsJobSpectraS3Response struct {
-    MasterObjectList MasterObjectList
-    Headers *http.Header
+	MasterObjectList MasterObjectList
+	Headers          *http.Header
 }
 
 func (stageObjectsJobSpectraS3Response *StageObjectsJobSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &stageObjectsJobSpectraS3Response.MasterObjectList)
+	return parseResponsePayload(webResponse, &stageObjectsJobSpectraS3Response.MasterObjectList)
 }
 
 func NewStageObjectsJobSpectraS3Response(webResponse WebResponse) (*StageObjectsJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body StageObjectsJobSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body StageObjectsJobSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type TruncateActiveJobSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewTruncateActiveJobSpectraS3Response(webResponse WebResponse) (*TruncateActiveJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &TruncateActiveJobSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &TruncateActiveJobSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type TruncateAllActiveJobsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewTruncateAllActiveJobsSpectraS3Response(webResponse WebResponse) (*TruncateAllActiveJobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &TruncateAllActiveJobsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &TruncateAllActiveJobsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type TruncateAllJobsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewTruncateAllJobsSpectraS3Response(webResponse WebResponse) (*TruncateAllJobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &TruncateAllJobsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &TruncateAllJobsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type TruncateJobSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewTruncateJobSpectraS3Response(webResponse WebResponse) (*TruncateJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &TruncateJobSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &TruncateJobSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifySafeToCreatePutJobSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewVerifySafeToCreatePutJobSpectraS3Response(webResponse WebResponse) (*VerifySafeToCreatePutJobSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        return &VerifySafeToCreatePutJobSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		return &VerifySafeToCreatePutJobSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetNodeSpectraS3Response struct {
-    Node Node
-    Headers *http.Header
+	Node    Node
+	Headers *http.Header
 }
 
 func (getNodeSpectraS3Response *GetNodeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getNodeSpectraS3Response.Node)
+	return parseResponsePayload(webResponse, &getNodeSpectraS3Response.Node)
 }
 
 func NewGetNodeSpectraS3Response(webResponse WebResponse) (*GetNodeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetNodeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetNodeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetNodesSpectraS3Response struct {
-    NodeList NodeList
-    Headers *http.Header
+	NodeList NodeList
+	Headers  *http.Header
 }
 
 func (getNodesSpectraS3Response *GetNodesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getNodesSpectraS3Response.NodeList)
+	return parseResponsePayload(webResponse, &getNodesSpectraS3Response.NodeList)
 }
 
 func NewGetNodesSpectraS3Response(webResponse WebResponse) (*GetNodesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetNodesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetNodesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyNodeSpectraS3Response struct {
-    Node Node
-    Headers *http.Header
+	Node    Node
+	Headers *http.Header
 }
 
 func (modifyNodeSpectraS3Response *ModifyNodeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyNodeSpectraS3Response.Node)
+	return parseResponsePayload(webResponse, &modifyNodeSpectraS3Response.Node)
 }
 
 func NewModifyNodeSpectraS3Response(webResponse WebResponse) (*ModifyNodeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyNodeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyNodeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutAzureTargetFailureNotificationRegistrationSpectraS3Response struct {
-    AzureTargetFailureNotificationRegistration AzureTargetFailureNotificationRegistration
-    Headers *http.Header
+	AzureTargetFailureNotificationRegistration AzureTargetFailureNotificationRegistration
+	Headers                                    *http.Header
 }
 
 func (putAzureTargetFailureNotificationRegistrationSpectraS3Response *PutAzureTargetFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putAzureTargetFailureNotificationRegistrationSpectraS3Response.AzureTargetFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &putAzureTargetFailureNotificationRegistrationSpectraS3Response.AzureTargetFailureNotificationRegistration)
 }
 
 func NewPutAzureTargetFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutAzureTargetFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutAzureTargetFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutBucketChangesNotificationRegistrationSpectraS3Response struct {
-    BucketChangesNotificationRegistration BucketChangesNotificationRegistration
-    Headers *http.Header
+	BucketChangesNotificationRegistration BucketChangesNotificationRegistration
+	Headers                               *http.Header
 }
 
 func (putBucketChangesNotificationRegistrationSpectraS3Response *PutBucketChangesNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putBucketChangesNotificationRegistrationSpectraS3Response.BucketChangesNotificationRegistration)
+	return parseResponsePayload(webResponse, &putBucketChangesNotificationRegistrationSpectraS3Response.BucketChangesNotificationRegistration)
 }
 
 func NewPutBucketChangesNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutBucketChangesNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutBucketChangesNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutBucketChangesNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutDs3TargetFailureNotificationRegistrationSpectraS3Response struct {
-    Ds3TargetFailureNotificationRegistration Ds3TargetFailureNotificationRegistration
-    Headers *http.Header
+	Ds3TargetFailureNotificationRegistration Ds3TargetFailureNotificationRegistration
+	Headers                                  *http.Header
 }
 
 func (putDs3TargetFailureNotificationRegistrationSpectraS3Response *PutDs3TargetFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putDs3TargetFailureNotificationRegistrationSpectraS3Response.Ds3TargetFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &putDs3TargetFailureNotificationRegistrationSpectraS3Response.Ds3TargetFailureNotificationRegistration)
 }
 
 func NewPutDs3TargetFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutDs3TargetFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutDs3TargetFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutJobCompletedNotificationRegistrationSpectraS3Response struct {
-    JobCompletedNotificationRegistration JobCompletedNotificationRegistration
-    Headers *http.Header
+	JobCompletedNotificationRegistration JobCompletedNotificationRegistration
+	Headers                              *http.Header
 }
 
 func (putJobCompletedNotificationRegistrationSpectraS3Response *PutJobCompletedNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putJobCompletedNotificationRegistrationSpectraS3Response.JobCompletedNotificationRegistration)
+	return parseResponsePayload(webResponse, &putJobCompletedNotificationRegistrationSpectraS3Response.JobCompletedNotificationRegistration)
 }
 
 func NewPutJobCompletedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutJobCompletedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutJobCompletedNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutJobCompletedNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutJobCreatedNotificationRegistrationSpectraS3Response struct {
-    JobCreatedNotificationRegistration JobCreatedNotificationRegistration
-    Headers *http.Header
+	JobCreatedNotificationRegistration JobCreatedNotificationRegistration
+	Headers                            *http.Header
 }
 
 func (putJobCreatedNotificationRegistrationSpectraS3Response *PutJobCreatedNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putJobCreatedNotificationRegistrationSpectraS3Response.JobCreatedNotificationRegistration)
+	return parseResponsePayload(webResponse, &putJobCreatedNotificationRegistrationSpectraS3Response.JobCreatedNotificationRegistration)
 }
 
 func NewPutJobCreatedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutJobCreatedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutJobCreatedNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutJobCreatedNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutJobCreationFailedNotificationRegistrationSpectraS3Response struct {
-    JobCreationFailedNotificationRegistration JobCreationFailedNotificationRegistration
-    Headers *http.Header
+	JobCreationFailedNotificationRegistration JobCreationFailedNotificationRegistration
+	Headers                                   *http.Header
 }
 
 func (putJobCreationFailedNotificationRegistrationSpectraS3Response *PutJobCreationFailedNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putJobCreationFailedNotificationRegistrationSpectraS3Response.JobCreationFailedNotificationRegistration)
+	return parseResponsePayload(webResponse, &putJobCreationFailedNotificationRegistrationSpectraS3Response.JobCreationFailedNotificationRegistration)
 }
 
 func NewPutJobCreationFailedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutJobCreationFailedNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutJobCreationFailedNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutObjectCachedNotificationRegistrationSpectraS3Response struct {
-    S3ObjectCachedNotificationRegistration S3ObjectCachedNotificationRegistration
-    Headers *http.Header
+	S3ObjectCachedNotificationRegistration S3ObjectCachedNotificationRegistration
+	Headers                                *http.Header
 }
 
 func (putObjectCachedNotificationRegistrationSpectraS3Response *PutObjectCachedNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putObjectCachedNotificationRegistrationSpectraS3Response.S3ObjectCachedNotificationRegistration)
+	return parseResponsePayload(webResponse, &putObjectCachedNotificationRegistrationSpectraS3Response.S3ObjectCachedNotificationRegistration)
 }
 
 func NewPutObjectCachedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutObjectCachedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutObjectCachedNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutObjectCachedNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutObjectLostNotificationRegistrationSpectraS3Response struct {
-    S3ObjectLostNotificationRegistration S3ObjectLostNotificationRegistration
-    Headers *http.Header
+	S3ObjectLostNotificationRegistration S3ObjectLostNotificationRegistration
+	Headers                              *http.Header
 }
 
 func (putObjectLostNotificationRegistrationSpectraS3Response *PutObjectLostNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putObjectLostNotificationRegistrationSpectraS3Response.S3ObjectLostNotificationRegistration)
+	return parseResponsePayload(webResponse, &putObjectLostNotificationRegistrationSpectraS3Response.S3ObjectLostNotificationRegistration)
 }
 
 func NewPutObjectLostNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutObjectLostNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutObjectLostNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutObjectLostNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutObjectPersistedNotificationRegistrationSpectraS3Response struct {
-    S3ObjectPersistedNotificationRegistration S3ObjectPersistedNotificationRegistration
-    Headers *http.Header
+	S3ObjectPersistedNotificationRegistration S3ObjectPersistedNotificationRegistration
+	Headers                                   *http.Header
 }
 
 func (putObjectPersistedNotificationRegistrationSpectraS3Response *PutObjectPersistedNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putObjectPersistedNotificationRegistrationSpectraS3Response.S3ObjectPersistedNotificationRegistration)
+	return parseResponsePayload(webResponse, &putObjectPersistedNotificationRegistrationSpectraS3Response.S3ObjectPersistedNotificationRegistration)
 }
 
 func NewPutObjectPersistedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutObjectPersistedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutObjectPersistedNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutObjectPersistedNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutPoolFailureNotificationRegistrationSpectraS3Response struct {
-    PoolFailureNotificationRegistration PoolFailureNotificationRegistration
-    Headers *http.Header
+	PoolFailureNotificationRegistration PoolFailureNotificationRegistration
+	Headers                             *http.Header
 }
 
 func (putPoolFailureNotificationRegistrationSpectraS3Response *PutPoolFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putPoolFailureNotificationRegistrationSpectraS3Response.PoolFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &putPoolFailureNotificationRegistrationSpectraS3Response.PoolFailureNotificationRegistration)
 }
 
 func NewPutPoolFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutPoolFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutPoolFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutPoolFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutS3TargetFailureNotificationRegistrationSpectraS3Response struct {
-    S3TargetFailureNotificationRegistration S3TargetFailureNotificationRegistration
-    Headers *http.Header
+	S3TargetFailureNotificationRegistration S3TargetFailureNotificationRegistration
+	Headers                                 *http.Header
 }
 
 func (putS3TargetFailureNotificationRegistrationSpectraS3Response *PutS3TargetFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putS3TargetFailureNotificationRegistrationSpectraS3Response.S3TargetFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &putS3TargetFailureNotificationRegistrationSpectraS3Response.S3TargetFailureNotificationRegistration)
 }
 
 func NewPutS3TargetFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutS3TargetFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutS3TargetFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutStorageDomainFailureNotificationRegistrationSpectraS3Response struct {
-    StorageDomainFailureNotificationRegistration StorageDomainFailureNotificationRegistration
-    Headers *http.Header
+	StorageDomainFailureNotificationRegistration StorageDomainFailureNotificationRegistration
+	Headers                                      *http.Header
 }
 
 func (putStorageDomainFailureNotificationRegistrationSpectraS3Response *PutStorageDomainFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putStorageDomainFailureNotificationRegistrationSpectraS3Response.StorageDomainFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &putStorageDomainFailureNotificationRegistrationSpectraS3Response.StorageDomainFailureNotificationRegistration)
 }
 
 func NewPutStorageDomainFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutStorageDomainFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutStorageDomainFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutSystemFailureNotificationRegistrationSpectraS3Response struct {
-    SystemFailureNotificationRegistration SystemFailureNotificationRegistration
-    Headers *http.Header
+	SystemFailureNotificationRegistration SystemFailureNotificationRegistration
+	Headers                               *http.Header
 }
 
 func (putSystemFailureNotificationRegistrationSpectraS3Response *PutSystemFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putSystemFailureNotificationRegistrationSpectraS3Response.SystemFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &putSystemFailureNotificationRegistrationSpectraS3Response.SystemFailureNotificationRegistration)
 }
 
 func NewPutSystemFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutSystemFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutSystemFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutSystemFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutTapeFailureNotificationRegistrationSpectraS3Response struct {
-    TapeFailureNotificationRegistration TapeFailureNotificationRegistration
-    Headers *http.Header
+	TapeFailureNotificationRegistration TapeFailureNotificationRegistration
+	Headers                             *http.Header
 }
 
 func (putTapeFailureNotificationRegistrationSpectraS3Response *PutTapeFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putTapeFailureNotificationRegistrationSpectraS3Response.TapeFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &putTapeFailureNotificationRegistrationSpectraS3Response.TapeFailureNotificationRegistration)
 }
 
 func NewPutTapeFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutTapeFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutTapeFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutTapeFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutTapePartitionFailureNotificationRegistrationSpectraS3Response struct {
-    TapePartitionFailureNotificationRegistration TapePartitionFailureNotificationRegistration
-    Headers *http.Header
+	TapePartitionFailureNotificationRegistration TapePartitionFailureNotificationRegistration
+	Headers                                      *http.Header
 }
 
 func (putTapePartitionFailureNotificationRegistrationSpectraS3Response *PutTapePartitionFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putTapePartitionFailureNotificationRegistrationSpectraS3Response.TapePartitionFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &putTapePartitionFailureNotificationRegistrationSpectraS3Response.TapePartitionFailureNotificationRegistration)
 }
 
 func NewPutTapePartitionFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*PutTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutTapePartitionFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutTapePartitionFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteAzureTargetFailureNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteAzureTargetFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteAzureTargetFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteAzureTargetFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteBucketChangesNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteBucketChangesNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteBucketChangesNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteBucketChangesNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteBucketChangesNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteDs3TargetFailureNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteDs3TargetFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteDs3TargetFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteDs3TargetFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteJobCompletedNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteJobCompletedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteJobCompletedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteJobCompletedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteJobCompletedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteJobCreatedNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteJobCreatedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteJobCreatedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteJobCreatedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteJobCreationFailedNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteJobCreationFailedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteJobCreationFailedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteJobCreationFailedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteObjectCachedNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteObjectCachedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteObjectCachedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteObjectCachedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteObjectCachedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteObjectLostNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteObjectLostNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteObjectLostNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteObjectLostNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteObjectLostNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteObjectPersistedNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteObjectPersistedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteObjectPersistedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteObjectPersistedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteObjectPersistedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeletePoolFailureNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeletePoolFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeletePoolFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeletePoolFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeletePoolFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteS3TargetFailureNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteS3TargetFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteS3TargetFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteS3TargetFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteStorageDomainFailureNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteStorageDomainFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteStorageDomainFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteStorageDomainFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteSystemFailureNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteSystemFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteSystemFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteSystemFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteSystemFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteTapeFailureNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteTapeFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteTapeFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteTapeFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteTapeFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteTapePartitionFailureNotificationRegistrationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteTapePartitionFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteTapePartitionFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteTapePartitionFailureNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetAzureTargetFailureNotificationRegistrationSpectraS3Response struct {
-    AzureTargetFailureNotificationRegistration AzureTargetFailureNotificationRegistration
-    Headers *http.Header
+	AzureTargetFailureNotificationRegistration AzureTargetFailureNotificationRegistration
+	Headers                                    *http.Header
 }
 
 func (getAzureTargetFailureNotificationRegistrationSpectraS3Response *GetAzureTargetFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getAzureTargetFailureNotificationRegistrationSpectraS3Response.AzureTargetFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &getAzureTargetFailureNotificationRegistrationSpectraS3Response.AzureTargetFailureNotificationRegistration)
 }
 
 func NewGetAzureTargetFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetAzureTargetFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetAzureTargetFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetAzureTargetFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetAzureTargetFailureNotificationRegistrationsSpectraS3Response struct {
-    AzureTargetFailureNotificationRegistrationList AzureTargetFailureNotificationRegistrationList
-    Headers *http.Header
+	AzureTargetFailureNotificationRegistrationList AzureTargetFailureNotificationRegistrationList
+	Headers                                        *http.Header
 }
 
 func (getAzureTargetFailureNotificationRegistrationsSpectraS3Response *GetAzureTargetFailureNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getAzureTargetFailureNotificationRegistrationsSpectraS3Response.AzureTargetFailureNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getAzureTargetFailureNotificationRegistrationsSpectraS3Response.AzureTargetFailureNotificationRegistrationList)
 }
 
 func NewGetAzureTargetFailureNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetAzureTargetFailureNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetAzureTargetFailureNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetAzureTargetFailureNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBucketChangesNotificationRegistrationSpectraS3Response struct {
-    BucketChangesNotificationRegistration BucketChangesNotificationRegistration
-    Headers *http.Header
+	BucketChangesNotificationRegistration BucketChangesNotificationRegistration
+	Headers                               *http.Header
 }
 
 func (getBucketChangesNotificationRegistrationSpectraS3Response *GetBucketChangesNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBucketChangesNotificationRegistrationSpectraS3Response.BucketChangesNotificationRegistration)
+	return parseResponsePayload(webResponse, &getBucketChangesNotificationRegistrationSpectraS3Response.BucketChangesNotificationRegistration)
 }
 
 func NewGetBucketChangesNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetBucketChangesNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBucketChangesNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBucketChangesNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBucketChangesNotificationRegistrationsSpectraS3Response struct {
-    BucketChangesNotificationRegistrationList BucketChangesNotificationRegistrationList
-    Headers *http.Header
+	BucketChangesNotificationRegistrationList BucketChangesNotificationRegistrationList
+	Headers                                   *http.Header
 }
 
 func (getBucketChangesNotificationRegistrationsSpectraS3Response *GetBucketChangesNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBucketChangesNotificationRegistrationsSpectraS3Response.BucketChangesNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getBucketChangesNotificationRegistrationsSpectraS3Response.BucketChangesNotificationRegistrationList)
 }
 
 func NewGetBucketChangesNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetBucketChangesNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBucketChangesNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBucketChangesNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBucketHistorySpectraS3Response struct {
-    BucketHistoryEventList BucketHistoryEventList
-    Headers *http.Header
+	BucketHistoryEventList BucketHistoryEventList
+	Headers                *http.Header
 }
 
 func (getBucketHistorySpectraS3Response *GetBucketHistorySpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBucketHistorySpectraS3Response.BucketHistoryEventList)
+	return parseResponsePayload(webResponse, &getBucketHistorySpectraS3Response.BucketHistoryEventList)
 }
 
 func NewGetBucketHistorySpectraS3Response(webResponse WebResponse) (*GetBucketHistorySpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBucketHistorySpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBucketHistorySpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDs3TargetFailureNotificationRegistrationSpectraS3Response struct {
-    Ds3TargetFailureNotificationRegistration Ds3TargetFailureNotificationRegistration
-    Headers *http.Header
+	Ds3TargetFailureNotificationRegistration Ds3TargetFailureNotificationRegistration
+	Headers                                  *http.Header
 }
 
 func (getDs3TargetFailureNotificationRegistrationSpectraS3Response *GetDs3TargetFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDs3TargetFailureNotificationRegistrationSpectraS3Response.Ds3TargetFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &getDs3TargetFailureNotificationRegistrationSpectraS3Response.Ds3TargetFailureNotificationRegistration)
 }
 
 func NewGetDs3TargetFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetDs3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDs3TargetFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDs3TargetFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDs3TargetFailureNotificationRegistrationsSpectraS3Response struct {
-    Ds3TargetFailureNotificationRegistrationList Ds3TargetFailureNotificationRegistrationList
-    Headers *http.Header
+	Ds3TargetFailureNotificationRegistrationList Ds3TargetFailureNotificationRegistrationList
+	Headers                                      *http.Header
 }
 
 func (getDs3TargetFailureNotificationRegistrationsSpectraS3Response *GetDs3TargetFailureNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDs3TargetFailureNotificationRegistrationsSpectraS3Response.Ds3TargetFailureNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getDs3TargetFailureNotificationRegistrationsSpectraS3Response.Ds3TargetFailureNotificationRegistrationList)
 }
 
 func NewGetDs3TargetFailureNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetDs3TargetFailureNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDs3TargetFailureNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDs3TargetFailureNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobCompletedNotificationRegistrationSpectraS3Response struct {
-    JobCompletedNotificationRegistration JobCompletedNotificationRegistration
-    Headers *http.Header
+	JobCompletedNotificationRegistration JobCompletedNotificationRegistration
+	Headers                              *http.Header
 }
 
 func (getJobCompletedNotificationRegistrationSpectraS3Response *GetJobCompletedNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobCompletedNotificationRegistrationSpectraS3Response.JobCompletedNotificationRegistration)
+	return parseResponsePayload(webResponse, &getJobCompletedNotificationRegistrationSpectraS3Response.JobCompletedNotificationRegistration)
 }
 
 func NewGetJobCompletedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetJobCompletedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobCompletedNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobCompletedNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobCompletedNotificationRegistrationsSpectraS3Response struct {
-    JobCompletedNotificationRegistrationList JobCompletedNotificationRegistrationList
-    Headers *http.Header
+	JobCompletedNotificationRegistrationList JobCompletedNotificationRegistrationList
+	Headers                                  *http.Header
 }
 
 func (getJobCompletedNotificationRegistrationsSpectraS3Response *GetJobCompletedNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobCompletedNotificationRegistrationsSpectraS3Response.JobCompletedNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getJobCompletedNotificationRegistrationsSpectraS3Response.JobCompletedNotificationRegistrationList)
 }
 
 func NewGetJobCompletedNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetJobCompletedNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobCompletedNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobCompletedNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobCreatedNotificationRegistrationSpectraS3Response struct {
-    JobCreatedNotificationRegistration JobCreatedNotificationRegistration
-    Headers *http.Header
+	JobCreatedNotificationRegistration JobCreatedNotificationRegistration
+	Headers                            *http.Header
 }
 
 func (getJobCreatedNotificationRegistrationSpectraS3Response *GetJobCreatedNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobCreatedNotificationRegistrationSpectraS3Response.JobCreatedNotificationRegistration)
+	return parseResponsePayload(webResponse, &getJobCreatedNotificationRegistrationSpectraS3Response.JobCreatedNotificationRegistration)
 }
 
 func NewGetJobCreatedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetJobCreatedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobCreatedNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobCreatedNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobCreatedNotificationRegistrationsSpectraS3Response struct {
-    JobCreatedNotificationRegistrationList JobCreatedNotificationRegistrationList
-    Headers *http.Header
+	JobCreatedNotificationRegistrationList JobCreatedNotificationRegistrationList
+	Headers                                *http.Header
 }
 
 func (getJobCreatedNotificationRegistrationsSpectraS3Response *GetJobCreatedNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobCreatedNotificationRegistrationsSpectraS3Response.JobCreatedNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getJobCreatedNotificationRegistrationsSpectraS3Response.JobCreatedNotificationRegistrationList)
 }
 
 func NewGetJobCreatedNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetJobCreatedNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobCreatedNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobCreatedNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobCreationFailedNotificationRegistrationSpectraS3Response struct {
-    JobCreationFailedNotificationRegistration JobCreationFailedNotificationRegistration
-    Headers *http.Header
+	JobCreationFailedNotificationRegistration JobCreationFailedNotificationRegistration
+	Headers                                   *http.Header
 }
 
 func (getJobCreationFailedNotificationRegistrationSpectraS3Response *GetJobCreationFailedNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobCreationFailedNotificationRegistrationSpectraS3Response.JobCreationFailedNotificationRegistration)
+	return parseResponsePayload(webResponse, &getJobCreationFailedNotificationRegistrationSpectraS3Response.JobCreationFailedNotificationRegistration)
 }
 
 func NewGetJobCreationFailedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetJobCreationFailedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobCreationFailedNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobCreationFailedNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetJobCreationFailedNotificationRegistrationsSpectraS3Response struct {
-    JobCreationFailedNotificationRegistrationList JobCreationFailedNotificationRegistrationList
-    Headers *http.Header
+	JobCreationFailedNotificationRegistrationList JobCreationFailedNotificationRegistrationList
+	Headers                                       *http.Header
 }
 
 func (getJobCreationFailedNotificationRegistrationsSpectraS3Response *GetJobCreationFailedNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getJobCreationFailedNotificationRegistrationsSpectraS3Response.JobCreationFailedNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getJobCreationFailedNotificationRegistrationsSpectraS3Response.JobCreationFailedNotificationRegistrationList)
 }
 
 func NewGetJobCreationFailedNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetJobCreationFailedNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetJobCreationFailedNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetJobCreationFailedNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetObjectCachedNotificationRegistrationSpectraS3Response struct {
-    S3ObjectCachedNotificationRegistration S3ObjectCachedNotificationRegistration
-    Headers *http.Header
+	S3ObjectCachedNotificationRegistration S3ObjectCachedNotificationRegistration
+	Headers                                *http.Header
 }
 
 func (getObjectCachedNotificationRegistrationSpectraS3Response *GetObjectCachedNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getObjectCachedNotificationRegistrationSpectraS3Response.S3ObjectCachedNotificationRegistration)
+	return parseResponsePayload(webResponse, &getObjectCachedNotificationRegistrationSpectraS3Response.S3ObjectCachedNotificationRegistration)
 }
 
 func NewGetObjectCachedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetObjectCachedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetObjectCachedNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetObjectCachedNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetObjectCachedNotificationRegistrationsSpectraS3Response struct {
-    S3ObjectCachedNotificationRegistrationList S3ObjectCachedNotificationRegistrationList
-    Headers *http.Header
+	S3ObjectCachedNotificationRegistrationList S3ObjectCachedNotificationRegistrationList
+	Headers                                    *http.Header
 }
 
 func (getObjectCachedNotificationRegistrationsSpectraS3Response *GetObjectCachedNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getObjectCachedNotificationRegistrationsSpectraS3Response.S3ObjectCachedNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getObjectCachedNotificationRegistrationsSpectraS3Response.S3ObjectCachedNotificationRegistrationList)
 }
 
 func NewGetObjectCachedNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetObjectCachedNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetObjectCachedNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetObjectCachedNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetObjectLostNotificationRegistrationSpectraS3Response struct {
-    S3ObjectLostNotificationRegistration S3ObjectLostNotificationRegistration
-    Headers *http.Header
+	S3ObjectLostNotificationRegistration S3ObjectLostNotificationRegistration
+	Headers                              *http.Header
 }
 
 func (getObjectLostNotificationRegistrationSpectraS3Response *GetObjectLostNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getObjectLostNotificationRegistrationSpectraS3Response.S3ObjectLostNotificationRegistration)
+	return parseResponsePayload(webResponse, &getObjectLostNotificationRegistrationSpectraS3Response.S3ObjectLostNotificationRegistration)
 }
 
 func NewGetObjectLostNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetObjectLostNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetObjectLostNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetObjectLostNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetObjectLostNotificationRegistrationsSpectraS3Response struct {
-    S3ObjectLostNotificationRegistrationList S3ObjectLostNotificationRegistrationList
-    Headers *http.Header
+	S3ObjectLostNotificationRegistrationList S3ObjectLostNotificationRegistrationList
+	Headers                                  *http.Header
 }
 
 func (getObjectLostNotificationRegistrationsSpectraS3Response *GetObjectLostNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getObjectLostNotificationRegistrationsSpectraS3Response.S3ObjectLostNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getObjectLostNotificationRegistrationsSpectraS3Response.S3ObjectLostNotificationRegistrationList)
 }
 
 func NewGetObjectLostNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetObjectLostNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetObjectLostNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetObjectLostNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetObjectPersistedNotificationRegistrationSpectraS3Response struct {
-    S3ObjectPersistedNotificationRegistration S3ObjectPersistedNotificationRegistration
-    Headers *http.Header
+	S3ObjectPersistedNotificationRegistration S3ObjectPersistedNotificationRegistration
+	Headers                                   *http.Header
 }
 
 func (getObjectPersistedNotificationRegistrationSpectraS3Response *GetObjectPersistedNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getObjectPersistedNotificationRegistrationSpectraS3Response.S3ObjectPersistedNotificationRegistration)
+	return parseResponsePayload(webResponse, &getObjectPersistedNotificationRegistrationSpectraS3Response.S3ObjectPersistedNotificationRegistration)
 }
 
 func NewGetObjectPersistedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetObjectPersistedNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetObjectPersistedNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetObjectPersistedNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetObjectPersistedNotificationRegistrationsSpectraS3Response struct {
-    S3ObjectPersistedNotificationRegistrationList S3ObjectPersistedNotificationRegistrationList
-    Headers *http.Header
+	S3ObjectPersistedNotificationRegistrationList S3ObjectPersistedNotificationRegistrationList
+	Headers                                       *http.Header
 }
 
 func (getObjectPersistedNotificationRegistrationsSpectraS3Response *GetObjectPersistedNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getObjectPersistedNotificationRegistrationsSpectraS3Response.S3ObjectPersistedNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getObjectPersistedNotificationRegistrationsSpectraS3Response.S3ObjectPersistedNotificationRegistrationList)
 }
 
 func NewGetObjectPersistedNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetObjectPersistedNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetObjectPersistedNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetObjectPersistedNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetPoolFailureNotificationRegistrationSpectraS3Response struct {
-    PoolFailureNotificationRegistration PoolFailureNotificationRegistration
-    Headers *http.Header
+	PoolFailureNotificationRegistration PoolFailureNotificationRegistration
+	Headers                             *http.Header
 }
 
 func (getPoolFailureNotificationRegistrationSpectraS3Response *GetPoolFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getPoolFailureNotificationRegistrationSpectraS3Response.PoolFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &getPoolFailureNotificationRegistrationSpectraS3Response.PoolFailureNotificationRegistration)
 }
 
 func NewGetPoolFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetPoolFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetPoolFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetPoolFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetPoolFailureNotificationRegistrationsSpectraS3Response struct {
-    PoolFailureNotificationRegistrationList PoolFailureNotificationRegistrationList
-    Headers *http.Header
+	PoolFailureNotificationRegistrationList PoolFailureNotificationRegistrationList
+	Headers                                 *http.Header
 }
 
 func (getPoolFailureNotificationRegistrationsSpectraS3Response *GetPoolFailureNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getPoolFailureNotificationRegistrationsSpectraS3Response.PoolFailureNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getPoolFailureNotificationRegistrationsSpectraS3Response.PoolFailureNotificationRegistrationList)
 }
 
 func NewGetPoolFailureNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetPoolFailureNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetPoolFailureNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetPoolFailureNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetS3TargetFailureNotificationRegistrationSpectraS3Response struct {
-    S3TargetFailureNotificationRegistration S3TargetFailureNotificationRegistration
-    Headers *http.Header
+	S3TargetFailureNotificationRegistration S3TargetFailureNotificationRegistration
+	Headers                                 *http.Header
 }
 
 func (getS3TargetFailureNotificationRegistrationSpectraS3Response *GetS3TargetFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getS3TargetFailureNotificationRegistrationSpectraS3Response.S3TargetFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &getS3TargetFailureNotificationRegistrationSpectraS3Response.S3TargetFailureNotificationRegistration)
 }
 
 func NewGetS3TargetFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetS3TargetFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetS3TargetFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetS3TargetFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetS3TargetFailureNotificationRegistrationsSpectraS3Response struct {
-    S3TargetFailureNotificationRegistrationList S3TargetFailureNotificationRegistrationList
-    Headers *http.Header
+	S3TargetFailureNotificationRegistrationList S3TargetFailureNotificationRegistrationList
+	Headers                                     *http.Header
 }
 
 func (getS3TargetFailureNotificationRegistrationsSpectraS3Response *GetS3TargetFailureNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getS3TargetFailureNotificationRegistrationsSpectraS3Response.S3TargetFailureNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getS3TargetFailureNotificationRegistrationsSpectraS3Response.S3TargetFailureNotificationRegistrationList)
 }
 
 func NewGetS3TargetFailureNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetS3TargetFailureNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetS3TargetFailureNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetS3TargetFailureNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetStorageDomainFailureNotificationRegistrationSpectraS3Response struct {
-    StorageDomainFailureNotificationRegistration StorageDomainFailureNotificationRegistration
-    Headers *http.Header
+	StorageDomainFailureNotificationRegistration StorageDomainFailureNotificationRegistration
+	Headers                                      *http.Header
 }
 
 func (getStorageDomainFailureNotificationRegistrationSpectraS3Response *GetStorageDomainFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getStorageDomainFailureNotificationRegistrationSpectraS3Response.StorageDomainFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &getStorageDomainFailureNotificationRegistrationSpectraS3Response.StorageDomainFailureNotificationRegistration)
 }
 
 func NewGetStorageDomainFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetStorageDomainFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetStorageDomainFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetStorageDomainFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetStorageDomainFailureNotificationRegistrationsSpectraS3Response struct {
-    StorageDomainFailureNotificationRegistrationList StorageDomainFailureNotificationRegistrationList
-    Headers *http.Header
+	StorageDomainFailureNotificationRegistrationList StorageDomainFailureNotificationRegistrationList
+	Headers                                          *http.Header
 }
 
 func (getStorageDomainFailureNotificationRegistrationsSpectraS3Response *GetStorageDomainFailureNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getStorageDomainFailureNotificationRegistrationsSpectraS3Response.StorageDomainFailureNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getStorageDomainFailureNotificationRegistrationsSpectraS3Response.StorageDomainFailureNotificationRegistrationList)
 }
 
 func NewGetStorageDomainFailureNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetStorageDomainFailureNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetStorageDomainFailureNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetStorageDomainFailureNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSystemFailureNotificationRegistrationSpectraS3Response struct {
-    SystemFailureNotificationRegistration SystemFailureNotificationRegistration
-    Headers *http.Header
+	SystemFailureNotificationRegistration SystemFailureNotificationRegistration
+	Headers                               *http.Header
 }
 
 func (getSystemFailureNotificationRegistrationSpectraS3Response *GetSystemFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSystemFailureNotificationRegistrationSpectraS3Response.SystemFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &getSystemFailureNotificationRegistrationSpectraS3Response.SystemFailureNotificationRegistration)
 }
 
 func NewGetSystemFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetSystemFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSystemFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSystemFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSystemFailureNotificationRegistrationsSpectraS3Response struct {
-    SystemFailureNotificationRegistrationList SystemFailureNotificationRegistrationList
-    Headers *http.Header
+	SystemFailureNotificationRegistrationList SystemFailureNotificationRegistrationList
+	Headers                                   *http.Header
 }
 
 func (getSystemFailureNotificationRegistrationsSpectraS3Response *GetSystemFailureNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSystemFailureNotificationRegistrationsSpectraS3Response.SystemFailureNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getSystemFailureNotificationRegistrationsSpectraS3Response.SystemFailureNotificationRegistrationList)
 }
 
 func NewGetSystemFailureNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetSystemFailureNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSystemFailureNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSystemFailureNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapeFailureNotificationRegistrationSpectraS3Response struct {
-    TapeFailureNotificationRegistration TapeFailureNotificationRegistration
-    Headers *http.Header
+	TapeFailureNotificationRegistration TapeFailureNotificationRegistration
+	Headers                             *http.Header
 }
 
 func (getTapeFailureNotificationRegistrationSpectraS3Response *GetTapeFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapeFailureNotificationRegistrationSpectraS3Response.TapeFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &getTapeFailureNotificationRegistrationSpectraS3Response.TapeFailureNotificationRegistration)
 }
 
 func NewGetTapeFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetTapeFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapeFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapeFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapeFailureNotificationRegistrationsSpectraS3Response struct {
-    TapeFailureNotificationRegistrationList TapeFailureNotificationRegistrationList
-    Headers *http.Header
+	TapeFailureNotificationRegistrationList TapeFailureNotificationRegistrationList
+	Headers                                 *http.Header
 }
 
 func (getTapeFailureNotificationRegistrationsSpectraS3Response *GetTapeFailureNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapeFailureNotificationRegistrationsSpectraS3Response.TapeFailureNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getTapeFailureNotificationRegistrationsSpectraS3Response.TapeFailureNotificationRegistrationList)
 }
 
 func NewGetTapeFailureNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetTapeFailureNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapeFailureNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapeFailureNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapePartitionFailureNotificationRegistrationSpectraS3Response struct {
-    TapePartitionFailureNotificationRegistration TapePartitionFailureNotificationRegistration
-    Headers *http.Header
+	TapePartitionFailureNotificationRegistration TapePartitionFailureNotificationRegistration
+	Headers                                      *http.Header
 }
 
 func (getTapePartitionFailureNotificationRegistrationSpectraS3Response *GetTapePartitionFailureNotificationRegistrationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapePartitionFailureNotificationRegistrationSpectraS3Response.TapePartitionFailureNotificationRegistration)
+	return parseResponsePayload(webResponse, &getTapePartitionFailureNotificationRegistrationSpectraS3Response.TapePartitionFailureNotificationRegistration)
 }
 
 func NewGetTapePartitionFailureNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*GetTapePartitionFailureNotificationRegistrationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapePartitionFailureNotificationRegistrationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapePartitionFailureNotificationRegistrationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapePartitionFailureNotificationRegistrationsSpectraS3Response struct {
-    TapePartitionFailureNotificationRegistrationList TapePartitionFailureNotificationRegistrationList
-    Headers *http.Header
+	TapePartitionFailureNotificationRegistrationList TapePartitionFailureNotificationRegistrationList
+	Headers                                          *http.Header
 }
 
 func (getTapePartitionFailureNotificationRegistrationsSpectraS3Response *GetTapePartitionFailureNotificationRegistrationsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapePartitionFailureNotificationRegistrationsSpectraS3Response.TapePartitionFailureNotificationRegistrationList)
+	return parseResponsePayload(webResponse, &getTapePartitionFailureNotificationRegistrationsSpectraS3Response.TapePartitionFailureNotificationRegistrationList)
 }
 
 func NewGetTapePartitionFailureNotificationRegistrationsSpectraS3Response(webResponse WebResponse) (*GetTapePartitionFailureNotificationRegistrationsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapePartitionFailureNotificationRegistrationsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapePartitionFailureNotificationRegistrationsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteFolderRecursivelySpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteFolderRecursivelySpectraS3Response(webResponse WebResponse) (*DeleteFolderRecursivelySpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteFolderRecursivelySpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteFolderRecursivelySpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBlobPersistenceSpectraS3Response struct {
-    Content string
-    Headers *http.Header
+	Content string
+	Headers *http.Header
 }
 
-
-
 func NewGetBlobPersistenceSpectraS3Response(webResponse WebResponse) (*GetBlobPersistenceSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        content, err := getResponseBodyAsString(webResponse)
-        if err != nil {
-            return nil, err
-        }
-        return &GetBlobPersistenceSpectraS3Response{Content: content, Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		content, err := getResponseBodyAsString(webResponse)
+		if err != nil {
+			return nil, err
+		}
+		return &GetBlobPersistenceSpectraS3Response{Content: content, Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetObjectDetailsSpectraS3Response struct {
-    S3Object S3Object
-    Headers *http.Header
+	S3Object S3Object
+	Headers  *http.Header
 }
 
 func (getObjectDetailsSpectraS3Response *GetObjectDetailsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getObjectDetailsSpectraS3Response.S3Object)
+	return parseResponsePayload(webResponse, &getObjectDetailsSpectraS3Response.S3Object)
 }
 
 func NewGetObjectDetailsSpectraS3Response(webResponse WebResponse) (*GetObjectDetailsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetObjectDetailsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetObjectDetailsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetObjectsDetailsSpectraS3Response struct {
-    S3ObjectList S3ObjectList
-    Headers *http.Header
+	S3ObjectList S3ObjectList
+	Headers      *http.Header
 }
 
 func (getObjectsDetailsSpectraS3Response *GetObjectsDetailsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getObjectsDetailsSpectraS3Response.S3ObjectList)
+	return parseResponsePayload(webResponse, &getObjectsDetailsSpectraS3Response.S3ObjectList)
 }
 
 func NewGetObjectsDetailsSpectraS3Response(webResponse WebResponse) (*GetObjectsDetailsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetObjectsDetailsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetObjectsDetailsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetObjectsWithFullDetailsSpectraS3Response struct {
-    DetailedS3ObjectList DetailedS3ObjectList
-    Headers *http.Header
+	DetailedS3ObjectList DetailedS3ObjectList
+	Headers              *http.Header
 }
 
 func (getObjectsWithFullDetailsSpectraS3Response *GetObjectsWithFullDetailsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getObjectsWithFullDetailsSpectraS3Response.DetailedS3ObjectList)
+	return parseResponsePayload(webResponse, &getObjectsWithFullDetailsSpectraS3Response.DetailedS3ObjectList)
 }
 
 func NewGetObjectsWithFullDetailsSpectraS3Response(webResponse WebResponse) (*GetObjectsWithFullDetailsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetObjectsWithFullDetailsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetObjectsWithFullDetailsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetPhysicalPlacementForObjectsSpectraS3Response struct {
-    PhysicalPlacement PhysicalPlacement
-    Headers *http.Header
+	PhysicalPlacement PhysicalPlacement
+	Headers           *http.Header
 }
 
 func (getPhysicalPlacementForObjectsSpectraS3Response *GetPhysicalPlacementForObjectsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getPhysicalPlacementForObjectsSpectraS3Response.PhysicalPlacement)
+	return parseResponsePayload(webResponse, &getPhysicalPlacementForObjectsSpectraS3Response.PhysicalPlacement)
 }
 
 func NewGetPhysicalPlacementForObjectsSpectraS3Response(webResponse WebResponse) (*GetPhysicalPlacementForObjectsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetPhysicalPlacementForObjectsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetPhysicalPlacementForObjectsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response struct {
-    BulkObjectList BulkObjectList
-    Headers *http.Header
+	BulkObjectList BulkObjectList
+	Headers        *http.Header
 }
 
 func (getPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response *GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response.BulkObjectList)
+	return parseResponsePayload(webResponse, &getPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response.BulkObjectList)
 }
 
 func NewGetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response(webResponse WebResponse) (*GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type UndeleteObjectSpectraS3Response struct {
-    S3Object S3Object
-    Headers *http.Header
+	S3Object S3Object
+	Headers  *http.Header
 }
 
 func (undeleteObjectSpectraS3Response *UndeleteObjectSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &undeleteObjectSpectraS3Response.S3Object)
+	return parseResponsePayload(webResponse, &undeleteObjectSpectraS3Response.S3Object)
 }
 
 func NewUndeleteObjectSpectraS3Response(webResponse WebResponse) (*UndeleteObjectSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body UndeleteObjectSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body UndeleteObjectSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifyPhysicalPlacementForObjectsSpectraS3Response struct {
-    PhysicalPlacement PhysicalPlacement
-    Headers *http.Header
+	PhysicalPlacement PhysicalPlacement
+	Headers           *http.Header
 }
 
 func (verifyPhysicalPlacementForObjectsSpectraS3Response *VerifyPhysicalPlacementForObjectsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &verifyPhysicalPlacementForObjectsSpectraS3Response.PhysicalPlacement)
+	return parseResponsePayload(webResponse, &verifyPhysicalPlacementForObjectsSpectraS3Response.PhysicalPlacement)
 }
 
 func NewVerifyPhysicalPlacementForObjectsSpectraS3Response(webResponse WebResponse) (*VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body VerifyPhysicalPlacementForObjectsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body VerifyPhysicalPlacementForObjectsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response struct {
-    BulkObjectList BulkObjectList
-    Headers *http.Header
+	BulkObjectList BulkObjectList
+	Headers        *http.Header
 }
 
 func (verifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response *VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &verifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response.BulkObjectList)
+	return parseResponsePayload(webResponse, &verifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response.BulkObjectList)
 }
 
 func NewVerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response(webResponse WebResponse) (*VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelImportOnAllPoolsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewCancelImportOnAllPoolsSpectraS3Response(webResponse WebResponse) (*CancelImportOnAllPoolsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CancelImportOnAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CancelImportOnAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelImportPoolSpectraS3Response struct {
-    Pool Pool
-    Headers *http.Header
+	Pool    Pool
+	Headers *http.Header
 }
 
 func (cancelImportPoolSpectraS3Response *CancelImportPoolSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &cancelImportPoolSpectraS3Response.Pool)
+	return parseResponsePayload(webResponse, &cancelImportPoolSpectraS3Response.Pool)
 }
 
 func NewCancelImportPoolSpectraS3Response(webResponse WebResponse) (*CancelImportPoolSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CancelImportPoolSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CancelImportPoolSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelVerifyOnAllPoolsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewCancelVerifyOnAllPoolsSpectraS3Response(webResponse WebResponse) (*CancelVerifyOnAllPoolsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CancelVerifyOnAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CancelVerifyOnAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelVerifyPoolSpectraS3Response struct {
-    Pool Pool
-    Headers *http.Header
+	Pool    Pool
+	Headers *http.Header
 }
 
 func (cancelVerifyPoolSpectraS3Response *CancelVerifyPoolSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &cancelVerifyPoolSpectraS3Response.Pool)
+	return parseResponsePayload(webResponse, &cancelVerifyPoolSpectraS3Response.Pool)
 }
 
 func NewCancelVerifyPoolSpectraS3Response(webResponse WebResponse) (*CancelVerifyPoolSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CancelVerifyPoolSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CancelVerifyPoolSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CompactAllPoolsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewCompactAllPoolsSpectraS3Response(webResponse WebResponse) (*CompactAllPoolsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CompactAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CompactAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CompactPoolSpectraS3Response struct {
-    Pool Pool
-    Headers *http.Header
+	Pool    Pool
+	Headers *http.Header
 }
 
 func (compactPoolSpectraS3Response *CompactPoolSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &compactPoolSpectraS3Response.Pool)
+	return parseResponsePayload(webResponse, &compactPoolSpectraS3Response.Pool)
 }
 
 func NewCompactPoolSpectraS3Response(webResponse WebResponse) (*CompactPoolSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CompactPoolSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CompactPoolSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutPoolPartitionSpectraS3Response struct {
-    PoolPartition PoolPartition
-    Headers *http.Header
+	PoolPartition PoolPartition
+	Headers       *http.Header
 }
 
 func (putPoolPartitionSpectraS3Response *PutPoolPartitionSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putPoolPartitionSpectraS3Response.PoolPartition)
+	return parseResponsePayload(webResponse, &putPoolPartitionSpectraS3Response.PoolPartition)
 }
 
 func NewPutPoolPartitionSpectraS3Response(webResponse WebResponse) (*PutPoolPartitionSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutPoolPartitionSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutPoolPartitionSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeallocatePoolSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeallocatePoolSpectraS3Response(webResponse WebResponse) (*DeallocatePoolSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeallocatePoolSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeallocatePoolSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeletePermanentlyLostPoolSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeletePermanentlyLostPoolSpectraS3Response(webResponse WebResponse) (*DeletePermanentlyLostPoolSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeletePermanentlyLostPoolSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeletePermanentlyLostPoolSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeletePoolFailureSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeletePoolFailureSpectraS3Response(webResponse WebResponse) (*DeletePoolFailureSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeletePoolFailureSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeletePoolFailureSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeletePoolPartitionSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeletePoolPartitionSpectraS3Response(webResponse WebResponse) (*DeletePoolPartitionSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeletePoolPartitionSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeletePoolPartitionSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ForcePoolEnvironmentRefreshSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewForcePoolEnvironmentRefreshSpectraS3Response(webResponse WebResponse) (*ForcePoolEnvironmentRefreshSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ForcePoolEnvironmentRefreshSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ForcePoolEnvironmentRefreshSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type FormatAllForeignPoolsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewFormatAllForeignPoolsSpectraS3Response(webResponse WebResponse) (*FormatAllForeignPoolsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &FormatAllForeignPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &FormatAllForeignPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type FormatForeignPoolSpectraS3Response struct {
-    Pool Pool
-    Headers *http.Header
+	Pool    Pool
+	Headers *http.Header
 }
 
 func (formatForeignPoolSpectraS3Response *FormatForeignPoolSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &formatForeignPoolSpectraS3Response.Pool)
+	return parseResponsePayload(webResponse, &formatForeignPoolSpectraS3Response.Pool)
 }
 
 func NewFormatForeignPoolSpectraS3Response(webResponse WebResponse) (*FormatForeignPoolSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body FormatForeignPoolSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body FormatForeignPoolSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBlobsOnPoolSpectraS3Response struct {
-    BulkObjectList BulkObjectList
-    Headers *http.Header
+	BulkObjectList BulkObjectList
+	Headers        *http.Header
 }
 
 func (getBlobsOnPoolSpectraS3Response *GetBlobsOnPoolSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBlobsOnPoolSpectraS3Response.BulkObjectList)
+	return parseResponsePayload(webResponse, &getBlobsOnPoolSpectraS3Response.BulkObjectList)
 }
 
 func NewGetBlobsOnPoolSpectraS3Response(webResponse WebResponse) (*GetBlobsOnPoolSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBlobsOnPoolSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBlobsOnPoolSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetPoolFailuresSpectraS3Response struct {
-    PoolFailureList PoolFailureList
-    Headers *http.Header
+	PoolFailureList PoolFailureList
+	Headers         *http.Header
 }
 
 func (getPoolFailuresSpectraS3Response *GetPoolFailuresSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getPoolFailuresSpectraS3Response.PoolFailureList)
+	return parseResponsePayload(webResponse, &getPoolFailuresSpectraS3Response.PoolFailureList)
 }
 
 func NewGetPoolFailuresSpectraS3Response(webResponse WebResponse) (*GetPoolFailuresSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetPoolFailuresSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetPoolFailuresSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetPoolPartitionSpectraS3Response struct {
-    PoolPartition PoolPartition
-    Headers *http.Header
+	PoolPartition PoolPartition
+	Headers       *http.Header
 }
 
 func (getPoolPartitionSpectraS3Response *GetPoolPartitionSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getPoolPartitionSpectraS3Response.PoolPartition)
+	return parseResponsePayload(webResponse, &getPoolPartitionSpectraS3Response.PoolPartition)
 }
 
 func NewGetPoolPartitionSpectraS3Response(webResponse WebResponse) (*GetPoolPartitionSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetPoolPartitionSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetPoolPartitionSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetPoolPartitionsSpectraS3Response struct {
-    PoolPartitionList PoolPartitionList
-    Headers *http.Header
+	PoolPartitionList PoolPartitionList
+	Headers           *http.Header
 }
 
 func (getPoolPartitionsSpectraS3Response *GetPoolPartitionsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getPoolPartitionsSpectraS3Response.PoolPartitionList)
+	return parseResponsePayload(webResponse, &getPoolPartitionsSpectraS3Response.PoolPartitionList)
 }
 
 func NewGetPoolPartitionsSpectraS3Response(webResponse WebResponse) (*GetPoolPartitionsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetPoolPartitionsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetPoolPartitionsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetPoolSpectraS3Response struct {
-    Pool Pool
-    Headers *http.Header
+	Pool    Pool
+	Headers *http.Header
 }
 
 func (getPoolSpectraS3Response *GetPoolSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getPoolSpectraS3Response.Pool)
+	return parseResponsePayload(webResponse, &getPoolSpectraS3Response.Pool)
 }
 
 func NewGetPoolSpectraS3Response(webResponse WebResponse) (*GetPoolSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetPoolSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetPoolSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetPoolsSpectraS3Response struct {
-    PoolList PoolList
-    Headers *http.Header
+	PoolList PoolList
+	Headers  *http.Header
 }
 
 func (getPoolsSpectraS3Response *GetPoolsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getPoolsSpectraS3Response.PoolList)
+	return parseResponsePayload(webResponse, &getPoolsSpectraS3Response.PoolList)
 }
 
 func NewGetPoolsSpectraS3Response(webResponse WebResponse) (*GetPoolsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetPoolsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetPoolsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ImportAllPoolsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewImportAllPoolsSpectraS3Response(webResponse WebResponse) (*ImportAllPoolsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ImportAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ImportAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ImportPoolSpectraS3Response struct {
-    Pool Pool
-    Headers *http.Header
+	Pool    Pool
+	Headers *http.Header
 }
 
 func (importPoolSpectraS3Response *ImportPoolSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &importPoolSpectraS3Response.Pool)
+	return parseResponsePayload(webResponse, &importPoolSpectraS3Response.Pool)
 }
 
 func NewImportPoolSpectraS3Response(webResponse WebResponse) (*ImportPoolSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ImportPoolSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ImportPoolSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyAllPoolsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewModifyAllPoolsSpectraS3Response(webResponse WebResponse) (*ModifyAllPoolsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ModifyAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ModifyAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyPoolPartitionSpectraS3Response struct {
-    PoolPartition PoolPartition
-    Headers *http.Header
+	PoolPartition PoolPartition
+	Headers       *http.Header
 }
 
 func (modifyPoolPartitionSpectraS3Response *ModifyPoolPartitionSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyPoolPartitionSpectraS3Response.PoolPartition)
+	return parseResponsePayload(webResponse, &modifyPoolPartitionSpectraS3Response.PoolPartition)
 }
 
 func NewModifyPoolPartitionSpectraS3Response(webResponse WebResponse) (*ModifyPoolPartitionSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyPoolPartitionSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyPoolPartitionSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyPoolSpectraS3Response struct {
-    Pool Pool
-    Headers *http.Header
+	Pool    Pool
+	Headers *http.Header
 }
 
 func (modifyPoolSpectraS3Response *ModifyPoolSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyPoolSpectraS3Response.Pool)
+	return parseResponsePayload(webResponse, &modifyPoolSpectraS3Response.Pool)
 }
 
 func NewModifyPoolSpectraS3Response(webResponse WebResponse) (*ModifyPoolSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyPoolSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyPoolSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifyAllPoolsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewVerifyAllPoolsSpectraS3Response(webResponse WebResponse) (*VerifyAllPoolsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &VerifyAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &VerifyAllPoolsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifyPoolSpectraS3Response struct {
-    Pool Pool
-    Headers *http.Header
+	Pool    Pool
+	Headers *http.Header
 }
 
 func (verifyPoolSpectraS3Response *VerifyPoolSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &verifyPoolSpectraS3Response.Pool)
+	return parseResponsePayload(webResponse, &verifyPoolSpectraS3Response.Pool)
 }
 
 func NewVerifyPoolSpectraS3Response(webResponse WebResponse) (*VerifyPoolSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body VerifyPoolSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body VerifyPoolSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ConvertStorageDomainToDs3TargetSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewConvertStorageDomainToDs3TargetSpectraS3Response(webResponse WebResponse) (*ConvertStorageDomainToDs3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ConvertStorageDomainToDs3TargetSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ConvertStorageDomainToDs3TargetSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutPoolStorageDomainMemberSpectraS3Response struct {
-    StorageDomainMember StorageDomainMember
-    Headers *http.Header
+	StorageDomainMember StorageDomainMember
+	Headers             *http.Header
 }
 
 func (putPoolStorageDomainMemberSpectraS3Response *PutPoolStorageDomainMemberSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putPoolStorageDomainMemberSpectraS3Response.StorageDomainMember)
+	return parseResponsePayload(webResponse, &putPoolStorageDomainMemberSpectraS3Response.StorageDomainMember)
 }
 
 func NewPutPoolStorageDomainMemberSpectraS3Response(webResponse WebResponse) (*PutPoolStorageDomainMemberSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutPoolStorageDomainMemberSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutPoolStorageDomainMemberSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutStorageDomainSpectraS3Response struct {
-    StorageDomain StorageDomain
-    Headers *http.Header
+	StorageDomain StorageDomain
+	Headers       *http.Header
 }
 
 func (putStorageDomainSpectraS3Response *PutStorageDomainSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putStorageDomainSpectraS3Response.StorageDomain)
+	return parseResponsePayload(webResponse, &putStorageDomainSpectraS3Response.StorageDomain)
 }
 
 func NewPutStorageDomainSpectraS3Response(webResponse WebResponse) (*PutStorageDomainSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutStorageDomainSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutStorageDomainSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutTapeStorageDomainMemberSpectraS3Response struct {
-    StorageDomainMember StorageDomainMember
-    Headers *http.Header
+	StorageDomainMember StorageDomainMember
+	Headers             *http.Header
 }
 
 func (putTapeStorageDomainMemberSpectraS3Response *PutTapeStorageDomainMemberSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putTapeStorageDomainMemberSpectraS3Response.StorageDomainMember)
+	return parseResponsePayload(webResponse, &putTapeStorageDomainMemberSpectraS3Response.StorageDomainMember)
 }
 
 func NewPutTapeStorageDomainMemberSpectraS3Response(webResponse WebResponse) (*PutTapeStorageDomainMemberSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutTapeStorageDomainMemberSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutTapeStorageDomainMemberSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteStorageDomainFailureSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteStorageDomainFailureSpectraS3Response(webResponse WebResponse) (*DeleteStorageDomainFailureSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteStorageDomainFailureSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteStorageDomainFailureSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteStorageDomainMemberSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteStorageDomainMemberSpectraS3Response(webResponse WebResponse) (*DeleteStorageDomainMemberSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteStorageDomainMemberSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteStorageDomainMemberSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteStorageDomainSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteStorageDomainSpectraS3Response(webResponse WebResponse) (*DeleteStorageDomainSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteStorageDomainSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteStorageDomainSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetStorageDomainFailuresSpectraS3Response struct {
-    StorageDomainFailureList StorageDomainFailureList
-    Headers *http.Header
+	StorageDomainFailureList StorageDomainFailureList
+	Headers                  *http.Header
 }
 
 func (getStorageDomainFailuresSpectraS3Response *GetStorageDomainFailuresSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getStorageDomainFailuresSpectraS3Response.StorageDomainFailureList)
+	return parseResponsePayload(webResponse, &getStorageDomainFailuresSpectraS3Response.StorageDomainFailureList)
 }
 
 func NewGetStorageDomainFailuresSpectraS3Response(webResponse WebResponse) (*GetStorageDomainFailuresSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetStorageDomainFailuresSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetStorageDomainFailuresSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetStorageDomainMemberSpectraS3Response struct {
-    StorageDomainMember StorageDomainMember
-    Headers *http.Header
+	StorageDomainMember StorageDomainMember
+	Headers             *http.Header
 }
 
 func (getStorageDomainMemberSpectraS3Response *GetStorageDomainMemberSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getStorageDomainMemberSpectraS3Response.StorageDomainMember)
+	return parseResponsePayload(webResponse, &getStorageDomainMemberSpectraS3Response.StorageDomainMember)
 }
 
 func NewGetStorageDomainMemberSpectraS3Response(webResponse WebResponse) (*GetStorageDomainMemberSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetStorageDomainMemberSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetStorageDomainMemberSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetStorageDomainMembersSpectraS3Response struct {
-    StorageDomainMemberList StorageDomainMemberList
-    Headers *http.Header
+	StorageDomainMemberList StorageDomainMemberList
+	Headers                 *http.Header
 }
 
 func (getStorageDomainMembersSpectraS3Response *GetStorageDomainMembersSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getStorageDomainMembersSpectraS3Response.StorageDomainMemberList)
+	return parseResponsePayload(webResponse, &getStorageDomainMembersSpectraS3Response.StorageDomainMemberList)
 }
 
 func NewGetStorageDomainMembersSpectraS3Response(webResponse WebResponse) (*GetStorageDomainMembersSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetStorageDomainMembersSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetStorageDomainMembersSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetStorageDomainSpectraS3Response struct {
-    StorageDomain StorageDomain
-    Headers *http.Header
+	StorageDomain StorageDomain
+	Headers       *http.Header
 }
 
 func (getStorageDomainSpectraS3Response *GetStorageDomainSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getStorageDomainSpectraS3Response.StorageDomain)
+	return parseResponsePayload(webResponse, &getStorageDomainSpectraS3Response.StorageDomain)
 }
 
 func NewGetStorageDomainSpectraS3Response(webResponse WebResponse) (*GetStorageDomainSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetStorageDomainSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetStorageDomainSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetStorageDomainsSpectraS3Response struct {
-    StorageDomainList StorageDomainList
-    Headers *http.Header
+	StorageDomainList StorageDomainList
+	Headers           *http.Header
 }
 
 func (getStorageDomainsSpectraS3Response *GetStorageDomainsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getStorageDomainsSpectraS3Response.StorageDomainList)
+	return parseResponsePayload(webResponse, &getStorageDomainsSpectraS3Response.StorageDomainList)
 }
 
 func NewGetStorageDomainsSpectraS3Response(webResponse WebResponse) (*GetStorageDomainsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetStorageDomainsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetStorageDomainsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyStorageDomainMemberSpectraS3Response struct {
-    StorageDomainMember StorageDomainMember
-    Headers *http.Header
+	StorageDomainMember StorageDomainMember
+	Headers             *http.Header
 }
 
 func (modifyStorageDomainMemberSpectraS3Response *ModifyStorageDomainMemberSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyStorageDomainMemberSpectraS3Response.StorageDomainMember)
+	return parseResponsePayload(webResponse, &modifyStorageDomainMemberSpectraS3Response.StorageDomainMember)
 }
 
 func NewModifyStorageDomainMemberSpectraS3Response(webResponse WebResponse) (*ModifyStorageDomainMemberSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyStorageDomainMemberSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyStorageDomainMemberSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyStorageDomainSpectraS3Response struct {
-    StorageDomain StorageDomain
-    Headers *http.Header
+	StorageDomain StorageDomain
+	Headers       *http.Header
 }
 
 func (modifyStorageDomainSpectraS3Response *ModifyStorageDomainSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyStorageDomainSpectraS3Response.StorageDomain)
+	return parseResponsePayload(webResponse, &modifyStorageDomainSpectraS3Response.StorageDomain)
 }
 
 func NewModifyStorageDomainSpectraS3Response(webResponse WebResponse) (*ModifyStorageDomainSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyStorageDomainSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyStorageDomainSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ForceFeatureKeyValidationSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewForceFeatureKeyValidationSpectraS3Response(webResponse WebResponse) (*ForceFeatureKeyValidationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ForceFeatureKeyValidationSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ForceFeatureKeyValidationSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetFeatureKeysSpectraS3Response struct {
-    FeatureKeyList FeatureKeyList
-    Headers *http.Header
+	FeatureKeyList FeatureKeyList
+	Headers        *http.Header
 }
 
 func (getFeatureKeysSpectraS3Response *GetFeatureKeysSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getFeatureKeysSpectraS3Response.FeatureKeyList)
+	return parseResponsePayload(webResponse, &getFeatureKeysSpectraS3Response.FeatureKeyList)
 }
 
 func NewGetFeatureKeysSpectraS3Response(webResponse WebResponse) (*GetFeatureKeysSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetFeatureKeysSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetFeatureKeysSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSystemFailuresSpectraS3Response struct {
-    SystemFailureList SystemFailureList
-    Headers *http.Header
+	SystemFailureList SystemFailureList
+	Headers           *http.Header
 }
 
 func (getSystemFailuresSpectraS3Response *GetSystemFailuresSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSystemFailuresSpectraS3Response.SystemFailureList)
+	return parseResponsePayload(webResponse, &getSystemFailuresSpectraS3Response.SystemFailureList)
 }
 
 func NewGetSystemFailuresSpectraS3Response(webResponse WebResponse) (*GetSystemFailuresSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSystemFailuresSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSystemFailuresSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetSystemInformationSpectraS3Response struct {
-    SystemInformation SystemInformation
-    Headers *http.Header
+	SystemInformation SystemInformation
+	Headers           *http.Header
 }
 
 func (getSystemInformationSpectraS3Response *GetSystemInformationSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getSystemInformationSpectraS3Response.SystemInformation)
+	return parseResponsePayload(webResponse, &getSystemInformationSpectraS3Response.SystemInformation)
 }
 
 func NewGetSystemInformationSpectraS3Response(webResponse WebResponse) (*GetSystemInformationSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetSystemInformationSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetSystemInformationSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ResetInstanceIdentifierSpectraS3Response struct {
-    DataPathBackend DataPathBackend
-    Headers *http.Header
+	DataPathBackend DataPathBackend
+	Headers         *http.Header
 }
 
 func (resetInstanceIdentifierSpectraS3Response *ResetInstanceIdentifierSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &resetInstanceIdentifierSpectraS3Response.DataPathBackend)
+	return parseResponsePayload(webResponse, &resetInstanceIdentifierSpectraS3Response.DataPathBackend)
 }
 
 func NewResetInstanceIdentifierSpectraS3Response(webResponse WebResponse) (*ResetInstanceIdentifierSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ResetInstanceIdentifierSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ResetInstanceIdentifierSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifySystemHealthSpectraS3Response struct {
-    HealthVerificationResult HealthVerificationResult
-    Headers *http.Header
+	HealthVerificationResult HealthVerificationResult
+	Headers                  *http.Header
 }
 
 func (verifySystemHealthSpectraS3Response *VerifySystemHealthSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &verifySystemHealthSpectraS3Response.HealthVerificationResult)
+	return parseResponsePayload(webResponse, &verifySystemHealthSpectraS3Response.HealthVerificationResult)
 }
 
 func NewVerifySystemHealthSpectraS3Response(webResponse WebResponse) (*VerifySystemHealthSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body VerifySystemHealthSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body VerifySystemHealthSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelEjectOnAllTapesSpectraS3Response struct {
-    TapeFailureList *TapeFailureList
-    Headers *http.Header
+	TapeFailureList *TapeFailureList
+	Headers         *http.Header
 }
 
 func (cancelEjectOnAllTapesSpectraS3Response *CancelEjectOnAllTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, cancelEjectOnAllTapesSpectraS3Response.TapeFailureList)
+	return parseResponsePayload(webResponse, cancelEjectOnAllTapesSpectraS3Response.TapeFailureList)
 }
 
 func NewCancelEjectOnAllTapesSpectraS3Response(webResponse WebResponse) (*CancelEjectOnAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204, 207 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204, 207}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CancelEjectOnAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    case 207:
-        var body CancelEjectOnAllTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CancelEjectOnAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	case 207:
+		var body CancelEjectOnAllTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelEjectTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (cancelEjectTapeSpectraS3Response *CancelEjectTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &cancelEjectTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &cancelEjectTapeSpectraS3Response.Tape)
 }
 
 func NewCancelEjectTapeSpectraS3Response(webResponse WebResponse) (*CancelEjectTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CancelEjectTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CancelEjectTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelFormatOnAllTapesSpectraS3Response struct {
-    TapeFailureList *TapeFailureList
-    Headers *http.Header
+	TapeFailureList *TapeFailureList
+	Headers         *http.Header
 }
 
 func (cancelFormatOnAllTapesSpectraS3Response *CancelFormatOnAllTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, cancelFormatOnAllTapesSpectraS3Response.TapeFailureList)
+	return parseResponsePayload(webResponse, cancelFormatOnAllTapesSpectraS3Response.TapeFailureList)
 }
 
 func NewCancelFormatOnAllTapesSpectraS3Response(webResponse WebResponse) (*CancelFormatOnAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204, 207 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204, 207}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CancelFormatOnAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    case 207:
-        var body CancelFormatOnAllTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CancelFormatOnAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	case 207:
+		var body CancelFormatOnAllTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelFormatTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (cancelFormatTapeSpectraS3Response *CancelFormatTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &cancelFormatTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &cancelFormatTapeSpectraS3Response.Tape)
 }
 
 func NewCancelFormatTapeSpectraS3Response(webResponse WebResponse) (*CancelFormatTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CancelFormatTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CancelFormatTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelImportOnAllTapesSpectraS3Response struct {
-    TapeFailureList *TapeFailureList
-    Headers *http.Header
+	TapeFailureList *TapeFailureList
+	Headers         *http.Header
 }
 
 func (cancelImportOnAllTapesSpectraS3Response *CancelImportOnAllTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, cancelImportOnAllTapesSpectraS3Response.TapeFailureList)
+	return parseResponsePayload(webResponse, cancelImportOnAllTapesSpectraS3Response.TapeFailureList)
 }
 
 func NewCancelImportOnAllTapesSpectraS3Response(webResponse WebResponse) (*CancelImportOnAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204, 207 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204, 207}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CancelImportOnAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    case 207:
-        var body CancelImportOnAllTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CancelImportOnAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	case 207:
+		var body CancelImportOnAllTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelImportTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (cancelImportTapeSpectraS3Response *CancelImportTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &cancelImportTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &cancelImportTapeSpectraS3Response.Tape)
 }
 
 func NewCancelImportTapeSpectraS3Response(webResponse WebResponse) (*CancelImportTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CancelImportTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CancelImportTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelOnlineOnAllTapesSpectraS3Response struct {
-    TapeFailureList *TapeFailureList
-    Headers *http.Header
+	TapeFailureList *TapeFailureList
+	Headers         *http.Header
 }
 
 func (cancelOnlineOnAllTapesSpectraS3Response *CancelOnlineOnAllTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, cancelOnlineOnAllTapesSpectraS3Response.TapeFailureList)
+	return parseResponsePayload(webResponse, cancelOnlineOnAllTapesSpectraS3Response.TapeFailureList)
 }
 
 func NewCancelOnlineOnAllTapesSpectraS3Response(webResponse WebResponse) (*CancelOnlineOnAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204, 207 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204, 207}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CancelOnlineOnAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    case 207:
-        var body CancelOnlineOnAllTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CancelOnlineOnAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	case 207:
+		var body CancelOnlineOnAllTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelOnlineTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (cancelOnlineTapeSpectraS3Response *CancelOnlineTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &cancelOnlineTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &cancelOnlineTapeSpectraS3Response.Tape)
 }
 
 func NewCancelOnlineTapeSpectraS3Response(webResponse WebResponse) (*CancelOnlineTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CancelOnlineTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CancelOnlineTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelTestTapeDriveSpectraS3Response struct {
-    TapeDrive TapeDrive
-    Headers *http.Header
+	TapeDrive TapeDrive
+	Headers   *http.Header
 }
 
 func (cancelTestTapeDriveSpectraS3Response *CancelTestTapeDriveSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &cancelTestTapeDriveSpectraS3Response.TapeDrive)
+	return parseResponsePayload(webResponse, &cancelTestTapeDriveSpectraS3Response.TapeDrive)
 }
 
 func NewCancelTestTapeDriveSpectraS3Response(webResponse WebResponse) (*CancelTestTapeDriveSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CancelTestTapeDriveSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CancelTestTapeDriveSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelVerifyOnAllTapesSpectraS3Response struct {
-    TapeFailureList *TapeFailureList
-    Headers *http.Header
+	TapeFailureList *TapeFailureList
+	Headers         *http.Header
 }
 
 func (cancelVerifyOnAllTapesSpectraS3Response *CancelVerifyOnAllTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, cancelVerifyOnAllTapesSpectraS3Response.TapeFailureList)
+	return parseResponsePayload(webResponse, cancelVerifyOnAllTapesSpectraS3Response.TapeFailureList)
 }
 
 func NewCancelVerifyOnAllTapesSpectraS3Response(webResponse WebResponse) (*CancelVerifyOnAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204, 207 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204, 207}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &CancelVerifyOnAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    case 207:
-        var body CancelVerifyOnAllTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &CancelVerifyOnAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	case 207:
+		var body CancelVerifyOnAllTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CancelVerifyTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (cancelVerifyTapeSpectraS3Response *CancelVerifyTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &cancelVerifyTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &cancelVerifyTapeSpectraS3Response.Tape)
 }
 
 func NewCancelVerifyTapeSpectraS3Response(webResponse WebResponse) (*CancelVerifyTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CancelVerifyTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CancelVerifyTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type CleanTapeDriveSpectraS3Response struct {
-    TapeDrive TapeDrive
-    Headers *http.Header
+	TapeDrive TapeDrive
+	Headers   *http.Header
 }
 
 func (cleanTapeDriveSpectraS3Response *CleanTapeDriveSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &cleanTapeDriveSpectraS3Response.TapeDrive)
+	return parseResponsePayload(webResponse, &cleanTapeDriveSpectraS3Response.TapeDrive)
 }
 
 func NewCleanTapeDriveSpectraS3Response(webResponse WebResponse) (*CleanTapeDriveSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body CleanTapeDriveSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body CleanTapeDriveSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutDriveDumpSpectraS3Response struct {
-    TapeDrive TapeDrive
-    Headers *http.Header
+	TapeDrive TapeDrive
+	Headers   *http.Header
 }
 
 func (putDriveDumpSpectraS3Response *PutDriveDumpSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putDriveDumpSpectraS3Response.TapeDrive)
+	return parseResponsePayload(webResponse, &putDriveDumpSpectraS3Response.TapeDrive)
 }
 
 func NewPutDriveDumpSpectraS3Response(webResponse WebResponse) (*PutDriveDumpSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body PutDriveDumpSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body PutDriveDumpSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutTapeDensityDirectiveSpectraS3Response struct {
-    TapeDensityDirective TapeDensityDirective
-    Headers *http.Header
+	TapeDensityDirective TapeDensityDirective
+	Headers              *http.Header
 }
 
 func (putTapeDensityDirectiveSpectraS3Response *PutTapeDensityDirectiveSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putTapeDensityDirectiveSpectraS3Response.TapeDensityDirective)
+	return parseResponsePayload(webResponse, &putTapeDensityDirectiveSpectraS3Response.TapeDensityDirective)
 }
 
 func NewPutTapeDensityDirectiveSpectraS3Response(webResponse WebResponse) (*PutTapeDensityDirectiveSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutTapeDensityDirectiveSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutTapeDensityDirectiveSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeletePermanentlyLostTapeSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeletePermanentlyLostTapeSpectraS3Response(webResponse WebResponse) (*DeletePermanentlyLostTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeletePermanentlyLostTapeSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeletePermanentlyLostTapeSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteTapeDensityDirectiveSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteTapeDensityDirectiveSpectraS3Response(webResponse WebResponse) (*DeleteTapeDensityDirectiveSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteTapeDensityDirectiveSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteTapeDensityDirectiveSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteTapeDriveSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteTapeDriveSpectraS3Response(webResponse WebResponse) (*DeleteTapeDriveSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteTapeDriveSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteTapeDriveSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteTapeFailureSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteTapeFailureSpectraS3Response(webResponse WebResponse) (*DeleteTapeFailureSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteTapeFailureSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteTapeFailureSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteTapePartitionFailureSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteTapePartitionFailureSpectraS3Response(webResponse WebResponse) (*DeleteTapePartitionFailureSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteTapePartitionFailureSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteTapePartitionFailureSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteTapePartitionSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteTapePartitionSpectraS3Response(webResponse WebResponse) (*DeleteTapePartitionSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteTapePartitionSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteTapePartitionSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type EjectAllTapesSpectraS3Response struct {
-    TapeFailureList *TapeFailureList
-    Headers *http.Header
+	TapeFailureList *TapeFailureList
+	Headers         *http.Header
 }
 
 func (ejectAllTapesSpectraS3Response *EjectAllTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, ejectAllTapesSpectraS3Response.TapeFailureList)
+	return parseResponsePayload(webResponse, ejectAllTapesSpectraS3Response.TapeFailureList)
 }
 
 func NewEjectAllTapesSpectraS3Response(webResponse WebResponse) (*EjectAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204, 207 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204, 207}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &EjectAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    case 207:
-        var body EjectAllTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &EjectAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	case 207:
+		var body EjectAllTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type EjectStorageDomainBlobsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewEjectStorageDomainBlobsSpectraS3Response(webResponse WebResponse) (*EjectStorageDomainBlobsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &EjectStorageDomainBlobsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &EjectStorageDomainBlobsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type EjectStorageDomainSpectraS3Response struct {
-    TapeFailureList *TapeFailureList
-    Headers *http.Header
+	TapeFailureList *TapeFailureList
+	Headers         *http.Header
 }
 
 func (ejectStorageDomainSpectraS3Response *EjectStorageDomainSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, ejectStorageDomainSpectraS3Response.TapeFailureList)
+	return parseResponsePayload(webResponse, ejectStorageDomainSpectraS3Response.TapeFailureList)
 }
 
 func NewEjectStorageDomainSpectraS3Response(webResponse WebResponse) (*EjectStorageDomainSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204, 207 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204, 207}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &EjectStorageDomainSpectraS3Response{Headers: webResponse.Header()}, nil
-    case 207:
-        var body EjectStorageDomainSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &EjectStorageDomainSpectraS3Response{Headers: webResponse.Header()}, nil
+	case 207:
+		var body EjectStorageDomainSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type EjectTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (ejectTapeSpectraS3Response *EjectTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &ejectTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &ejectTapeSpectraS3Response.Tape)
 }
 
 func NewEjectTapeSpectraS3Response(webResponse WebResponse) (*EjectTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body EjectTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body EjectTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ForceTapeEnvironmentRefreshSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewForceTapeEnvironmentRefreshSpectraS3Response(webResponse WebResponse) (*ForceTapeEnvironmentRefreshSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ForceTapeEnvironmentRefreshSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ForceTapeEnvironmentRefreshSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type FormatAllTapesSpectraS3Response struct {
-    TapeFailureList *TapeFailureList
-    Headers *http.Header
+	TapeFailureList *TapeFailureList
+	Headers         *http.Header
 }
 
 func (formatAllTapesSpectraS3Response *FormatAllTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, formatAllTapesSpectraS3Response.TapeFailureList)
+	return parseResponsePayload(webResponse, formatAllTapesSpectraS3Response.TapeFailureList)
 }
 
 func NewFormatAllTapesSpectraS3Response(webResponse WebResponse) (*FormatAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204, 207 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204, 207}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &FormatAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    case 207:
-        var body FormatAllTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &FormatAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	case 207:
+		var body FormatAllTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type FormatTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (formatTapeSpectraS3Response *FormatTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &formatTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &formatTapeSpectraS3Response.Tape)
 }
 
 func NewFormatTapeSpectraS3Response(webResponse WebResponse) (*FormatTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body FormatTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body FormatTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBlobsOnTapeSpectraS3Response struct {
-    BulkObjectList BulkObjectList
-    Headers *http.Header
+	BulkObjectList BulkObjectList
+	Headers        *http.Header
 }
 
 func (getBlobsOnTapeSpectraS3Response *GetBlobsOnTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBlobsOnTapeSpectraS3Response.BulkObjectList)
+	return parseResponsePayload(webResponse, &getBlobsOnTapeSpectraS3Response.BulkObjectList)
 }
 
 func NewGetBlobsOnTapeSpectraS3Response(webResponse WebResponse) (*GetBlobsOnTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBlobsOnTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBlobsOnTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapeDensityDirectiveSpectraS3Response struct {
-    TapeDensityDirective TapeDensityDirective
-    Headers *http.Header
+	TapeDensityDirective TapeDensityDirective
+	Headers              *http.Header
 }
 
 func (getTapeDensityDirectiveSpectraS3Response *GetTapeDensityDirectiveSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapeDensityDirectiveSpectraS3Response.TapeDensityDirective)
+	return parseResponsePayload(webResponse, &getTapeDensityDirectiveSpectraS3Response.TapeDensityDirective)
 }
 
 func NewGetTapeDensityDirectiveSpectraS3Response(webResponse WebResponse) (*GetTapeDensityDirectiveSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapeDensityDirectiveSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapeDensityDirectiveSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapeDensityDirectivesSpectraS3Response struct {
-    TapeDensityDirectiveList TapeDensityDirectiveList
-    Headers *http.Header
+	TapeDensityDirectiveList TapeDensityDirectiveList
+	Headers                  *http.Header
 }
 
 func (getTapeDensityDirectivesSpectraS3Response *GetTapeDensityDirectivesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapeDensityDirectivesSpectraS3Response.TapeDensityDirectiveList)
+	return parseResponsePayload(webResponse, &getTapeDensityDirectivesSpectraS3Response.TapeDensityDirectiveList)
 }
 
 func NewGetTapeDensityDirectivesSpectraS3Response(webResponse WebResponse) (*GetTapeDensityDirectivesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapeDensityDirectivesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapeDensityDirectivesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapeDriveSpectraS3Response struct {
-    TapeDrive TapeDrive
-    Headers *http.Header
+	TapeDrive TapeDrive
+	Headers   *http.Header
 }
 
 func (getTapeDriveSpectraS3Response *GetTapeDriveSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapeDriveSpectraS3Response.TapeDrive)
+	return parseResponsePayload(webResponse, &getTapeDriveSpectraS3Response.TapeDrive)
 }
 
 func NewGetTapeDriveSpectraS3Response(webResponse WebResponse) (*GetTapeDriveSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapeDriveSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapeDriveSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapeDrivesSpectraS3Response struct {
-    TapeDriveList TapeDriveList
-    Headers *http.Header
+	TapeDriveList TapeDriveList
+	Headers       *http.Header
 }
 
 func (getTapeDrivesSpectraS3Response *GetTapeDrivesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapeDrivesSpectraS3Response.TapeDriveList)
+	return parseResponsePayload(webResponse, &getTapeDrivesSpectraS3Response.TapeDriveList)
 }
 
 func NewGetTapeDrivesSpectraS3Response(webResponse WebResponse) (*GetTapeDrivesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapeDrivesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapeDrivesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapeFailuresSpectraS3Response struct {
-    DetailedTapeFailureList DetailedTapeFailureList
-    Headers *http.Header
+	DetailedTapeFailureList DetailedTapeFailureList
+	Headers                 *http.Header
 }
 
 func (getTapeFailuresSpectraS3Response *GetTapeFailuresSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapeFailuresSpectraS3Response.DetailedTapeFailureList)
+	return parseResponsePayload(webResponse, &getTapeFailuresSpectraS3Response.DetailedTapeFailureList)
 }
 
 func NewGetTapeFailuresSpectraS3Response(webResponse WebResponse) (*GetTapeFailuresSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapeFailuresSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapeFailuresSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapeLibrariesSpectraS3Response struct {
-    TapeLibraryList TapeLibraryList
-    Headers *http.Header
+	TapeLibraryList TapeLibraryList
+	Headers         *http.Header
 }
 
 func (getTapeLibrariesSpectraS3Response *GetTapeLibrariesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapeLibrariesSpectraS3Response.TapeLibraryList)
+	return parseResponsePayload(webResponse, &getTapeLibrariesSpectraS3Response.TapeLibraryList)
 }
 
 func NewGetTapeLibrariesSpectraS3Response(webResponse WebResponse) (*GetTapeLibrariesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapeLibrariesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapeLibrariesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapeLibrarySpectraS3Response struct {
-    TapeLibrary TapeLibrary
-    Headers *http.Header
+	TapeLibrary TapeLibrary
+	Headers     *http.Header
 }
 
 func (getTapeLibrarySpectraS3Response *GetTapeLibrarySpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapeLibrarySpectraS3Response.TapeLibrary)
+	return parseResponsePayload(webResponse, &getTapeLibrarySpectraS3Response.TapeLibrary)
 }
 
 func NewGetTapeLibrarySpectraS3Response(webResponse WebResponse) (*GetTapeLibrarySpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapeLibrarySpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapeLibrarySpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapePartitionFailuresSpectraS3Response struct {
-    TapePartitionFailureList TapePartitionFailureList
-    Headers *http.Header
+	TapePartitionFailureList TapePartitionFailureList
+	Headers                  *http.Header
 }
 
 func (getTapePartitionFailuresSpectraS3Response *GetTapePartitionFailuresSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapePartitionFailuresSpectraS3Response.TapePartitionFailureList)
+	return parseResponsePayload(webResponse, &getTapePartitionFailuresSpectraS3Response.TapePartitionFailureList)
 }
 
 func NewGetTapePartitionFailuresSpectraS3Response(webResponse WebResponse) (*GetTapePartitionFailuresSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapePartitionFailuresSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapePartitionFailuresSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapePartitionSpectraS3Response struct {
-    TapePartition TapePartition
-    Headers *http.Header
+	TapePartition TapePartition
+	Headers       *http.Header
 }
 
 func (getTapePartitionSpectraS3Response *GetTapePartitionSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapePartitionSpectraS3Response.TapePartition)
+	return parseResponsePayload(webResponse, &getTapePartitionSpectraS3Response.TapePartition)
 }
 
 func NewGetTapePartitionSpectraS3Response(webResponse WebResponse) (*GetTapePartitionSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapePartitionSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapePartitionSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapePartitionWithFullDetailsSpectraS3Response struct {
-    DetailedTapePartition DetailedTapePartition
-    Headers *http.Header
+	DetailedTapePartition DetailedTapePartition
+	Headers               *http.Header
 }
 
 func (getTapePartitionWithFullDetailsSpectraS3Response *GetTapePartitionWithFullDetailsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapePartitionWithFullDetailsSpectraS3Response.DetailedTapePartition)
+	return parseResponsePayload(webResponse, &getTapePartitionWithFullDetailsSpectraS3Response.DetailedTapePartition)
 }
 
 func NewGetTapePartitionWithFullDetailsSpectraS3Response(webResponse WebResponse) (*GetTapePartitionWithFullDetailsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapePartitionWithFullDetailsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapePartitionWithFullDetailsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapePartitionsSpectraS3Response struct {
-    TapePartitionList TapePartitionList
-    Headers *http.Header
+	TapePartitionList TapePartitionList
+	Headers           *http.Header
 }
 
 func (getTapePartitionsSpectraS3Response *GetTapePartitionsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapePartitionsSpectraS3Response.TapePartitionList)
+	return parseResponsePayload(webResponse, &getTapePartitionsSpectraS3Response.TapePartitionList)
 }
 
 func NewGetTapePartitionsSpectraS3Response(webResponse WebResponse) (*GetTapePartitionsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapePartitionsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapePartitionsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapePartitionsWithFullDetailsSpectraS3Response struct {
-    NamedDetailedTapePartitionList NamedDetailedTapePartitionList
-    Headers *http.Header
+	NamedDetailedTapePartitionList NamedDetailedTapePartitionList
+	Headers                        *http.Header
 }
 
 func (getTapePartitionsWithFullDetailsSpectraS3Response *GetTapePartitionsWithFullDetailsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapePartitionsWithFullDetailsSpectraS3Response.NamedDetailedTapePartitionList)
+	return parseResponsePayload(webResponse, &getTapePartitionsWithFullDetailsSpectraS3Response.NamedDetailedTapePartitionList)
 }
 
 func NewGetTapePartitionsWithFullDetailsSpectraS3Response(webResponse WebResponse) (*GetTapePartitionsWithFullDetailsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapePartitionsWithFullDetailsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapePartitionsWithFullDetailsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (getTapeSpectraS3Response *GetTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &getTapeSpectraS3Response.Tape)
 }
 
 func NewGetTapeSpectraS3Response(webResponse WebResponse) (*GetTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetTapesSpectraS3Response struct {
-    TapeList TapeList
-    Headers *http.Header
+	TapeList TapeList
+	Headers  *http.Header
 }
 
 func (getTapesSpectraS3Response *GetTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getTapesSpectraS3Response.TapeList)
+	return parseResponsePayload(webResponse, &getTapesSpectraS3Response.TapeList)
 }
 
 func NewGetTapesSpectraS3Response(webResponse WebResponse) (*GetTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ImportAllTapesSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewImportAllTapesSpectraS3Response(webResponse WebResponse) (*ImportAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ImportAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ImportAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ImportTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (importTapeSpectraS3Response *ImportTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &importTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &importTapeSpectraS3Response.Tape)
 }
 
 func NewImportTapeSpectraS3Response(webResponse WebResponse) (*ImportTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ImportTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ImportTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type InspectAllTapesSpectraS3Response struct {
-    TapeFailureList *TapeFailureList
-    Headers *http.Header
+	TapeFailureList *TapeFailureList
+	Headers         *http.Header
 }
 
 func (inspectAllTapesSpectraS3Response *InspectAllTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, inspectAllTapesSpectraS3Response.TapeFailureList)
+	return parseResponsePayload(webResponse, inspectAllTapesSpectraS3Response.TapeFailureList)
 }
 
 func NewInspectAllTapesSpectraS3Response(webResponse WebResponse) (*InspectAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204, 207 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204, 207}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &InspectAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    case 207:
-        var body InspectAllTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &InspectAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	case 207:
+		var body InspectAllTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type InspectTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (inspectTapeSpectraS3Response *InspectTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &inspectTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &inspectTapeSpectraS3Response.Tape)
 }
 
 func NewInspectTapeSpectraS3Response(webResponse WebResponse) (*InspectTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body InspectTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body InspectTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type MarkTapeForCompactionSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (markTapeForCompactionSpectraS3Response *MarkTapeForCompactionSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &markTapeForCompactionSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &markTapeForCompactionSpectraS3Response.Tape)
 }
 
 func NewMarkTapeForCompactionSpectraS3Response(webResponse WebResponse) (*MarkTapeForCompactionSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body MarkTapeForCompactionSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body MarkTapeForCompactionSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyAllTapePartitionsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewModifyAllTapePartitionsSpectraS3Response(webResponse WebResponse) (*ModifyAllTapePartitionsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ModifyAllTapePartitionsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ModifyAllTapePartitionsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyTapeDriveSpectraS3Response struct {
-    TapeDrive TapeDrive
-    Headers *http.Header
+	TapeDrive TapeDrive
+	Headers   *http.Header
 }
 
 func (modifyTapeDriveSpectraS3Response *ModifyTapeDriveSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyTapeDriveSpectraS3Response.TapeDrive)
+	return parseResponsePayload(webResponse, &modifyTapeDriveSpectraS3Response.TapeDrive)
 }
 
 func NewModifyTapeDriveSpectraS3Response(webResponse WebResponse) (*ModifyTapeDriveSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyTapeDriveSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyTapeDriveSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyTapePartitionSpectraS3Response struct {
-    TapePartition TapePartition
-    Headers *http.Header
+	TapePartition TapePartition
+	Headers       *http.Header
 }
 
 func (modifyTapePartitionSpectraS3Response *ModifyTapePartitionSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyTapePartitionSpectraS3Response.TapePartition)
+	return parseResponsePayload(webResponse, &modifyTapePartitionSpectraS3Response.TapePartition)
 }
 
 func NewModifyTapePartitionSpectraS3Response(webResponse WebResponse) (*ModifyTapePartitionSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyTapePartitionSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyTapePartitionSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (modifyTapeSpectraS3Response *ModifyTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &modifyTapeSpectraS3Response.Tape)
 }
 
 func NewModifyTapeSpectraS3Response(webResponse WebResponse) (*ModifyTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type OnlineAllTapesSpectraS3Response struct {
-    TapeFailureList *TapeFailureList
-    Headers *http.Header
+	TapeFailureList *TapeFailureList
+	Headers         *http.Header
 }
 
 func (onlineAllTapesSpectraS3Response *OnlineAllTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, onlineAllTapesSpectraS3Response.TapeFailureList)
+	return parseResponsePayload(webResponse, onlineAllTapesSpectraS3Response.TapeFailureList)
 }
 
 func NewOnlineAllTapesSpectraS3Response(webResponse WebResponse) (*OnlineAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204, 207 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204, 207}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &OnlineAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    case 207:
-        var body OnlineAllTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &OnlineAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	case 207:
+		var body OnlineAllTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type OnlineTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (onlineTapeSpectraS3Response *OnlineTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &onlineTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &onlineTapeSpectraS3Response.Tape)
 }
 
 func NewOnlineTapeSpectraS3Response(webResponse WebResponse) (*OnlineTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body OnlineTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body OnlineTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type RawImportAllTapesSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewRawImportAllTapesSpectraS3Response(webResponse WebResponse) (*RawImportAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &RawImportAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &RawImportAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type RawImportTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (rawImportTapeSpectraS3Response *RawImportTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &rawImportTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &rawImportTapeSpectraS3Response.Tape)
 }
 
 func NewRawImportTapeSpectraS3Response(webResponse WebResponse) (*RawImportTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body RawImportTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body RawImportTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type TestTapeDriveSpectraS3Response struct {
-    TapeDrive TapeDrive
-    Headers *http.Header
+	TapeDrive TapeDrive
+	Headers   *http.Header
 }
 
 func (testTapeDriveSpectraS3Response *TestTapeDriveSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &testTapeDriveSpectraS3Response.TapeDrive)
+	return parseResponsePayload(webResponse, &testTapeDriveSpectraS3Response.TapeDrive)
 }
 
 func NewTestTapeDriveSpectraS3Response(webResponse WebResponse) (*TestTapeDriveSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body TestTapeDriveSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body TestTapeDriveSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifyAllTapesSpectraS3Response struct {
-    TapeFailureList *TapeFailureList
-    Headers *http.Header
+	TapeFailureList *TapeFailureList
+	Headers         *http.Header
 }
 
 func (verifyAllTapesSpectraS3Response *VerifyAllTapesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, verifyAllTapesSpectraS3Response.TapeFailureList)
+	return parseResponsePayload(webResponse, verifyAllTapesSpectraS3Response.TapeFailureList)
 }
 
 func NewVerifyAllTapesSpectraS3Response(webResponse WebResponse) (*VerifyAllTapesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204, 207 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204, 207}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &VerifyAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
-    case 207:
-        var body VerifyAllTapesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &VerifyAllTapesSpectraS3Response{Headers: webResponse.Header()}, nil
+	case 207:
+		var body VerifyAllTapesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifyTapeSpectraS3Response struct {
-    Tape Tape
-    Headers *http.Header
+	Tape    Tape
+	Headers *http.Header
 }
 
 func (verifyTapeSpectraS3Response *VerifyTapeSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &verifyTapeSpectraS3Response.Tape)
+	return parseResponsePayload(webResponse, &verifyTapeSpectraS3Response.Tape)
 }
 
 func NewVerifyTapeSpectraS3Response(webResponse WebResponse) (*VerifyTapeSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body VerifyTapeSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body VerifyTapeSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ForceTargetEnvironmentRefreshSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewForceTargetEnvironmentRefreshSpectraS3Response(webResponse WebResponse) (*ForceTargetEnvironmentRefreshSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ForceTargetEnvironmentRefreshSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ForceTargetEnvironmentRefreshSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutAzureTargetBucketNameSpectraS3Response struct {
-    AzureTargetBucketName AzureTargetBucketName
-    Headers *http.Header
+	AzureTargetBucketName AzureTargetBucketName
+	Headers               *http.Header
 }
 
 func (putAzureTargetBucketNameSpectraS3Response *PutAzureTargetBucketNameSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putAzureTargetBucketNameSpectraS3Response.AzureTargetBucketName)
+	return parseResponsePayload(webResponse, &putAzureTargetBucketNameSpectraS3Response.AzureTargetBucketName)
 }
 
 func NewPutAzureTargetBucketNameSpectraS3Response(webResponse WebResponse) (*PutAzureTargetBucketNameSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutAzureTargetBucketNameSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutAzureTargetBucketNameSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutAzureTargetReadPreferenceSpectraS3Response struct {
-    AzureTargetReadPreference AzureTargetReadPreference
-    Headers *http.Header
+	AzureTargetReadPreference AzureTargetReadPreference
+	Headers                   *http.Header
 }
 
 func (putAzureTargetReadPreferenceSpectraS3Response *PutAzureTargetReadPreferenceSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putAzureTargetReadPreferenceSpectraS3Response.AzureTargetReadPreference)
+	return parseResponsePayload(webResponse, &putAzureTargetReadPreferenceSpectraS3Response.AzureTargetReadPreference)
 }
 
 func NewPutAzureTargetReadPreferenceSpectraS3Response(webResponse WebResponse) (*PutAzureTargetReadPreferenceSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutAzureTargetReadPreferenceSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutAzureTargetReadPreferenceSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteAzureTargetBucketNameSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteAzureTargetBucketNameSpectraS3Response(webResponse WebResponse) (*DeleteAzureTargetBucketNameSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteAzureTargetBucketNameSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteAzureTargetBucketNameSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteAzureTargetFailureSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteAzureTargetFailureSpectraS3Response(webResponse WebResponse) (*DeleteAzureTargetFailureSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteAzureTargetFailureSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteAzureTargetFailureSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteAzureTargetReadPreferenceSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteAzureTargetReadPreferenceSpectraS3Response(webResponse WebResponse) (*DeleteAzureTargetReadPreferenceSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteAzureTargetReadPreferenceSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteAzureTargetReadPreferenceSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteAzureTargetSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteAzureTargetSpectraS3Response(webResponse WebResponse) (*DeleteAzureTargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteAzureTargetSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteAzureTargetSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetAzureTargetBucketNamesSpectraS3Response struct {
-    AzureTargetBucketNameList AzureTargetBucketNameList
-    Headers *http.Header
+	AzureTargetBucketNameList AzureTargetBucketNameList
+	Headers                   *http.Header
 }
 
 func (getAzureTargetBucketNamesSpectraS3Response *GetAzureTargetBucketNamesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getAzureTargetBucketNamesSpectraS3Response.AzureTargetBucketNameList)
+	return parseResponsePayload(webResponse, &getAzureTargetBucketNamesSpectraS3Response.AzureTargetBucketNameList)
 }
 
 func NewGetAzureTargetBucketNamesSpectraS3Response(webResponse WebResponse) (*GetAzureTargetBucketNamesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetAzureTargetBucketNamesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetAzureTargetBucketNamesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetAzureTargetFailuresSpectraS3Response struct {
-    AzureTargetFailureList AzureTargetFailureList
-    Headers *http.Header
+	AzureTargetFailureList AzureTargetFailureList
+	Headers                *http.Header
 }
 
 func (getAzureTargetFailuresSpectraS3Response *GetAzureTargetFailuresSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getAzureTargetFailuresSpectraS3Response.AzureTargetFailureList)
+	return parseResponsePayload(webResponse, &getAzureTargetFailuresSpectraS3Response.AzureTargetFailureList)
 }
 
 func NewGetAzureTargetFailuresSpectraS3Response(webResponse WebResponse) (*GetAzureTargetFailuresSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetAzureTargetFailuresSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetAzureTargetFailuresSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetAzureTargetReadPreferenceSpectraS3Response struct {
-    AzureTargetReadPreference AzureTargetReadPreference
-    Headers *http.Header
+	AzureTargetReadPreference AzureTargetReadPreference
+	Headers                   *http.Header
 }
 
 func (getAzureTargetReadPreferenceSpectraS3Response *GetAzureTargetReadPreferenceSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getAzureTargetReadPreferenceSpectraS3Response.AzureTargetReadPreference)
+	return parseResponsePayload(webResponse, &getAzureTargetReadPreferenceSpectraS3Response.AzureTargetReadPreference)
 }
 
 func NewGetAzureTargetReadPreferenceSpectraS3Response(webResponse WebResponse) (*GetAzureTargetReadPreferenceSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetAzureTargetReadPreferenceSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetAzureTargetReadPreferenceSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetAzureTargetReadPreferencesSpectraS3Response struct {
-    AzureTargetReadPreferenceList AzureTargetReadPreferenceList
-    Headers *http.Header
+	AzureTargetReadPreferenceList AzureTargetReadPreferenceList
+	Headers                       *http.Header
 }
 
 func (getAzureTargetReadPreferencesSpectraS3Response *GetAzureTargetReadPreferencesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getAzureTargetReadPreferencesSpectraS3Response.AzureTargetReadPreferenceList)
+	return parseResponsePayload(webResponse, &getAzureTargetReadPreferencesSpectraS3Response.AzureTargetReadPreferenceList)
 }
 
 func NewGetAzureTargetReadPreferencesSpectraS3Response(webResponse WebResponse) (*GetAzureTargetReadPreferencesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetAzureTargetReadPreferencesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetAzureTargetReadPreferencesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetAzureTargetSpectraS3Response struct {
-    AzureTarget AzureTarget
-    Headers *http.Header
+	AzureTarget AzureTarget
+	Headers     *http.Header
 }
 
 func (getAzureTargetSpectraS3Response *GetAzureTargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getAzureTargetSpectraS3Response.AzureTarget)
+	return parseResponsePayload(webResponse, &getAzureTargetSpectraS3Response.AzureTarget)
 }
 
 func NewGetAzureTargetSpectraS3Response(webResponse WebResponse) (*GetAzureTargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetAzureTargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetAzureTargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetAzureTargetsSpectraS3Response struct {
-    AzureTargetList AzureTargetList
-    Headers *http.Header
+	AzureTargetList AzureTargetList
+	Headers         *http.Header
 }
 
 func (getAzureTargetsSpectraS3Response *GetAzureTargetsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getAzureTargetsSpectraS3Response.AzureTargetList)
+	return parseResponsePayload(webResponse, &getAzureTargetsSpectraS3Response.AzureTargetList)
 }
 
 func NewGetAzureTargetsSpectraS3Response(webResponse WebResponse) (*GetAzureTargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetAzureTargetsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetAzureTargetsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBlobsOnAzureTargetSpectraS3Response struct {
-    BulkObjectList BulkObjectList
-    Headers *http.Header
+	BulkObjectList BulkObjectList
+	Headers        *http.Header
 }
 
 func (getBlobsOnAzureTargetSpectraS3Response *GetBlobsOnAzureTargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBlobsOnAzureTargetSpectraS3Response.BulkObjectList)
+	return parseResponsePayload(webResponse, &getBlobsOnAzureTargetSpectraS3Response.BulkObjectList)
 }
 
 func NewGetBlobsOnAzureTargetSpectraS3Response(webResponse WebResponse) (*GetBlobsOnAzureTargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBlobsOnAzureTargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBlobsOnAzureTargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ImportAzureTargetSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewImportAzureTargetSpectraS3Response(webResponse WebResponse) (*ImportAzureTargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ImportAzureTargetSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ImportAzureTargetSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyAllAzureTargetsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewModifyAllAzureTargetsSpectraS3Response(webResponse WebResponse) (*ModifyAllAzureTargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ModifyAllAzureTargetsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ModifyAllAzureTargetsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyAzureTargetSpectraS3Response struct {
-    AzureTarget AzureTarget
-    Headers *http.Header
+	AzureTarget AzureTarget
+	Headers     *http.Header
 }
 
 func (modifyAzureTargetSpectraS3Response *ModifyAzureTargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyAzureTargetSpectraS3Response.AzureTarget)
+	return parseResponsePayload(webResponse, &modifyAzureTargetSpectraS3Response.AzureTarget)
 }
 
 func NewModifyAzureTargetSpectraS3Response(webResponse WebResponse) (*ModifyAzureTargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyAzureTargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyAzureTargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type RegisterAzureTargetSpectraS3Response struct {
-    AzureTarget AzureTarget
-    Headers *http.Header
+	AzureTarget AzureTarget
+	Headers     *http.Header
 }
 
 func (registerAzureTargetSpectraS3Response *RegisterAzureTargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &registerAzureTargetSpectraS3Response.AzureTarget)
+	return parseResponsePayload(webResponse, &registerAzureTargetSpectraS3Response.AzureTarget)
 }
 
 func NewRegisterAzureTargetSpectraS3Response(webResponse WebResponse) (*RegisterAzureTargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body RegisterAzureTargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body RegisterAzureTargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifyAzureTargetSpectraS3Response struct {
-    AzureTarget AzureTarget
-    Headers *http.Header
+	AzureTarget AzureTarget
+	Headers     *http.Header
 }
 
 func (verifyAzureTargetSpectraS3Response *VerifyAzureTargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &verifyAzureTargetSpectraS3Response.AzureTarget)
+	return parseResponsePayload(webResponse, &verifyAzureTargetSpectraS3Response.AzureTarget)
 }
 
 func NewVerifyAzureTargetSpectraS3Response(webResponse WebResponse) (*VerifyAzureTargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body VerifyAzureTargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body VerifyAzureTargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutDs3TargetReadPreferenceSpectraS3Response struct {
-    Ds3TargetReadPreference Ds3TargetReadPreference
-    Headers *http.Header
+	Ds3TargetReadPreference Ds3TargetReadPreference
+	Headers                 *http.Header
 }
 
 func (putDs3TargetReadPreferenceSpectraS3Response *PutDs3TargetReadPreferenceSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putDs3TargetReadPreferenceSpectraS3Response.Ds3TargetReadPreference)
+	return parseResponsePayload(webResponse, &putDs3TargetReadPreferenceSpectraS3Response.Ds3TargetReadPreference)
 }
 
 func NewPutDs3TargetReadPreferenceSpectraS3Response(webResponse WebResponse) (*PutDs3TargetReadPreferenceSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutDs3TargetReadPreferenceSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutDs3TargetReadPreferenceSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteDs3TargetFailureSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteDs3TargetFailureSpectraS3Response(webResponse WebResponse) (*DeleteDs3TargetFailureSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteDs3TargetFailureSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteDs3TargetFailureSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteDs3TargetReadPreferenceSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteDs3TargetReadPreferenceSpectraS3Response(webResponse WebResponse) (*DeleteDs3TargetReadPreferenceSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteDs3TargetReadPreferenceSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteDs3TargetReadPreferenceSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteDs3TargetSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteDs3TargetSpectraS3Response(webResponse WebResponse) (*DeleteDs3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteDs3TargetSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteDs3TargetSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBlobsOnDs3TargetSpectraS3Response struct {
-    BulkObjectList BulkObjectList
-    Headers *http.Header
+	BulkObjectList BulkObjectList
+	Headers        *http.Header
 }
 
 func (getBlobsOnDs3TargetSpectraS3Response *GetBlobsOnDs3TargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBlobsOnDs3TargetSpectraS3Response.BulkObjectList)
+	return parseResponsePayload(webResponse, &getBlobsOnDs3TargetSpectraS3Response.BulkObjectList)
 }
 
 func NewGetBlobsOnDs3TargetSpectraS3Response(webResponse WebResponse) (*GetBlobsOnDs3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBlobsOnDs3TargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBlobsOnDs3TargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDs3TargetDataPoliciesSpectraS3Response struct {
-    DataPolicyList DataPolicyList
-    Headers *http.Header
+	DataPolicyList DataPolicyList
+	Headers        *http.Header
 }
 
 func (getDs3TargetDataPoliciesSpectraS3Response *GetDs3TargetDataPoliciesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDs3TargetDataPoliciesSpectraS3Response.DataPolicyList)
+	return parseResponsePayload(webResponse, &getDs3TargetDataPoliciesSpectraS3Response.DataPolicyList)
 }
 
 func NewGetDs3TargetDataPoliciesSpectraS3Response(webResponse WebResponse) (*GetDs3TargetDataPoliciesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDs3TargetDataPoliciesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDs3TargetDataPoliciesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDs3TargetFailuresSpectraS3Response struct {
-    Ds3TargetFailureList Ds3TargetFailureList
-    Headers *http.Header
+	Ds3TargetFailureList Ds3TargetFailureList
+	Headers              *http.Header
 }
 
 func (getDs3TargetFailuresSpectraS3Response *GetDs3TargetFailuresSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDs3TargetFailuresSpectraS3Response.Ds3TargetFailureList)
+	return parseResponsePayload(webResponse, &getDs3TargetFailuresSpectraS3Response.Ds3TargetFailureList)
 }
 
 func NewGetDs3TargetFailuresSpectraS3Response(webResponse WebResponse) (*GetDs3TargetFailuresSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDs3TargetFailuresSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDs3TargetFailuresSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDs3TargetReadPreferenceSpectraS3Response struct {
-    Ds3TargetReadPreference Ds3TargetReadPreference
-    Headers *http.Header
+	Ds3TargetReadPreference Ds3TargetReadPreference
+	Headers                 *http.Header
 }
 
 func (getDs3TargetReadPreferenceSpectraS3Response *GetDs3TargetReadPreferenceSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDs3TargetReadPreferenceSpectraS3Response.Ds3TargetReadPreference)
+	return parseResponsePayload(webResponse, &getDs3TargetReadPreferenceSpectraS3Response.Ds3TargetReadPreference)
 }
 
 func NewGetDs3TargetReadPreferenceSpectraS3Response(webResponse WebResponse) (*GetDs3TargetReadPreferenceSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDs3TargetReadPreferenceSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDs3TargetReadPreferenceSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDs3TargetReadPreferencesSpectraS3Response struct {
-    Ds3TargetReadPreferenceList Ds3TargetReadPreferenceList
-    Headers *http.Header
+	Ds3TargetReadPreferenceList Ds3TargetReadPreferenceList
+	Headers                     *http.Header
 }
 
 func (getDs3TargetReadPreferencesSpectraS3Response *GetDs3TargetReadPreferencesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDs3TargetReadPreferencesSpectraS3Response.Ds3TargetReadPreferenceList)
+	return parseResponsePayload(webResponse, &getDs3TargetReadPreferencesSpectraS3Response.Ds3TargetReadPreferenceList)
 }
 
 func NewGetDs3TargetReadPreferencesSpectraS3Response(webResponse WebResponse) (*GetDs3TargetReadPreferencesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDs3TargetReadPreferencesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDs3TargetReadPreferencesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDs3TargetSpectraS3Response struct {
-    Ds3Target Ds3Target
-    Headers *http.Header
+	Ds3Target Ds3Target
+	Headers   *http.Header
 }
 
 func (getDs3TargetSpectraS3Response *GetDs3TargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDs3TargetSpectraS3Response.Ds3Target)
+	return parseResponsePayload(webResponse, &getDs3TargetSpectraS3Response.Ds3Target)
 }
 
 func NewGetDs3TargetSpectraS3Response(webResponse WebResponse) (*GetDs3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDs3TargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDs3TargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetDs3TargetsSpectraS3Response struct {
-    Ds3TargetList Ds3TargetList
-    Headers *http.Header
+	Ds3TargetList Ds3TargetList
+	Headers       *http.Header
 }
 
 func (getDs3TargetsSpectraS3Response *GetDs3TargetsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getDs3TargetsSpectraS3Response.Ds3TargetList)
+	return parseResponsePayload(webResponse, &getDs3TargetsSpectraS3Response.Ds3TargetList)
 }
 
 func NewGetDs3TargetsSpectraS3Response(webResponse WebResponse) (*GetDs3TargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetDs3TargetsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetDs3TargetsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyAllDs3TargetsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewModifyAllDs3TargetsSpectraS3Response(webResponse WebResponse) (*ModifyAllDs3TargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ModifyAllDs3TargetsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ModifyAllDs3TargetsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyDs3TargetSpectraS3Response struct {
-    Ds3Target Ds3Target
-    Headers *http.Header
+	Ds3Target Ds3Target
+	Headers   *http.Header
 }
 
 func (modifyDs3TargetSpectraS3Response *ModifyDs3TargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyDs3TargetSpectraS3Response.Ds3Target)
+	return parseResponsePayload(webResponse, &modifyDs3TargetSpectraS3Response.Ds3Target)
 }
 
 func NewModifyDs3TargetSpectraS3Response(webResponse WebResponse) (*ModifyDs3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyDs3TargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyDs3TargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PairBackRegisteredDs3TargetSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewPairBackRegisteredDs3TargetSpectraS3Response(webResponse WebResponse) (*PairBackRegisteredDs3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &PairBackRegisteredDs3TargetSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &PairBackRegisteredDs3TargetSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type RegisterDs3TargetSpectraS3Response struct {
-    Ds3Target Ds3Target
-    Headers *http.Header
+	Ds3Target Ds3Target
+	Headers   *http.Header
 }
 
 func (registerDs3TargetSpectraS3Response *RegisterDs3TargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &registerDs3TargetSpectraS3Response.Ds3Target)
+	return parseResponsePayload(webResponse, &registerDs3TargetSpectraS3Response.Ds3Target)
 }
 
 func NewRegisterDs3TargetSpectraS3Response(webResponse WebResponse) (*RegisterDs3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body RegisterDs3TargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body RegisterDs3TargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifyDs3TargetSpectraS3Response struct {
-    Ds3Target Ds3Target
-    Headers *http.Header
+	Ds3Target Ds3Target
+	Headers   *http.Header
 }
 
 func (verifyDs3TargetSpectraS3Response *VerifyDs3TargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &verifyDs3TargetSpectraS3Response.Ds3Target)
+	return parseResponsePayload(webResponse, &verifyDs3TargetSpectraS3Response.Ds3Target)
 }
 
 func NewVerifyDs3TargetSpectraS3Response(webResponse WebResponse) (*VerifyDs3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body VerifyDs3TargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body VerifyDs3TargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutS3TargetBucketNameSpectraS3Response struct {
-    S3TargetBucketName S3TargetBucketName
-    Headers *http.Header
+	S3TargetBucketName S3TargetBucketName
+	Headers            *http.Header
 }
 
 func (putS3TargetBucketNameSpectraS3Response *PutS3TargetBucketNameSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putS3TargetBucketNameSpectraS3Response.S3TargetBucketName)
+	return parseResponsePayload(webResponse, &putS3TargetBucketNameSpectraS3Response.S3TargetBucketName)
 }
 
 func NewPutS3TargetBucketNameSpectraS3Response(webResponse WebResponse) (*PutS3TargetBucketNameSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutS3TargetBucketNameSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutS3TargetBucketNameSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type PutS3TargetReadPreferenceSpectraS3Response struct {
-    S3TargetReadPreference S3TargetReadPreference
-    Headers *http.Header
+	S3TargetReadPreference S3TargetReadPreference
+	Headers                *http.Header
 }
 
 func (putS3TargetReadPreferenceSpectraS3Response *PutS3TargetReadPreferenceSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &putS3TargetReadPreferenceSpectraS3Response.S3TargetReadPreference)
+	return parseResponsePayload(webResponse, &putS3TargetReadPreferenceSpectraS3Response.S3TargetReadPreference)
 }
 
 func NewPutS3TargetReadPreferenceSpectraS3Response(webResponse WebResponse) (*PutS3TargetReadPreferenceSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body PutS3TargetReadPreferenceSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body PutS3TargetReadPreferenceSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteS3TargetBucketNameSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteS3TargetBucketNameSpectraS3Response(webResponse WebResponse) (*DeleteS3TargetBucketNameSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteS3TargetBucketNameSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteS3TargetBucketNameSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteS3TargetFailureSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteS3TargetFailureSpectraS3Response(webResponse WebResponse) (*DeleteS3TargetFailureSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteS3TargetFailureSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteS3TargetFailureSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteS3TargetReadPreferenceSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteS3TargetReadPreferenceSpectraS3Response(webResponse WebResponse) (*DeleteS3TargetReadPreferenceSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteS3TargetReadPreferenceSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteS3TargetReadPreferenceSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DeleteS3TargetSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDeleteS3TargetSpectraS3Response(webResponse WebResponse) (*DeleteS3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DeleteS3TargetSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DeleteS3TargetSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetBlobsOnS3TargetSpectraS3Response struct {
-    BulkObjectList BulkObjectList
-    Headers *http.Header
+	BulkObjectList BulkObjectList
+	Headers        *http.Header
 }
 
 func (getBlobsOnS3TargetSpectraS3Response *GetBlobsOnS3TargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getBlobsOnS3TargetSpectraS3Response.BulkObjectList)
+	return parseResponsePayload(webResponse, &getBlobsOnS3TargetSpectraS3Response.BulkObjectList)
 }
 
 func NewGetBlobsOnS3TargetSpectraS3Response(webResponse WebResponse) (*GetBlobsOnS3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetBlobsOnS3TargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetBlobsOnS3TargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetS3TargetBucketNamesSpectraS3Response struct {
-    S3TargetBucketNameList S3TargetBucketNameList
-    Headers *http.Header
+	S3TargetBucketNameList S3TargetBucketNameList
+	Headers                *http.Header
 }
 
 func (getS3TargetBucketNamesSpectraS3Response *GetS3TargetBucketNamesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getS3TargetBucketNamesSpectraS3Response.S3TargetBucketNameList)
+	return parseResponsePayload(webResponse, &getS3TargetBucketNamesSpectraS3Response.S3TargetBucketNameList)
 }
 
 func NewGetS3TargetBucketNamesSpectraS3Response(webResponse WebResponse) (*GetS3TargetBucketNamesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetS3TargetBucketNamesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetS3TargetBucketNamesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetS3TargetFailuresSpectraS3Response struct {
-    S3TargetFailureList S3TargetFailureList
-    Headers *http.Header
+	S3TargetFailureList S3TargetFailureList
+	Headers             *http.Header
 }
 
 func (getS3TargetFailuresSpectraS3Response *GetS3TargetFailuresSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getS3TargetFailuresSpectraS3Response.S3TargetFailureList)
+	return parseResponsePayload(webResponse, &getS3TargetFailuresSpectraS3Response.S3TargetFailureList)
 }
 
 func NewGetS3TargetFailuresSpectraS3Response(webResponse WebResponse) (*GetS3TargetFailuresSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetS3TargetFailuresSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetS3TargetFailuresSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetS3TargetReadPreferenceSpectraS3Response struct {
-    S3TargetReadPreference S3TargetReadPreference
-    Headers *http.Header
+	S3TargetReadPreference S3TargetReadPreference
+	Headers                *http.Header
 }
 
 func (getS3TargetReadPreferenceSpectraS3Response *GetS3TargetReadPreferenceSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getS3TargetReadPreferenceSpectraS3Response.S3TargetReadPreference)
+	return parseResponsePayload(webResponse, &getS3TargetReadPreferenceSpectraS3Response.S3TargetReadPreference)
 }
 
 func NewGetS3TargetReadPreferenceSpectraS3Response(webResponse WebResponse) (*GetS3TargetReadPreferenceSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetS3TargetReadPreferenceSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetS3TargetReadPreferenceSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetS3TargetReadPreferencesSpectraS3Response struct {
-    S3TargetReadPreferenceList S3TargetReadPreferenceList
-    Headers *http.Header
+	S3TargetReadPreferenceList S3TargetReadPreferenceList
+	Headers                    *http.Header
 }
 
 func (getS3TargetReadPreferencesSpectraS3Response *GetS3TargetReadPreferencesSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getS3TargetReadPreferencesSpectraS3Response.S3TargetReadPreferenceList)
+	return parseResponsePayload(webResponse, &getS3TargetReadPreferencesSpectraS3Response.S3TargetReadPreferenceList)
 }
 
 func NewGetS3TargetReadPreferencesSpectraS3Response(webResponse WebResponse) (*GetS3TargetReadPreferencesSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetS3TargetReadPreferencesSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetS3TargetReadPreferencesSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetS3TargetSpectraS3Response struct {
-    S3Target S3Target
-    Headers *http.Header
+	S3Target S3Target
+	Headers  *http.Header
 }
 
 func (getS3TargetSpectraS3Response *GetS3TargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getS3TargetSpectraS3Response.S3Target)
+	return parseResponsePayload(webResponse, &getS3TargetSpectraS3Response.S3Target)
 }
 
 func NewGetS3TargetSpectraS3Response(webResponse WebResponse) (*GetS3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetS3TargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetS3TargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetS3TargetsSpectraS3Response struct {
-    S3TargetList S3TargetList
-    Headers *http.Header
+	S3TargetList S3TargetList
+	Headers      *http.Header
 }
 
 func (getS3TargetsSpectraS3Response *GetS3TargetsSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getS3TargetsSpectraS3Response.S3TargetList)
+	return parseResponsePayload(webResponse, &getS3TargetsSpectraS3Response.S3TargetList)
 }
 
 func NewGetS3TargetsSpectraS3Response(webResponse WebResponse) (*GetS3TargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetS3TargetsSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetS3TargetsSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ImportS3TargetSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewImportS3TargetSpectraS3Response(webResponse WebResponse) (*ImportS3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ImportS3TargetSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ImportS3TargetSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyAllS3TargetsSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewModifyAllS3TargetsSpectraS3Response(webResponse WebResponse) (*ModifyAllS3TargetsSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &ModifyAllS3TargetsSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &ModifyAllS3TargetsSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyS3TargetSpectraS3Response struct {
-    S3Target S3Target
-    Headers *http.Header
+	S3Target S3Target
+	Headers  *http.Header
 }
 
 func (modifyS3TargetSpectraS3Response *ModifyS3TargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyS3TargetSpectraS3Response.S3Target)
+	return parseResponsePayload(webResponse, &modifyS3TargetSpectraS3Response.S3Target)
 }
 
 func NewModifyS3TargetSpectraS3Response(webResponse WebResponse) (*ModifyS3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyS3TargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyS3TargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type RegisterS3TargetSpectraS3Response struct {
-    S3Target S3Target
-    Headers *http.Header
+	S3Target S3Target
+	Headers  *http.Header
 }
 
 func (registerS3TargetSpectraS3Response *RegisterS3TargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &registerS3TargetSpectraS3Response.S3Target)
+	return parseResponsePayload(webResponse, &registerS3TargetSpectraS3Response.S3Target)
 }
 
 func NewRegisterS3TargetSpectraS3Response(webResponse WebResponse) (*RegisterS3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body RegisterS3TargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body RegisterS3TargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type VerifyS3TargetSpectraS3Response struct {
-    S3Target S3Target
-    Headers *http.Header
+	S3Target S3Target
+	Headers  *http.Header
 }
 
 func (verifyS3TargetSpectraS3Response *VerifyS3TargetSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &verifyS3TargetSpectraS3Response.S3Target)
+	return parseResponsePayload(webResponse, &verifyS3TargetSpectraS3Response.S3Target)
 }
 
 func NewVerifyS3TargetSpectraS3Response(webResponse WebResponse) (*VerifyS3TargetSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body VerifyS3TargetSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body VerifyS3TargetSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DelegateCreateUserSpectraS3Response struct {
-    SpectraUser SpectraUser
-    Headers *http.Header
+	SpectraUser SpectraUser
+	Headers     *http.Header
 }
 
 func (delegateCreateUserSpectraS3Response *DelegateCreateUserSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &delegateCreateUserSpectraS3Response.SpectraUser)
+	return parseResponsePayload(webResponse, &delegateCreateUserSpectraS3Response.SpectraUser)
 }
 
 func NewDelegateCreateUserSpectraS3Response(webResponse WebResponse) (*DelegateCreateUserSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 201 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{201}
 
-    switch code := webResponse.StatusCode(); code {
-    case 201:
-        var body DelegateCreateUserSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 201:
+		var body DelegateCreateUserSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type DelegateDeleteUserSpectraS3Response struct {
-    
-    Headers *http.Header
+	Headers *http.Header
 }
 
-
-
 func NewDelegateDeleteUserSpectraS3Response(webResponse WebResponse) (*DelegateDeleteUserSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 204 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{204}
 
-    switch code := webResponse.StatusCode(); code {
-    case 204:
-        return &DelegateDeleteUserSpectraS3Response{Headers: webResponse.Header()}, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 204:
+		return &DelegateDeleteUserSpectraS3Response{Headers: webResponse.Header()}, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetUserSpectraS3Response struct {
-    SpectraUser SpectraUser
-    Headers *http.Header
+	SpectraUser SpectraUser
+	Headers     *http.Header
 }
 
 func (getUserSpectraS3Response *GetUserSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getUserSpectraS3Response.SpectraUser)
+	return parseResponsePayload(webResponse, &getUserSpectraS3Response.SpectraUser)
 }
 
 func NewGetUserSpectraS3Response(webResponse WebResponse) (*GetUserSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetUserSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetUserSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type GetUsersSpectraS3Response struct {
-    SpectraUserList SpectraUserList
-    Headers *http.Header
+	SpectraUserList SpectraUserList
+	Headers         *http.Header
 }
 
 func (getUsersSpectraS3Response *GetUsersSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &getUsersSpectraS3Response.SpectraUserList)
+	return parseResponsePayload(webResponse, &getUsersSpectraS3Response.SpectraUserList)
 }
 
 func NewGetUsersSpectraS3Response(webResponse WebResponse) (*GetUsersSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body GetUsersSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body GetUsersSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type ModifyUserSpectraS3Response struct {
-    SpectraUser SpectraUser
-    Headers *http.Header
+	SpectraUser SpectraUser
+	Headers     *http.Header
 }
 
 func (modifyUserSpectraS3Response *ModifyUserSpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &modifyUserSpectraS3Response.SpectraUser)
+	return parseResponsePayload(webResponse, &modifyUserSpectraS3Response.SpectraUser)
 }
 
 func NewModifyUserSpectraS3Response(webResponse WebResponse) (*ModifyUserSpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body ModifyUserSpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body ModifyUserSpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
 
 type RegenerateUserSecretKeySpectraS3Response struct {
-    SpectraUser SpectraUser
-    Headers *http.Header
+	SpectraUser SpectraUser
+	Headers     *http.Header
 }
 
 func (regenerateUserSecretKeySpectraS3Response *RegenerateUserSecretKeySpectraS3Response) parse(webResponse WebResponse) error {
-        return parseResponsePayload(webResponse, &regenerateUserSecretKeySpectraS3Response.SpectraUser)
+	return parseResponsePayload(webResponse, &regenerateUserSecretKeySpectraS3Response.SpectraUser)
 }
 
 func NewRegenerateUserSecretKeySpectraS3Response(webResponse WebResponse) (*RegenerateUserSecretKeySpectraS3Response, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { 200 }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{200}
 
-    switch code := webResponse.StatusCode(); code {
-    case 200:
-        var body RegenerateUserSecretKeySpectraS3Response
-        if err := body.parse(webResponse); err != nil {
-            return nil, err
-        }
-        body.Headers = webResponse.Header()
-        return &body, nil
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+	case 200:
+		var body RegenerateUserSecretKeySpectraS3Response
+		if err := body.parse(webResponse); err != nil {
+			return nil, err
+		}
+		body.Headers = webResponse.Header()
+		return &body, nil
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
-

--- a/ds3/models/xmlTree.go
+++ b/ds3/models/xmlTree.go
@@ -14,21 +14,21 @@
 package models
 
 import (
-    "encoding/xml"
+	"encoding/xml"
 )
 
 type XmlNode struct {
-    XMLName  xml.Name
-    Attrs    []xml.Attr `xml:"-"` // Does not parse attributes in sax parser
-    Content  []byte     `xml:",chardata"`
-    Children []XmlNode     `xml:",any"`
+	XMLName  xml.Name
+	Attrs    []xml.Attr `xml:"-"` // Does not parse attributes in sax parser
+	Content  []byte     `xml:",chardata"`
+	Children []XmlNode  `xml:",any"`
 }
 
 // Uses the Go library to unmarshal XML into a simple node structure
 func (xmlNode *XmlNode) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-    xmlNode.Attrs = start.Attr
+	xmlNode.Attrs = start.Attr
 
-    type n XmlNode
+	type n XmlNode
 
-    return d.DecodeElement((*n)(xmlNode), &start)
+	return d.DecodeElement((*n)(xmlNode), &start)
 }

--- a/ds3/networking/CustomUrlValues.go
+++ b/ds3/networking/CustomUrlValues.go
@@ -12,56 +12,56 @@
 package networking
 
 import (
-    "net/url"
-    "bytes"
-    "sort"
+	"bytes"
+	"net/url"
+	"sort"
 )
 
 // Wrapper for url.Values to be used for encoding query parameters
 // without the '=' sign when there is no corresponding value, ex:
 // key, value -> key=value
-// key, '' -> key
+// key, ” -> key
 type CustomUrlValues struct {
-    values url.Values
+	values url.Values
 }
 
 func NewCustomUrlValues() CustomUrlValues {
-    return CustomUrlValues{ values:url.Values{} }
+	return CustomUrlValues{values: url.Values{}}
 }
 
 // Copied and modified from url.Values to remove '=' when there are no values to add
 func (customValues CustomUrlValues) Encode() string {
-    if customValues.values == nil {
-        return ""
-    }
-    var buf bytes.Buffer
-    keys := make([]string, 0, len(customValues.values))
-    for key := range customValues.values {
-        keys = append(keys, key)
-    }
-    sort.Strings(keys)
-    for _, key := range keys {
-        values := customValues.values[key]
-        prefix := url.QueryEscape(key)
-        for _, value := range values {
-            if buf.Len() > 0 {
-                buf.WriteByte('&')
-            }
-            buf.WriteString(prefix)
+	if customValues.values == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	keys := make([]string, 0, len(customValues.values))
+	for key := range customValues.values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		values := customValues.values[key]
+		prefix := url.QueryEscape(key)
+		for _, value := range values {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(prefix)
 
-            // If there is a value, then append
-            if value != "" {
-                buf.WriteString("=" + url.QueryEscape(value))
-            }
-        }
-    }
-    return buf.String()
+			// If there is a value, then append
+			if value != "" {
+				buf.WriteString("=" + url.QueryEscape(value))
+			}
+		}
+	}
+	return buf.String()
 }
 
 func (customValues CustomUrlValues) Add(key string, value string) {
-    customValues.values.Add(key, value)
+	customValues.values.Add(key, value)
 }
 
 func (customValues CustomUrlValues) Size() int {
-    return len(customValues.values)
+	return len(customValues.values)
 }

--- a/ds3/networking/canonicalHeaders.go
+++ b/ds3/networking/canonicalHeaders.go
@@ -1,8 +1,8 @@
 package networking
 
 // Used to correctly sort headers when creating the stringToSign for the authorization header.
-type CanonicalHeader struct{
-	key string // key is assumed to be lower cased
+type CanonicalHeader struct {
+	key    string // key is assumed to be lower cased
 	values []string
 }
 type CanonicalHeaders []CanonicalHeader

--- a/ds3/networking/headers.go
+++ b/ds3/networking/headers.go
@@ -12,14 +12,14 @@
 package networking
 
 import (
-    "crypto/hmac"
-    "crypto/sha1"
-    "encoding/base64"
-    "errors"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "net/url"
-    "time"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"net/url"
+	"time"
 )
 
 // Http Headers
@@ -31,79 +31,84 @@ const ContentSha512 string = "Content-SHA512"
 const ContentTypeKey string = "Content-Type" // This header describes the format of the contents
 
 type headerFields struct {
-    AuthHeaderVal string
-    DateHeaderVal string
-    ChecksumType  models.ChecksumType
-    ContentHash   string
+	AuthHeaderVal string
+	DateHeaderVal string
+	ChecksumType  models.ChecksumType
+	ContentHash   string
 }
 
 // Gets the correct header key for the specified checksum type
 func getChecksumHeaderKey(checksumType models.ChecksumType) (string, error) {
-    switch checksumType {
-        case models.CHECKSUM_TYPE_CRC_32: return ContentCRC32, nil
-        case models.CHECKSUM_TYPE_CRC_32C: return ContentCRC32C, nil
-        case models.CHECKSUM_TYPE_MD5: return ContentMd5, nil
-        case models.CHECKSUM_TYPE_SHA_256: return ContentSha256, nil
-        case models.CHECKSUM_TYPE_SHA_512: return ContentSha512, nil
-        case models.NONE: return "", nil
-        default:
-            return "", errors.New(fmt.Sprintf("Invalid ChecksumType represented by: %d", checksumType))
-    }
+	switch checksumType {
+	case models.CHECKSUM_TYPE_CRC_32:
+		return ContentCRC32, nil
+	case models.CHECKSUM_TYPE_CRC_32C:
+		return ContentCRC32C, nil
+	case models.CHECKSUM_TYPE_MD5:
+		return ContentMd5, nil
+	case models.CHECKSUM_TYPE_SHA_256:
+		return ContentSha256, nil
+	case models.CHECKSUM_TYPE_SHA_512:
+		return ContentSha512, nil
+	case models.NONE:
+		return "", nil
+	default:
+		return "", errors.New(fmt.Sprintf("Invalid ChecksumType represented by: %d", checksumType))
+	}
 }
 
 // Retrieves the current UTC date in a specific format to be used in creating the Date header value
-func getCurrentTime() (string) {
-    return time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 +0000")
+func getCurrentTime() string {
+	return time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 +0000")
 }
 
 type signatureFields struct {
-    Verb                      string
-    ContentHash               string
-    ContentType               string
-    Date                      string
-    CanonicalizedAmzHeaders   string
-    CanonicalizedSubResources string
-    Path                      string
+	Verb                      string
+	ContentHash               string
+	ContentType               string
+	Date                      string
+	CanonicalizedAmzHeaders   string
+	CanonicalizedSubResources string
+	Path                      string
 }
 
-func (fields *signatureFields) BuildAuthHeaderValue(creds *Credentials) (string) {
-    // Build the string that we need to compute the MAC on.
+func (fields *signatureFields) BuildAuthHeaderValue(creds *Credentials) string {
+	// Build the string that we need to compute the MAC on.
 
-    // Create a URL containing just the path so that we can use the library's escaping logic
-    // to match the http request escaping
-    var urlPath url.URL
-    urlPath.Path = fields.Path
+	// Create a URL containing just the path so that we can use the library's escaping logic
+	// to match the http request escaping
+	var urlPath url.URL
+	urlPath.Path = fields.Path
 
-    stringToSign := fmt.Sprintf(
-        "%s\n%s\n%s\n%s\n%s%s%s",
-        fields.Verb,
-        fields.ContentHash,
-        fields.ContentType,
-        fields.Date,
-        fields.CanonicalizedAmzHeaders,
-        customEscapePath(urlPath),
-        fields.CanonicalizedSubResources,
-    )
+	stringToSign := fmt.Sprintf(
+		"%s\n%s\n%s\n%s\n%s%s%s",
+		fields.Verb,
+		fields.ContentHash,
+		fields.ContentType,
+		fields.Date,
+		fields.CanonicalizedAmzHeaders,
+		customEscapePath(urlPath),
+		fields.CanonicalizedSubResources,
+	)
 
-    signature := computeSignature(creds.Key, stringToSign)
+	signature := computeSignature(creds.Key, stringToSign)
 
-    // Return the pieces in the correct format.
-    return fmt.Sprintf("AWS %s:%s", creds.AccessId, signature)
+	// Return the pieces in the correct format.
+	return fmt.Sprintf("AWS %s:%s", creds.AccessId, signature)
 }
 
-func computeSignature(key string, stringToSign string) (string) {
-    // Compute the MAC and base64 encode the result.
-    return base64.StdEncoding.EncodeToString(calcSha1Mac(key, stringToSign))
+func computeSignature(key string, stringToSign string) string {
+	// Compute the MAC and base64 encode the result.
+	return base64.StdEncoding.EncodeToString(calcSha1Mac(key, stringToSign))
 }
 
 func calcSha1Mac(key, stringToSign string) []byte {
-    // Create a new mac with a secret key.
-    mac := hmac.New(sha1.New, []byte(key))
+	// Create a new mac with a secret key.
+	mac := hmac.New(sha1.New, []byte(key))
 
-    // Write the string to it.
-    mac.Write([]byte(stringToSign))
+	// Write the string to it.
+	mac.Write([]byte(stringToSign))
 
-    // Compute the checksum.
-    return mac.Sum(nil)
+	// Compute the checksum.
+	return mac.Sum(nil)
 }
-

--- a/ds3/networking/headers_test.go
+++ b/ds3/networking/headers_test.go
@@ -12,25 +12,25 @@
 package networking
 
 import (
-    "testing"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"testing"
 )
 
 func TestBuildAuthHeaderValue(t *testing.T) {
-    expected := "AWS access:gmW4yg/tw02UYleIqGn5ebvKbr8="
+	expected := "AWS access:gmW4yg/tw02UYleIqGn5ebvKbr8="
 
-    fields := signatureFields{
-        Verb:"PUT",
-        Date:"Tue, 31 Jul 2018 17:23:50 +0000",
-        Path:"abc/1+2+3/e f g/aÀˠϠૐ༺ᎀ",
-    }
+	fields := signatureFields{
+		Verb: "PUT",
+		Date: "Tue, 31 Jul 2018 17:23:50 +0000",
+		Path: "abc/1+2+3/e f g/aÀˠϠૐ༺ᎀ",
+	}
 
-    credentials := Credentials{
-        AccessId:"access",
-        Key:"key",
-    }
+	credentials := Credentials{
+		AccessId: "access",
+		Key:      "key",
+	}
 
-    result := fields.BuildAuthHeaderValue(&credentials)
+	result := fields.BuildAuthHeaderValue(&credentials)
 
-    ds3Testing.AssertString(t, "authorization header", expected, result)
+	ds3Testing.AssertString(t, "authorization header", expected, result)
 }

--- a/ds3/networking/httpRedirect.go
+++ b/ds3/networking/httpRedirect.go
@@ -1,48 +1,48 @@
 package networking
 
 import (
-    "errors"
-    "fmt"
-    "net/http"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"errors"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"net/http"
 )
 
 type httpRedirectPolicy struct {
-    maxRedirect int
+	maxRedirect int
 }
 
 // Decorator for Network which handles 307 temporary redirect retries
 type HttpTempRedirectDecorator struct {
-    network Network
-    policy *httpRedirectPolicy
+	network Network
+	policy  *httpRedirectPolicy
 }
 
-func NewHttpTempRedirectDecorator(network Network, maxRedirect int) (Network) {
-    return &HttpTempRedirectDecorator{
-        network: network,
-        policy: &httpRedirectPolicy{maxRedirect: maxRedirect},
-    }
+func NewHttpTempRedirectDecorator(network Network, maxRedirect int) Network {
+	return &HttpTempRedirectDecorator{
+		network: network,
+		policy:  &httpRedirectPolicy{maxRedirect: maxRedirect},
+	}
 }
 
 func (tempRedirectDecorator *HttpTempRedirectDecorator) Invoke(httpRequest *http.Request) (models.WebResponse, error) {
-    // Handle as many 307's as we're allowed.
-    for i := 0; i <= tempRedirectDecorator.policy.maxRedirect; i++ {
-        ds3Response, err := tempRedirectDecorator.network.Invoke(httpRequest)
+	// Handle as many 307's as we're allowed.
+	for i := 0; i <= tempRedirectDecorator.policy.maxRedirect; i++ {
+		ds3Response, err := tempRedirectDecorator.network.Invoke(httpRequest)
 
-        // If request was performed successfully then return response.
-        if err == nil {
-            return ds3Response, nil
-        }
+		// If request was performed successfully then return response.
+		if err == nil {
+			return ds3Response, nil
+		}
 
-        // If there was a non-redirect error then return.
-        if statusErr, ok := err.(models.BadStatusCodeError); ok == false || statusErr.ActualStatusCode != http.StatusTemporaryRedirect {
-            return nil, err
-        }
-    }
+		// If there was a non-redirect error then return.
+		if statusErr, ok := err.(models.BadStatusCodeError); ok == false || statusErr.ActualStatusCode != http.StatusTemporaryRedirect {
+			return nil, err
+		}
+	}
 
-    // We had as many 307 redirects as we were allowed to use.
-    return nil, errors.New(fmt.Sprintf(
-        "The server is busy. Retried the max number of %d times.",
-        tempRedirectDecorator.policy.maxRedirect,
-    ))
+	// We had as many 307 redirects as we were allowed to use.
+	return nil, errors.New(fmt.Sprintf(
+		"The server is busy. Retried the max number of %d times.",
+		tempRedirectDecorator.policy.maxRedirect,
+	))
 }

--- a/ds3/networking/httpRequestBuilder.go
+++ b/ds3/networking/httpRequestBuilder.go
@@ -12,199 +12,199 @@
 package networking
 
 import (
-    "context"
-    "io"
-    "net/http"
-    "net/url"
-    "strings"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "sort"
+	"context"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
 )
 
 type HttpRequestBuilder struct {
-    reader io.Reader
-    contentLength *int64
-    queryParams *url.Values
-    headers *http.Header
-    signatureFields signatureFields
-    checksumType models.ChecksumType
+	reader          io.Reader
+	contentLength   *int64
+	queryParams     *url.Values
+	headers         *http.Header
+	signatureFields signatureFields
+	checksumType    models.ChecksumType
 }
 
 func NewHttpRequestBuilder() *HttpRequestBuilder {
-    return &HttpRequestBuilder{
-        queryParams:&url.Values{},
-        headers:&http.Header{},
-        checksumType:models.NONE,
-    }
+	return &HttpRequestBuilder{
+		queryParams:  &url.Values{},
+		headers:      &http.Header{},
+		checksumType: models.NONE,
+	}
 }
 
 // Internally converts reader with size decorator to limit reader to ensure size is respected
 func (builder *HttpRequestBuilder) WithReader(stream models.ReaderWithSizeDecorator) *HttpRequestBuilder {
-    streamSize, _ := stream.Size()
-    builder.reader = io.LimitReader(stream, streamSize)
-    builder.contentLength = &streamSize
-    return builder
+	streamSize, _ := stream.Size()
+	builder.reader = io.LimitReader(stream, streamSize)
+	builder.contentLength = &streamSize
+	return builder
 }
 
 // Internally converts reader with size decorator to limit reader to ensure size is respected
 // and adds the closer functionality to the limit reader. The send network will automatically
 // close the reader when finished.
 func (builder *HttpRequestBuilder) WithReadCloser(stream models.ReadCloserWithSizeDecorator) *HttpRequestBuilder {
-    streamSize, _ := stream.Size()
-    builder.reader = NewLimitReadCloser(stream)
-    builder.contentLength = &streamSize
-    return builder
+	streamSize, _ := stream.Size()
+	builder.reader = NewLimitReadCloser(stream)
+	builder.contentLength = &streamSize
+	return builder
 }
 
 func (builder *HttpRequestBuilder) WithHttpVerb(verb string) *HttpRequestBuilder {
-    builder.signatureFields.Verb = verb
-    return builder
+	builder.signatureFields.Verb = verb
+	return builder
 }
 
 func (builder *HttpRequestBuilder) WithPath(path string) *HttpRequestBuilder {
-    builder.signatureFields.Path = path
-    return builder
+	builder.signatureFields.Path = path
+	return builder
 }
 
 func (builder *HttpRequestBuilder) WithHeader(key string, value string) *HttpRequestBuilder {
-    builder.headers.Add(key, value)
-    return builder
+	builder.headers.Add(key, value)
+	return builder
 }
 
 func (builder *HttpRequestBuilder) WithHeaders(headers map[string]string) *HttpRequestBuilder {
-    for key, value := range headers {
-        builder.WithHeader(key, value)
-    }
-    return builder
+	for key, value := range headers {
+		builder.WithHeader(key, value)
+	}
+	return builder
 }
 
 func (builder *HttpRequestBuilder) WithQueryParam(key string, value string) *HttpRequestBuilder {
-    builder.queryParams.Set(key, value)
-    return builder
+	builder.queryParams.Set(key, value)
+	return builder
 }
 
 func (builder *HttpRequestBuilder) WithOptionalQueryParam(key string, value *string) *HttpRequestBuilder {
-    if value == nil {
-        return builder
-    }
-    builder.queryParams.Set(key, *value)
-    return builder
+	if value == nil {
+		return builder
+	}
+	builder.queryParams.Set(key, *value)
+	return builder
 }
 
 func (builder *HttpRequestBuilder) WithOptionalVoidQueryParam(key string, value bool) *HttpRequestBuilder {
-    if value {
-        builder.queryParams.Set(key, "")
-    }
-    return builder
+	if value {
+		builder.queryParams.Set(key, "")
+	}
+	return builder
 }
 
 func (builder *HttpRequestBuilder) WithChecksum(checksum models.Checksum) *HttpRequestBuilder {
-    builder.signatureFields.ContentHash = checksum.ContentHash
-    builder.checksumType = checksum.Type
-    return builder
+	builder.signatureFields.ContentHash = checksum.ContentHash
+	builder.checksumType = checksum.Type
+	return builder
 }
 
 func (builder *HttpRequestBuilder) WithContentType(contentType string) *HttpRequestBuilder {
-    builder.signatureFields.ContentType = contentType
-    return builder
+	builder.signatureFields.ContentType = contentType
+	return builder
 }
 
 func (builder *HttpRequestBuilder) Build(ctx context.Context, conn *ConnectionInfo) (*http.Request, error) {
-    httpRequest, err := http.NewRequestWithContext(ctx, builder.signatureFields.Verb, builder.buildUrl(conn), builder.reader)
-    if err != nil {
-        return nil, err
-    }
+	httpRequest, err := http.NewRequestWithContext(ctx, builder.signatureFields.Verb, builder.buildUrl(conn), builder.reader)
+	if err != nil {
+		return nil, err
+	}
 
-    if builder.contentLength != nil {
-        httpRequest.ContentLength = *builder.contentLength
+	if builder.contentLength != nil {
+		httpRequest.ContentLength = *builder.contentLength
 
-        // Special casing for content length == 0.  Go won't include the content length header
-        // if the length is 0, but BlackPearl needs the content length header to be there and be 0
-        // to create a folder.
-        // See https://github.com/golang/go/issues/20257
-        if *builder.contentLength == 0 {
-            httpRequest.Body = http.NoBody
-        }
-    }
+		// Special casing for content length == 0.  Go won't include the content length header
+		// if the length is 0, but BlackPearl needs the content length header to be there and be 0
+		// to create a folder.
+		// See https://github.com/golang/go/issues/20257
+		if *builder.contentLength == 0 {
+			httpRequest.Body = http.NoBody
+		}
+	}
 
-    builder.signatureFields.Date = getCurrentTime()
+	builder.signatureFields.Date = getCurrentTime()
 
-    builder.maybeAddAmazonCanonicalHeaders()
-    builder.maybeAddSignatureQueryParams()
+	builder.maybeAddAmazonCanonicalHeaders()
+	builder.maybeAddSignatureQueryParams()
 
-    authHeaderVal := builder.signatureFields.BuildAuthHeaderValue(conn.Credentials)
+	authHeaderVal := builder.signatureFields.BuildAuthHeaderValue(conn.Credentials)
 
-    // Set the http request headers such as authorization and date.
-    return builder.addHttpRequestHeaders(httpRequest, authHeaderVal)
+	// Set the http request headers such as authorization and date.
+	return builder.addHttpRequestHeaders(httpRequest, authHeaderVal)
 }
 
 func (builder *HttpRequestBuilder) buildUrl(conn *ConnectionInfo) string {
-    var httpUrl = *conn.Endpoint
-    httpUrl.Path = builder.signatureFields.Path
-    httpUrl.RawQuery = encodeQueryParams(builder.queryParams)
+	var httpUrl = *conn.Endpoint
+	httpUrl.Path = builder.signatureFields.Path
+	httpUrl.RawQuery = encodeQueryParams(builder.queryParams)
 
-    // Perform a custom percent encoding of the path to ensure ; and + are percent encoded as BP expects
-    httpUrl.RawPath = customEscapePath(httpUrl)
+	// Perform a custom percent encoding of the path to ensure ; and + are percent encoded as BP expects
+	httpUrl.RawPath = customEscapePath(httpUrl)
 
-    return httpUrl.String()
+	return httpUrl.String()
 }
 
 // Returns the percent encoded path of the provided URL in a format that is congruent with BP.
 // This uses the standard path escaping plus it explicitly percent encodes ; and + since the
 // http library does not encode them by default.
 func customEscapePath(httpUrl url.URL) string {
-    replacer := strings.NewReplacer(";", "%3B", "+", "%2B")
-    return replacer.Replace(httpUrl.EscapedPath())
+	replacer := strings.NewReplacer(";", "%3B", "+", "%2B")
+	return replacer.Replace(httpUrl.EscapedPath())
 }
 
 func (builder *HttpRequestBuilder) maybeAddSignatureQueryParams() {
-    if len(*builder.queryParams) == 0 {
-        return
-    }
+	if len(*builder.queryParams) == 0 {
+		return
+	}
 
-    signatureQueryParams := NewCustomUrlValues()
+	signatureQueryParams := NewCustomUrlValues()
 
-    // get the list of query parameters that are required in the signature
-    for key, values := range *builder.queryParams {
-        switch key {
-        case "acl",
-            "lifecycle",
-            "location",
-            "logging",
-            "notification",
-            "partNumber",
-            "requestPayment",
-            "torrent",
-            "uploadId",
-            "uploads",
-            "versionId",
-            "versioning",
-            "versions",
-            "website",
-            "delete",
-            "response-content-type",
-            "response-content-language",
-            "response-expires",
-            "response-cache-control",
-            "response-content-disposition",
-            "response-content-encoding":
+	// get the list of query parameters that are required in the signature
+	for key, values := range *builder.queryParams {
+		switch key {
+		case "acl",
+			"lifecycle",
+			"location",
+			"logging",
+			"notification",
+			"partNumber",
+			"requestPayment",
+			"torrent",
+			"uploadId",
+			"uploads",
+			"versionId",
+			"versioning",
+			"versions",
+			"website",
+			"delete",
+			"response-content-type",
+			"response-content-language",
+			"response-expires",
+			"response-cache-control",
+			"response-content-disposition",
+			"response-content-encoding":
 
-            // add all values associated with the key to the signature
-            for _, value := range values {
-                signatureQueryParams.Add(key, value)
-            }
+			// add all values associated with the key to the signature
+			for _, value := range values {
+				signatureQueryParams.Add(key, value)
+			}
 
-        default:
-            //do nothing
-        }
-    }
+		default:
+			//do nothing
+		}
+	}
 
-    if signatureQueryParams.Size() == 0 {
-        return
-    }
+	if signatureQueryParams.Size() == 0 {
+		return
+	}
 
-    // encode query parameters and percent encode the spaces
-    builder.signatureFields.CanonicalizedSubResources = "?" + strings.Replace(signatureQueryParams.Encode(), "+", "%20", -1)
+	// encode query parameters and percent encode the spaces
+	builder.signatureFields.CanonicalizedSubResources = "?" + strings.Replace(signatureQueryParams.Encode(), "+", "%20", -1)
 }
 
 func (builder *HttpRequestBuilder) maybeAddAmazonCanonicalHeaders() {
@@ -213,10 +213,10 @@ func (builder *HttpRequestBuilder) maybeAddAmazonCanonicalHeaders() {
 	for key, value := range *builder.headers {
 		lowerCaseKey := strings.ToLower(key)
 		if strings.HasPrefix(lowerCaseKey, models.AMZ_META_HEADER) && len(value) > 0 {
-            canonicalHeaders = append(canonicalHeaders, CanonicalHeader{
-                key:   lowerCaseKey,
-                values: value,
-            })
+			canonicalHeaders = append(canonicalHeaders, CanonicalHeader{
+				key:    lowerCaseKey,
+				values: value,
+			})
 		}
 	}
 
@@ -245,29 +245,28 @@ func (builder *HttpRequestBuilder) maybeAddAmazonCanonicalHeaders() {
 }
 
 func (builder *HttpRequestBuilder) addHttpRequestHeaders(httpRequest *http.Request, authHeader string) (*http.Request, error) {
-    httpRequest.Header.Add("Date", builder.signatureFields.Date)
-    httpRequest.Header.Add("Authorization", authHeader)
+	httpRequest.Header.Add("Date", builder.signatureFields.Date)
+	httpRequest.Header.Add("Authorization", authHeader)
 
-    if builder.checksumType != models.NONE {
-        checksumKey, err := getChecksumHeaderKey(builder.checksumType)
-        if err != nil {
-            return nil, err
-        }
-        httpRequest.Header.Add(checksumKey, builder.signatureFields.ContentHash)
-    }
+	if builder.checksumType != models.NONE {
+		checksumKey, err := getChecksumHeaderKey(builder.checksumType)
+		if err != nil {
+			return nil, err
+		}
+		httpRequest.Header.Add(checksumKey, builder.signatureFields.ContentHash)
+	}
 
-    // Copy the headers from the Ds3Request object.
-    for key, val := range *builder.headers {
-        httpRequest.Header.Add(key, val[0])
-    }
-    return httpRequest, nil
+	// Copy the headers from the Ds3Request object.
+	for key, val := range *builder.headers {
+		httpRequest.Header.Add(key, val[0])
+	}
+	return httpRequest, nil
 }
 
 // Percent encodes query parameters and constructs encoded string.
 // Spaces are percent encoded as '%20'
 func encodeQueryParams(queryParams *url.Values) string {
-    // url.Encode encodes spaces as plus (+), so after urlEncode we replace plus (+) signs
-    // with percent encoding for spaces (%20)
-    return strings.Replace(queryParams.Encode(), "+", "%20", -1)
+	// url.Encode encodes spaces as plus (+), so after urlEncode we replace plus (+) signs
+	// with percent encoding for spaces (%20)
+	return strings.Replace(queryParams.Encode(), "+", "%20", -1)
 }
-

--- a/ds3/networking/httpRequestBuilder_test.go
+++ b/ds3/networking/httpRequestBuilder_test.go
@@ -1,58 +1,58 @@
 package networking
 
 import (
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
-    "net/url"
-    "testing"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"net/url"
+	"testing"
 )
 
 func TestBuildUrlEscapingPath(t *testing.T) {
-    testCases := []struct {
-        input string
-        encoded string
-    }{
-        {input:"-", encoded:"-"},
-        {input:".", encoded:"."},
-        {input:"_", encoded:"_"},
-        {input:"~", encoded:"~"},
-        {input:"$", encoded:"$"},
-        {input:",", encoded:","},
-        {input:"&", encoded:"&"},
-        {input:"=", encoded:"="},
-        {input:"@", encoded:"@"},
-        {input:":", encoded:":"},
-        {input:"/", encoded:"/"},
-        {input:";", encoded:"%3B"},
-        {input:"+", encoded:"%2B"},
-        {input:"?", encoded:"%3F"},
-        {input:" ", encoded:"%20"},
-        {input:"%", encoded:"%25"},
-        {input:"#", encoded:"%23"},
-        {input:"'", encoded:"%27"},
-        {input:"\t", encoded:"%09"},
-    }
+	testCases := []struct {
+		input   string
+		encoded string
+	}{
+		{input: "-", encoded: "-"},
+		{input: ".", encoded: "."},
+		{input: "_", encoded: "_"},
+		{input: "~", encoded: "~"},
+		{input: "$", encoded: "$"},
+		{input: ",", encoded: ","},
+		{input: "&", encoded: "&"},
+		{input: "=", encoded: "="},
+		{input: "@", encoded: "@"},
+		{input: ":", encoded: ":"},
+		{input: "/", encoded: "/"},
+		{input: ";", encoded: "%3B"},
+		{input: "+", encoded: "%2B"},
+		{input: "?", encoded: "%3F"},
+		{input: " ", encoded: "%20"},
+		{input: "%", encoded: "%25"},
+		{input: "#", encoded: "%23"},
+		{input: "'", encoded: "%27"},
+		{input: "\t", encoded: "%09"},
+	}
 
-    const bucketName = "myBucket"
+	const bucketName = "myBucket"
 
-    endPoint, err := url.Parse("http://sm2u-1-10g.eng.sldomain.com")
-    ds3Testing.AssertNilError(t, err)
+	endPoint, err := url.Parse("http://sm2u-1-10g.eng.sldomain.com")
+	ds3Testing.AssertNilError(t, err)
 
-    connectionInfo := &ConnectionInfo{
-        Endpoint: endPoint,
-    }
+	connectionInfo := &ConnectionInfo{
+		Endpoint: endPoint,
+	}
 
-    for _, testCase := range testCases {
-        objectName := fmt.Sprintf("object%swithsymbol", testCase.input)
+	for _, testCase := range testCases {
+		objectName := fmt.Sprintf("object%swithsymbol", testCase.input)
 
-        requestBuilder := NewHttpRequestBuilder().
-            WithHttpVerb("PUT").
-            WithPath("/" + bucketName + "/" + objectName)
+		requestBuilder := NewHttpRequestBuilder().
+			WithHttpVerb("PUT").
+			WithPath("/" + bucketName + "/" + objectName)
 
-        encodedUrl := requestBuilder.buildUrl(connectionInfo)
+		encodedUrl := requestBuilder.buildUrl(connectionInfo)
 
-        expectedObjectName := fmt.Sprintf("object%swithsymbol", testCase.encoded)
-        expected := fmt.Sprintf("%s/%s/%s", endPoint.String(), bucketName, expectedObjectName)
-        ds3Testing.AssertString(t, fmt.Sprintf("encoding symbol %s", testCase.input), expected, encodedUrl)
-    }
+		expectedObjectName := fmt.Sprintf("object%swithsymbol", testCase.encoded)
+		expected := fmt.Sprintf("%s/%s/%s", endPoint.String(), bucketName, expectedObjectName)
+		ds3Testing.AssertString(t, fmt.Sprintf("encoding symbol %s", testCase.input), expected, encodedUrl)
+	}
 }

--- a/ds3/networking/net.go
+++ b/ds3/networking/net.go
@@ -1,34 +1,34 @@
 package networking
 
 import (
-    "crypto/tls"
-    "net/http"
-    "net/url"
-    "time"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"crypto/tls"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"net/http"
+	"net/url"
+	"time"
 )
 
 type ConnectionInfo struct {
-    Endpoint                *url.URL
-    Credentials             *Credentials
-    Proxy                   *url.URL
-    IgnoreServerCertificate bool
-    MaxIdleConnsPerHost     int
-    IdleConnTimeout         time.Duration
+	Endpoint                *url.URL
+	Credentials             *Credentials
+	Proxy                   *url.URL
+	IgnoreServerCertificate bool
+	MaxIdleConnsPerHost     int
+	IdleConnTimeout         time.Duration
 }
 
 type Credentials struct {
-    AccessId string
-    Key string
+	AccessId string
+	Key      string
 }
 
 type Network interface {
-    Invoke(httpRequest *http.Request) (models.WebResponse, error)
+	Invoke(httpRequest *http.Request) (models.WebResponse, error)
 }
 
 // Performs http requests
 type SendNetwork struct {
-    transport *http.Transport
+	transport *http.Transport
 }
 
 // Default idle connection timeout that's applied to the transport.
@@ -37,37 +37,37 @@ type SendNetwork struct {
 const DEFAULT_IDLE_CONN_TIMEOUT = 30 * time.Second
 
 func NewSendNetwork(connectionInfo *ConnectionInfo) Network {
-    transport := http.DefaultTransport.(*http.Transport).Clone()
-    transport.IdleConnTimeout = DEFAULT_IDLE_CONN_TIMEOUT
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.IdleConnTimeout = DEFAULT_IDLE_CONN_TIMEOUT
 
-    if connectionInfo.Proxy != nil {
-        transport.Proxy = http.ProxyURL(connectionInfo.Proxy)
-    }
-    if connectionInfo.IgnoreServerCertificate {
-        transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-    }
-    if connectionInfo.MaxIdleConnsPerHost > 0 {
-        transport.MaxIdleConnsPerHost = connectionInfo.MaxIdleConnsPerHost
-    }
-    if connectionInfo.IdleConnTimeout > 0 {
-        transport.IdleConnTimeout = connectionInfo.IdleConnTimeout
-    }
+	if connectionInfo.Proxy != nil {
+		transport.Proxy = http.ProxyURL(connectionInfo.Proxy)
+	}
+	if connectionInfo.IgnoreServerCertificate {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	if connectionInfo.MaxIdleConnsPerHost > 0 {
+		transport.MaxIdleConnsPerHost = connectionInfo.MaxIdleConnsPerHost
+	}
+	if connectionInfo.IdleConnTimeout > 0 {
+		transport.IdleConnTimeout = connectionInfo.IdleConnTimeout
+	}
 
-    // Pin HTTP/1.1: BlackPearl's Tomcat h2 connector trips a 64 KB
-    // stream-window stall on streaming PUTs (RMS-10959). The C SDK
-    // (libds3v5) does the same.
-    transport.ForceAttemptHTTP2 = false
-    transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
+	// Pin HTTP/1.1: BlackPearl's Tomcat h2 connector trips a 64 KB
+	// stream-window stall on streaming PUTs (RMS-10959). The C SDK
+	// (libds3v5) does the same.
+	transport.ForceAttemptHTTP2 = false
+	transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
 
-    return &SendNetwork{transport: transport}
+	return &SendNetwork{transport: transport}
 }
 
 func (sendNetwork *SendNetwork) Invoke(httpRequest *http.Request) (models.WebResponse, error) {
-    // Perform the request.
-    httpResponse, reqErr := sendNetwork.transport.RoundTrip(httpRequest)
-    if reqErr != nil {
-        return nil, reqErr
-    }
+	// Perform the request.
+	httpResponse, reqErr := sendNetwork.transport.RoundTrip(httpRequest)
+	if reqErr != nil {
+		return nil, reqErr
+	}
 
-    return models.NewWrappedHttpResponse(httpResponse), nil
+	return models.NewWrappedHttpResponse(httpResponse), nil
 }

--- a/ds3/networking/networkRetry.go
+++ b/ds3/networking/networkRetry.go
@@ -1,56 +1,56 @@
 package networking
 
 import (
-    "errors"
-    "fmt"
-    "log"
-    "net/http"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"errors"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"log"
+	"net/http"
 )
 
 type networkRetryPolicy struct {
-    maxRetries int
+	maxRetries int
 }
 
 // Decorator for Network which handles network related retries
 type NetworkRetryDecorator struct {
-    network Network
-    policy *networkRetryPolicy
+	network Network
+	policy  *networkRetryPolicy
 }
 
-func NewNetworkRetryDecorator(network Network, maxRetires int) (Network) {
-    return &NetworkRetryDecorator{
-        network: network,
-        policy: &networkRetryPolicy{ maxRetries: maxRetires },
-    }
+func NewNetworkRetryDecorator(network Network, maxRetires int) Network {
+	return &NetworkRetryDecorator{
+		network: network,
+		policy:  &networkRetryPolicy{maxRetries: maxRetires},
+	}
 }
 
 func (networkRetryDecorator *NetworkRetryDecorator) Invoke(httpRequest *http.Request) (models.WebResponse, error) {
-    // Handle as many Network related retries as we're allowed.
-    var lastErr error
-    for i := 0; i <= networkRetryDecorator.policy.maxRetries; i++ {
-        // Bail early if the request's context has been cancelled or its deadline exceeded
-        // — otherwise we'd keep slamming attempts at an already-dead context.
-        if err := httpRequest.Context().Err(); err != nil {
-            return nil, err
-        }
+	// Handle as many Network related retries as we're allowed.
+	var lastErr error
+	for i := 0; i <= networkRetryDecorator.policy.maxRetries; i++ {
+		// Bail early if the request's context has been cancelled or its deadline exceeded
+		// — otherwise we'd keep slamming attempts at an already-dead context.
+		if err := httpRequest.Context().Err(); err != nil {
+			return nil, err
+		}
 
-        ds3Response, err := networkRetryDecorator.network.Invoke(httpRequest)
+		ds3Response, err := networkRetryDecorator.network.Invoke(httpRequest)
 
-        // If request was performed successfully then return response.
-        if err == nil {
-            return ds3Response, nil
-        }
+		// If request was performed successfully then return response.
+		if err == nil {
+			return ds3Response, nil
+		}
 
-        // Log the network error, and try again if max retries has not been attempted
-        log.Printf("Encountered network error '%s'.", err.Error())
-        lastErr = err
-    }
+		// Log the network error, and try again if max retries has not been attempted
+		log.Printf("Encountered network error '%s'.", err.Error())
+		lastErr = err
+	}
 
-    // We had as many network related retries as we're allowed to use.
-    return nil, errors.New(fmt.Sprintf(
-        "Cannot send request. Retried the network connection the maximum number of %d times. Error: `%s`.",
-        networkRetryDecorator.policy.maxRetries,
-        lastErr.Error(),
-    ))
+	// We had as many network related retries as we're allowed to use.
+	return nil, errors.New(fmt.Sprintf(
+		"Cannot send request. Retried the network connection the maximum number of %d times. Error: `%s`.",
+		networkRetryDecorator.policy.maxRetries,
+		lastErr.Error(),
+	))
 }

--- a/ds3/networking/networking_test.go
+++ b/ds3/networking/networking_test.go
@@ -12,25 +12,25 @@
 package networking
 
 import (
-    "context"
-    "testing"
-    "net/url"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "strings"
+	"context"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"net/url"
+	"strings"
+	"testing"
 )
 
 func TestEncodeQueryParams(t *testing.T) {
-    expected := "key%20space%20=value%20space%20&key%2Bplus=value%2Bplus&key%3Bsemicolon=value%3Bsemicolon"
+	expected := "key%20space%20=value%20space%20&key%2Bplus=value%2Bplus&key%3Bsemicolon=value%3Bsemicolon"
 
-    queryParams := &url.Values{}
-    queryParams.Set("key space ", "value space ")
-    queryParams.Set("key;semicolon", "value;semicolon")
-    queryParams.Set("key+plus", "value+plus")
+	queryParams := &url.Values{}
+	queryParams.Set("key space ", "value space ")
+	queryParams.Set("key;semicolon", "value;semicolon")
+	queryParams.Set("key+plus", "value+plus")
 
-    result := encodeQueryParams(queryParams)
+	result := encodeQueryParams(queryParams)
 
-    ds3Testing.AssertString(t, "Encoded Query Params", expected, result)
+	ds3Testing.AssertString(t, "Encoded Query Params", expected, result)
 }
 
 func TestBuildingAuthorizationDigestWithMetadata(t *testing.T) {
@@ -50,8 +50,8 @@ func TestBuildingAuthorizationDigestWithMetadata(t *testing.T) {
 		Proxy:       nil}
 
 	httpRequestBuilder.
-		WithHeader(models.AMZ_META_HEADER + shasta, samoyed).
-		WithHeader(models.AMZ_META_HEADER + gracie, eskimo).
+		WithHeader(models.AMZ_META_HEADER+shasta, samoyed).
+		WithHeader(models.AMZ_META_HEADER+gracie, eskimo).
 		Build(context.Background(), &connectionInfo)
 
 	amazonHeaders := httpRequestBuilder.signatureFields.CanonicalizedAmzHeaders

--- a/ds3/networking/readerWithSizeDecorator.go
+++ b/ds3/networking/readerWithSizeDecorator.go
@@ -1,33 +1,33 @@
 package networking
 
 import (
-    "io"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"io"
 )
 
 // Defines a limited reader that also supports closing
 type LimitReadCloser struct {
-    reader io.LimitedReader
-    closer io.Closer
+	reader io.LimitedReader
+	closer io.Closer
 }
 
 // Creates a ReadCloser that wraps the reader in a LimitedReader, and preserves
 // the closability of the original reader
 func NewLimitReadCloser(readCloser models.ReadCloserWithSizeDecorator) io.ReadCloser {
-    size, _ := readCloser.Size()
-    limitReader := io.LimitedReader{R:readCloser, N:size}
-    return &LimitReadCloser{
-        reader: limitReader,
-        closer: readCloser,
-    }
+	size, _ := readCloser.Size()
+	limitReader := io.LimitedReader{R: readCloser, N: size}
+	return &LimitReadCloser{
+		reader: limitReader,
+		closer: readCloser,
+	}
 }
 
 // Reads from the limited reader
 func (limitedReadCloser *LimitReadCloser) Read(p []byte) (n int, err error) {
-    return limitedReadCloser.reader.Read(p)
+	return limitedReadCloser.reader.Read(p)
 }
 
 // Closes the original reader
 func (limitedReadCloser *LimitReadCloser) Close() error {
-    return limitedReadCloser.closer.Close()
+	return limitedReadCloser.closer.Close()
 }

--- a/ds3/networking/typeConverterUtils.go
+++ b/ds3/networking/typeConverterUtils.go
@@ -1,7 +1,7 @@
 package networking
 
 import (
-    "strconv"
+	"strconv"
 )
 
 // Contains utils for converting pointers to primitives into string pointers.
@@ -10,49 +10,49 @@ import (
 
 // Converts an *int64 into a *string
 func Int64PtrToStrPtr(int *int64) *string {
-    if int == nil {
-        return nil
-    }
-    str := strconv.FormatInt(*int, 10)
-    return &str
+	if int == nil {
+		return nil
+	}
+	str := strconv.FormatInt(*int, 10)
+	return &str
 }
 
 // Converts an *int into a *string
 func IntPtrToStrPtr(int *int) *string {
-    if int == nil {
-        return nil
-    }
-    str := strconv.Itoa(*int)
-    return &str
+	if int == nil {
+		return nil
+	}
+	str := strconv.Itoa(*int)
+	return &str
 }
 
 // Converts a *bool into a *string
 func BoolPtrToStrPtr(bool *bool) *string {
-    if bool == nil {
-        return nil
-    }
-    str := strconv.FormatBool(*bool)
-    return &str
+	if bool == nil {
+		return nil
+	}
+	str := strconv.FormatBool(*bool)
+	return &str
 }
 
 // Converts a *float64 into a *string
 func Float64PtrToStrPtr(float *float64) *string {
-    if float == nil {
-        return nil
-    }
-    str := strconv.FormatFloat(*float, 'f', -1, 64)
-    return &str
+	if float == nil {
+		return nil
+	}
+	str := strconv.FormatFloat(*float, 'f', -1, 64)
+	return &str
 }
 
 // Interface for a to string method
 type ToStringPtrInterface interface {
-    StringPtr() *string
+	StringPtr() *string
 }
 
 // Converts an item that meets the ToStringInterface into a *string
 func InterfaceToStrPtr(item ToStringPtrInterface) *string {
-    if item == nil {
-        return nil
-    }
-    return item.StringPtr()
+	if item == nil {
+		return nil
+	}
+	return item.StringPtr()
 }

--- a/ds3/requestPayloadUtils.go
+++ b/ds3/requestPayloadUtils.go
@@ -12,164 +12,162 @@
 package ds3
 
 import (
-    "encoding/xml"
-    "bytes"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"bytes"
+	"encoding/xml"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
 // Converts the parts list into a request payload stream of format:
 // <CompleteMultipartUpload><Part><PartNumber>partNumber</PartNumber><ETag>eTag</ETag></Part>...</CompleteMultipartUpload>
 func buildPartsListStream(parts []models.Part) models.ReadCloserWithSizeDecorator {
-    completeMultipartUpload := models.CompleteMultipartUpload{ Parts:parts }
-    return marshalRequestPayload(completeMultipartUpload)
+	completeMultipartUpload := models.CompleteMultipartUpload{Parts: parts}
+	return marshalRequestPayload(completeMultipartUpload)
 }
 
 type ds3PutObjectList struct {
-    XMLName xml.Name
-    Ds3PutObjects []models.Ds3PutObject `xml:"Object"`
+	XMLName       xml.Name
+	Ds3PutObjects []models.Ds3PutObject `xml:"Object"`
 }
 
 // Used to encapsulate a slice of Ds3PutObjects with xml marshaling information
 func newDs3PutObjectList(ds3PutObjects []models.Ds3PutObject) *ds3PutObjectList {
-    return &ds3PutObjectList{
-        XMLName: xml.Name{Local:"Objects"},
-        Ds3PutObjects: ds3PutObjects,
-    }
+	return &ds3PutObjectList{
+		XMLName:       xml.Name{Local: "Objects"},
+		Ds3PutObjects: ds3PutObjects,
+	}
 }
 
 // Converts the ds3 put object list into a request payload stream of format:
 // <Objects><Object Name="o1" Size="2048"></Object><Object Name="o2" Size="2048"></Object>...</Objects>
 func buildDs3PutObjectListStream(ds3PutObjects []models.Ds3PutObject) models.ReadCloserWithSizeDecorator {
-    // Build the ds3 put object list entity.
-    objects := newDs3PutObjectList(ds3PutObjects)
-    return marshalRequestPayload(objects)
+	// Build the ds3 put object list entity.
+	objects := newDs3PutObjectList(ds3PutObjects)
+	return marshalRequestPayload(objects)
 }
 
-
-
 type ds3GetObjectList struct {
-    XMLName xml.Name
-    Ds3GetObjects []models.Ds3GetObject `xml:"Object"`
+	XMLName       xml.Name
+	Ds3GetObjects []models.Ds3GetObject `xml:"Object"`
 }
 
 // Used to encapsulate a slice of Ds3GetObjects with xml marshaling information
 func newDs3GetObjectList(ds3GetObjects []models.Ds3GetObject) *ds3GetObjectList {
-    return &ds3GetObjectList{
-        XMLName: xml.Name{Local:"Objects"},
-        Ds3GetObjects: ds3GetObjects,
-    }
+	return &ds3GetObjectList{
+		XMLName:       xml.Name{Local: "Objects"},
+		Ds3GetObjects: ds3GetObjects,
+	}
 }
 
 // Converts string list into Ds3Object and marshals to request payload stream of format:
 // <Objects><Object Name="o1"></Object><Object Name="o2"></Object>...</Objects>
 func buildDs3ObjectStreamFromNames(objectNames []string) models.ReadCloserWithSizeDecorator {
-    // Build the ds3 get object list entity.
-    var objects []models.Ds3GetObject
-    for _, name := range objectNames {
-        objects = append(objects, models.NewDs3GetObject(name))
-    }
+	// Build the ds3 get object list entity.
+	var objects []models.Ds3GetObject
+	for _, name := range objectNames {
+		objects = append(objects, models.NewDs3GetObject(name))
+	}
 
-    objectList := newDs3GetObjectList(objects)
+	objectList := newDs3GetObjectList(objects)
 
-    return marshalRequestPayload(objectList)
+	return marshalRequestPayload(objectList)
 }
 
 // Converts the ds3 get object list into a request payload stream of format:
 // <Objects><Object Name="o1" Length="2" Offset="3"></Object><Object Name="o2" Length="3" offset="4"></Object>...</Objects>
 func buildDs3GetObjectListStream(ds3GetObjects []models.Ds3GetObject) models.ReadCloserWithSizeDecorator {
-    // Build the ds3 get object list entity.
-    objects := newDs3GetObjectList(ds3GetObjects)
-    return marshalRequestPayload(objects)
+	// Build the ds3 get object list entity.
+	objects := newDs3GetObjectList(ds3GetObjects)
+	return marshalRequestPayload(objects)
 }
 
 type deleteObjectList struct {
-    XMLName xml.Name
-    Objects []deleteObject `xml:"Object"`
+	XMLName xml.Name
+	Objects []deleteObject `xml:"Object"`
 }
 
 type deleteObject struct {
-    Key string `xml:"Key"`
+	Key string `xml:"Key"`
 }
 
 // Used to encapsulate a list of object names with xml marshaling information
 // for creating a delete objects request payload
 func newDeleteObjectList(objectNames []string) *deleteObjectList {
-    objects := make([]deleteObject, len(objectNames))
-    for index, name := range objectNames {
-        objects[index].Key = name
-    }
-    return &deleteObjectList{
-        XMLName: xml.Name{Local:"Delete"},
-        Objects: objects,
-    }
+	objects := make([]deleteObject, len(objectNames))
+	for index, name := range objectNames {
+		objects[index].Key = name
+	}
+	return &deleteObjectList{
+		XMLName: xml.Name{Local: "Delete"},
+		Objects: objects,
+	}
 }
 
 // Converts a list of object names into a request payload stream for delete objects of format:
 // <Delete><Object><Key>o1</Key></Object><Object><Key>o2</Key></Object>...</Delete>
 func buildDeleteObjectsPayload(objectNames []string) models.ReadCloserWithSizeDecorator {
-    deleteObjects := newDeleteObjectList(objectNames)
-    return marshalRequestPayload(deleteObjects)
+	deleteObjects := newDeleteObjectList(objectNames)
+	return marshalRequestPayload(deleteObjects)
 }
 
 type idList struct {
-    XMLName xml.Name
-    IdList []string `xml:"Id"`
+	XMLName xml.Name
+	IdList  []string `xml:"Id"`
 }
 
 // Used to encapsulate a list of ids with xml marshaling information
 func newIdList(objectNames []string) *idList {
-    return &idList{
-        XMLName: xml.Name{Local:"Ids"},
-        IdList:objectNames,
-    }
+	return &idList{
+		XMLName: xml.Name{Local: "Ids"},
+		IdList:  objectNames,
+	}
 }
 
 // Converts a list of ids into a request payload stream of format:
 // <Ids><Id>id1</Id><Id>id2</Id>...</Ids>
 func buildIdListPayload(ids []string) models.ReadCloserWithSizeDecorator {
-    idList := newIdList(ids)
-    return marshalRequestPayload(idList)
+	idList := newIdList(ids)
+	return marshalRequestPayload(idList)
 }
 
 // Converts a string request payload into a request payload stream.
 func buildStreamFromString(payload string) models.ReadCloserWithSizeDecorator {
-    return BuildByteReaderWithSizeDecorator([]byte(payload))
+	return BuildByteReaderWithSizeDecorator([]byte(payload))
 }
 
 func marshalRequestPayload(model interface{}) models.ReadCloserWithSizeDecorator {
-    xmlBytes, err := xml.Marshal(model)
-    if err != nil {
-        // Should never happen
-        panic(err)
-    }
-    return BuildByteReaderWithSizeDecorator(xmlBytes)
+	xmlBytes, err := xml.Marshal(model)
+	if err != nil {
+		// Should never happen
+		panic(err)
+	}
+	return BuildByteReaderWithSizeDecorator(xmlBytes)
 }
 
 // Defines a ReaderWithSizeDecorator based on an array of bytes.
 type byteReaderWithSizeDecorator struct {
-    reader *bytes.Reader
-    size int64
+	reader *bytes.Reader
+	size   int64
 }
 
 func BuildByteReaderWithSizeDecorator(contentBytes []byte) models.ReadCloserWithSizeDecorator {
-    return &byteReaderWithSizeDecorator{
-        bytes.NewReader(contentBytes),
-        int64(len(contentBytes)),
-    }
+	return &byteReaderWithSizeDecorator{
+		bytes.NewReader(contentBytes),
+		int64(len(contentBytes)),
+	}
 }
 
 func (byteReaderWithSizeDecorator *byteReaderWithSizeDecorator) Read(b []byte) (int, error) {
-    return byteReaderWithSizeDecorator.reader.Read(b)
+	return byteReaderWithSizeDecorator.reader.Read(b)
 }
 
 func (byteReaderWithSizeDecorator) Close() error {
-    return nil
+	return nil
 }
 
 func (byteReaderWithSizeDecorator *byteReaderWithSizeDecorator) Seek(offset int64, whence int) (int64, error) {
-    return byteReaderWithSizeDecorator.reader.Seek(offset, whence)
+	return byteReaderWithSizeDecorator.reader.Seek(offset, whence)
 }
 
 func (byteReaderWithSizeDecorator *byteReaderWithSizeDecorator) Size() (int64, error) {
-    return byteReaderWithSizeDecorator.size, nil
+	return byteReaderWithSizeDecorator.size, nil
 }

--- a/ds3/requestPayloadUtils_test.go
+++ b/ds3/requestPayloadUtils_test.go
@@ -12,96 +12,96 @@
 package ds3
 
 import (
-    "testing"
-    "io/ioutil"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"io/ioutil"
+	"testing"
 )
 
 func verifyStreamContent(t *testing.T, contentStream models.ReaderWithSizeDecorator, expected string) {
-    bs, readErr := ioutil.ReadAll(contentStream)
-    if readErr != nil {
-        t.Fatalf("Unexpected error: '%s'.", readErr.Error())
-    }
-    result := string(bs)
-    if result != expected {
-        t.Fatalf("Expected '%s' but got '%s'.", expected, result)
-    }
+	bs, readErr := ioutil.ReadAll(contentStream)
+	if readErr != nil {
+		t.Fatalf("Unexpected error: '%s'.", readErr.Error())
+	}
+	result := string(bs)
+	if result != expected {
+		t.Fatalf("Expected '%s' but got '%s'.", expected, result)
+	}
 }
 
 func TestBuildPartsListStream(t *testing.T) {
-    expected := "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>eTag1</ETag></Part><Part><PartNumber>2</PartNumber><ETag>eTag2</ETag></Part><Part><PartNumber>3</PartNumber><ETag>eTag3</ETag></Part></CompleteMultipartUpload>"
+	expected := "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>eTag1</ETag></Part><Part><PartNumber>2</PartNumber><ETag>eTag2</ETag></Part><Part><PartNumber>3</PartNumber><ETag>eTag3</ETag></Part></CompleteMultipartUpload>"
 
-    parts := []models.Part{
-        {PartNumber:1, ETag:"eTag1"},
-        {PartNumber:2, ETag:"eTag2"},
-        {PartNumber:3, ETag:"eTag3"},
-    }
+	parts := []models.Part{
+		{PartNumber: 1, ETag: "eTag1"},
+		{PartNumber: 2, ETag: "eTag2"},
+		{PartNumber: 3, ETag: "eTag3"},
+	}
 
-    contentStream := buildPartsListStream(parts)
+	contentStream := buildPartsListStream(parts)
 
-    defer contentStream.Close()
-    verifyStreamContent(t, contentStream, expected)
+	defer contentStream.Close()
+	verifyStreamContent(t, contentStream, expected)
 }
 
 func TestBuildDs3PutObjectListStream(t *testing.T) {
-    expected := "<Objects><Object Name=\"o1\" Size=\"1\"></Object><Object Name=\"o2\" Size=\"2\"></Object><Object Name=\"o3\" Size=\"3\"></Object></Objects>"
+	expected := "<Objects><Object Name=\"o1\" Size=\"1\"></Object><Object Name=\"o2\" Size=\"2\"></Object><Object Name=\"o3\" Size=\"3\"></Object></Objects>"
 
-    ds3PutObjects := []models.Ds3PutObject{
-        {Name:"o1", Size:1},
-        {Name:"o2", Size:2},
-        {Name:"o3", Size:3},
-    }
+	ds3PutObjects := []models.Ds3PutObject{
+		{Name: "o1", Size: 1},
+		{Name: "o2", Size: 2},
+		{Name: "o3", Size: 3},
+	}
 
-    contentStream := buildDs3PutObjectListStream(ds3PutObjects)
+	contentStream := buildDs3PutObjectListStream(ds3PutObjects)
 
-    defer contentStream.Close()
-    verifyStreamContent(t, contentStream, expected)
+	defer contentStream.Close()
+	verifyStreamContent(t, contentStream, expected)
 }
 
 func TestBuildDs3ObjectStreamFromNames(t *testing.T) {
-    expected := "<Objects><Object Name=\"o1\"></Object><Object Name=\"o2\"></Object><Object Name=\"o3\"></Object></Objects>"
+	expected := "<Objects><Object Name=\"o1\"></Object><Object Name=\"o2\"></Object><Object Name=\"o3\"></Object></Objects>"
 
-    names := []string {"o1", "o2", "o3"}
+	names := []string{"o1", "o2", "o3"}
 
-    contentStream := buildDs3ObjectStreamFromNames(names)
+	contentStream := buildDs3ObjectStreamFromNames(names)
 
-    defer contentStream.Close()
-    verifyStreamContent(t, contentStream, expected)
+	defer contentStream.Close()
+	verifyStreamContent(t, contentStream, expected)
 }
 
 func TestBuildDs3GetObjectListStream(t *testing.T) {
-    expected := "<Objects><Object Name=\"o1\" Length=\"10\" Offset=\"1\"></Object><Object Name=\"o2\" Length=\"20\" Offset=\"2\"></Object><Object Name=\"o3\" Length=\"30\" Offset=\"3\"></Object></Objects>"
+	expected := "<Objects><Object Name=\"o1\" Length=\"10\" Offset=\"1\"></Object><Object Name=\"o2\" Length=\"20\" Offset=\"2\"></Object><Object Name=\"o3\" Length=\"30\" Offset=\"3\"></Object></Objects>"
 
-    ds3GetObjects := []models.Ds3GetObject {
-        models.NewPartialDs3GetObject("o1", 10, 1),
-        models.NewPartialDs3GetObject("o2", 20, 2),
-        models.NewPartialDs3GetObject("o3", 30, 3),
-    }
+	ds3GetObjects := []models.Ds3GetObject{
+		models.NewPartialDs3GetObject("o1", 10, 1),
+		models.NewPartialDs3GetObject("o2", 20, 2),
+		models.NewPartialDs3GetObject("o3", 30, 3),
+	}
 
-    contentStream := buildDs3GetObjectListStream(ds3GetObjects)
+	contentStream := buildDs3GetObjectListStream(ds3GetObjects)
 
-    defer contentStream.Close()
-    verifyStreamContent(t, contentStream, expected)
+	defer contentStream.Close()
+	verifyStreamContent(t, contentStream, expected)
 }
 
 func TestBuildDeleteObjectsPayload(t *testing.T) {
-    expected := "<Delete><Object><Key>o1</Key></Object><Object><Key>o2</Key></Object><Object><Key>o3</Key></Object></Delete>"
+	expected := "<Delete><Object><Key>o1</Key></Object><Object><Key>o2</Key></Object><Object><Key>o3</Key></Object></Delete>"
 
-    names := []string {"o1", "o2", "o3"}
+	names := []string{"o1", "o2", "o3"}
 
-    contentStream := buildDeleteObjectsPayload(names)
+	contentStream := buildDeleteObjectsPayload(names)
 
-    defer contentStream.Close()
-    verifyStreamContent(t, contentStream, expected)
+	defer contentStream.Close()
+	verifyStreamContent(t, contentStream, expected)
 }
 
 func TestBuildIdListPayload(t *testing.T) {
-    expected := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
+	expected := "<Ids><Id>id1</Id><Id>id2</Id><Id>id3</Id></Ids>"
 
-    ids := []string{"id1", "id2", "id3"}
+	ids := []string{"id1", "id2", "id3"}
 
-    contentStream := buildIdListPayload(ids)
+	contentStream := buildIdListPayload(ids)
 
-    defer contentStream.Close()
-    verifyStreamContent(t, contentStream, expected)
+	defer contentStream.Close()
+	verifyStreamContent(t, contentStream, expected)
 }

--- a/ds3_cli/commands/aggregateError.go
+++ b/ds3_cli/commands/aggregateError.go
@@ -5,21 +5,20 @@ import "bytes"
 // Provides a way to combine error messages together. This is useful for
 // displaying errors that occur during parallel processing.
 type aggregateError struct {
-    errors []error
+	errors []error
 }
 
 // Adds an error to the aggregate.
 func (aggregateError *aggregateError) Add(err error) {
-    aggregateError.errors = append(aggregateError.errors, err)
+	aggregateError.errors = append(aggregateError.errors, err)
 }
 
 // Implements the error interface.
 func (aggregateError *aggregateError) Error() string {
-    var buffer bytes.Buffer
-    for _, err := range aggregateError.errors {
-        buffer.WriteString(err.Error())
-        buffer.WriteString("\n")
-    }
-    return buffer.String()
+	var buffer bytes.Buffer
+	for _, err := range aggregateError.errors {
+		buffer.WriteString(err.Error())
+		buffer.WriteString("\n")
+	}
+	return buffer.String()
 }
-

--- a/ds3_cli/commands/args.go
+++ b/ds3_cli/commands/args.go
@@ -1,69 +1,76 @@
 package commands
 
 import (
-    "errors"
-    "os"
-    "flag"
+	"errors"
+	"flag"
+	"os"
 )
 
 // Represents the parsed command line arguments that we may be interested in.
 type Arguments struct {
-    Endpoint, Proxy string
-    AccessKey, SecretKey string
-    Command string
-    Bucket string
-    Key string
-    KeyPrefix string
-    MaxKeys int
-    Start, End int
+	Endpoint, Proxy      string
+	AccessKey, SecretKey string
+	Command              string
+	Bucket               string
+	Key                  string
+	KeyPrefix            string
+	MaxKeys              int
+	Start, End           int
 }
 
 func ParseArgs() (*Arguments, error) {
-    // Parse command line arguments.
-    endpointParam := flag.String("endpoint", "", "Specifies the url to the DS3 server.")
-    accessKeyParam := flag.String("access_key", "", "Specifies the access_key for the DS3 user.")
-    secretKeyParam := flag.String("secret_key", "", "Specifies the secret_key for the DS3 user.")
-    proxyParam := flag.String("proxy", "", "Specifies the HTTP proxy to route through.")
-    commandParam := flag.String("command", "", "The HTTP call to execute.")
-    bucketParam := flag.String("bucket", "", "The name of the bucket to constrict the request to.")
-    keyParam := flag.String("key", "", "The key for the object to get.")
-    keyPrefixParam := flag.String("prefix", "", "The key prefix by which to constrain the results.")
-    maxKeysParam := flag.Int("max-keys", 0, "The maximum number of objects to return.")
-    startParam := flag.Int("start", 0, "The object location at which to start.")
-    endParam := flag.Int("end", 0, "The object location at which to end.")
-    flag.Parse()
+	// Parse command line arguments.
+	endpointParam := flag.String("endpoint", "", "Specifies the url to the DS3 server.")
+	accessKeyParam := flag.String("access_key", "", "Specifies the access_key for the DS3 user.")
+	secretKeyParam := flag.String("secret_key", "", "Specifies the secret_key for the DS3 user.")
+	proxyParam := flag.String("proxy", "", "Specifies the HTTP proxy to route through.")
+	commandParam := flag.String("command", "", "The HTTP call to execute.")
+	bucketParam := flag.String("bucket", "", "The name of the bucket to constrict the request to.")
+	keyParam := flag.String("key", "", "The key for the object to get.")
+	keyPrefixParam := flag.String("prefix", "", "The key prefix by which to constrain the results.")
+	maxKeysParam := flag.Int("max-keys", 0, "The maximum number of objects to return.")
+	startParam := flag.Int("start", 0, "The object location at which to start.")
+	endParam := flag.Int("end", 0, "The object location at which to end.")
+	flag.Parse()
 
-    // Build the arguments object.
-    args := Arguments{
-        Endpoint: paramOrEnv(*endpointParam, "DS3_ENDPOINT"),
-        AccessKey: paramOrEnv(*accessKeyParam, "DS3_ACCESS_KEY"),
-        SecretKey: paramOrEnv(*secretKeyParam, "DS3_SECRET_KEY"),
-        Proxy: paramOrEnv(*proxyParam, "DS3_PROXY"),
-        Command: *commandParam,
-        Bucket: *bucketParam,
-        Key: *keyParam,
-        KeyPrefix: *keyPrefixParam,
-        MaxKeys: *maxKeysParam,
-        Start: *startParam,
-        End: *endParam,
-    }
+	// Build the arguments object.
+	args := Arguments{
+		Endpoint:  paramOrEnv(*endpointParam, "DS3_ENDPOINT"),
+		AccessKey: paramOrEnv(*accessKeyParam, "DS3_ACCESS_KEY"),
+		SecretKey: paramOrEnv(*secretKeyParam, "DS3_SECRET_KEY"),
+		Proxy:     paramOrEnv(*proxyParam, "DS3_PROXY"),
+		Command:   *commandParam,
+		Bucket:    *bucketParam,
+		Key:       *keyParam,
+		KeyPrefix: *keyPrefixParam,
+		MaxKeys:   *maxKeysParam,
+		Start:     *startParam,
+		End:       *endParam,
+	}
 
-    // Validate required arguments.
-    switch {
-        case args.Endpoint == "": return nil, errors.New("Must specify an endpoint.")
-        case args.AccessKey == "": return nil, errors.New("Must specify an access key.")
-        case args.SecretKey == "": return nil, errors.New("Must specify an secret key.")
-        case args.Command == "": return nil, errors.New("Must specify a command.")
-        default: return &args, nil
-    }
+	// Validate required arguments.
+	switch {
+	case args.Endpoint == "":
+		return nil, errors.New("Must specify an endpoint.")
+	case args.AccessKey == "":
+		return nil, errors.New("Must specify an access key.")
+	case args.SecretKey == "":
+		return nil, errors.New("Must specify an secret key.")
+	case args.Command == "":
+		return nil, errors.New("Must specify a command.")
+	default:
+		return &args, nil
+	}
 }
 
 func paramOrEnv(param, envName string) string {
-    env := os.Getenv(envName)
-    switch {
-        case param != "": return param
-        case env != "": return env
-        default: return ""
-    }
+	env := os.Getenv(envName)
+	switch {
+	case param != "":
+		return param
+	case env != "":
+		return env
+	default:
+		return ""
+	}
 }
-

--- a/ds3_cli/commands/bulk.go
+++ b/ds3_cli/commands/bulk.go
@@ -5,36 +5,35 @@ import "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 type bulkHandler func(object models.BulkObject) error
 
 func handleBulkResponse(objectLists []models.Objects, objectHandler bulkHandler) error {
-    // Make a channel to keep track of the errors and how many goroutines have finished.
-    finish := make(chan error)
+	// Make a channel to keep track of the errors and how many goroutines have finished.
+	finish := make(chan error)
 
-    // Spawn goroutines to perform the actual gets or puts.
-    for _, objectList := range objectLists {
-        go func() {
-            // Loop over each object and call the bulk handler.
-            for _, obj := range objectList.Objects {
-                // If there was an error, pass it onto the error channel and
-                // terminate the goroutine.
-                if err := objectHandler(obj); err != nil {
-                    finish <- err
-                    return
-                }
-            }
+	// Spawn goroutines to perform the actual gets or puts.
+	for _, objectList := range objectLists {
+		go func() {
+			// Loop over each object and call the bulk handler.
+			for _, obj := range objectList.Objects {
+				// If there was an error, pass it onto the error channel and
+				// terminate the goroutine.
+				if err := objectHandler(obj); err != nil {
+					finish <- err
+					return
+				}
+			}
 
-            // Signal that the object list is done.
-            finish <- nil
-        }()
-    }
+			// Signal that the object list is done.
+			finish <- nil
+		}()
+	}
 
-    // Wait for every goroutine to stop and accumulate their errors.
-    errors := &aggregateError{}
-    for i := len(objectLists); i > 0; i-- {
-        err := <-finish
-        if err != nil {
-            errors.Add(err)
-        }
-    }
+	// Wait for every goroutine to stop and accumulate their errors.
+	errors := &aggregateError{}
+	for i := len(objectLists); i > 0; i-- {
+		err := <-finish
+		if err != nil {
+			errors.Add(err)
+		}
+	}
 
-    return errors
+	return errors
 }
-

--- a/ds3_cli/commands/bulkGet.go
+++ b/ds3_cli/commands/bulkGet.go
@@ -1,79 +1,78 @@
 package commands
 
 import (
-    "context"
-    "io"
-    "os"
-    "path"
-    "errors"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"context"
+	"errors"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"io"
+	"os"
+	"path"
 )
 
 func bulkGet(ctx context.Context, client *ds3.Client, args *Arguments) error {
-    // Validate arguments.
-    if args.Bucket == "" {
-        return errors.New("Must specify a bucket name when doing a bulk_get.")
-    }
+	// Validate arguments.
+	if args.Bucket == "" {
+		return errors.New("Must specify a bucket name when doing a bulk_get.")
+	}
 
-    // Determine the objects that we need to queue a bulk get for.
-    objects, err := getBucketObjects(ctx, client, args)
-    if err != nil {
-        return err
-    }
+	// Determine the objects that we need to queue a bulk get for.
+	objects, err := getBucketObjects(ctx, client, args)
+	if err != nil {
+		return err
+	}
 
-    var ds3GetObjects []models.Ds3GetObject
-    for _, obj := range objects {
-        ds3GetObjects = append(ds3GetObjects, models.NewDs3GetObject(obj.Name))
-    }
+	var ds3GetObjects []models.Ds3GetObject
+	for _, obj := range objects {
+		ds3GetObjects = append(ds3GetObjects, models.NewDs3GetObject(obj.Name))
+	}
 
-    // Run request.
-    response, err := client.GetBulkJobSpectraS3(ctx, models.NewGetBulkJobSpectraS3RequestWithPartialObjects(args.Bucket, ds3GetObjects))
-    if err != nil {
-        return err
-    }
+	// Run request.
+	response, err := client.GetBulkJobSpectraS3(ctx, models.NewGetBulkJobSpectraS3RequestWithPartialObjects(args.Bucket, ds3GetObjects))
+	if err != nil {
+		return err
+	}
 
-    // Handle the responses in parallel
-    return handleBulkResponse(response.MasterObjectList.Objects, buildBulkHandler(ctx, client, args.Bucket))
+	// Handle the responses in parallel
+	return handleBulkResponse(response.MasterObjectList.Objects, buildBulkHandler(ctx, client, args.Bucket))
 }
 
 // Returns a function that gets an object from a bulk get.
 func buildBulkHandler(ctx context.Context, client *ds3.Client, bucketName string) bulkHandler {
-    return func(obj models.BulkObject) error {
-        // Perform the request.
-        response, requestErr := client.GetObject(ctx, models.NewGetObjectRequest(bucketName, *obj.Name))
-        if requestErr != nil {
-            return requestErr
-        }
-        defer response.Content.Close()
+	return func(obj models.BulkObject) error {
+		// Perform the request.
+		response, requestErr := client.GetObject(ctx, models.NewGetObjectRequest(bucketName, *obj.Name))
+		if requestErr != nil {
+			return requestErr
+		}
+		defer response.Content.Close()
 
-        // Get a file to write to.
-        file, fileErr := ensureDirectoryAndOpenFile(*obj.Name)
-        if fileErr != nil {
-            return fileErr
-        }
-        defer file.Close()
+		// Get a file to write to.
+		file, fileErr := ensureDirectoryAndOpenFile(*obj.Name)
+		if fileErr != nil {
+			return fileErr
+		}
+		defer file.Close()
 
-        // Copy the request stream to the file.
-        _, copyErr := io.Copy(file, response.Content)
-        return copyErr
-    }
+		// Copy the request stream to the file.
+		_, copyErr := io.Copy(file, response.Content)
+		return copyErr
+	}
 }
 
 func ensureDirectoryAndOpenFile(destination string) (*os.File, error) {
-    // Get the current directory so we can use the same permissions when
-    // creating directories inside of it.
-    currentDir, dirErr := os.Stat(".")
-    if dirErr != nil {
-        return nil, dirErr
-    }
+	// Get the current directory so we can use the same permissions when
+	// creating directories inside of it.
+	currentDir, dirErr := os.Stat(".")
+	if dirErr != nil {
+		return nil, dirErr
+	}
 
-    // Create the directory where we're going to store the file.
-    if mkdirErr := os.MkdirAll(path.Dir(destination), currentDir.Mode()); mkdirErr != nil {
-        return nil, mkdirErr
-    }
+	// Create the directory where we're going to store the file.
+	if mkdirErr := os.MkdirAll(path.Dir(destination), currentDir.Mode()); mkdirErr != nil {
+		return nil, mkdirErr
+	}
 
-    // Open the file to write.
-    return os.Create(destination)
+	// Open the file to write.
+	return os.Create(destination)
 }
-

--- a/ds3_cli/commands/bulkPut.go
+++ b/ds3_cli/commands/bulkPut.go
@@ -1,99 +1,98 @@
 package commands
 
 import (
-    "context"
-    "errors"
-    "io/ioutil"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"context"
+	"errors"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"io/ioutil"
 )
 
 func bulkPut(ctx context.Context, client *ds3.Client, args *Arguments) error {
-    // Validate arguments.
-    if args.Bucket == "" {
-        return errors.New("Must specify a bucket name when doing a bulk_put.")
-    }
-    if args.KeyPrefix == "" {
-        return errors.New("Must specify a key prefix when doing a bulk_put.")
-    }
+	// Validate arguments.
+	if args.Bucket == "" {
+		return errors.New("Must specify a bucket name when doing a bulk_put.")
+	}
+	if args.KeyPrefix == "" {
+		return errors.New("Must specify a key prefix when doing a bulk_put.")
+	}
 
-    // List the files.
-    files, filesErr := recursivelyListFiles(args.KeyPrefix)
-    if filesErr != nil {
-        return filesErr
-    }
+	// List the files.
+	files, filesErr := recursivelyListFiles(args.KeyPrefix)
+	if filesErr != nil {
+		return filesErr
+	}
 
-    // Create object entities that we can query with for each file.
-    objects := make([]models.Ds3PutObject, len(files))
-    for i, file := range files {
-        objects[i] = models.Ds3PutObject{Name: file.path, Size: file.size}
-    }
+	// Create object entities that we can query with for each file.
+	objects := make([]models.Ds3PutObject, len(files))
+	for i, file := range files {
+		objects[i] = models.Ds3PutObject{Name: file.path, Size: file.size}
+	}
 
-    // Run request.
-    response, err := client.PutBulkJobSpectraS3(ctx, models.NewPutBulkJobSpectraS3Request(args.Bucket, objects))
-    if err != nil {
-        return err
-    }
+	// Run request.
+	response, err := client.PutBulkJobSpectraS3(ctx, models.NewPutBulkJobSpectraS3Request(args.Bucket, objects))
+	if err != nil {
+		return err
+	}
 
-    // Handle the responses in parallel
-    return handleBulkResponse(response.MasterObjectList.Objects, buildFilePutter(ctx, client, args.Bucket))
+	// Handle the responses in parallel
+	return handleBulkResponse(response.MasterObjectList.Objects, buildFilePutter(ctx, client, args.Bucket))
 }
 
 // Returns a function that puts an object for a bulk put.
 func buildFilePutter(ctx context.Context, client *ds3.Client, bucketName string) bulkHandler {
-    return func(obj models.BulkObject) error {
-        // Read the file.
-        sizeReadCloser, fileErr := readFile(*obj.Name)
-        if fileErr != nil {
-            return fileErr
-        }
+	return func(obj models.BulkObject) error {
+		// Read the file.
+		sizeReadCloser, fileErr := readFile(*obj.Name)
+		if fileErr != nil {
+			return fileErr
+		}
 
-        // Submit the put object request.
-        _, putErr := client.PutObject(ctx, models.NewPutObjectRequest(
-            bucketName,
-            *obj.Name,
-            sizeReadCloser,
-        ))
-        return putErr
-    }
+		// Submit the put object request.
+		_, putErr := client.PutObject(ctx, models.NewPutObjectRequest(
+			bucketName,
+			*obj.Name,
+			sizeReadCloser,
+		))
+		return putErr
+	}
 }
 
 // Represent a file that we found in a recursive directory traverse. We need
 // the relative path as well as the size. The FileInfo structure has the size
 // and the filename, but not the relative path.
 type file struct {
-    path string
-    size int64
+	path string
+	size int64
 }
 
 func recursivelyListFiles(path string) ([]file, error) {
-    // Read the specified directory.
-    infos, err := ioutil.ReadDir(path)
-    if err != nil {
-        return nil, err
-    }
+	// Read the specified directory.
+	infos, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
 
-    // For each file or directory...
-    var results []file
-    for _, info := range infos {
-        // Build its relative path.
-        name := path + "/" + info.Name()
+	// For each file or directory...
+	var results []file
+	for _, info := range infos {
+		// Build its relative path.
+		name := path + "/" + info.Name()
 
-        // If it's a directory...
-        if info.IsDir() {
-            // List all of the files in there too.
-            files, err := recursivelyListFiles(name)
-            if err != nil {
-                return nil, err
-            }
+		// If it's a directory...
+		if info.IsDir() {
+			// List all of the files in there too.
+			files, err := recursivelyListFiles(name)
+			if err != nil {
+				return nil, err
+			}
 
-            // Append the results.
-            results = append(results, files...)
-        } else {
-            // Append the current file.
-            results = append(results, file{name, info.Size()})
-        }
-    }
-    return results, nil
+			// Append the results.
+			results = append(results, files...)
+		} else {
+			// Append the current file.
+			results = append(results, file{name, info.Size()})
+		}
+	}
+	return results, nil
 }
-

--- a/ds3_cli/commands/deleteBucket.go
+++ b/ds3_cli/commands/deleteBucket.go
@@ -1,21 +1,19 @@
 package commands
 
 import (
-    "context"
-    "errors"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"context"
+	"errors"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
 func deleteBucket(ctx context.Context, client *ds3.Client, args *Arguments) error {
-    // Validate arguments.
-    if args.Bucket == "" {
-        return errors.New("Must specify a bucket name when doing delete_bucket.")
-    }
+	// Validate arguments.
+	if args.Bucket == "" {
+		return errors.New("Must specify a bucket name when doing delete_bucket.")
+	}
 
-    // Run request.
-    _, err := client.DeleteBucket(ctx, models.NewDeleteBucketRequest(args.Bucket))
-    return err
+	// Run request.
+	_, err := client.DeleteBucket(ctx, models.NewDeleteBucketRequest(args.Bucket))
+	return err
 }
-
-

--- a/ds3_cli/commands/deleteObject.go
+++ b/ds3_cli/commands/deleteObject.go
@@ -1,25 +1,22 @@
 package commands
 
 import (
-    "context"
-    "errors"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"context"
+	"errors"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
 func deleteObject(ctx context.Context, client *ds3.Client, args *Arguments) error {
-    // Validate arguments.
-    if args.Bucket == "" {
-        return errors.New("Must specify a bucket name when doing delete_object.")
-    }
-    if args.Key == "" {
-        return errors.New("Must specify an object key when doing delete_object.")
-    }
+	// Validate arguments.
+	if args.Bucket == "" {
+		return errors.New("Must specify a bucket name when doing delete_object.")
+	}
+	if args.Key == "" {
+		return errors.New("Must specify an object key when doing delete_object.")
+	}
 
-    // Run request.
-    _, err := client.DeleteObject(ctx, models.NewDeleteObjectRequest(args.Bucket, args.Key))
-    return err
+	// Run request.
+	_, err := client.DeleteObject(ctx, models.NewDeleteObjectRequest(args.Bucket, args.Key))
+	return err
 }
-
-
-

--- a/ds3_cli/commands/ds3Command.go
+++ b/ds3_cli/commands/ds3Command.go
@@ -1,33 +1,33 @@
 package commands
 
 import (
-    "context"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
 )
 
 type command func(context.Context, *ds3.Client, *Arguments) error
 
-var availableCommands = map[string]command {
-    "get_service": getService,
-    "get_bucket": getBucket,
-    "get_object": getObject,
+var availableCommands = map[string]command{
+	"get_service": getService,
+	"get_bucket":  getBucket,
+	"get_object":  getObject,
 
-    "put_bucket": putBucket,
-    "put_object": putObject,
+	"put_bucket": putBucket,
+	"put_object": putObject,
 
-    "delete_bucket": deleteBucket,
-    "delete_object": deleteObject,
+	"delete_bucket": deleteBucket,
+	"delete_object": deleteObject,
 
-    "bulk_get": bulkGet,
-    "bulk_put": bulkPut,
+	"bulk_get": bulkGet,
+	"bulk_put": bulkPut,
 }
 
 func RunCommand(ctx context.Context, client *ds3.Client, args *Arguments) error {
-    cmd, ok := availableCommands[args.Command]
-    if ok {
-        return cmd(ctx, client, args)
-    } else {
-        return fmt.Errorf("Unsupported command: '%s'", args.Command)
-    }
+	cmd, ok := availableCommands[args.Command]
+	if ok {
+		return cmd(ctx, client, args)
+	} else {
+		return fmt.Errorf("Unsupported command: '%s'", args.Command)
+	}
 }

--- a/ds3_cli/commands/fileWithSizeDecorator.go
+++ b/ds3_cli/commands/fileWithSizeDecorator.go
@@ -5,34 +5,33 @@ import "os"
 // Implements the SizedReadCloser interface for a file.
 // Decorates an os.File and adds a Size function which determines the length of the file
 type fileWithSizeDecorator struct {
-    file *os.File
+	file *os.File
 }
 
 func readFile(path string) (*fileWithSizeDecorator, error) {
-    content, fileErr := os.Open(path)
-    if fileErr != nil {
-        return nil, fileErr
-    }
-    return &fileWithSizeDecorator{content}, nil
+	content, fileErr := os.Open(path)
+	if fileErr != nil {
+		return nil, fileErr
+	}
+	return &fileWithSizeDecorator{content}, nil
 }
 
 func (fileWithSizeDecorator *fileWithSizeDecorator) Size() (int64, error) {
-    fi, err := fileWithSizeDecorator.file.Stat()
-    if err != nil {
-        return 0, err
-    }
-    return fi.Size(), nil
+	fi, err := fileWithSizeDecorator.file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
 }
 
 func (fileWithSizeDecorator *fileWithSizeDecorator) Read(p []byte) (int, error) {
-    return fileWithSizeDecorator.file.Read(p)
+	return fileWithSizeDecorator.file.Read(p)
 }
 
 func (fileWithSizeDecorator *fileWithSizeDecorator) Seek(offset int64, whence int) (int64, error) {
-    return fileWithSizeDecorator.file.Seek(offset, whence)
+	return fileWithSizeDecorator.file.Seek(offset, whence)
 }
 
 func (fileWithSizeDecorator *fileWithSizeDecorator) Close() error {
-    return fileWithSizeDecorator.file.Close()
+	return fileWithSizeDecorator.file.Close()
 }
-

--- a/ds3_cli/commands/getBucket.go
+++ b/ds3_cli/commands/getBucket.go
@@ -1,30 +1,29 @@
 package commands
 
 import (
-    "context"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
 )
 
 const maxInt = int(^uint(0) >> 1)
 const defaultMaxKeys = 1000
 
 func getMinInt(a, b int) int {
-    if a < b {
-        return a
-    } else {
-        return b
-    }
+	if a < b {
+		return a
+	} else {
+		return b
+	}
 }
 
 func getBucket(ctx context.Context, client *ds3.Client, args *Arguments) error {
-    objects, err := getBucketObjects(ctx, client, args)
-    if err != nil {
-        return err
-    }
-    for _, obj := range objects {
-        fmt.Println(obj.Name)
-    }
-    return nil
+	objects, err := getBucketObjects(ctx, client, args)
+	if err != nil {
+		return err
+	}
+	for _, obj := range objects {
+		fmt.Println(obj.Name)
+	}
+	return nil
 }
-

--- a/ds3_cli/commands/getBucketObjects.go
+++ b/ds3_cli/commands/getBucketObjects.go
@@ -1,71 +1,70 @@
 package commands
 
 import (
-    "context"
-    "errors"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"context"
+	"errors"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
 // Gets all objects in a bucket, performing multiple requests if the results
 // are paged. Also supports limiting to an arbitrary number of keys independent
 // of page size.
 func getBucketObjects(ctx context.Context, client *ds3.Client, args *Arguments) ([]models.Ds3PutObject, error) {
-    // Validate arguments.
-    if args.Bucket == "" {
-        return nil, errors.New("Must specify a bucket name when doing get_bucket.")
-    }
+	// Validate arguments.
+	if args.Bucket == "" {
+		return nil, errors.New("Must specify a bucket name when doing get_bucket.")
+	}
 
-    // Figure out how many keys to restrict to.
-    remainingKeys := maxInt
-    if args.MaxKeys > 0 {
-        remainingKeys = args.MaxKeys
-    }
+	// Figure out how many keys to restrict to.
+	remainingKeys := maxInt
+	if args.MaxKeys > 0 {
+		remainingKeys = args.MaxKeys
+	}
 
-    // Do a do...while pattern to do as many requests as needed.
-    var results []models.Ds3PutObject
-    marker := ""
-    for {
-        // Build the request.
-        request := buildRequest(args, remainingKeys, marker)
+	// Do a do...while pattern to do as many requests as needed.
+	var results []models.Ds3PutObject
+	marker := ""
+	for {
+		// Build the request.
+		request := buildRequest(args, remainingKeys, marker)
 
-        // Send the request.
-        response, err := client.GetBucket(ctx, request)
-        if err != nil {
-            return nil, err
-        }
+		// Send the request.
+		response, err := client.GetBucket(ctx, request)
+		if err != nil {
+			return nil, err
+		}
 
-        // Output the results.
-        for _, obj := range response.ListBucketResult.Objects {
-            ds3object := models.Ds3PutObject{Name:*obj.Key, Size:obj.Size}
-            results = append(results, ds3object)
-        }
+		// Output the results.
+		for _, obj := range response.ListBucketResult.Objects {
+			ds3object := models.Ds3PutObject{Name: *obj.Key, Size: obj.Size}
+			results = append(results, ds3object)
+		}
 
-        // Subtract the number of keys that we got from the number of keys that
-        // we need to get.
-        remainingKeys -= len(response.ListBucketResult.Objects)
+		// Subtract the number of keys that we got from the number of keys that
+		// we need to get.
+		remainingKeys -= len(response.ListBucketResult.Objects)
 
-        // Take note of the next marker to get.
-        marker = *response.ListBucketResult.NextMarker
+		// Take note of the next marker to get.
+		marker = *response.ListBucketResult.NextMarker
 
-        // Take care of the do...while.
-        if response.ListBucketResult.Truncated == false || remainingKeys <= 0 {
-            break
-        }
-    }
+		// Take care of the do...while.
+		if response.ListBucketResult.Truncated == false || remainingKeys <= 0 {
+			break
+		}
+	}
 
-    return results, nil
+	return results, nil
 }
 
 func buildRequest(args *Arguments, remainingKeys int, marker string) *models.GetBucketRequest {
-    request := models.NewGetBucketRequest(args.Bucket)
-    request.WithMaxKeys(getMinInt(remainingKeys, defaultMaxKeys))
-    if args.KeyPrefix != "" {
-        request.WithPrefix(args.KeyPrefix)
-    }
-    if marker != "" {
-        request.WithMarker(marker)
-    }
-    return request
+	request := models.NewGetBucketRequest(args.Bucket)
+	request.WithMaxKeys(getMinInt(remainingKeys, defaultMaxKeys))
+	if args.KeyPrefix != "" {
+		request.WithPrefix(args.KeyPrefix)
+	}
+	if marker != "" {
+		request.WithMarker(marker)
+	}
+	return request
 }
-

--- a/ds3_cli/commands/getObject.go
+++ b/ds3_cli/commands/getObject.go
@@ -1,51 +1,50 @@
 package commands
 
 import (
-    "context"
-    "os"
-    "io"
-    "errors"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"context"
+	"errors"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"io"
+	"os"
 )
 
 func getObject(ctx context.Context, client *ds3.Client, args *Arguments) error {
-    // Validate the arguments.
-    if args.Bucket == "" {
-        return errors.New("Must specify a bucket.")
-    }
-    if args.Key == "" {
-        return errors.New("Must specify an object key.")
-    }
+	// Validate the arguments.
+	if args.Bucket == "" {
+		return errors.New("Must specify a bucket.")
+	}
+	if args.Key == "" {
+		return errors.New("Must specify an object key.")
+	}
 
-    // Make sure the file doesn't already exist.
-    if _, err := os.Stat(args.Key); err == nil {
-        return errors.New("File already exists")
-    }
+	// Make sure the file doesn't already exist.
+	if _, err := os.Stat(args.Key); err == nil {
+		return errors.New("File already exists")
+	}
 
-    // Build the request.
-    request := models.NewGetObjectRequest(args.Bucket, args.Key)
-    if args.End > 0 {
-        request.WithRanges(models.Range{ int64(args.Start), int64(args.End) })
-    }
+	// Build the request.
+	request := models.NewGetObjectRequest(args.Bucket, args.Key)
+	if args.End > 0 {
+		request.WithRanges(models.Range{int64(args.Start), int64(args.End)})
+	}
 
-    // Perform the request.
-    response, requestErr := client.GetObject(ctx, request)
-    if requestErr != nil {
-        return requestErr
-    }
-    defer response.Content.Close()
+	// Perform the request.
+	response, requestErr := client.GetObject(ctx, request)
+	if requestErr != nil {
+		return requestErr
+	}
+	defer response.Content.Close()
 
-    // Open the file to write.
-    file, fileErr := os.Create(args.Key)
-    if fileErr != nil {
-        return fileErr
-    }
-    defer file.Close()
+	// Open the file to write.
+	file, fileErr := os.Create(args.Key)
+	if fileErr != nil {
+		return fileErr
+	}
+	defer file.Close()
 
-    // Copy the request stream to the file.
-    io.Copy(file, response.Content)
+	// Copy the request stream to the file.
+	io.Copy(file, response.Content)
 
-    return nil
+	return nil
 }
-

--- a/ds3_cli/commands/getService.go
+++ b/ds3_cli/commands/getService.go
@@ -1,20 +1,18 @@
 package commands
 
 import (
-    "context"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
 func getService(ctx context.Context, client *ds3.Client, args *Arguments) error {
-    response, err := client.GetService(ctx, models.NewGetServiceRequest())
-    if err == nil {
-        for _, bucket := range response.ListAllMyBucketsResult.Buckets {
-            fmt.Println(bucket.Name)
-        }
-    }
-    return err
+	response, err := client.GetService(ctx, models.NewGetServiceRequest())
+	if err == nil {
+		for _, bucket := range response.ListAllMyBucketsResult.Buckets {
+			fmt.Println(bucket.Name)
+		}
+	}
+	return err
 }
-
-

--- a/ds3_cli/commands/putBucket.go
+++ b/ds3_cli/commands/putBucket.go
@@ -1,20 +1,19 @@
 package commands
 
 import (
-    "context"
-    "errors"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"context"
+	"errors"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
 func putBucket(ctx context.Context, client *ds3.Client, args *Arguments) error {
-    // Validate arguments.
-    if args.Bucket == "" {
-        return errors.New("Must specify a bucket name when doing put_bucket.")
-    }
+	// Validate arguments.
+	if args.Bucket == "" {
+		return errors.New("Must specify a bucket name when doing put_bucket.")
+	}
 
-    // Run request.
-    _, err := client.PutBucket(ctx, models.NewPutBucketRequest(args.Bucket))
-    return err
+	// Run request.
+	_, err := client.PutBucket(ctx, models.NewPutBucketRequest(args.Bucket))
+	return err
 }
-

--- a/ds3_cli/commands/putObject.go
+++ b/ds3_cli/commands/putObject.go
@@ -1,29 +1,28 @@
 package commands
 
 import (
-    "context"
-    "errors"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"context"
+	"errors"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
 func putObject(ctx context.Context, client *ds3.Client, args *Arguments) error {
-    // Validate arguments.
-    if args.Bucket == "" {
-        return errors.New("Must specify a bucket name when doing put_object.")
-    }
-    if args.Key == "" {
-        return errors.New("Must specify an object key when doing put_object.")
-    }
+	// Validate arguments.
+	if args.Bucket == "" {
+		return errors.New("Must specify a bucket name when doing put_object.")
+	}
+	if args.Key == "" {
+		return errors.New("Must specify an object key when doing put_object.")
+	}
 
-    // Open the file.
-    sizedContent, fileErr := readFile(args.Key)
-    if fileErr != nil {
-        return fileErr
-    }
+	// Open the file.
+	sizedContent, fileErr := readFile(args.Key)
+	if fileErr != nil {
+		return fileErr
+	}
 
-    // Run request.
-    _, err := client.PutObject(ctx, models.NewPutObjectRequest(args.Bucket, args.Key, sizedContent))
-    return err
+	// Run request.
+	_, err := client.PutObject(ctx, models.NewPutObjectRequest(args.Bucket, args.Key, sizedContent))
+	return err
 }
-

--- a/ds3_cli/main.go
+++ b/ds3_cli/main.go
@@ -1,35 +1,35 @@
 package main
 
 import (
-    "context"
-    "log"
-    "os"
-    "os/signal"
-    "syscall"
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_cli/commands"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_cli/commands"
 )
 
 func main() {
-    // Cancel the operation if the user interrupts (Ctrl+C) or the process is asked to terminate.
-    ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-    defer stop()
+	// Cancel the operation if the user interrupts (Ctrl+C) or the process is asked to terminate.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
-    // Parse the arguments.
-    args, argsErr := commands.ParseArgs()
-    if argsErr != nil {
-        log.Fatal(argsErr)
-    }
+	// Parse the arguments.
+	args, argsErr := commands.ParseArgs()
+	if argsErr != nil {
+		log.Fatal(argsErr)
+	}
 
-    // Build the client.
-    client, clientErr := buildclient.FromArgs(args)
-    if clientErr != nil {
-        log.Fatal(clientErr)
-    }
+	// Build the client.
+	client, clientErr := buildclient.FromArgs(args)
+	if clientErr != nil {
+		log.Fatal(clientErr)
+	}
 
-    // Run the command
-    if cmdErr := commands.RunCommand(ctx, client, args); cmdErr != nil {
-        log.Fatal(cmdErr)
-    }
+	// Run the command
+	if cmdErr := commands.RunCommand(ctx, client, args); cmdErr != nil {
+		log.Fatal(cmdErr)
+	}
 }

--- a/ds3_integration/concurrency_test.go
+++ b/ds3_integration/concurrency_test.go
@@ -1,147 +1,147 @@
 package ds3_integration
 
 import (
-    "context"
-    "testing"
-    "sync"
-    "log"
-    "fmt"
-    "runtime/debug"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_integration/utils"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
-    "os"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
-    "net/url"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_integration/utils"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"log"
+	"net/url"
+	"os"
+	"runtime/debug"
+	"sync"
+	"testing"
 )
 
 func putFileWithClient(name string, offset int64, jobId string, content *[]byte, group *sync.WaitGroup, t *testing.T) {
-    defer group.Done()
-    log.Printf("Putting file %s", name)
+	defer group.Done()
+	log.Printf("Putting file %s", name)
 
-    _, err := client.PutObject(context.Background(), models.NewPutObjectRequest(testBucket, name, ds3.BuildByteReaderWithSizeDecorator(*content)).
-        WithOffset(offset).
-        WithJob(jobId))
+	_, err := client.PutObject(context.Background(), models.NewPutObjectRequest(testBucket, name, ds3.BuildByteReaderWithSizeDecorator(*content)).
+		WithOffset(offset).
+		WithJob(jobId))
 
-    if err != nil {
-        t.Errorf("Unexpected error when putting file '%s': '%s'.", name, err.Error())
-        debug.PrintStack()
-        t.Fail()
-    }
+	if err != nil {
+		t.Errorf("Unexpected error when putting file '%s': '%s'.", name, err.Error())
+		debug.PrintStack()
+		t.Fail()
+	}
 }
 
 func TestConcurrentClientUsage(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    content, err := testutils.LoadBook(testutils.BookTitles[0])
-    ds3Testing.AssertNilError(t, err)
+	content, err := testutils.LoadBook(testutils.BookTitles[0])
+	ds3Testing.AssertNilError(t, err)
 
-    size := int64(len(content))
+	size := int64(len(content))
 
-    // create a job for putting n instances of file
-    n := 30
+	// create a job for putting n instances of file
+	n := 30
 
-    var ds3Objects []models.Ds3PutObject
-    for i := 0; i < n; i++ {
-        ds3Objects = append(ds3Objects, models.Ds3PutObject{ Name:fmt.Sprintf("file%d", i), Size:size })
-    }
+	var ds3Objects []models.Ds3PutObject
+	for i := 0; i < n; i++ {
+		ds3Objects = append(ds3Objects, models.Ds3PutObject{Name: fmt.Sprintf("file%d", i), Size: size})
+	}
 
-    bulkPut, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
-    ds3Testing.AssertNilError(t, err)
+	bulkPut, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
+	ds3Testing.AssertNilError(t, err)
 
-    // launch go routines to put files concurrently
-    var group sync.WaitGroup
-    group.Add(n)
+	// launch go routines to put files concurrently
+	var group sync.WaitGroup
+	group.Add(n)
 
-    for _, chunk := range bulkPut.MasterObjectList.Objects {
-        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
-        ds3Testing.AssertNilError(t, allocateErr)
-        for _, obj := range allocateChunk.Objects.Objects {
-            go putFileWithClient(*obj.Name, obj.Offset, bulkPut.MasterObjectList.JobId, &content, &group, t)
-        }
-    }
+	for _, chunk := range bulkPut.MasterObjectList.Objects {
+		allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
+		ds3Testing.AssertNilError(t, allocateErr)
+		for _, obj := range allocateChunk.Objects.Objects {
+			go putFileWithClient(*obj.Name, obj.Offset, bulkPut.MasterObjectList.JobId, &content, &group, t)
+		}
+	}
 
-    group.Wait()
+	group.Wait()
 }
 
 func putFileWithSendNetwork(name string, offset int64, jobId string, content *[]byte, bucketName string, group *sync.WaitGroup, t *testing.T, network networking.Network, info *networking.ConnectionInfo) {
-    defer group.Done()
+	defer group.Done()
 
-    // manually create http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        WithHttpVerb(ds3.HTTP_VERB_PUT).
-        WithPath("/" + bucketName + "/" + name).
-        WithOptionalQueryParam("job", &jobId).
-        WithOptionalQueryParam("offset", networking.Int64PtrToStrPtr(&offset)).
-        WithReader(ds3.BuildByteReaderWithSizeDecorator(*content)).
-        WithChecksum(models.NewNoneChecksum()).
-        WithHeaders(make(map[string]string)).
-        Build(context.Background(), info)
+	// manually create http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		WithHttpVerb(ds3.HTTP_VERB_PUT).
+		WithPath("/"+bucketName+"/"+name).
+		WithOptionalQueryParam("job", &jobId).
+		WithOptionalQueryParam("offset", networking.Int64PtrToStrPtr(&offset)).
+		WithReader(ds3.BuildByteReaderWithSizeDecorator(*content)).
+		WithChecksum(models.NewNoneChecksum()).
+		WithHeaders(make(map[string]string)).
+		Build(context.Background(), info)
 
-    //networkRetryDecorator := networking.NewNetworkRetryDecorator(network, 5)
-    t.Logf("Created request to for file '%s' to url '%s'", name, httpRequest.URL.String())
-    response, err := network.Invoke(httpRequest)
-    if err != nil {
-        t.Errorf("Unexpected error when putting file '%s': '%s'.", name, err.Error())
-        debug.PrintStack()
-        t.Fail()
-    }
+	//networkRetryDecorator := networking.NewNetworkRetryDecorator(network, 5)
+	t.Logf("Created request to for file '%s' to url '%s'", name, httpRequest.URL.String())
+	response, err := network.Invoke(httpRequest)
+	if err != nil {
+		t.Errorf("Unexpected error when putting file '%s': '%s'.", name, err.Error())
+		debug.PrintStack()
+		t.Fail()
+	}
 
-    _, err = models.NewPutObjectResponse(response)
-    if err != nil {
-        t.Errorf("Unexpected error when putting file '%s': '%s'.", name, err.Error())
-        debug.PrintStack()
-        t.Fail()
-    }
+	_, err = models.NewPutObjectResponse(response)
+	if err != nil {
+		t.Errorf("Unexpected error when putting file '%s': '%s'.", name, err.Error())
+		debug.PrintStack()
+		t.Fail()
+	}
 }
 
 func TestConcurrentSendNetworkUsage(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    content, err := testutils.LoadBook(testutils.BookTitles[0])
-    ds3Testing.AssertNilError(t, err)
+	content, err := testutils.LoadBook(testutils.BookTitles[0])
+	ds3Testing.AssertNilError(t, err)
 
-    size := int64(len(content))
+	size := int64(len(content))
 
-    // create a job for putting n instances of file
-    n := 30
+	// create a job for putting n instances of file
+	n := 30
 
-    var ds3Objects []models.Ds3PutObject
-    for i := 0; i < n; i++ {
-        ds3Objects = append(ds3Objects, models.Ds3PutObject{ Name:fmt.Sprintf("file%d", i), Size:size })
-    }
+	var ds3Objects []models.Ds3PutObject
+	for i := 0; i < n; i++ {
+		ds3Objects = append(ds3Objects, models.Ds3PutObject{Name: fmt.Sprintf("file%d", i), Size: size})
+	}
 
-    bulkPut, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
-    ds3Testing.AssertNilError(t, err)
+	bulkPut, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
+	ds3Testing.AssertNilError(t, err)
 
-    // launch go routines to put files concurrently
-    var group sync.WaitGroup
-    group.Add(n)
+	// launch go routines to put files concurrently
+	var group sync.WaitGroup
+	group.Add(n)
 
-    //Retrieve the environment variables
-    endpoint := os.Getenv(buildclient.EndpointEnv)
-    accessKey := os.Getenv(buildclient.AccessKeyEnv)
-    secretKey := os.Getenv(buildclient.SecretKeyEnv)
+	//Retrieve the environment variables
+	endpoint := os.Getenv(buildclient.EndpointEnv)
+	accessKey := os.Getenv(buildclient.AccessKeyEnv)
+	secretKey := os.Getenv(buildclient.SecretKeyEnv)
 
-    endpointUrl, err := url.Parse(endpoint)
-    ds3Testing.AssertNilError(t, err)
-    info := networking.ConnectionInfo{
-        Endpoint:    endpointUrl,
-        Credentials: &networking.Credentials{AccessId: accessKey, Key: secretKey},
-        Proxy:       nil}
+	endpointUrl, err := url.Parse(endpoint)
+	ds3Testing.AssertNilError(t, err)
+	info := networking.ConnectionInfo{
+		Endpoint:    endpointUrl,
+		Credentials: &networking.Credentials{AccessId: accessKey, Key: secretKey},
+		Proxy:       nil}
 
-    network := networking.NewSendNetwork(&info)
+	network := networking.NewSendNetwork(&info)
 
-    for _, chunk := range bulkPut.MasterObjectList.Objects {
-        //TODO Try get available job chunks ready for client processing instead
-        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
-        ds3Testing.AssertNilError(t, allocateErr)
-        for _, obj := range allocateChunk.Objects.Objects {
-            go putFileWithSendNetwork(*obj.Name, obj.Offset, bulkPut.MasterObjectList.JobId, &content, testBucket, &group, t, network, &info)
-        }
-    }
+	for _, chunk := range bulkPut.MasterObjectList.Objects {
+		//TODO Try get available job chunks ready for client processing instead
+		allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
+		ds3Testing.AssertNilError(t, allocateErr)
+		for _, obj := range allocateChunk.Objects.Objects {
+			go putFileWithSendNetwork(*obj.Name, obj.Offset, bulkPut.MasterObjectList.JobId, &content, testBucket, &group, t, network, &info)
+		}
+	}
 
-    group.Wait()
+	group.Wait()
 }

--- a/ds3_integration/digest_test.go
+++ b/ds3_integration/digest_test.go
@@ -12,54 +12,54 @@
 package ds3_integration
 
 import (
-    "testing"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_integration/utils"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
-    "bytes"
-    "io/ioutil"
+	"bytes"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_integration/utils"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"io/ioutil"
+	"testing"
 )
 
 func testPutBeowulfWithSpecifiedObjectName(objectName string, t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
-    fileName := "beowulf.txt"
+	defer testutils.DeleteBucketContents(client, testBucket)
+	fileName := "beowulf.txt"
 
-    //Put object to BP
-    book, err := testutils.LoadBookLogError(t, fileName)
-    ds3Testing.AssertNilError(t, err)
+	//Put object to BP
+	book, err := testutils.LoadBookLogError(t, fileName)
+	ds3Testing.AssertNilError(t, err)
 
-    err = testutils.PutObjectLogError(t, client, testBucket, objectName, book)
-    ds3Testing.AssertNilError(t, err)
-    defer testutils.DeleteObjectLogError(t, client, testBucket, objectName)
+	err = testutils.PutObjectLogError(t, client, testBucket, objectName, book)
+	ds3Testing.AssertNilError(t, err)
+	defer testutils.DeleteObjectLogError(t, client, testBucket, objectName)
 
-    //Verify that object exists
-    getObjectResponse, err := testutils.GetObjectLogError(t, client, testBucket, objectName)
-    ds3Testing.AssertNilError(t, err)
-    if err == nil {
-        defer getObjectResponse.Content.Close()
-        bs, err := ioutil.ReadAll(getObjectResponse.Content)
-        ds3Testing.AssertNilError(t, err)
-        if bytes.Compare(bs, book) != 0 {
-            t.Error("Retrieved book does not match uploaded book.")
-        }
-    }
+	//Verify that object exists
+	getObjectResponse, err := testutils.GetObjectLogError(t, client, testBucket, objectName)
+	ds3Testing.AssertNilError(t, err)
+	if err == nil {
+		defer getObjectResponse.Content.Close()
+		bs, err := ioutil.ReadAll(getObjectResponse.Content)
+		ds3Testing.AssertNilError(t, err)
+		if bytes.Compare(bs, book) != 0 {
+			t.Error("Retrieved book does not match uploaded book.")
+		}
+	}
 }
 
 func TestObjectWithSpaces(t *testing.T) {
-    objectName := "b e o w u l f"
-    testPutBeowulfWithSpecifiedObjectName(objectName, t)
+	objectName := "b e o w u l f"
+	testPutBeowulfWithSpecifiedObjectName(objectName, t)
 }
 
 func TestObjectWithSlashes(t *testing.T) {
-    objectName := "be/owu/lf"
-    testPutBeowulfWithSpecifiedObjectName(objectName, t)
+	objectName := "be/owu/lf"
+	testPutBeowulfWithSpecifiedObjectName(objectName, t)
 }
 
 func TestObjectWithPlus(t *testing.T) {
-    objectName := "beo+wulf"
-    testPutBeowulfWithSpecifiedObjectName(objectName, t)
+	objectName := "beo+wulf"
+	testPutBeowulfWithSpecifiedObjectName(objectName, t)
 }
 
 func TestObjectWithUtf8Chars(t *testing.T) {
-    objectName := "aÀˠϠૐ༺ᎀ"
-    testPutBeowulfWithSpecifiedObjectName(objectName, t)
+	objectName := "aÀˠϠૐ༺ᎀ"
+	testPutBeowulfWithSpecifiedObjectName(objectName, t)
 }

--- a/ds3_integration/nilReadSizer.go
+++ b/ds3_integration/nilReadSizer.go
@@ -14,12 +14,12 @@ package ds3_integration
 import "io"
 
 type nilReadSizer struct {
-	reader io.Reader
+	reader   io.Reader
 	fileSize int64
 }
 
 func newNilReadSizer(reader io.Reader, fileSize int64) nilReadSizer {
-	return nilReadSizer { reader: reader, fileSize: fileSize }
+	return nilReadSizer{reader: reader, fileSize: fileSize}
 }
 
 func (readSizer *nilReadSizer) Read(p []byte) (n int, err error) {

--- a/ds3_integration/smoke_test.go
+++ b/ds3_integration/smoke_test.go
@@ -12,18 +12,18 @@
 package ds3_integration
 
 import (
-    "bytes"
-    "context"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_integration/utils"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
-    "io/ioutil"
-    "log"
-    "os"
-    "strconv"
-    "testing"
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_integration/utils"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"io/ioutil"
+	"log"
+	"os"
+	"strconv"
+	"testing"
 )
 
 var client *ds3.Client
@@ -32,562 +32,562 @@ var envTestNameSpace = "GoIntegrationSmokeTest"
 var defaultUser = "Administrator"
 
 func TestMain(m *testing.M) {
-    var err error
-    var exitVal int
-    var ids *testutils.TestIds
-    client, ids, err = testutils.SetupTestEnv(testBucket, defaultUser, envTestNameSpace)
-    if err != nil {
-        log.Printf("Unable to setup test environment '%s'.", err.Error())
-        exitVal = 1
-    } else {
-        exitVal = m.Run()
-    }
-    testutils.TeardownTestEnv(client, ids, testBucket)
-    os.Exit(exitVal)
+	var err error
+	var exitVal int
+	var ids *testutils.TestIds
+	client, ids, err = testutils.SetupTestEnv(testBucket, defaultUser, envTestNameSpace)
+	if err != nil {
+		log.Printf("Unable to setup test environment '%s'.", err.Error())
+		exitVal = 1
+	} else {
+		exitVal = m.Run()
+	}
+	testutils.TeardownTestEnv(client, ids, testBucket)
+	os.Exit(exitVal)
 }
 
 func TestGetService(t *testing.T) {
-    response, err := client.GetService(context.Background(), models.NewGetServiceRequest())
-    ds3Testing.AssertNilError(t, err)
-    if response == nil {
-        t.Fatal("Received an unexpected nil response.")
-    }
+	response, err := client.GetService(context.Background(), models.NewGetServiceRequest())
+	ds3Testing.AssertNilError(t, err)
+	if response == nil {
+		t.Fatal("Received an unexpected nil response.")
+	}
 }
 
 func TestBucket(t *testing.T) {
-    //Create bucket
-    bucketName := "GoTestPutBucket"
-    putErr := testutils.PutBucketLogError(t, client, bucketName)
-    ds3Testing.AssertNilError(t, putErr)
-    defer testutils.DeleteBucketLogError(t, client, bucketName)
+	//Create bucket
+	bucketName := "GoTestPutBucket"
+	putErr := testutils.PutBucketLogError(t, client, bucketName)
+	ds3Testing.AssertNilError(t, putErr)
+	defer testutils.DeleteBucketLogError(t, client, bucketName)
 
-    //Verify that bucket exists
-    getBucketResponse, getErr := testutils.GetBucketLogError(t, client, bucketName)
-    ds3Testing.AssertNilError(t, getErr)
-    ds3Testing.AssertNonNilStringPtr(t, "Name", bucketName, getBucketResponse.ListBucketResult.Name)
+	//Verify that bucket exists
+	getBucketResponse, getErr := testutils.GetBucketLogError(t, client, bucketName)
+	ds3Testing.AssertNilError(t, getErr)
+	ds3Testing.AssertNonNilStringPtr(t, "Name", bucketName, getBucketResponse.ListBucketResult.Name)
 }
 
 func TestObject(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
-    beowulf := "beowulf.txt"
+	defer testutils.DeleteBucketContents(client, testBucket)
+	beowulf := "beowulf.txt"
 
-    //Put object to BP
-    book, bookErr := testutils.LoadBookLogError(t, beowulf)
-    ds3Testing.AssertNilError(t, bookErr)
-    defer testutils.DeleteObjectLogError(t, client, testBucket, beowulf)
+	//Put object to BP
+	book, bookErr := testutils.LoadBookLogError(t, beowulf)
+	ds3Testing.AssertNilError(t, bookErr)
+	defer testutils.DeleteObjectLogError(t, client, testBucket, beowulf)
 
-    putObjErr := testutils.PutObjectLogError(t, client, testBucket, beowulf, book)
-    ds3Testing.AssertNilError(t, putObjErr)
+	putObjErr := testutils.PutObjectLogError(t, client, testBucket, beowulf, book)
+	ds3Testing.AssertNilError(t, putObjErr)
 
-    //Verify that object exists
-    getObjectResponse, getObjErr := testutils.GetObjectLogError(t, client, testBucket, beowulf)
-    ds3Testing.AssertNilError(t, putObjErr)
-    if getObjErr == nil {
-        defer getObjectResponse.Content.Close()
-        bs, readErr := ioutil.ReadAll(getObjectResponse.Content)
-        ds3Testing.AssertNilError(t, readErr)
-        if bytes.Compare(bs, book) != 0 {
-            t.Error("Retrieved book does not match uploaded book.")
-        }
-    }
+	//Verify that object exists
+	getObjectResponse, getObjErr := testutils.GetObjectLogError(t, client, testBucket, beowulf)
+	ds3Testing.AssertNilError(t, putObjErr)
+	if getObjErr == nil {
+		defer getObjectResponse.Content.Close()
+		bs, readErr := ioutil.ReadAll(getObjectResponse.Content)
+		ds3Testing.AssertNilError(t, readErr)
+		if bytes.Compare(bs, book) != 0 {
+			t.Error("Retrieved book does not match uploaded book.")
+		}
+	}
 }
 
 func TestPutGetFilePercentEncodingObjectNames(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    inputSymbols := []string {"-", ".", "_", "~", "!", "$", "'", "(", ")", "*", ",", "&", "=", "@", ":", "/", ";", "+", "?", " ", "%", "#", "'", "\t"}
+	inputSymbols := []string{"-", ".", "_", "~", "!", "$", "'", "(", ")", "*", ",", "&", "=", "@", ":", "/", ";", "+", "?", " ", "%", "#", "'", "\t"}
 
-    for i, input := range inputSymbols {
-        objectName := fmt.Sprintf("test%ssymbol%d", input, i)
+	for i, input := range inputSymbols {
+		objectName := fmt.Sprintf("test%ssymbol%d", input, i)
 
-        func() {
-            //Put object to BP
-            content := []byte("hello world")
-            defer testutils.DeleteObjectLogError(t, client, testBucket, objectName)
+		func() {
+			//Put object to BP
+			content := []byte("hello world")
+			defer testutils.DeleteObjectLogError(t, client, testBucket, objectName)
 
-            putObjErr := testutils.PutObjectLogError(t, client, testBucket, objectName, content)
-            ds3Testing.AssertNilError(t, putObjErr)
+			putObjErr := testutils.PutObjectLogError(t, client, testBucket, objectName, content)
+			ds3Testing.AssertNilError(t, putObjErr)
 
-            //Verify that object exists
-            getObjectResponse, getObjErr := testutils.GetObjectLogError(t, client, testBucket, objectName)
-            ds3Testing.AssertNilError(t, getObjErr)
-            if getObjErr == nil {
-                defer getObjectResponse.Content.Close()
-                retrievedContent, readErr := ioutil.ReadAll(getObjectResponse.Content)
-                ds3Testing.AssertNilError(t, readErr)
-                if bytes.Compare(retrievedContent, content) != 0 {
-                    t.Error("Retrieved content does not match uploaded content.")
-                }
-            }
-        }()
-    }
+			//Verify that object exists
+			getObjectResponse, getObjErr := testutils.GetObjectLogError(t, client, testBucket, objectName)
+			ds3Testing.AssertNilError(t, getObjErr)
+			if getObjErr == nil {
+				defer getObjectResponse.Content.Close()
+				retrievedContent, readErr := ioutil.ReadAll(getObjectResponse.Content)
+				ds3Testing.AssertNilError(t, readErr)
+				if bytes.Compare(retrievedContent, content) != 0 {
+					t.Error("Retrieved content does not match uploaded content.")
+				}
+			}
+		}()
+	}
 }
 
 func TestBadBucket(t *testing.T) {
-    // Attempt to create a malformed bucket
-    badBucketName := ""
-    err := testutils.PutBucket(client, badBucketName)
-    ds3Testing.AssertBadStatusCodeError(t, 400, err)
+	// Attempt to create a malformed bucket
+	badBucketName := ""
+	err := testutils.PutBucket(client, badBucketName)
+	ds3Testing.AssertBadStatusCodeError(t, 400, err)
 }
 
 func TestBucketAlreadyExists(t *testing.T) {
-    // Attempt to create a bucket that already exists
-    err := testutils.PutBucket(client, testBucket)
-    ds3Testing.AssertBadStatusCodeError(t, 409, err)
+	// Attempt to create a bucket that already exists
+	err := testutils.PutBucket(client, testBucket)
+	ds3Testing.AssertBadStatusCodeError(t, 409, err)
 }
 
 func TestDeleteEmptyBucket(t *testing.T) {
-    bucketName := "GoDeleteEmptyBucket"
-    putErr := testutils.PutBucketLogError(t, client, bucketName)
-    ds3Testing.AssertNilError(t, putErr)
+	bucketName := "GoDeleteEmptyBucket"
+	putErr := testutils.PutBucketLogError(t, client, bucketName)
+	ds3Testing.AssertNilError(t, putErr)
 
-    //Delete bucket
-    deleteErr := testutils.DeleteBucketLogError(t, client, bucketName)
-    ds3Testing.AssertNilError(t, deleteErr)
+	//Delete bucket
+	deleteErr := testutils.DeleteBucketLogError(t, client, bucketName)
+	ds3Testing.AssertNilError(t, deleteErr)
 
-    //Verify bucket does not exist
-    _, getDeletedErr := testutils.GetBucket(client, bucketName)
-    ds3Testing.AssertBadStatusCodeError(t, 404, getDeletedErr)
+	//Verify bucket does not exist
+	_, getDeletedErr := testutils.GetBucket(client, bucketName)
+	ds3Testing.AssertBadStatusCodeError(t, 404, getDeletedErr)
 }
 
 func TestDeleteBucketMalformedName(t *testing.T) {
-    err := testutils.DeleteBucket(client, "")
-    ds3Testing.AssertBadStatusCodeError(t, 400, err)
+	err := testutils.DeleteBucket(client, "")
+	ds3Testing.AssertBadStatusCodeError(t, 400, err)
 }
 
 func TestDeleteBucketNonexistent(t *testing.T) {
-    err := testutils.DeleteBucket(client, "not-here")
-    ds3Testing.AssertBadStatusCodeError(t, 404, err)
+	err := testutils.DeleteBucket(client, "not-here")
+	ds3Testing.AssertBadStatusCodeError(t, 404, err)
 }
 
 func TestDeleteBucketNonEmpty(t *testing.T) {
-    beowulf := "beowulf.txt"
-    bucketName := "GoTestDeleteBucketNonEmpty"
+	beowulf := "beowulf.txt"
+	bucketName := "GoTestDeleteBucketNonEmpty"
 
-    //Create test bucket
-    err := testutils.PutBucket(client, bucketName)
-    ds3Testing.AssertNilError(t, err)
-    defer testutils.DeleteBucketLogError(t, client, bucketName)
+	//Create test bucket
+	err := testutils.PutBucket(client, bucketName)
+	ds3Testing.AssertNilError(t, err)
+	defer testutils.DeleteBucketLogError(t, client, bucketName)
 
-    //Put object to test bucket
-    book, bookErr := testutils.LoadBookLogError(t, beowulf)
-    ds3Testing.AssertNilError(t, bookErr)
-    defer testutils.DeleteObjectLogError(t, client, bucketName, beowulf)
+	//Put object to test bucket
+	book, bookErr := testutils.LoadBookLogError(t, beowulf)
+	ds3Testing.AssertNilError(t, bookErr)
+	defer testutils.DeleteObjectLogError(t, client, bucketName, beowulf)
 
-    putObjErr := testutils.PutObjectLogError(t, client, bucketName, beowulf, book)
-    ds3Testing.AssertNilError(t, putObjErr)
+	putObjErr := testutils.PutObjectLogError(t, client, bucketName, beowulf, book)
+	ds3Testing.AssertNilError(t, putObjErr)
 
-    //Attempt to delete non-empty bucket without force
-    _, deleteErr := client.DeleteBucketSpectraS3(context.Background(), models.NewDeleteBucketSpectraS3Request(bucketName))
-    ds3Testing.AssertBadStatusCodeError(t, 409, deleteErr)
+	//Attempt to delete non-empty bucket without force
+	_, deleteErr := client.DeleteBucketSpectraS3(context.Background(), models.NewDeleteBucketSpectraS3Request(bucketName))
+	ds3Testing.AssertBadStatusCodeError(t, 409, deleteErr)
 }
 
 func TestGetBucket(t *testing.T) {
-    response, err := testutils.GetBucket(client, testBucket)
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertNonNilStringPtr(t, "Name", testBucket, response.ListBucketResult.Name)
+	response, err := testutils.GetBucket(client, testBucket)
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertNonNilStringPtr(t, "Name", testBucket, response.ListBucketResult.Name)
 }
 
 func TestGetBucketNonexistent(t *testing.T) {
-    badBucketName := "not-there"
-    _, err := testutils.GetBucket(client, badBucketName)
-    ds3Testing.AssertBadStatusCodeError(t, 404, err)
+	badBucketName := "not-there"
+	_, err := testutils.GetBucket(client, badBucketName)
+	ds3Testing.AssertBadStatusCodeError(t, 404, err)
 }
 
 func TestHeadBucket(t *testing.T) {
-    _, err := client.HeadBucket(context.Background(), models.NewHeadBucketRequest(testBucket))
-    ds3Testing.AssertNilError(t, err)
+	_, err := client.HeadBucket(context.Background(), models.NewHeadBucketRequest(testBucket))
+	ds3Testing.AssertNilError(t, err)
 }
 
 func TestHeadBucketNonExistent(t *testing.T) {
-    bucketName := "not-here"
-    _, err := client.HeadBucket(context.Background(), models.NewHeadBucketRequest(bucketName))
-    ds3Testing.AssertBadStatusCodeError(t, 404, err)
+	bucketName := "not-here"
+	_, err := client.HeadBucket(context.Background(), models.NewHeadBucketRequest(bucketName))
+	ds3Testing.AssertBadStatusCodeError(t, 404, err)
 }
 
 func TestGetBucketPagination(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    var ds3PutObjects []models.Ds3PutObject
-    for i := 0; i < 15; i++ {
-        name := "file" + strconv.Itoa(i + 10) // Start at 10 to avoid alphabetical reordering 0, 1, 10, 11, etc
-        curObj := models.Ds3PutObject{Name:name, Size:0}
-        ds3PutObjects = append(ds3PutObjects, curObj)
-    }
+	var ds3PutObjects []models.Ds3PutObject
+	for i := 0; i < 15; i++ {
+		name := "file" + strconv.Itoa(i+10) // Start at 10 to avoid alphabetical reordering 0, 1, 10, 11, etc
+		curObj := models.Ds3PutObject{Name: name, Size: 0}
+		ds3PutObjects = append(ds3PutObjects, curObj)
+	}
 
-    err := testutils.PutEmptyObjects(client, testBucket, ds3PutObjects)
-    ds3Testing.AssertNilError(t, err)
+	err := testutils.PutEmptyObjects(client, testBucket, ds3PutObjects)
+	ds3Testing.AssertNilError(t, err)
 
-    //Test files indexed 0-4
-    result1, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket).WithMaxKeys(5))
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertInt(t, "Number of Objects", 5, len(result1.ListBucketResult.Objects))
-    if result1.ListBucketResult.NextMarker == nil {
-        t.Fatal("Expected NextMarker to be non-nil value.")
-    }
-    for i, obj := range result1.ListBucketResult.Objects {
-        ds3Testing.AssertNonNilStringPtr(t, "ObjectName", ds3PutObjects[i].Name, obj.Key)
-    }
+	//Test files indexed 0-4
+	result1, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket).WithMaxKeys(5))
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertInt(t, "Number of Objects", 5, len(result1.ListBucketResult.Objects))
+	if result1.ListBucketResult.NextMarker == nil {
+		t.Fatal("Expected NextMarker to be non-nil value.")
+	}
+	for i, obj := range result1.ListBucketResult.Objects {
+		ds3Testing.AssertNonNilStringPtr(t, "ObjectName", ds3PutObjects[i].Name, obj.Key)
+	}
 
-    // Test files indexed 5-9
-    result2, err := client.GetBucket(
-        context.Background(),
-        models.NewGetBucketRequest(testBucket).
-            WithMaxKeys(5).
-            WithMarker(*result1.ListBucketResult.NextMarker))
+	// Test files indexed 5-9
+	result2, err := client.GetBucket(
+		context.Background(),
+		models.NewGetBucketRequest(testBucket).
+			WithMaxKeys(5).
+			WithMarker(*result1.ListBucketResult.NextMarker))
 
-        ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertInt(t, "Number of Objects", 5, len(result2.ListBucketResult.Objects))
-    if result2.ListBucketResult.NextMarker == nil {
-        t.Fatal("Expected NextMarker to be non-nil value.")
-    }
-    for i, obj := range result2.ListBucketResult.Objects {
-        ds3Testing.AssertNonNilStringPtr(t, "ObjectName", ds3PutObjects[i + 5].Name, obj.Key)
-    }
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertInt(t, "Number of Objects", 5, len(result2.ListBucketResult.Objects))
+	if result2.ListBucketResult.NextMarker == nil {
+		t.Fatal("Expected NextMarker to be non-nil value.")
+	}
+	for i, obj := range result2.ListBucketResult.Objects {
+		ds3Testing.AssertNonNilStringPtr(t, "ObjectName", ds3PutObjects[i+5].Name, obj.Key)
+	}
 
-    // Test files indexed 10-14
-    result3, err := client.GetBucket(
-        context.Background(),
-        models.NewGetBucketRequest(testBucket).
-            WithMaxKeys(5).
-            WithMarker(*result2.ListBucketResult.NextMarker))
+	// Test files indexed 10-14
+	result3, err := client.GetBucket(
+		context.Background(),
+		models.NewGetBucketRequest(testBucket).
+			WithMaxKeys(5).
+			WithMarker(*result2.ListBucketResult.NextMarker))
 
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertInt(t, "Number of Objects", 5, len(result3.ListBucketResult.Objects))
-    if result2.ListBucketResult.NextMarker == nil {
-        t.Fatal("Expected NextMarker to be non-nil value.")
-    }
-    for i, obj := range result3.ListBucketResult.Objects {
-        ds3Testing.AssertNonNilStringPtr(t, "ObjectName", ds3PutObjects[i + 10].Name, obj.Key)
-    }
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertInt(t, "Number of Objects", 5, len(result3.ListBucketResult.Objects))
+	if result2.ListBucketResult.NextMarker == nil {
+		t.Fatal("Expected NextMarker to be non-nil value.")
+	}
+	for i, obj := range result3.ListBucketResult.Objects {
+		ds3Testing.AssertNonNilStringPtr(t, "ObjectName", ds3PutObjects[i+10].Name, obj.Key)
+	}
 }
 
 func TestGetBucketDelimiter(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    var ds3PutObjects []models.Ds3PutObject
-    for i := 0; i < 10; i++ {
-        name := "file" + strconv.Itoa(i)
-        curObj := models.Ds3PutObject{Name:name, Size:0}
-        ds3PutObjects = append(ds3PutObjects, curObj)
-    }
-    for i := 0; i < 10; i++ {
-        name := "dir/file" + strconv.Itoa(i)
-        curObj := models.Ds3PutObject{Name:name, Size:0}
-        ds3PutObjects = append(ds3PutObjects, curObj)
-    }
+	var ds3PutObjects []models.Ds3PutObject
+	for i := 0; i < 10; i++ {
+		name := "file" + strconv.Itoa(i)
+		curObj := models.Ds3PutObject{Name: name, Size: 0}
+		ds3PutObjects = append(ds3PutObjects, curObj)
+	}
+	for i := 0; i < 10; i++ {
+		name := "dir/file" + strconv.Itoa(i)
+		curObj := models.Ds3PutObject{Name: name, Size: 0}
+		ds3PutObjects = append(ds3PutObjects, curObj)
+	}
 
-    err := testutils.PutEmptyObjects(client, testBucket, ds3PutObjects)
-    ds3Testing.AssertNilError(t, err)
+	err := testutils.PutEmptyObjects(client, testBucket, ds3PutObjects)
+	ds3Testing.AssertNilError(t, err)
 
-    //Test files indexed 0-4
-    result, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket).WithDelimiter("/"))
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertInt(t, "Number of Objects", 10, len(result.ListBucketResult.Objects))
-    ds3Testing.AssertInt(t, "Number of Common Prefixes", 1, len(result.ListBucketResult.CommonPrefixes))
-    ds3Testing.AssertString(t, "CommonPrefix", "dir/", result.ListBucketResult.CommonPrefixes[0])
+	//Test files indexed 0-4
+	result, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket).WithDelimiter("/"))
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertInt(t, "Number of Objects", 10, len(result.ListBucketResult.Objects))
+	ds3Testing.AssertInt(t, "Number of Common Prefixes", 1, len(result.ListBucketResult.CommonPrefixes))
+	ds3Testing.AssertString(t, "CommonPrefix", "dir/", result.ListBucketResult.CommonPrefixes[0])
 }
 
 func TestBulkPut(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    books, bookErr := testutils.GetResourceBooks()
-    ds3Testing.AssertNilError(t, bookErr)
+	books, bookErr := testutils.GetResourceBooks()
+	ds3Testing.AssertNilError(t, bookErr)
 
-    ds3Objects, objErr := testutils.ConvertBooksToDs3Objects(books)
-    ds3Testing.AssertNilError(t, objErr)
+	ds3Objects, objErr := testutils.ConvertBooksToDs3Objects(books)
+	ds3Testing.AssertNilError(t, objErr)
 
-    // Create bulk put job
-    bulkPut, bulkPutErr := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
-    ds3Testing.AssertNilError(t, bulkPutErr)
+	// Create bulk put job
+	bulkPut, bulkPutErr := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(testBucket, ds3Objects))
+	ds3Testing.AssertNilError(t, bulkPutErr)
 
-    for _, chunk := range bulkPut.MasterObjectList.Objects {
-        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
-        ds3Testing.AssertNilError(t, allocateErr)
-        for _, obj := range allocateChunk.Objects.Objects {
-            content := books[*obj.Name]
-            _, putObjErr := client.PutObject(context.Background(), models.NewPutObjectRequest(testBucket, *obj.Name, content).
-                WithOffset(obj.Offset).
-                WithJob(bulkPut.MasterObjectList.JobId))
+	for _, chunk := range bulkPut.MasterObjectList.Objects {
+		allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
+		ds3Testing.AssertNilError(t, allocateErr)
+		for _, obj := range allocateChunk.Objects.Objects {
+			content := books[*obj.Name]
+			_, putObjErr := client.PutObject(context.Background(), models.NewPutObjectRequest(testBucket, *obj.Name, content).
+				WithOffset(obj.Offset).
+				WithJob(bulkPut.MasterObjectList.JobId))
 
-            ds3Testing.AssertNilError(t, putObjErr)
-        }
-    }
+			ds3Testing.AssertNilError(t, putObjErr)
+		}
+	}
 
-    // Verify books are in the bucket
-    getBucket, getBucketErr := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket))
-    ds3Testing.AssertNilError(t, getBucketErr)
-    if len(getBucket.ListBucketResult.Objects) != len(books) {
-        t.Fatalf("Expected '%d' objects in bucket '%s', but found '%d'.", len(books), testBucket, len(getBucket.ListBucketResult.Objects))
-    }
-    for i, obj := range getBucket.ListBucketResult.Objects {
-        ds3Testing.AssertNonNilStringPtr(t, "BookName", testutils.BookTitles[i], obj.Key)
-    }
+	// Verify books are in the bucket
+	getBucket, getBucketErr := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket))
+	ds3Testing.AssertNilError(t, getBucketErr)
+	if len(getBucket.ListBucketResult.Objects) != len(books) {
+		t.Fatalf("Expected '%d' objects in bucket '%s', but found '%d'.", len(books), testBucket, len(getBucket.ListBucketResult.Objects))
+	}
+	for i, obj := range getBucket.ListBucketResult.Objects {
+		ds3Testing.AssertNonNilStringPtr(t, "BookName", testutils.BookTitles[i], obj.Key)
+	}
 }
 
 func TestBulkGet(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    bookErr := testutils.PutTestBooks(client, testBucket)
-    ds3Testing.AssertNilError(t, bookErr)
+	bookErr := testutils.PutTestBooks(client, testBucket)
+	ds3Testing.AssertNilError(t, bookErr)
 
-    // Create bulk get job
-    bucketContents, bucketErr := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket))
-    ds3Testing.AssertNilError(t, bucketErr)
-    ds3Testing.AssertInt(t, "Number of Objects on BP", 4, len(bucketContents.ListBucketResult.Objects))
+	// Create bulk get job
+	bucketContents, bucketErr := client.GetBucket(context.Background(), models.NewGetBucketRequest(testBucket))
+	ds3Testing.AssertNilError(t, bucketErr)
+	ds3Testing.AssertInt(t, "Number of Objects on BP", 4, len(bucketContents.ListBucketResult.Objects))
 
-    objectNames := testutils.ConvertObjectsIntoObjectNameList(bucketContents.ListBucketResult.Objects)
-    bulkGet, bulkGetErr := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3Request(testBucket, objectNames))
-    ds3Testing.AssertNilError(t, bulkGetErr)
+	objectNames := testutils.ConvertObjectsIntoObjectNameList(bucketContents.ListBucketResult.Objects)
+	bulkGet, bulkGetErr := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3Request(testBucket, objectNames))
+	ds3Testing.AssertNilError(t, bulkGetErr)
 
-    availableChunks, chunksErr := client.GetJobChunkSpectraS3(context.Background(), models.NewGetJobChunkSpectraS3Request(bulkGet.MasterObjectList.JobId))
-    ds3Testing.AssertNilError(t, chunksErr)
+	availableChunks, chunksErr := client.GetJobChunkSpectraS3(context.Background(), models.NewGetJobChunkSpectraS3Request(bulkGet.MasterObjectList.JobId))
+	ds3Testing.AssertNilError(t, chunksErr)
 
-    // Get all objects and verify content
-    for _, obj := range availableChunks.Objects.Objects {
-        func() {
-            getObj, objErr := client.GetObject(context.Background(), models.NewGetObjectRequest(testBucket, *obj.Name))
-            ds3Testing.AssertNilError(t, objErr)
+	// Get all objects and verify content
+	for _, obj := range availableChunks.Objects.Objects {
+		func() {
+			getObj, objErr := client.GetObject(context.Background(), models.NewGetObjectRequest(testBucket, *obj.Name))
+			ds3Testing.AssertNilError(t, objErr)
 
-            defer getObj.Content.Close()
-            testutils.VerifyBookContent(t, *obj.Name, getObj.Content)
-        }()
-    }
+			defer getObj.Content.Close()
+			testutils.VerifyBookContent(t, *obj.Name, getObj.Content)
+		}()
+	}
 }
 
 func TestGetUsersSpectraS3WithName(t *testing.T) {
-    user, err := testutils.GetUserByNameLogError(t, client, defaultUser)
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertNonNilStringPtr(t, "Name", defaultUser, user.Name)
+	user, err := testutils.GetUserByNameLogError(t, client, defaultUser)
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertNonNilStringPtr(t, "Name", defaultUser, user.Name)
 }
 
 func TestDataPolicySpectraS3(t *testing.T) {
-    dataPolicyName := "GoTestDataPolicy"
+	dataPolicyName := "GoTestDataPolicy"
 
-    // Create data policy and verify creation
-    putResponse, putErr := testutils.PutDataPolicyLogError(t, client, dataPolicyName)
-    ds3Testing.AssertNilError(t, putErr)
+	// Create data policy and verify creation
+	putResponse, putErr := testutils.PutDataPolicyLogError(t, client, dataPolicyName)
+	ds3Testing.AssertNilError(t, putErr)
 
-    defer testutils.DeleteDataPolicyLogError(t, client, dataPolicyName)
+	defer testutils.DeleteDataPolicyLogError(t, client, dataPolicyName)
 
-    getResponse, getErr := testutils.GetDataPolicyLogError(t, client, putResponse.DataPolicy.Id)
-    ds3Testing.AssertNilError(t, getErr)
-    ds3Testing.AssertNonNilStringPtr(t, "Data Policy Name", dataPolicyName, getResponse.DataPolicy.Name)
+	getResponse, getErr := testutils.GetDataPolicyLogError(t, client, putResponse.DataPolicy.Id)
+	ds3Testing.AssertNilError(t, getErr)
+	ds3Testing.AssertNonNilStringPtr(t, "Data Policy Name", dataPolicyName, getResponse.DataPolicy.Name)
 }
 
 func TestSettingDefaultDataPolicy(t *testing.T) {
-    dataPolicyName := "GoTestSettingDefaultDataPolicy"
+	dataPolicyName := "GoTestSettingDefaultDataPolicy"
 
-    // Create data policy
-    putDataPolicyResponse, putErr := testutils.PutDataPolicyLogError(t, client, dataPolicyName)
-    ds3Testing.AssertNilError(t, putErr)
+	// Create data policy
+	putDataPolicyResponse, putErr := testutils.PutDataPolicyLogError(t, client, dataPolicyName)
+	ds3Testing.AssertNilError(t, putErr)
 
-    defer testutils.DeleteDataPolicyLogError(t, client, dataPolicyName)
+	defer testutils.DeleteDataPolicyLogError(t, client, dataPolicyName)
 
-    // Get default user and make note of default data policy if one is set
-    user, userErr := testutils.GetUserByNameLogError(t, client, defaultUser)
-    ds3Testing.AssertNilError(t, userErr)
-    curDataPolicy := user.DefaultDataPolicyId
+	// Get default user and make note of default data policy if one is set
+	user, userErr := testutils.GetUserByNameLogError(t, client, defaultUser)
+	ds3Testing.AssertNilError(t, userErr)
+	curDataPolicy := user.DefaultDataPolicyId
 
-    // Modify user's default data policy and verify
-    getDataPolicyResponse, getErr := testutils.GetDataPolicyLogError(t, client, dataPolicyName)
-    ds3Testing.AssertNilError(t, getErr)
+	// Modify user's default data policy and verify
+	getDataPolicyResponse, getErr := testutils.GetDataPolicyLogError(t, client, dataPolicyName)
+	ds3Testing.AssertNilError(t, getErr)
 
-    modifyResponse, modifyErr := client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(user.Id).
-        WithDefaultDataPolicyId(getDataPolicyResponse.DataPolicy.Id))
-    ds3Testing.AssertNilError(t, modifyErr)
+	modifyResponse, modifyErr := client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(user.Id).
+		WithDefaultDataPolicyId(getDataPolicyResponse.DataPolicy.Id))
+	ds3Testing.AssertNilError(t, modifyErr)
 
-    defer client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(user.Id).
-        WithDefaultDataPolicyId(*curDataPolicy))
+	defer client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(user.Id).
+		WithDefaultDataPolicyId(*curDataPolicy))
 
-    ds3Testing.AssertNonNilStringPtr(t, "Name", defaultUser, modifyResponse.SpectraUser.Name)
-    ds3Testing.AssertNonNilStringPtr(t, "DataPolicyId", putDataPolicyResponse.DataPolicy.Id, modifyResponse.SpectraUser.DefaultDataPolicyId)
+	ds3Testing.AssertNonNilStringPtr(t, "Name", defaultUser, modifyResponse.SpectraUser.Name)
+	ds3Testing.AssertNonNilStringPtr(t, "DataPolicyId", putDataPolicyResponse.DataPolicy.Id, modifyResponse.SpectraUser.DefaultDataPolicyId)
 }
 
 func TestStorageDomain(t *testing.T) {
-    storageDomainName := "GoTestStorageDomain"
+	storageDomainName := "GoTestStorageDomain"
 
-    // Create storage domain
-    putResponse, putErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(storageDomainName))
-    ds3Testing.AssertNilError(t, putErr)
+	// Create storage domain
+	putResponse, putErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(storageDomainName))
+	ds3Testing.AssertNilError(t, putErr)
 
-    defer client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(storageDomainName))
+	defer client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(storageDomainName))
 
-    ds3Testing.AssertNonNilStringPtr(t, "Name", storageDomainName, putResponse.StorageDomain.Name)
+	ds3Testing.AssertNonNilStringPtr(t, "Name", storageDomainName, putResponse.StorageDomain.Name)
 }
 
 func TestPoolPartition(t *testing.T) {
-    poolPartitionName := "GoTestPoolPartition"
+	poolPartitionName := "GoTestPoolPartition"
 
-    // Create pool partition
-    putResponse, putErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(poolPartitionName, models.POOL_TYPE_ONLINE))
-    ds3Testing.AssertNilError(t, putErr)
+	// Create pool partition
+	putResponse, putErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(poolPartitionName, models.POOL_TYPE_ONLINE))
+	ds3Testing.AssertNilError(t, putErr)
 
-    defer client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(poolPartitionName))
+	defer client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(poolPartitionName))
 
-    ds3Testing.AssertNonNilStringPtr(t, "Name", poolPartitionName, putResponse.PoolPartition.Name)
-    if putResponse.PoolPartition.Type != models.POOL_TYPE_ONLINE {
-        t.Fatalf("Expected pool partition type of ONLINE but was '%s'.", putResponse.PoolPartition.Type.String())
-    }
+	ds3Testing.AssertNonNilStringPtr(t, "Name", poolPartitionName, putResponse.PoolPartition.Name)
+	if putResponse.PoolPartition.Type != models.POOL_TYPE_ONLINE {
+		t.Fatalf("Expected pool partition type of ONLINE but was '%s'.", putResponse.PoolPartition.Type.String())
+	}
 }
 
 func TestStorageDomainMember(t *testing.T) {
-    varTestName := "GoTestStorageDomainMember"
+	varTestName := "GoTestStorageDomainMember"
 
-    // Create storage domain
-    storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(varTestName))
-    ds3Testing.AssertNilError(t, storageDomainErr)
+	// Create storage domain
+	storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(varTestName))
+	ds3Testing.AssertNilError(t, storageDomainErr)
 
-    defer client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(varTestName))
+	defer client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(varTestName))
 
-    // Create pool partition
-    poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(varTestName, models.POOL_TYPE_ONLINE))
-    ds3Testing.AssertNilError(t, poolPartitionErr)
+	// Create pool partition
+	poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(varTestName, models.POOL_TYPE_ONLINE))
+	ds3Testing.AssertNilError(t, poolPartitionErr)
 
-    defer client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(varTestName))
+	defer client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(varTestName))
 
-    // Create storage domain member linking pool partition to storage domain
-    response, err := client.PutPoolStorageDomainMemberSpectraS3(context.Background(), models.NewPutPoolStorageDomainMemberSpectraS3Request(
-        poolPartitionResponse.PoolPartition.Id,
-        storageDomainResponse.StorageDomain.Id))
-    ds3Testing.AssertNilError(t, err)
+	// Create storage domain member linking pool partition to storage domain
+	response, err := client.PutPoolStorageDomainMemberSpectraS3(context.Background(), models.NewPutPoolStorageDomainMemberSpectraS3Request(
+		poolPartitionResponse.PoolPartition.Id,
+		storageDomainResponse.StorageDomain.Id))
+	ds3Testing.AssertNilError(t, err)
 
-    defer client.DeleteStorageDomainMemberSpectraS3(context.Background(), models.NewDeleteStorageDomainMemberSpectraS3Request(response.StorageDomainMember.Id))
+	defer client.DeleteStorageDomainMemberSpectraS3(context.Background(), models.NewDeleteStorageDomainMemberSpectraS3Request(response.StorageDomainMember.Id))
 
-    ds3Testing.AssertNonNilStringPtr(t, "PoolPartitionId", poolPartitionResponse.PoolPartition.Id, response.StorageDomainMember.PoolPartitionId)
-    ds3Testing.AssertString(t, "StorageDomainId", storageDomainResponse.StorageDomain.Id, response.StorageDomainMember.StorageDomainId)
+	ds3Testing.AssertNonNilStringPtr(t, "PoolPartitionId", poolPartitionResponse.PoolPartition.Id, response.StorageDomainMember.PoolPartitionId)
+	ds3Testing.AssertString(t, "StorageDomainId", storageDomainResponse.StorageDomain.Id, response.StorageDomainMember.StorageDomainId)
 }
 
 func TestDataPersistenceRule(t *testing.T) {
-    varTestName := "GoTestDataPersistenceRule"
-    dataPersistenceRuleType := models.DATA_PERSISTENCE_RULE_TYPE_PERMANENT
-    dataIsolationLevel := models.DATA_ISOLATION_LEVEL_STANDARD
+	varTestName := "GoTestDataPersistenceRule"
+	dataPersistenceRuleType := models.DATA_PERSISTENCE_RULE_TYPE_PERMANENT
+	dataIsolationLevel := models.DATA_ISOLATION_LEVEL_STANDARD
 
-    // Create data policy
-    putDataPolicyResponse, putErr := testutils.PutDataPolicyLogError(t, client, varTestName)
-    ds3Testing.AssertNilError(t, putErr)
+	// Create data policy
+	putDataPolicyResponse, putErr := testutils.PutDataPolicyLogError(t, client, varTestName)
+	ds3Testing.AssertNilError(t, putErr)
 
-    defer testutils.DeleteDataPolicyLogError(t, client, varTestName)
+	defer testutils.DeleteDataPolicyLogError(t, client, varTestName)
 
-    // Create storage domain
-    storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(varTestName))
-    ds3Testing.AssertNilError(t, storageDomainErr)
+	// Create storage domain
+	storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(varTestName))
+	ds3Testing.AssertNilError(t, storageDomainErr)
 
-    defer client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(varTestName))
+	defer client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(varTestName))
 
-    // Create pool partition
-    poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(varTestName, models.POOL_TYPE_ONLINE))
-    ds3Testing.AssertNilError(t, poolPartitionErr)
+	// Create pool partition
+	poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(varTestName, models.POOL_TYPE_ONLINE))
+	ds3Testing.AssertNilError(t, poolPartitionErr)
 
-    defer client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(varTestName))
+	defer client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(varTestName))
 
-    // Create storage domain member linking pool partition to storage domain
-    memberResponse, memberErr := client.PutPoolStorageDomainMemberSpectraS3(context.Background(), models.NewPutPoolStorageDomainMemberSpectraS3Request(
-        poolPartitionResponse.PoolPartition.Id,
-        storageDomainResponse.StorageDomain.Id))
-    ds3Testing.AssertNilError(t, memberErr)
+	// Create storage domain member linking pool partition to storage domain
+	memberResponse, memberErr := client.PutPoolStorageDomainMemberSpectraS3(context.Background(), models.NewPutPoolStorageDomainMemberSpectraS3Request(
+		poolPartitionResponse.PoolPartition.Id,
+		storageDomainResponse.StorageDomain.Id))
+	ds3Testing.AssertNilError(t, memberErr)
 
-    defer client.DeleteStorageDomainMemberSpectraS3(context.Background(), models.NewDeleteStorageDomainMemberSpectraS3Request(memberResponse.StorageDomainMember.Id))
+	defer client.DeleteStorageDomainMemberSpectraS3(context.Background(), models.NewDeleteStorageDomainMemberSpectraS3Request(memberResponse.StorageDomainMember.Id))
 
-    // Create data persistence rule linking data policy and storage domain
-    response, err := client.PutDataPersistenceRuleSpectraS3(context.Background(), models.NewPutDataPersistenceRuleSpectraS3Request(
-        dataPersistenceRuleType,
-        putDataPolicyResponse.DataPolicy.Id,
-        dataIsolationLevel,
-        storageDomainResponse.StorageDomain.Id))
-    ds3Testing.AssertNilError(t, err)
+	// Create data persistence rule linking data policy and storage domain
+	response, err := client.PutDataPersistenceRuleSpectraS3(context.Background(), models.NewPutDataPersistenceRuleSpectraS3Request(
+		dataPersistenceRuleType,
+		putDataPolicyResponse.DataPolicy.Id,
+		dataIsolationLevel,
+		storageDomainResponse.StorageDomain.Id))
+	ds3Testing.AssertNilError(t, err)
 
-    defer client.DeleteDataPersistenceRuleSpectraS3(context.Background(), models.NewDeleteDataPersistenceRuleSpectraS3Request(response.DataPersistenceRule.Id))
+	defer client.DeleteDataPersistenceRuleSpectraS3(context.Background(), models.NewDeleteDataPersistenceRuleSpectraS3Request(response.DataPersistenceRule.Id))
 
-    ds3Testing.AssertString(t, "DataPolicyId", putDataPolicyResponse.DataPolicy.Id, response.DataPersistenceRule.DataPolicyId)
-    ds3Testing.AssertString(t, "StorageDomainId", storageDomainResponse.StorageDomain.Id, response.DataPersistenceRule.StorageDomainId)
-    if response.DataPersistenceRule.Type != dataPersistenceRuleType {
-        t.Fatalf("Expected DataPersistenceRuleType to be '%s' but was '%s'.", dataPersistenceRuleType.String(), response.DataPersistenceRule.Type.String())
-    }
-    if response.DataPersistenceRule.IsolationLevel != dataIsolationLevel {
-        t.Fatalf("Expected DataIsolationLevel to be '%s' but was '%s'.", dataIsolationLevel.String(), response.DataPersistenceRule.IsolationLevel.String())
-    }
+	ds3Testing.AssertString(t, "DataPolicyId", putDataPolicyResponse.DataPolicy.Id, response.DataPersistenceRule.DataPolicyId)
+	ds3Testing.AssertString(t, "StorageDomainId", storageDomainResponse.StorageDomain.Id, response.DataPersistenceRule.StorageDomainId)
+	if response.DataPersistenceRule.Type != dataPersistenceRuleType {
+		t.Fatalf("Expected DataPersistenceRuleType to be '%s' but was '%s'.", dataPersistenceRuleType.String(), response.DataPersistenceRule.Type.String())
+	}
+	if response.DataPersistenceRule.IsolationLevel != dataIsolationLevel {
+		t.Fatalf("Expected DataIsolationLevel to be '%s' but was '%s'.", dataIsolationLevel.String(), response.DataPersistenceRule.IsolationLevel.String())
+	}
 }
 
 func TestPuttingFolder(t *testing.T) {
-    bucketName := "GoTestPuttingFolder"
-    err := testutils.PutBucketLogError(t, client, bucketName)
-    ds3Testing.AssertNilError(t, err)
+	bucketName := "GoTestPuttingFolder"
+	err := testutils.PutBucketLogError(t, client, bucketName)
+	ds3Testing.AssertNilError(t, err)
 
-    defer deleteBucketAndContent(t, bucketName)
+	defer deleteBucketAndContent(t, bucketName)
 
-    const folderPath = "Gracie/Eskimo/"
+	const folderPath = "Gracie/Eskimo/"
 
-    readSizer := newNilReadSizer(nil, 0)
-    putObjectRequest := models.NewPutObjectRequest(bucketName, folderPath, &readSizer)
-    _, err = client.PutObject(context.Background(), putObjectRequest)
-    ds3Testing.AssertNilError(t, err)
+	readSizer := newNilReadSizer(nil, 0)
+	putObjectRequest := models.NewPutObjectRequest(bucketName, folderPath, &readSizer)
+	_, err = client.PutObject(context.Background(), putObjectRequest)
+	ds3Testing.AssertNilError(t, err)
 
-    getBucketRequest := models.NewGetBucketRequest(bucketName)
-    getBucketResponse, err := client.GetBucket(context.Background(), getBucketRequest)
-    ds3Testing.AssertNilError(t, err)
+	getBucketRequest := models.NewGetBucketRequest(bucketName)
+	getBucketResponse, err := client.GetBucket(context.Background(), getBucketRequest)
+	ds3Testing.AssertNilError(t, err)
 
-    ds3Testing.AssertInt(t, "Number of objects in bucket", 1, len(getBucketResponse.ListBucketResult.Objects))
-    ds3Testing.AssertString(t, "Folder names equal", folderPath, *getBucketResponse.ListBucketResult.Objects[0].Key)
+	ds3Testing.AssertInt(t, "Number of objects in bucket", 1, len(getBucketResponse.ListBucketResult.Objects))
+	ds3Testing.AssertString(t, "Folder names equal", folderPath, *getBucketResponse.ListBucketResult.Objects[0].Key)
 }
 
 func deleteBucketAndContent(t *testing.T, bucketName string) {
-    testutils.DeleteBucketContents(client, bucketName)
-    testutils.DeleteBucketLogError(t, client, bucketName)
+	testutils.DeleteBucketContents(client, bucketName)
+	testutils.DeleteBucketLogError(t, client, bucketName)
 }
 
 func TestPuttingZeroLengthObject(t *testing.T) {
-    bucketName := "GoTestPuttingZeroLengthObject"
-    err := testutils.PutBucketLogError(t, client, bucketName)
-    ds3Testing.AssertNilError(t, err)
+	bucketName := "GoTestPuttingZeroLengthObject"
+	err := testutils.PutBucketLogError(t, client, bucketName)
+	ds3Testing.AssertNilError(t, err)
 
-    defer deleteBucketAndContent(t, bucketName)
+	defer deleteBucketAndContent(t, bucketName)
 
-    const objectName = "Gracie"
+	const objectName = "Gracie"
 
-    zeroBytes := make([]byte, 0)
+	zeroBytes := make([]byte, 0)
 
-    putObjectRequest := models.NewPutObjectRequest(bucketName, objectName, ds3.BuildByteReaderWithSizeDecorator(zeroBytes)).
-        WithMetaData("_c", "C").
-        WithMetaData("d", "D").
-        WithMetaData("_a", "A").
-        WithMetaData("b", "B")
+	putObjectRequest := models.NewPutObjectRequest(bucketName, objectName, ds3.BuildByteReaderWithSizeDecorator(zeroBytes)).
+		WithMetaData("_c", "C").
+		WithMetaData("d", "D").
+		WithMetaData("_a", "A").
+		WithMetaData("b", "B")
 
-    _, err = client.PutObject(context.Background(), putObjectRequest)
+	_, err = client.PutObject(context.Background(), putObjectRequest)
 
-    ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertNilError(t, err)
 
-    getBucketRequest := models.NewGetBucketRequest(bucketName)
-    getBucketResponse, err := client.GetBucket(context.Background(), getBucketRequest)
-    ds3Testing.AssertNilError(t, err)
+	getBucketRequest := models.NewGetBucketRequest(bucketName)
+	getBucketResponse, err := client.GetBucket(context.Background(), getBucketRequest)
+	ds3Testing.AssertNilError(t, err)
 
-    ds3Testing.AssertInt(t, "Number of objects in bucket", 1, len(getBucketResponse.ListBucketResult.Objects))
-    ds3Testing.AssertString(t, "Object names equal", objectName, *getBucketResponse.ListBucketResult.Objects[0].Key)
-    ds3Testing.AssertInt64(t, "Object size equal", 0, getBucketResponse.ListBucketResult.Objects[0].Size)
+	ds3Testing.AssertInt(t, "Number of objects in bucket", 1, len(getBucketResponse.ListBucketResult.Objects))
+	ds3Testing.AssertString(t, "Object names equal", objectName, *getBucketResponse.ListBucketResult.Objects[0].Key)
+	ds3Testing.AssertInt64(t, "Object size equal", 0, getBucketResponse.ListBucketResult.Objects[0].Size)
 }
 
 func TestDeleteObjects(t *testing.T) {
-    bucketName := "GoTestDeleteObjects"
+	bucketName := "GoTestDeleteObjects"
 
-    // create bucket
-    err := testutils.PutBucketLogError(t, client, bucketName)
-    ds3Testing.AssertNilError(t, err)
-    defer deleteBucketAndContent(t, bucketName)
+	// create bucket
+	err := testutils.PutBucketLogError(t, client, bucketName)
+	ds3Testing.AssertNilError(t, err)
+	defer deleteBucketAndContent(t, bucketName)
 
-    // put the test books into the bucket
-    testutils.PutTestBooks(client, bucketName)
+	// put the test books into the bucket
+	testutils.PutTestBooks(client, bucketName)
 
-    // list all objects in the bucket
-    getBucket, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(bucketName))
+	// list all objects in the bucket
+	getBucket, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(bucketName))
 
-    ds3Testing.AssertInt(t, "number of objects to delete", 4, len(getBucket.ListBucketResult.Objects))
+	ds3Testing.AssertInt(t, "number of objects to delete", 4, len(getBucket.ListBucketResult.Objects))
 
-    names := make([]string, 0)
-    for _, obj := range getBucket.ListBucketResult.Objects {
-        names = append(names, *obj.Key)
-    }
+	names := make([]string, 0)
+	for _, obj := range getBucket.ListBucketResult.Objects {
+		names = append(names, *obj.Key)
+	}
 
-    deleteObjs := models.NewDeleteObjectsRequest(bucketName, names)
-    _, err = client.DeleteObjects(context.Background(), deleteObjs)
-    ds3Testing.AssertNilError(t, err)
+	deleteObjs := models.NewDeleteObjectsRequest(bucketName, names)
+	_, err = client.DeleteObjects(context.Background(), deleteObjs)
+	ds3Testing.AssertNilError(t, err)
 }

--- a/ds3_integration/utils/testUtils.go
+++ b/ds3_integration/utils/testUtils.go
@@ -1,475 +1,475 @@
 package testutils
 
 import (
-    "context"
-    "testing"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "io/ioutil"
-    "errors"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
-    "log"
-    "io"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
-    "bytes"
-    "fmt"
-    "time"
-    "os"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+	"time"
 )
 
 var BookPath = "./resources/books/"
 var nilResponse error = errors.New("Received an unexpected nil response.")
-var BookTitles = []string{ "beowulf.txt", "sherlock_holmes.txt", "tale_of_two_cities.txt", "ulysses.txt"}
+var BookTitles = []string{"beowulf.txt", "sherlock_holmes.txt", "tale_of_two_cities.txt", "ulysses.txt"}
 
 // Retrieves the specified objects from the BP bucket and compares the content to
 // to local files. Assumes that local file names and BP object names are the same.
 func VerifyFilesOnBP(t *testing.T, bucketName string, objectNames []string, filePath string, client *ds3.Client) {
-    bulkGet, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3Request(bucketName, objectNames))
-    ds3Testing.AssertNilError(t, err)
-    totalChunkCount := len(bulkGet.MasterObjectList.Objects)
-    curChunkCount := 0
-    for curChunkCount < totalChunkCount {
-        chunksReady, err := client.GetJobChunksReadyForClientProcessingSpectraS3(
-            context.Background(),
-            models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(bulkGet.MasterObjectList.JobId))
+	bulkGet, err := client.GetBulkJobSpectraS3(context.Background(), models.NewGetBulkJobSpectraS3Request(bucketName, objectNames))
+	ds3Testing.AssertNilError(t, err)
+	totalChunkCount := len(bulkGet.MasterObjectList.Objects)
+	curChunkCount := 0
+	for curChunkCount < totalChunkCount {
+		chunksReady, err := client.GetJobChunksReadyForClientProcessingSpectraS3(
+			context.Background(),
+			models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(bulkGet.MasterObjectList.JobId))
 
-        ds3Testing.AssertNilError(t, err)
+		ds3Testing.AssertNilError(t, err)
 
-        numberOfChunks := len(chunksReady.MasterObjectList.Objects)
-        if numberOfChunks > 0 {
-            for _, curChunk := range chunksReady.MasterObjectList.Objects {
-                for _, curObj := range curChunk.Objects {
+		numberOfChunks := len(chunksReady.MasterObjectList.Objects)
+		if numberOfChunks > 0 {
+			for _, curChunk := range chunksReady.MasterObjectList.Objects {
+				for _, curObj := range curChunk.Objects {
 
-                    getObj, getErr := client.GetObject(context.Background(), models.NewGetObjectRequest(bucketName, *curObj.Name).
-                        WithJob(bulkGet.MasterObjectList.JobId).
-                        WithOffset(curObj.Offset))
-                    ds3Testing.AssertNilError(t, getErr)
+					getObj, getErr := client.GetObject(context.Background(), models.NewGetObjectRequest(bucketName, *curObj.Name).
+						WithJob(bulkGet.MasterObjectList.JobId).
+						WithOffset(curObj.Offset))
+					ds3Testing.AssertNilError(t, getErr)
 
-                    VerifyPartialFile(t, filePath + *curObj.Name, curObj.Length, curObj.Offset, getObj.Content)
-                    getObj.Content.Close()
-                }
-                curChunkCount++
-            }
-        } else {
-            time.Sleep(time.Second * 5)
-        }
-    }
+					VerifyPartialFile(t, filePath+*curObj.Name, curObj.Length, curObj.Offset, getObj.Content)
+					getObj.Content.Close()
+				}
+				curChunkCount++
+			}
+		} else {
+			time.Sleep(time.Second * 5)
+		}
+	}
 }
 
 func VerifyBookContent(t *testing.T, bookName string, actual io.ReadCloser) {
-    expected, loadErr := LoadBook(bookName)
-    ds3Testing.AssertNilError(t, loadErr)
-    verifyContent(t, expected, actual)
+	expected, loadErr := LoadBook(bookName)
+	ds3Testing.AssertNilError(t, loadErr)
+	verifyContent(t, expected, actual)
 }
 
 func VerifyPartialFile(t *testing.T, filePath string, length int64, offset int64, actual io.Reader) {
-    f, err := os.Open(filePath)
-    ds3Testing.AssertNilError(t, err)
+	f, err := os.Open(filePath)
+	ds3Testing.AssertNilError(t, err)
 
-    _, err = f.Seek(offset, io.SeekStart)
-    ds3Testing.AssertNilError(t, err)
+	_, err = f.Seek(offset, io.SeekStart)
+	ds3Testing.AssertNilError(t, err)
 
-    expected, err := getNBytesFromReader(f, length)
-    ds3Testing.AssertNilError(t, err)
+	expected, err := getNBytesFromReader(f, length)
+	ds3Testing.AssertNilError(t, err)
 
-    verifyPartialContent(t, *expected, actual, length)
+	verifyPartialContent(t, *expected, actual, length)
 }
 
 func verifyPartialContent(t *testing.T, expected []byte, actual io.Reader, length int64) {
-    content, err := getNBytesFromReader(actual, length)
-    ds3Testing.AssertNilError(t, err)
+	content, err := getNBytesFromReader(actual, length)
+	ds3Testing.AssertNilError(t, err)
 
-    ds3Testing.AssertInt(t, "amount of data read", len(expected), len(*content))
-    if bytes.Compare(*content, expected) != 0 {
-        t.Error("Retrieved book does not match uploaded book.")
-    }
+	ds3Testing.AssertInt(t, "amount of data read", len(expected), len(*content))
+	if bytes.Compare(*content, expected) != 0 {
+		t.Error("Retrieved book does not match uploaded book.")
+	}
 }
 
 func verifyContent(t *testing.T, expected []byte, actual io.ReadCloser) {
-    content, err := ioutil.ReadAll(actual)
-    ds3Testing.AssertNilError(t, err)
+	content, err := ioutil.ReadAll(actual)
+	ds3Testing.AssertNilError(t, err)
 
-    ds3Testing.AssertInt(t, "amount of data read", len(expected), len(content))
-    if bytes.Compare(content, expected) != 0 {
-        t.Error("Retrieved book does not match uploaded book.")
-    }
+	ds3Testing.AssertInt(t, "amount of data read", len(expected), len(content))
+	if bytes.Compare(content, expected) != 0 {
+		t.Error("Retrieved book does not match uploaded book.")
+	}
 }
 
 // Retrieves N bytes from the provided reader. If N bytes cannot be retrieved, then an error occurs.
 func getNBytesFromReader(reader io.Reader, n int64) (*[]byte, error) {
-    content := make([]byte, 0)
-    toRetrieve := n
+	content := make([]byte, 0)
+	toRetrieve := n
 
-    for {
-        buf := make([]byte, toRetrieve)
-        v, _ := reader.Read(buf)
+	for {
+		buf := make([]byte, toRetrieve)
+		v, _ := reader.Read(buf)
 
-        if v == 0 {
+		if v == 0 {
 
-            if curLen := int64(len(content)); curLen != n {
-                return nil, errors.New(fmt.Sprintf("GetNBytesFromReader: Expected content of length %d but got %d", n, curLen))
-            }
-            //done
-            return &content, nil
-        }
+			if curLen := int64(len(content)); curLen != n {
+				return nil, errors.New(fmt.Sprintf("GetNBytesFromReader: Expected content of length %d but got %d", n, curLen))
+			}
+			//done
+			return &content, nil
+		}
 
-        toRetrieve = toRetrieve - int64(v)
-        content = append(content, buf[:v]...)
-    }
+		toRetrieve = toRetrieve - int64(v)
+		content = append(content, buf[:v]...)
+	}
 }
 
 func ConvertObjectsIntoObjectNameList(objects []models.Contents) []string {
-    var objectNames []string
-    for _, obj := range objects{
-        objectNames = append(objectNames, *obj.Key)
-    }
-    return objectNames
+	var objectNames []string
+	for _, obj := range objects {
+		objectNames = append(objectNames, *obj.Key)
+	}
+	return objectNames
 }
 
-//Puts the test books onto the BP
+// Puts the test books onto the BP
 func PutTestBooks(client *ds3.Client, bucketName string) error {
-    books, bookErr := GetResourceBooks()
-    if bookErr != nil {
-        return bookErr
-    }
+	books, bookErr := GetResourceBooks()
+	if bookErr != nil {
+		return bookErr
+	}
 
-    ds3Objects, objErr := ConvertBooksToDs3Objects(books)
-    if objErr != nil {
-        return objErr
-    }
+	ds3Objects, objErr := ConvertBooksToDs3Objects(books)
+	if objErr != nil {
+		return objErr
+	}
 
-    // Create bulk put job
-    bulkPut, bulkPutErr := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(bucketName, ds3Objects))
-    if bulkPutErr != nil {
-        return bulkPutErr
-    }
+	// Create bulk put job
+	bulkPut, bulkPutErr := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(bucketName, ds3Objects))
+	if bulkPutErr != nil {
+		return bulkPutErr
+	}
 
-    for _, chunk := range bulkPut.MasterObjectList.Objects {
-        allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
-        if allocateErr != nil {
-            return allocateErr
-        }
-        for _, obj := range allocateChunk.Objects.Objects {
-            content := books[*obj.Name]
-            _, putObjErr := client.PutObject(context.Background(), models.NewPutObjectRequest(bucketName, *obj.Name, content).
-                WithOffset(obj.Offset).
-                WithJob(bulkPut.MasterObjectList.JobId))
+	for _, chunk := range bulkPut.MasterObjectList.Objects {
+		allocateChunk, allocateErr := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
+		if allocateErr != nil {
+			return allocateErr
+		}
+		for _, obj := range allocateChunk.Objects.Objects {
+			content := books[*obj.Name]
+			_, putObjErr := client.PutObject(context.Background(), models.NewPutObjectRequest(bucketName, *obj.Name, content).
+				WithOffset(obj.Offset).
+				WithJob(bulkPut.MasterObjectList.JobId))
 
-            if putObjErr != nil {
-                return putObjErr
-            }
-        }
-    }
-    return nil
+			if putObjErr != nil {
+				return putObjErr
+			}
+		}
+	}
+	return nil
 }
 
 func CancelAllJobsForBucket(client *ds3.Client, bucketName string) {
-    //Cancel all jobs on bucket
-    getJobs, err := client.GetJobsSpectraS3(context.Background(), models.NewGetJobsSpectraS3Request())
-    if err != nil {
-        log.Printf("WARNING: Cleanup error when attempting to get all jobs for bucket '%s': '%s.", bucketName, err.Error())
-        return
-    }
-    for _, job := range getJobs.JobList.Jobs {
-        if job.BucketName == nil || *job.BucketName != bucketName {
-            continue
-        }
-        if _, err = client.CancelJobSpectraS3(context.Background(), models.NewCancelJobSpectraS3Request(job.JobId)); err != nil {
-            log.Printf("WARNING: Unable to cancel job %s for bucket %s: %s", job.JobId, bucketName, err)
-        }
-    }
+	//Cancel all jobs on bucket
+	getJobs, err := client.GetJobsSpectraS3(context.Background(), models.NewGetJobsSpectraS3Request())
+	if err != nil {
+		log.Printf("WARNING: Cleanup error when attempting to get all jobs for bucket '%s': '%s.", bucketName, err.Error())
+		return
+	}
+	for _, job := range getJobs.JobList.Jobs {
+		if job.BucketName == nil || *job.BucketName != bucketName {
+			continue
+		}
+		if _, err = client.CancelJobSpectraS3(context.Background(), models.NewCancelJobSpectraS3Request(job.JobId)); err != nil {
+			log.Printf("WARNING: Unable to cancel job %s for bucket %s: %s", job.JobId, bucketName, err)
+		}
+	}
 }
 
 func DeleteBucketContents(client *ds3.Client, bucketName string) {
-    CancelAllJobsForBucket(client, bucketName)
+	CancelAllJobsForBucket(client, bucketName)
 
-    //Get the contents of bucket
-    getBucket, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(bucketName))
-    if err != nil {
-        log.Printf("WARNING: Cleanup error when attempting to get contents of bucket '%s': '%s'.", bucketName, err.Error())
-        return
-    }
-    for _, obj := range getBucket.ListBucketResult.Objects {
-        deleteErr := DeleteObject(client, bucketName, *obj.Key)
-        if deleteErr != nil {
-            log.Printf("WARNING: Cleanup error when attempting to delete object '%s' from bucket '%s': '%s'.", *obj.Key, bucketName, deleteErr.Error())
-        }
-    }
+	//Get the contents of bucket
+	getBucket, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(bucketName))
+	if err != nil {
+		log.Printf("WARNING: Cleanup error when attempting to get contents of bucket '%s': '%s'.", bucketName, err.Error())
+		return
+	}
+	for _, obj := range getBucket.ListBucketResult.Objects {
+		deleteErr := DeleteObject(client, bucketName, *obj.Key)
+		if deleteErr != nil {
+			log.Printf("WARNING: Cleanup error when attempting to delete object '%s' from bucket '%s': '%s'.", *obj.Key, bucketName, deleteErr.Error())
+		}
+	}
 }
 
 func GetResourceBooks() (map[string]models.ReaderWithSizeDecorator, error) {
-    result := make(map[string]models.ReaderWithSizeDecorator)
-    for _, title := range BookTitles {
-        curStream, err := GetResourceBookAsStream(title)
-        if err != nil {
-            return nil, err
-        }
-        result[title] = *curStream
-    }
-    return result, nil
+	result := make(map[string]models.ReaderWithSizeDecorator)
+	for _, title := range BookTitles {
+		curStream, err := GetResourceBookAsStream(title)
+		if err != nil {
+			return nil, err
+		}
+		result[title] = *curStream
+	}
+	return result, nil
 }
 
 func ConvertBooksToDs3Objects(books map[string]models.ReaderWithSizeDecorator) ([]models.Ds3PutObject, error) {
-    var ds3Objects []models.Ds3PutObject
-    for title, stream := range books {
-        size, err := stream.Size()
-        if err != nil {
-            return nil, err
-        }
-        var curObj models.Ds3PutObject = models.Ds3PutObject{
-            Name:title,
-            Size:size,
-        }
-        ds3Objects = append(ds3Objects, curObj)
-    }
-    return ds3Objects, nil
+	var ds3Objects []models.Ds3PutObject
+	for title, stream := range books {
+		size, err := stream.Size()
+		if err != nil {
+			return nil, err
+		}
+		var curObj models.Ds3PutObject = models.Ds3PutObject{
+			Name: title,
+			Size: size,
+		}
+		ds3Objects = append(ds3Objects, curObj)
+	}
+	return ds3Objects, nil
 }
 
 func GetResourceBookAsStream(book string) (*models.ReadCloserWithSizeDecorator, error) {
-    content, err := LoadBook(book)
-    if err != nil {
-        return nil, err
-    }
-    stream := ds3.BuildByteReaderWithSizeDecorator(content)
-    return &stream, nil
+	content, err := LoadBook(book)
+	if err != nil {
+		return nil, err
+	}
+	stream := ds3.BuildByteReaderWithSizeDecorator(content)
+	return &stream, nil
 }
 
 // Loads the specified book. If an error occurs, it is logged, and the calling
 // test is marked as failed.
 func LoadBookLogError(t *testing.T, book string) ([]byte, error) {
-    data, err := LoadBook(book)
-    if err != nil {
-        t.Errorf("Unexpected error when loading test file: %s", err.Error())
-        return nil, err
-    }
-    return data, nil
+	data, err := LoadBook(book)
+	if err != nil {
+		t.Errorf("Unexpected error when loading test file: %s", err.Error())
+		return nil, err
+	}
+	return data, nil
 }
 
 // Loads the specified book. Assumes that the book is located in the /resources/books/ folder.
 func LoadBook(book string) ([]byte, error) {
-    return ioutil.ReadFile(BookPath + book)
+	return ioutil.ReadFile(BookPath + book)
 }
 
 // Puts the specified object. If an error occurs, it is logged, and the calling
 // test is marked as failed.
-func PutObjectLogError(t *testing.T, client *ds3.Client, bucketName string, objectName string, data []byte) (error) {
-    err := PutObject(client, bucketName, objectName, data)
-    if err != nil {
-        t.Error(err)
-    }
-    return nil
+func PutObjectLogError(t *testing.T, client *ds3.Client, bucketName string, objectName string, data []byte) error {
+	err := PutObject(client, bucketName, objectName, data)
+	if err != nil {
+		t.Error(err)
+	}
+	return nil
 }
 
 // Puts the specified object. Returns an error if not successful.
-func PutObject(client *ds3.Client, bucketName string, objectName string, data []byte) (error) {
-    return PutObjectWithJobId(client, bucketName, objectName, "", data)
+func PutObject(client *ds3.Client, bucketName string, objectName string, data []byte) error {
+	return PutObjectWithJobId(client, bucketName, objectName, "", data)
 }
 
 // Puts the specified object. Returns an error if not successful.
-func PutObjectWithJobId(client *ds3.Client, bucketName string, objectName string, jobId string, data []byte) (error) {
-    putObjRequest := models.NewPutObjectRequest(bucketName, objectName, ds3.BuildByteReaderWithSizeDecorator(data))
-    if jobId != "" {
-        putObjRequest = putObjRequest.WithJob(jobId)
-    }
-    putObjectResponse, putErr := client.PutObject(context.Background(), putObjRequest)
-    if putErr != nil {
-        return putErr
-    }
-    if putObjectResponse == nil {
-        return nilResponse
-    }
-    return nil
+func PutObjectWithJobId(client *ds3.Client, bucketName string, objectName string, jobId string, data []byte) error {
+	putObjRequest := models.NewPutObjectRequest(bucketName, objectName, ds3.BuildByteReaderWithSizeDecorator(data))
+	if jobId != "" {
+		putObjRequest = putObjRequest.WithJob(jobId)
+	}
+	putObjectResponse, putErr := client.PutObject(context.Background(), putObjRequest)
+	if putErr != nil {
+		return putErr
+	}
+	if putObjectResponse == nil {
+		return nilResponse
+	}
+	return nil
 }
 
-func PutEmptyObjects(client *ds3.Client, bucketName string, objects []models.Ds3PutObject) (error) {
-    putBulk, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(bucketName, objects))
-    if err != nil {
-        return err
-    }
-    for _, chunk := range putBulk.MasterObjectList.Objects {
-        allocateChunk, err := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
-        if err != nil {
-            client.CancelJobSpectraS3(context.Background(), models.NewCancelJobSpectraS3Request(putBulk.MasterObjectList.JobId))
-            return err
-        }
-        for _, obj := range allocateChunk.Objects.Objects {
-            if err = PutObjectWithJobId(client, bucketName, *obj.Name, putBulk.MasterObjectList.JobId, []byte{}); err != nil {
-                client.CancelJobSpectraS3(context.Background(), models.NewCancelJobSpectraS3Request(putBulk.MasterObjectList.JobId))
-                return err
-            }
-        }
-    }
-    return nil
+func PutEmptyObjects(client *ds3.Client, bucketName string, objects []models.Ds3PutObject) error {
+	putBulk, err := client.PutBulkJobSpectraS3(context.Background(), models.NewPutBulkJobSpectraS3Request(bucketName, objects))
+	if err != nil {
+		return err
+	}
+	for _, chunk := range putBulk.MasterObjectList.Objects {
+		allocateChunk, err := client.AllocateJobChunkSpectraS3(context.Background(), models.NewAllocateJobChunkSpectraS3Request(chunk.ChunkId))
+		if err != nil {
+			client.CancelJobSpectraS3(context.Background(), models.NewCancelJobSpectraS3Request(putBulk.MasterObjectList.JobId))
+			return err
+		}
+		for _, obj := range allocateChunk.Objects.Objects {
+			if err = PutObjectWithJobId(client, bucketName, *obj.Name, putBulk.MasterObjectList.JobId, []byte{}); err != nil {
+				client.CancelJobSpectraS3(context.Background(), models.NewCancelJobSpectraS3Request(putBulk.MasterObjectList.JobId))
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // Deletes the specified object. If an error occurs, it is logged, and the calling
 // test is marked as failed.
-func DeleteObjectLogError(t *testing.T, client *ds3.Client, bucketName string, objectName string) (error) {
-    err := DeleteObject(client, bucketName, objectName)
-    if err != nil {
-        t.Error(err)
-    }
-    return err
+func DeleteObjectLogError(t *testing.T, client *ds3.Client, bucketName string, objectName string) error {
+	err := DeleteObject(client, bucketName, objectName)
+	if err != nil {
+		t.Error(err)
+	}
+	return err
 }
 
 // Deletes the specified object. Returns an error if not successful.
-func DeleteObject(client *ds3.Client, bucketName string, objectName string) (error) {
-    deleteObjectResponse, deleteErr := client.DeleteObject(context.Background(), models.NewDeleteObjectRequest(bucketName, objectName))
-    if deleteErr != nil {
-        return deleteErr
-    }
-    if deleteObjectResponse == nil {
-        return nilResponse
-    }
-    return nil
+func DeleteObject(client *ds3.Client, bucketName string, objectName string) error {
+	deleteObjectResponse, deleteErr := client.DeleteObject(context.Background(), models.NewDeleteObjectRequest(bucketName, objectName))
+	if deleteErr != nil {
+		return deleteErr
+	}
+	if deleteObjectResponse == nil {
+		return nilResponse
+	}
+	return nil
 }
 
 // Retrieves the specified object. If an error occurs, it is logged, and the calling
 // test is marked as failed.
 func GetObjectLogError(t *testing.T, client *ds3.Client, bucketName string, objectName string) (*models.GetObjectResponse, error) {
-    response, err := GetObject(client, bucketName, objectName)
-    if err != nil {
-        t.Error(err.Error())
-        return nil, err
-    }
-    return response, nil
+	response, err := GetObject(client, bucketName, objectName)
+	if err != nil {
+		t.Error(err.Error())
+		return nil, err
+	}
+	return response, nil
 }
 
 // Retrieves the specified object. Returns an error if not successful.
 func GetObject(client *ds3.Client, bucketName string, objectName string) (*models.GetObjectResponse, error) {
-    response, err := client.GetObject(context.Background(), models.NewGetObjectRequest(bucketName, objectName))
-    if err != nil {
-        return nil, err
-    } else if response == nil {
-        return nil, nilResponse
-    }
-    return response, nil
+	response, err := client.GetObject(context.Background(), models.NewGetObjectRequest(bucketName, objectName))
+	if err != nil {
+		return nil, err
+	} else if response == nil {
+		return nil, nilResponse
+	}
+	return response, nil
 }
 
 // Puts the specified bucket. If an error occurs, it is logged, and the calling
 // test is marked as failed.
-func PutBucketLogError(t *testing.T, client *ds3.Client, bucketName string) (error) {
-    err := PutBucket(client, bucketName)
-    if err != nil {
-        t.Error(err)
-    }
-    return err
+func PutBucketLogError(t *testing.T, client *ds3.Client, bucketName string) error {
+	err := PutBucket(client, bucketName)
+	if err != nil {
+		t.Error(err)
+	}
+	return err
 }
 
 // Puts the specified bucket. Returns an error if not successful.
-func PutBucket(client *ds3.Client, bucketName string) (error) {
-    putBucketResponse, putErr := client.PutBucket(context.Background(), models.NewPutBucketRequest(bucketName))
-    if putErr != nil {
-        return putErr
-    }
-    if putBucketResponse == nil {
-        return nilResponse
-    }
-    return nil
+func PutBucket(client *ds3.Client, bucketName string) error {
+	putBucketResponse, putErr := client.PutBucket(context.Background(), models.NewPutBucketRequest(bucketName))
+	if putErr != nil {
+		return putErr
+	}
+	if putBucketResponse == nil {
+		return nilResponse
+	}
+	return nil
 }
 
 // Deletes the specified bucket. If an error occurs, it is logged, and the calling
 // test is marked as failed.
-func DeleteBucketLogError(t *testing.T, client *ds3.Client, bucketName string) (error) {
-    err := DeleteBucket(client, bucketName)
-    if err != nil {
-        t.Error(err)
-    }
-    return err
+func DeleteBucketLogError(t *testing.T, client *ds3.Client, bucketName string) error {
+	err := DeleteBucket(client, bucketName)
+	if err != nil {
+		t.Error(err)
+	}
+	return err
 }
 
 // Deletes the specified bucket and returns an error if one occurs
-func DeleteBucket(client *ds3.Client, bucketName string) (error) {
-    deleteBucket, deleteErr := client.DeleteBucketSpectraS3(context.Background(), models.NewDeleteBucketSpectraS3Request(bucketName).WithForce())
-    if deleteErr != nil {
-        return deleteErr
-    }
-    if deleteBucket == nil {
-        return nilResponse
-    }
-    return nil
+func DeleteBucket(client *ds3.Client, bucketName string) error {
+	deleteBucket, deleteErr := client.DeleteBucketSpectraS3(context.Background(), models.NewDeleteBucketSpectraS3Request(bucketName).WithForce())
+	if deleteErr != nil {
+		return deleteErr
+	}
+	if deleteBucket == nil {
+		return nilResponse
+	}
+	return nil
 }
 
 // Retrieves the specified bucket. If an error occurs, it is logged, and the calling
 // test is marked as failed.
 func GetBucketLogError(t *testing.T, client *ds3.Client, bucketName string) (*models.GetBucketResponse, error) {
-    response, err := GetBucket(client, bucketName)
-    if err != nil {
-        t.Error(err)
-        return nil, nilResponse
-    }
-    return response, nil
+	response, err := GetBucket(client, bucketName)
+	if err != nil {
+		t.Error(err)
+		return nil, nilResponse
+	}
+	return response, nil
 }
 
 // Retrieves the specified bucket. Returns an error if unsuccessful.
 func GetBucket(client *ds3.Client, bucketName string) (*models.GetBucketResponse, error) {
-    response, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(bucketName))
-    if err != nil {
-        return nil, err
-    } else if response == nil {
-        return nil, nilResponse
-    }
-    return response, nil
+	response, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(bucketName))
+	if err != nil {
+		return nil, err
+	} else if response == nil {
+		return nil, nilResponse
+	}
+	return response, nil
 }
 
 // Deletes the specified data policy. If an error occurs, it is logged, and the calling
 // test is marked as failed, but continues running.
-func DeleteDataPolicyLogError(t *testing.T, client *ds3.Client, dataPolicyId string) (error) {
-    _, deleteErr := client.DeleteDataPolicySpectraS3(context.Background(), models.NewDeleteDataPolicySpectraS3Request(dataPolicyId))
-    if deleteErr != nil {
-        t.Errorf("Unable to delete Data Policy '%s': '%s'.", dataPolicyId, deleteErr.Error())
-    }
-    return deleteErr
+func DeleteDataPolicyLogError(t *testing.T, client *ds3.Client, dataPolicyId string) error {
+	_, deleteErr := client.DeleteDataPolicySpectraS3(context.Background(), models.NewDeleteDataPolicySpectraS3Request(dataPolicyId))
+	if deleteErr != nil {
+		t.Errorf("Unable to delete Data Policy '%s': '%s'.", dataPolicyId, deleteErr.Error())
+	}
+	return deleteErr
 }
 
 // Creates the specified data policy. If an error occurs, it is logged, and the calling
 // test is marked as failed, but continues running.
 func PutDataPolicyLogError(t *testing.T, client *ds3.Client, dataPolicyName string) (*models.PutDataPolicySpectraS3Response, error) {
-    response, err := client.PutDataPolicySpectraS3(context.Background(), models.NewPutDataPolicySpectraS3Request(dataPolicyName))
-    if err != nil {
-        t.Errorf("Unable to create Data Policy '%s': '%s'.", dataPolicyName, err.Error())
-    }
-    return response, err
+	response, err := client.PutDataPolicySpectraS3(context.Background(), models.NewPutDataPolicySpectraS3Request(dataPolicyName))
+	if err != nil {
+		t.Errorf("Unable to create Data Policy '%s': '%s'.", dataPolicyName, err.Error())
+	}
+	return response, err
 }
 
 // Retrieves the specified data policy. If an error occurs, it is logged, and the calling
 // test is marked as failed, but continues running
 func GetDataPolicyLogError(t *testing.T, client *ds3.Client, dataPolicyId string) (*models.GetDataPolicySpectraS3Response, error) {
-    response, err := client.GetDataPolicySpectraS3(context.Background(), models.NewGetDataPolicySpectraS3Request(dataPolicyId))
-    if err != nil {
-        t.Errorf("Unable to get Data Policy '%s': '%s'.", dataPolicyId, err.Error())
-    }
-    return response, err
+	response, err := client.GetDataPolicySpectraS3(context.Background(), models.NewGetDataPolicySpectraS3Request(dataPolicyId))
+	if err != nil {
+		t.Errorf("Unable to get Data Policy '%s': '%s'.", dataPolicyId, err.Error())
+	}
+	return response, err
 }
 
 // Retrieves the specified user by name. Expects there to be one user with the specified name.
 // If there is not exactly 1 user with the specified name, it is treated as an error. If an
 // error occurs, it is logged, and the calling  test is marked as failed, but continues running.
 func GetUserByNameLogError(t *testing.T, client *ds3.Client, userName string) (*models.SpectraUser, error) {
-    response, err := client.GetUsersSpectraS3(context.Background(), models.NewGetUsersSpectraS3Request().WithName(userName))
-    if err != nil {
-        t.Errorf("Unable to get user '%s': '%s'.", userName, err.Error())
-        return nil, err
-    }
-    if len(response.SpectraUserList.SpectraUsers) != 1 {
-        lenErr := fmt.Errorf("Expected number of users with name '%s' to be 1, but got '%d'.", userName, len(response.SpectraUserList.SpectraUsers))
-        t.Errorf(lenErr.Error())
-        return nil, lenErr
-    }
-    return &response.SpectraUserList.SpectraUsers[0], nil
+	response, err := client.GetUsersSpectraS3(context.Background(), models.NewGetUsersSpectraS3Request().WithName(userName))
+	if err != nil {
+		t.Errorf("Unable to get user '%s': '%s'.", userName, err.Error())
+		return nil, err
+	}
+	if len(response.SpectraUserList.SpectraUsers) != 1 {
+		lenErr := fmt.Errorf("Expected number of users with name '%s' to be 1, but got '%d'.", userName, len(response.SpectraUserList.SpectraUsers))
+		t.Errorf(lenErr.Error())
+		return nil, lenErr
+	}
+	return &response.SpectraUserList.SpectraUsers[0], nil
 }
 
 // Used to keep track of all IDs for items created in SetupTestEnv, and used
 // in TeardownTestEnv. Items that have not been initialized are represented
 // with nil, denoting no teardown is required for that element.
 type TestIds struct {
-    DataPersistenceRuleId *string
-    DataPolicyId *string
-    OriginalDataPolicyId *string
-    PoolPartitionId *string
-    StorageDomainId *string
-    StorageDomainMemberId *string
-    UserId *string
+	DataPersistenceRuleId *string
+	DataPolicyId          *string
+	OriginalDataPolicyId  *string
+	PoolPartitionId       *string
+	StorageDomainId       *string
+	StorageDomainMemberId *string
+	UserId                *string
 }
 
 // Sets up the test environment by
@@ -482,126 +482,126 @@ type TestIds struct {
 // 7) creating a storage domain member
 // 8) creating a data persistence rule
 func SetupTestEnv(testBucket string, userName string, envTestNameSpace string) (*ds3.Client, *TestIds, error) {
-    var ids TestIds
+	var ids TestIds
 
-    // Build the client from environment variables
-    client, clientErr := buildclient.FromEnv()
-    if clientErr != nil {
-        return nil, &ids, clientErr
-    }
+	// Build the client from environment variables
+	client, clientErr := buildclient.FromEnv()
+	if clientErr != nil {
+		return nil, &ids, clientErr
+	}
 
-    // Create data policy
-    dataPolicyResponse, dataPolicyErr := client.PutDataPolicySpectraS3(context.Background(), models.NewPutDataPolicySpectraS3Request(envTestNameSpace))
-    if dataPolicyErr != nil {
-        return nil, &ids, dataPolicyErr
-    }
-    ids.DataPolicyId = &dataPolicyResponse.DataPolicy.Id
+	// Create data policy
+	dataPolicyResponse, dataPolicyErr := client.PutDataPolicySpectraS3(context.Background(), models.NewPutDataPolicySpectraS3Request(envTestNameSpace))
+	if dataPolicyErr != nil {
+		return nil, &ids, dataPolicyErr
+	}
+	ids.DataPolicyId = &dataPolicyResponse.DataPolicy.Id
 
-    // Modify default user to use new data policy
-    modifyResponse, modifyErr := client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(userName).
-        WithDefaultDataPolicyId(dataPolicyResponse.DataPolicy.Id))
-    if modifyErr != nil {
-        return nil, &ids, modifyErr
-    }
-    ids.OriginalDataPolicyId = modifyResponse.SpectraUser.DefaultDataPolicyId
-    ids.UserId = &modifyResponse.SpectraUser.Id
+	// Modify default user to use new data policy
+	modifyResponse, modifyErr := client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(userName).
+		WithDefaultDataPolicyId(dataPolicyResponse.DataPolicy.Id))
+	if modifyErr != nil {
+		return nil, &ids, modifyErr
+	}
+	ids.OriginalDataPolicyId = modifyResponse.SpectraUser.DefaultDataPolicyId
+	ids.UserId = &modifyResponse.SpectraUser.Id
 
-    // Create pool partition
-    poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(
-        envTestNameSpace,
-        models.POOL_TYPE_ONLINE))
-    if poolPartitionErr != nil {
-        return nil, &ids, poolPartitionErr
-    }
-    ids.PoolPartitionId = &poolPartitionResponse.PoolPartition.Id
+	// Create pool partition
+	poolPartitionResponse, poolPartitionErr := client.PutPoolPartitionSpectraS3(context.Background(), models.NewPutPoolPartitionSpectraS3Request(
+		envTestNameSpace,
+		models.POOL_TYPE_ONLINE))
+	if poolPartitionErr != nil {
+		return nil, &ids, poolPartitionErr
+	}
+	ids.PoolPartitionId = &poolPartitionResponse.PoolPartition.Id
 
-    // Create storage domain
-    storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(envTestNameSpace))
-    if storageDomainErr != nil {
-        return nil, &ids, storageDomainErr
-    }
-    ids.StorageDomainId = &storageDomainResponse.StorageDomain.Id
+	// Create storage domain
+	storageDomainResponse, storageDomainErr := client.PutStorageDomainSpectraS3(context.Background(), models.NewPutStorageDomainSpectraS3Request(envTestNameSpace))
+	if storageDomainErr != nil {
+		return nil, &ids, storageDomainErr
+	}
+	ids.StorageDomainId = &storageDomainResponse.StorageDomain.Id
 
-    // Create storage domain member linking pool partition to storage domain
-    memberResponse, memberErr := client.PutPoolStorageDomainMemberSpectraS3(context.Background(), models.NewPutPoolStorageDomainMemberSpectraS3Request(
-        poolPartitionResponse.PoolPartition.Id,
-        storageDomainResponse.StorageDomain.Id))
-    if memberErr != nil {
-        return nil, &ids, memberErr
-    }
-    ids.StorageDomainMemberId = &memberResponse.StorageDomainMember.Id
+	// Create storage domain member linking pool partition to storage domain
+	memberResponse, memberErr := client.PutPoolStorageDomainMemberSpectraS3(context.Background(), models.NewPutPoolStorageDomainMemberSpectraS3Request(
+		poolPartitionResponse.PoolPartition.Id,
+		storageDomainResponse.StorageDomain.Id))
+	if memberErr != nil {
+		return nil, &ids, memberErr
+	}
+	ids.StorageDomainMemberId = &memberResponse.StorageDomainMember.Id
 
-    // Create data persistence rule
-    ruleResponse, ruleErr := client.PutDataPersistenceRuleSpectraS3(context.Background(), models.NewPutDataPersistenceRuleSpectraS3Request(
-        models.DATA_PERSISTENCE_RULE_TYPE_PERMANENT,
-        dataPolicyResponse.DataPolicy.Id,
-        models.DATA_ISOLATION_LEVEL_STANDARD,
-        storageDomainResponse.StorageDomain.Id))
-    if ruleErr != nil {
-        return nil, &ids, ruleErr
-    }
-    ids.DataPersistenceRuleId = &ruleResponse.DataPersistenceRule.Id
+	// Create data persistence rule
+	ruleResponse, ruleErr := client.PutDataPersistenceRuleSpectraS3(context.Background(), models.NewPutDataPersistenceRuleSpectraS3Request(
+		models.DATA_PERSISTENCE_RULE_TYPE_PERMANENT,
+		dataPolicyResponse.DataPolicy.Id,
+		models.DATA_ISOLATION_LEVEL_STANDARD,
+		storageDomainResponse.StorageDomain.Id))
+	if ruleErr != nil {
+		return nil, &ids, ruleErr
+	}
+	ids.DataPersistenceRuleId = &ruleResponse.DataPersistenceRule.Id
 
-    // Create the test bucket
-    putBucketErr := PutBucket(client, testBucket)
-    if putBucketErr != nil {
-        return nil, &ids, putBucketErr
-    }
+	// Create the test bucket
+	putBucketErr := PutBucket(client, testBucket)
+	if putBucketErr != nil {
+		return nil, &ids, putBucketErr
+	}
 
-    return client, &ids, nil
+	return client, &ids, nil
 }
 
 // Logs an error via printing. Used in TeardownTestEnv for best-effort teardown.
 func logErrViaPrint(err error) {
-    if err != nil {
-        log.Print(err)
-    }
+	if err != nil {
+		log.Print(err)
+	}
 }
 
 // Tears down the test environment by deleting all contents in the
 // test bucket and deleting all items created in SetupTestEnv
 func TeardownTestEnv(client *ds3.Client, ids *TestIds, testBucket string) {
-    //Delete contents in test bucket
-    DeleteBucketContents(client, testBucket)
+	//Delete contents in test bucket
+	DeleteBucketContents(client, testBucket)
 
-    //Delete the test bucket
-    err := DeleteBucket(client, testBucket)
-    logErrViaPrint(err)
+	//Delete the test bucket
+	err := DeleteBucket(client, testBucket)
+	logErrViaPrint(err)
 
-    // Delete data persistence rule
-    if ids.DataPersistenceRuleId != nil {
-        _, err := client.DeleteDataPersistenceRuleSpectraS3(context.Background(), models.NewDeleteDataPersistenceRuleSpectraS3Request(*ids.DataPersistenceRuleId))
-        logErrViaPrint(err)
-    }
+	// Delete data persistence rule
+	if ids.DataPersistenceRuleId != nil {
+		_, err := client.DeleteDataPersistenceRuleSpectraS3(context.Background(), models.NewDeleteDataPersistenceRuleSpectraS3Request(*ids.DataPersistenceRuleId))
+		logErrViaPrint(err)
+	}
 
-    // Delete storage domain member
-    if ids.StorageDomainMemberId != nil {
-        _, err := client.DeleteStorageDomainMemberSpectraS3(context.Background(), models.NewDeleteStorageDomainMemberSpectraS3Request(*ids.StorageDomainMemberId))
-        logErrViaPrint(err)
-    }
+	// Delete storage domain member
+	if ids.StorageDomainMemberId != nil {
+		_, err := client.DeleteStorageDomainMemberSpectraS3(context.Background(), models.NewDeleteStorageDomainMemberSpectraS3Request(*ids.StorageDomainMemberId))
+		logErrViaPrint(err)
+	}
 
-    // Delete storage domain
-    if ids.StorageDomainId != nil {
-        _, err := client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(*ids.StorageDomainId))
-        logErrViaPrint(err)
-    }
+	// Delete storage domain
+	if ids.StorageDomainId != nil {
+		_, err := client.DeleteStorageDomainSpectraS3(context.Background(), models.NewDeleteStorageDomainSpectraS3Request(*ids.StorageDomainId))
+		logErrViaPrint(err)
+	}
 
-    // Delete pool partition
-    if ids.PoolPartitionId != nil {
-        _, err := client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(*ids.PoolPartitionId))
-        logErrViaPrint(err)
-    }
+	// Delete pool partition
+	if ids.PoolPartitionId != nil {
+		_, err := client.DeletePoolPartitionSpectraS3(context.Background(), models.NewDeletePoolPartitionSpectraS3Request(*ids.PoolPartitionId))
+		logErrViaPrint(err)
+	}
 
-    // Modify user to use its original data policy
-    if ids.OriginalDataPolicyId != nil {
-        _, err := client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(*ids.UserId).
-            WithDefaultDataPolicyId(*ids.OriginalDataPolicyId))
-        logErrViaPrint(err)
-    }
+	// Modify user to use its original data policy
+	if ids.OriginalDataPolicyId != nil {
+		_, err := client.ModifyUserSpectraS3(context.Background(), models.NewModifyUserSpectraS3Request(*ids.UserId).
+			WithDefaultDataPolicyId(*ids.OriginalDataPolicyId))
+		logErrViaPrint(err)
+	}
 
-    // Delete data policy
-    if ids.DataPolicyId != nil {
-        _, err := client.DeleteDataPolicySpectraS3(context.Background(), models.NewDeleteDataPolicySpectraS3Request(*ids.DataPolicyId))
-        logErrViaPrint(err)
-    }
+	// Delete data policy
+	if ids.DataPolicyId != nil {
+		_, err := client.DeleteDataPolicySpectraS3(context.Background(), models.NewDeleteDataPolicySpectraS3Request(*ids.DataPolicyId))
+		logErrViaPrint(err)
+	}
 }

--- a/ds3_utils/ds3Testing/assertUtil.go
+++ b/ds3_utils/ds3Testing/assertUtil.go
@@ -12,116 +12,116 @@
 package ds3Testing
 
 import (
-    "testing"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "reflect"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"reflect"
+	"testing"
 )
 
 // Asserts if a specified bool pointer has the expected value. If not, Fatal.
 func AssertNonNilBoolPtr(t *testing.T, label string, expected bool, actual *bool) {
-    if actual == nil {
-        t.Fatalf("Expected %s to be '%t' but was 'nil'.", label, expected)
-    }
-    AssertBool(t, label, expected, *actual)
+	if actual == nil {
+		t.Fatalf("Expected %s to be '%t' but was 'nil'.", label, expected)
+	}
+	AssertBool(t, label, expected, *actual)
 }
 
 // Asserts if a specified bool pointer is nil. If not, Fatal.
 func AssertBoolPtrIsNil(t *testing.T, label string, actual *bool) {
-    if actual != nil {
-        t.Fatalf("Expected %s to be 'nil' but was '%t'.", label, *actual)
-    }
+	if actual != nil {
+		t.Fatalf("Expected %s to be 'nil' but was '%t'.", label, *actual)
+	}
 }
 
 // Asserts if a specified bool has the expected value. If not, Fatal.
 func AssertBool(t *testing.T, label string, expected bool, actual bool) {
-    if expected != actual {
-        t.Fatalf("Expected %s to be '%t' but was '%t'.", label, expected, actual)
-    }
+	if expected != actual {
+		t.Fatalf("Expected %s to be '%t' but was '%t'.", label, expected, actual)
+	}
 }
 
 // Asserts if a specified int64 pointer has the expected value. If not, Fatal.
 func AssertNonNilIntPtr(t *testing.T, label string, expected int, actual *int) {
-    if actual == nil {
-        t.Fatalf("Expected %s to be '%d' but was 'nil'.", label, expected)
-    }
-    AssertInt(t, label, expected, *actual)
+	if actual == nil {
+		t.Fatalf("Expected %s to be '%d' but was 'nil'.", label, expected)
+	}
+	AssertInt(t, label, expected, *actual)
 }
 
 // Asserts if a specified int64 is nil. If not, Fatal.
 func AssertIntPtrIsNil(t *testing.T, label string, actual *int) {
-    if actual != nil {
-        t.Fatalf("Expected %s to be 'nil' but was '%d'.", label, *actual)
-    }
+	if actual != nil {
+		t.Fatalf("Expected %s to be 'nil' but was '%d'.", label, *actual)
+	}
 }
 
 // Asserts if a specified int64 has the expected value. If not, Fatal.
 func AssertInt(t *testing.T, label string, expected int, actual int) {
-    if expected != actual {
-        t.Fatalf("Expected %s to be '%d' but was '%d'.", label, expected, actual)
-    }
+	if expected != actual {
+		t.Fatalf("Expected %s to be '%d' but was '%d'.", label, expected, actual)
+	}
 }
 
 // Asserts if a specified int64 pointer has the expected value. If not, Fatal.
 func AssertNonNilInt64Ptr(t *testing.T, label string, expected int64, actual *int64) {
-    if actual == nil {
-        t.Fatalf("Expected %s to be '%d' but was 'nil'.", label, expected)
-    }
-    AssertInt64(t, label, expected, *actual)
+	if actual == nil {
+		t.Fatalf("Expected %s to be '%d' but was 'nil'.", label, expected)
+	}
+	AssertInt64(t, label, expected, *actual)
 }
 
 // Asserts if a specified int64 is nil. If not, Fatal.
 func AssertInt64PtrIsNil(t *testing.T, label string, actual *int64) {
-    if actual != nil {
-        t.Fatalf("Expected %s to be 'nil' but was '%d'.", label, *actual)
-    }
+	if actual != nil {
+		t.Fatalf("Expected %s to be 'nil' but was '%d'.", label, *actual)
+	}
 }
 
 // Asserts if a specified int64 has the expected value. If not, Fatal.
 func AssertInt64(t *testing.T, label string, expected int64, actual int64) {
-    if expected != actual {
-        t.Fatalf("Expected %s to be '%d' but was '%d'.", label, expected, actual)
-    }
+	if expected != actual {
+		t.Fatalf("Expected %s to be '%d' but was '%d'.", label, expected, actual)
+	}
 }
 
 // Asserts if a specified string pointer has the expected value. If not, Fatal.
 func AssertNonNilStringPtr(t *testing.T, label string, expected string, actual *string) {
-    if actual == nil {
-        t.Fatalf("Expected %s to be '%s' but was 'nil'.", label, expected)
-    }
-    AssertString(t, label, expected, *actual)
+	if actual == nil {
+		t.Fatalf("Expected %s to be '%s' but was 'nil'.", label, expected)
+	}
+	AssertString(t, label, expected, *actual)
 }
 
 // Asserts if a specified string pointer is nil. If not, Fatal.
 func AssertStringPtrIsNil(t *testing.T, label string, actual *string) {
-    if actual != nil {
-        t.Fatalf("Expected %s to be 'nil' but was '%s'.", label, *actual)
-    }
+	if actual != nil {
+		t.Fatalf("Expected %s to be 'nil' but was '%s'.", label, *actual)
+	}
 }
 
 // Asserts if a specified string has the expected value. If not, Fatal.
 func AssertString(t *testing.T, label string, expected string, actual string) {
-    if expected != actual {
-        t.Fatalf("Expected %s to be '%s' but was '%s'.", label, expected, actual)
-    }
+	if expected != actual {
+		t.Fatalf("Expected %s to be '%s' but was '%s'.", label, expected, actual)
+	}
 }
 
 // Asserts that an error is nil, else Fatal.
 func AssertNilError(t *testing.T, err error) {
-    if err != nil {
-        t.Fatalf("Unexpected error '%s'.", err.Error())
-    }
+	if err != nil {
+		t.Fatalf("Unexpected error '%s'.", err.Error())
+	}
 }
 
 func AssertBadStatusCodeError(t *testing.T, expectedCode int, err error) {
-    if err == nil {
-        t.Fatal("Expected a bad status code error, but the error is nil.")
-        return
-    }
-    if statusCodeErr, ok := err.(*models.BadStatusCodeError); ok {
-        if statusCodeErr.ActualStatusCode != expectedCode {
-            t.Fatalf("Expected a BadStatusCode of '%d' but got '%d'.", expectedCode, statusCodeErr.ActualStatusCode)
-        }
-        return
-    }
-    t.Fatalf("Expected '*models.BadStatusCodeError' but instead got '%v'.", reflect.TypeOf(err))
+	if err == nil {
+		t.Fatal("Expected a bad status code error, but the error is nil.")
+		return
+	}
+	if statusCodeErr, ok := err.(*models.BadStatusCodeError); ok {
+		if statusCodeErr.ActualStatusCode != expectedCode {
+			t.Fatalf("Expected a BadStatusCode of '%d' but got '%d'.", expectedCode, statusCodeErr.ActualStatusCode)
+		}
+		return
+	}
+	t.Fatalf("Expected '*models.BadStatusCodeError' but instead got '%v'.", reflect.TypeOf(err))
 }

--- a/helpers/blobQueue.go
+++ b/helpers/blobQueue.go
@@ -1,49 +1,49 @@
 package helpers
 
 import (
-    "errors"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "reflect"
+	"errors"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"reflect"
 )
 
 // A queue that manages descriptions of blobs
 // Used to track blobs that are waiting to be transferred
 type BlobDescriptionQueue interface {
-    Push(description *helperModels.BlobDescription)
-    Pop() (*helperModels.BlobDescription, error)
-    Size() int
+	Push(description *helperModels.BlobDescription)
+	Pop() (*helperModels.BlobDescription, error)
+	Size() int
 }
 
 // Implements BlobDescriptionQueue using a slice
 // NOT thread safe
 type blobDescriptionQueueImpl struct {
-    queue []*helperModels.BlobDescription
+	queue []*helperModels.BlobDescription
 }
 
 func NewBlobDescriptionQueue() BlobDescriptionQueue {
-    queue :=make([]*helperModels.BlobDescription, 0)
-    return &blobDescriptionQueueImpl{queue:queue}
+	queue := make([]*helperModels.BlobDescription, 0)
+	return &blobDescriptionQueueImpl{queue: queue}
 }
 
 func (queue *blobDescriptionQueueImpl) Push(description *helperModels.BlobDescription) {
-    // verify that this blob isn't already in the queue before adding it
-    for _, existingBlob := range queue.queue {
-        if reflect.DeepEqual(*existingBlob, *description) {
-            return
-        }
-    }
-    queue.queue = append(queue.queue, description)
+	// verify that this blob isn't already in the queue before adding it
+	for _, existingBlob := range queue.queue {
+		if reflect.DeepEqual(*existingBlob, *description) {
+			return
+		}
+	}
+	queue.queue = append(queue.queue, description)
 }
 
 func (queue *blobDescriptionQueueImpl) Pop() (*helperModels.BlobDescription, error) {
-    if queue.Size() == 0 {
-        return nil, errors.New("Cannot perform Pop() from blobDescriptionQueueImpl as queue is empty")
-    }
-    descriptor := queue.queue[0]
-    queue.queue = queue.queue[1:]
-    return descriptor, nil
+	if queue.Size() == 0 {
+		return nil, errors.New("Cannot perform Pop() from blobDescriptionQueueImpl as queue is empty")
+	}
+	descriptor := queue.queue[0]
+	queue.queue = queue.queue[1:]
+	return descriptor, nil
 }
 
 func (queue *blobDescriptionQueueImpl) Size() int {
-    return len(queue.queue)
+	return len(queue.queue)
 }

--- a/helpers/blobStrategy.go
+++ b/helpers/blobStrategy.go
@@ -4,33 +4,33 @@ import "time"
 
 // Strategy for how to blob objects, used both in writing and reading blob strategies
 type BlobStrategy interface {
-    // Determines the maximum amount to delay between calls to getAvailableJobChunk.
-    // If blobs are finishing processing, then we will query for more ready blobs earlier.
-    // The recommended duration is five minutes.
-    delay() time.Duration
+	// Determines the maximum amount to delay between calls to getAvailableJobChunk.
+	// If blobs are finishing processing, then we will query for more ready blobs earlier.
+	// The recommended duration is five minutes.
+	delay() time.Duration
 
-    // determines the maximum number of go routines to be created when transferring objects to/from BP
-    maxConcurrentTransfers() uint
+	// determines the maximum number of go routines to be created when transferring objects to/from BP
+	maxConcurrentTransfers() uint
 
-    // determines the maximum number of blobs that are waiting to be transferred in the operations queue
-    // i.e. the size of the operation queue
-    maxWaitingTransfers() uint
+	// determines the maximum number of blobs that are waiting to be transferred in the operations queue
+	// i.e. the size of the operation queue
+	maxWaitingTransfers() uint
 }
 
 type SimpleBlobStrategy struct {
-    Delay                  time.Duration
-    MaxConcurrentTransfers uint
-    MaxWaitingTransfers    uint
+	Delay                  time.Duration
+	MaxConcurrentTransfers uint
+	MaxWaitingTransfers    uint
 }
 
 func (strategy *SimpleBlobStrategy) delay() time.Duration {
-    return strategy.Delay
+	return strategy.Delay
 }
 
 func (strategy *SimpleBlobStrategy) maxConcurrentTransfers() uint {
-    return strategy.MaxConcurrentTransfers
+	return strategy.MaxConcurrentTransfers
 }
 
 func (strategy *SimpleBlobStrategy) maxWaitingTransfers() uint {
-    return strategy.MaxWaitingTransfers
+	return strategy.MaxWaitingTransfers
 }

--- a/helpers/blobTracker.go
+++ b/helpers/blobTracker.go
@@ -1,31 +1,31 @@
 package helpers
 
 import (
-    helperModels"github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
 )
 
 type blobTracker struct {
-    blobMap map[helperModels.BlobDescription]bool
-    blobCount int64
+	blobMap   map[helperModels.BlobDescription]bool
+	blobCount int64
 }
 
 func newProcessedBlobTracker() blobTracker {
-    return blobTracker{
-        blobMap: make(map[helperModels.BlobDescription]bool),
-        blobCount: 0,
-    }
+	return blobTracker{
+		blobMap:   make(map[helperModels.BlobDescription]bool),
+		blobCount: 0,
+	}
 }
 
 // Determines if a blob has been processed
 func (tracker *blobTracker) IsProcessed(blob helperModels.BlobDescription) bool {
-    return tracker.blobMap[blob]
+	return tracker.blobMap[blob]
 }
 
 func (tracker *blobTracker) MarkProcessed(blob helperModels.BlobDescription) {
-    tracker.blobMap[blob] = true
-    tracker.blobCount++
+	tracker.blobMap[blob] = true
+	tracker.blobCount++
 }
 
 func (tracker *blobTracker) NumberOfProcessedBlobs() int64 {
-    return tracker.blobCount
+	return tracker.blobCount
 }

--- a/helpers/channels/ds3OjectReadCloserDecorator.go
+++ b/helpers/channels/ds3OjectReadCloserDecorator.go
@@ -7,7 +7,7 @@ type Ds3ObjectReadCloser struct {
 }
 
 func NewDs3ObjectReadCloserDecorator(reader io.Reader) io.ReadCloser {
-	return Ds3ObjectReadCloser { Reader: reader }
+	return Ds3ObjectReadCloser{Reader: reader}
 }
 
 func (Ds3ObjectReadCloser Ds3ObjectReadCloser) Close() error {
@@ -17,7 +17,3 @@ func (Ds3ObjectReadCloser Ds3ObjectReadCloser) Close() error {
 	}
 	return nil
 }
-
-
-
-

--- a/helpers/channels/fatalErrorHandler.go
+++ b/helpers/channels/fatalErrorHandler.go
@@ -6,31 +6,31 @@ import "sync"
 // This is used to track if a file has encountered a fatal error such that
 // future blobs for a given file should not be processed.
 type FatalErrorHandler struct {
-    errLock sync.RWMutex
-    fatalError error
+	errLock    sync.RWMutex
+	fatalError error
 }
 
 func (errHandler *FatalErrorHandler) HasFatalError() bool {
-    errHandler.errLock.RLock()
-    defer errHandler.errLock.RUnlock()
+	errHandler.errLock.RLock()
+	defer errHandler.errLock.RUnlock()
 
-    return errHandler.fatalError != nil
+	return errHandler.fatalError != nil
 }
 
 // Captures the first fatal error that occurs.
 // In a multi-threaded environment, all subsequent errors will be ignored.
 func (errHandler *FatalErrorHandler) SetFatalError(err error) {
-    errHandler.errLock.Lock()
-    defer errHandler.errLock.Unlock()
+	errHandler.errLock.Lock()
+	defer errHandler.errLock.Unlock()
 
-    if errHandler.fatalError == nil {
-        errHandler.fatalError = err
-    }
+	if errHandler.fatalError == nil {
+		errHandler.fatalError = err
+	}
 }
 
 func (errHandler *FatalErrorHandler) GetFatalError() error {
-    errHandler.errLock.RLock()
-    defer errHandler.errLock.RUnlock()
+	errHandler.errLock.RLock()
+	defer errHandler.errLock.RUnlock()
 
-    return errHandler.fatalError
+	return errHandler.fatalError
 }

--- a/helpers/channels/objectReadChannelBuilder.go
+++ b/helpers/channels/objectReadChannelBuilder.go
@@ -1,9 +1,9 @@
 package channels
 
 import (
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "io"
-    "os"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"io"
+	"os"
 )
 
 const defaultPermissions = 0
@@ -11,27 +11,27 @@ const defaultPermissions = 0
 // Implements the ReadChannelBuilder interface and uses a file as the ReadCloser implementation.
 // This channel functions as a random-access and can be used concurrently.
 type ObjectReadChannelBuilder struct {
-    name string
-    FatalErrorHandler
+	name string
+	FatalErrorHandler
 }
 
 func NewReadChannelBuilder(name string) helperModels.ReadChannelBuilder {
-    return &ObjectReadChannelBuilder{name:name}
+	return &ObjectReadChannelBuilder{name: name}
 }
 
 func (builder *ObjectReadChannelBuilder) GetChannel(offset int64) (io.ReadCloser, error) {
-    f, err := os.OpenFile(builder.name, os.O_RDONLY, defaultPermissions)
-    if err != nil {
-        return nil, err
-    }
-    f.Seek(offset, io.SeekStart)
-    return f, nil
+	f, err := os.OpenFile(builder.name, os.O_RDONLY, defaultPermissions)
+	if err != nil {
+		return nil, err
+	}
+	f.Seek(offset, io.SeekStart)
+	return f, nil
 }
 
 func (builder *ObjectReadChannelBuilder) IsChannelAvailable(offset int64) bool {
-    return true
+	return true
 }
 
 func (ObjectReadChannelBuilder) OnDone(reader io.ReadCloser) {
-    reader.Close()
+	reader.Close()
 }

--- a/helpers/channels/objectReadChannelDecorator.go
+++ b/helpers/channels/objectReadChannelDecorator.go
@@ -1,8 +1,8 @@
 package channels
 
 import (
-	"io"
 	"github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"io"
 )
 
 type ObjectReadChannelDecorator struct {
@@ -11,7 +11,7 @@ type ObjectReadChannelDecorator struct {
 }
 
 func NewObjectReadChannelDecorator(reader io.Reader) models.ReadChannelBuilder {
-	return &ObjectReadChannelDecorator { readCloser: NewDs3ObjectReadCloserDecorator(reader) }
+	return &ObjectReadChannelDecorator{readCloser: NewDs3ObjectReadCloserDecorator(reader)}
 }
 
 func (readChannelDecorator *ObjectReadChannelDecorator) IsChannelAvailable(offset int64) bool {

--- a/helpers/channels/objectWriteChannelBuilder.go
+++ b/helpers/channels/objectWriteChannelBuilder.go
@@ -1,37 +1,37 @@
 package channels
 
 import (
-    "io"
-    "os"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"io"
+	"os"
 )
 
 // Implements the WriteChannelBuilder interface and uses a file as the WriteCloser implementation.
 // This channel functions as a random-access and can be used concurrently so long as two writers
 // are not writing to the same location within the file.
 type ObjectWriteChannelBuilder struct {
-    name string
-    FatalErrorHandler
+	name string
+	FatalErrorHandler
 }
 
 func NewWriteChannelBuilder(name string) helperModels.WriteChannelBuilder {
-    return &ObjectWriteChannelBuilder{name:name}
+	return &ObjectWriteChannelBuilder{name: name}
 }
 
 func (builder *ObjectWriteChannelBuilder) IsChannelAvailable(offset int64) bool {
-    return true
+	return true
 }
 
 func (builder *ObjectWriteChannelBuilder) GetChannel(offset int64) (io.WriteCloser, error) {
-    f, err := os.OpenFile(builder.name, os.O_WRONLY | os.O_CREATE, os.ModePerm)
-    if err != nil {
-        return nil, err
-    }
+	f, err := os.OpenFile(builder.name, os.O_WRONLY|os.O_CREATE, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
 
-    f.Seek(offset, io.SeekStart)
-    return f, nil
+	f.Seek(offset, io.SeekStart)
+	return f, nil
 }
 
 func (builder *ObjectWriteChannelBuilder) OnDone(writer io.WriteCloser) {
-    writer.Close()
+	writer.Close()
 }

--- a/helpers/channels/partialObjectRangeMap.go
+++ b/helpers/channels/partialObjectRangeMap.go
@@ -1,44 +1,44 @@
 package channels
 
 import (
-    ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/helpers/ranges"
-    "reflect"
-    "fmt"
-    "errors"
+	"errors"
+	"fmt"
+	ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/helpers/ranges"
+	"reflect"
 )
 
 // Manages the mapping of object ranges to end destination offsets
 type partialObjectRangeMap struct {
-    // map of object ranges to destination offset for start of range
-    rangeMap map[ds3Models.Range]int64
+	// map of object ranges to destination offset for start of range
+	rangeMap map[ds3Models.Range]int64
 }
 
 func newPartialObjectRangeMap(objRanges []ds3Models.Range) partialObjectRangeMap {
-    collapser := ranges.RangeCollapserImpl{}
-    collapsedRanges := collapser.Collapse(objRanges)
+	collapser := ranges.RangeCollapserImpl{}
+	collapsedRanges := collapser.Collapse(objRanges)
 
-    rangeMap := make(map[ds3Models.Range]int64, len(collapsedRanges))
+	rangeMap := make(map[ds3Models.Range]int64, len(collapsedRanges))
 
-    var prevStartOffset int64 = 0
-    var prevLength int64 = 0
-    for _, r := range collapsedRanges {
-        curStartOffset := prevStartOffset + prevLength
-        rangeMap[r] = curStartOffset
-        prevStartOffset = curStartOffset
-        prevLength = r.End - r.Start + 1
-    }
-    return partialObjectRangeMap{rangeMap:rangeMap}
+	var prevStartOffset int64 = 0
+	var prevLength int64 = 0
+	for _, r := range collapsedRanges {
+		curStartOffset := prevStartOffset + prevLength
+		rangeMap[r] = curStartOffset
+		prevStartOffset = curStartOffset
+		prevLength = r.End - r.Start + 1
+	}
+	return partialObjectRangeMap{rangeMap: rangeMap}
 }
 
 // Retrieves the destination offset that correlates to the object offset based on the ranges.
 func (rangeMap *partialObjectRangeMap) getDestinationOffset(objectOffset int64) (int64, error) {
-    for curRange, destinationOffset := range rangeMap.rangeMap {
-        if objectOffset >= curRange.Start && objectOffset <= curRange.End {
-            return destinationOffset + (objectOffset - curRange.Start), nil
-        }
-    }
+	for curRange, destinationOffset := range rangeMap.rangeMap {
+		if objectOffset >= curRange.Start && objectOffset <= curRange.End {
+			return destinationOffset + (objectOffset - curRange.Start), nil
+		}
+	}
 
-    ranges := reflect.ValueOf(rangeMap.rangeMap).MapKeys()
-    return -1, errors.New(fmt.Sprintf("Partial Object Channel Builder: specified object offset '%d' is outside of expected ranges '%v'", objectOffset, ranges))
+	ranges := reflect.ValueOf(rangeMap.rangeMap).MapKeys()
+	return -1, errors.New(fmt.Sprintf("Partial Object Channel Builder: specified object offset '%d' is outside of expected ranges '%v'", objectOffset, ranges))
 }

--- a/helpers/channels/partialObjectRangeMap_test.go
+++ b/helpers/channels/partialObjectRangeMap_test.go
@@ -1,115 +1,115 @@
 package channels
 
 import (
-    "testing"
-    ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "reflect"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
-    "fmt"
+	"fmt"
+	ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"reflect"
+	"testing"
 )
 
 func getTestRanges() []ds3Models.Range {
-    return []ds3Models.Range {
-        {1, 5},
-        {4, 7},
-        {10, 11},
-        {12, 13},
-        {15, 16},
-    }
+	return []ds3Models.Range{
+		{1, 5},
+		{4, 7},
+		{10, 11},
+		{12, 13},
+		{15, 16},
+	}
 }
 
 func TestCreatingRangeMap(t *testing.T) {
-    result := newPartialObjectRangeMap(getTestRanges())
+	result := newPartialObjectRangeMap(getTestRanges())
 
-    // expected map
-    expected := make(map[ds3Models.Range]int64)
-    expected[ds3Models.Range{Start: 1, End: 7}] = 0
-    expected[ds3Models.Range{Start: 10, End: 13}] = 7
-    expected[ds3Models.Range{Start: 15, End: 16}] = 11
+	// expected map
+	expected := make(map[ds3Models.Range]int64)
+	expected[ds3Models.Range{Start: 1, End: 7}] = 0
+	expected[ds3Models.Range{Start: 10, End: 13}] = 7
+	expected[ds3Models.Range{Start: 15, End: 16}] = 11
 
-    if !reflect.DeepEqual(result.rangeMap, expected) {
-        t.Errorf("Expected map '%v' but got '%v'", expected, result)
-    }
+	if !reflect.DeepEqual(result.rangeMap, expected) {
+		t.Errorf("Expected map '%v' but got '%v'", expected, result)
+	}
 }
 
 func TestGettingDestinationOffset(t *testing.T) {
-    mapper := newPartialObjectRangeMap(getTestRanges())
+	mapper := newPartialObjectRangeMap(getTestRanges())
 
-    type testResponse struct {
-        input    int64
-        expected int64
-        error    bool
-    }
+	type testResponse struct {
+		input    int64
+		expected int64
+		error    bool
+	}
 
-    expected := []testResponse {
-        { 0, -1, true },
-        { 1, 0, false },
-        { 2, 1, false },
-        { 3, 2, false },
-        { 4, 3, false },
-        { 5, 4, false },
-        { 6, 5, false },
-        { 7, 6, false },
-        { 8, -1, true },
-        { 9, -1, true },
-        { 10, 7, false },
-        { 11, 8, false },
-        { 12, 9, false },
-        { 13, 10, false },
-        { 14, -1, true },
-        { 15, 11, false },
-        { 16, 12, false },
-        { 17, -1, true },
-    }
+	expected := []testResponse{
+		{0, -1, true},
+		{1, 0, false},
+		{2, 1, false},
+		{3, 2, false},
+		{4, 3, false},
+		{5, 4, false},
+		{6, 5, false},
+		{7, 6, false},
+		{8, -1, true},
+		{9, -1, true},
+		{10, 7, false},
+		{11, 8, false},
+		{12, 9, false},
+		{13, 10, false},
+		{14, -1, true},
+		{15, 11, false},
+		{16, 12, false},
+		{17, -1, true},
+	}
 
-    for _, exp := range expected {
-        result, err := mapper.getDestinationOffset(exp.input)
-        ds3Testing.AssertBool(t, fmt.Sprintf("input '%d' errored", exp.input), exp.error, err != nil)
-        ds3Testing.AssertInt64(t, "destination offset", exp.expected, result)
-    }
+	for _, exp := range expected {
+		result, err := mapper.getDestinationOffset(exp.input)
+		ds3Testing.AssertBool(t, fmt.Sprintf("input '%d' errored", exp.input), exp.error, err != nil)
+		ds3Testing.AssertInt64(t, "destination offset", exp.expected, result)
+	}
 }
 
 func TestGettingDestinationOffsetWithUnorderedRanges(t *testing.T) {
-    ranges := []ds3Models.Range {
-        {12, 13},
-        {1, 5},
-        {10, 11},
-        {4, 7},
-        {15, 16},
-    }
+	ranges := []ds3Models.Range{
+		{12, 13},
+		{1, 5},
+		{10, 11},
+		{4, 7},
+		{15, 16},
+	}
 
-    mapper := newPartialObjectRangeMap(ranges)
+	mapper := newPartialObjectRangeMap(ranges)
 
-    type testResponse struct {
-        input    int64
-        expected int64
-        error    bool
-    }
+	type testResponse struct {
+		input    int64
+		expected int64
+		error    bool
+	}
 
-    expected := []testResponse {
-        { 0, -1, true },
-        { 1, 0, false },
-        { 2, 1, false },
-        { 3, 2, false },
-        { 4, 3, false },
-        { 5, 4, false },
-        { 6, 5, false },
-        { 7, 6, false },
-        { 8, -1, true },
-        { 9, -1, true },
-        { 10, 7, false },
-        { 11, 8, false },
-        { 12, 9, false },
-        { 13, 10, false },
-        { 14, -1, true },
-        { 15, 11, false },
-        { 16, 12, false },
-        { 17, -1, true },
-    }
+	expected := []testResponse{
+		{0, -1, true},
+		{1, 0, false},
+		{2, 1, false},
+		{3, 2, false},
+		{4, 3, false},
+		{5, 4, false},
+		{6, 5, false},
+		{7, 6, false},
+		{8, -1, true},
+		{9, -1, true},
+		{10, 7, false},
+		{11, 8, false},
+		{12, 9, false},
+		{13, 10, false},
+		{14, -1, true},
+		{15, 11, false},
+		{16, 12, false},
+		{17, -1, true},
+	}
 
-    for _, exp := range expected {
-        result, err := mapper.getDestinationOffset(exp.input)
-        ds3Testing.AssertBool(t, fmt.Sprintf("input '%d' errored", exp.input), exp.error, err != nil)
-        ds3Testing.AssertInt64(t, "destination offset", exp.expected, result)
-    }
+	for _, exp := range expected {
+		result, err := mapper.getDestinationOffset(exp.input)
+		ds3Testing.AssertBool(t, fmt.Sprintf("input '%d' errored", exp.input), exp.error, err != nil)
+		ds3Testing.AssertInt64(t, "destination offset", exp.expected, result)
+	}
 }

--- a/helpers/channels/partialObjectWriteChannelBuilder.go
+++ b/helpers/channels/partialObjectWriteChannelBuilder.go
@@ -1,50 +1,50 @@
 package channels
 
 import (
-    ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "io"
-    "os"
+	ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"io"
+	"os"
 )
 
 type PartialObjectWriteChannelBuilder struct {
-    name string
-    // map of object ranges to destination offset for start of range
-    rangeMap partialObjectRangeMap
-    FatalErrorHandler
+	name string
+	// map of object ranges to destination offset for start of range
+	rangeMap partialObjectRangeMap
+	FatalErrorHandler
 }
 
 func NewPartialObjectChannelBuilder(name string, objRanges []ds3Models.Range) helperModels.WriteChannelBuilder {
 
-    return &PartialObjectWriteChannelBuilder{
-        name: name,
-        rangeMap: newPartialObjectRangeMap(objRanges),
-    }
+	return &PartialObjectWriteChannelBuilder{
+		name:     name,
+		rangeMap: newPartialObjectRangeMap(objRanges),
+	}
 }
 
 func (builder *PartialObjectWriteChannelBuilder) IsChannelAvailable(objectOffset int64) bool {
-    return true
+	return true
 }
 
 func (builder *PartialObjectWriteChannelBuilder) GetChannel(objectOffset int64) (io.WriteCloser, error) {
-    destinationOffset, err := builder.rangeMap.getDestinationOffset(objectOffset)
-    if err != nil {
-        return nil, err
-    }
+	destinationOffset, err := builder.rangeMap.getDestinationOffset(objectOffset)
+	if err != nil {
+		return nil, err
+	}
 
-    f, err := os.OpenFile(builder.name, os.O_WRONLY, defaultPermissions)
-    if err != nil {
-        return nil, err
-    }
+	f, err := os.OpenFile(builder.name, os.O_WRONLY, defaultPermissions)
+	if err != nil {
+		return nil, err
+	}
 
-    _, err = f.Seek(destinationOffset, io.SeekStart)
-    if err != nil {
-        f.Close()
-        return nil, err
-    }
-    return f, nil
+	_, err = f.Seek(destinationOffset, io.SeekStart)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return f, nil
 }
 
 func (builder *PartialObjectWriteChannelBuilder) OnDone(writer io.WriteCloser) {
-    writer.Close()
+	writer.Close()
 }

--- a/helpers/channels/partialObjectWriteChannelBuilder_test.go
+++ b/helpers/channels/partialObjectWriteChannelBuilder_test.go
@@ -1,41 +1,41 @@
 package channels
 
 import (
-    "testing"
-    "io/ioutil"
-    "os"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
-    ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "reflect"
+	ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
 )
 
 func TestPartialObjectWriteChannel(t *testing.T) {
-    file, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file.Close()
-    defer os.Remove(file.Name())
+	file, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file.Close()
+	defer os.Remove(file.Name())
 
-    ranges := []ds3Models.Range {
-        {1, 3},
-        {4, 5},
-        {8, 10},
-        {15, 20},
-    }
+	ranges := []ds3Models.Range{
+		{1, 3},
+		{4, 5},
+		{8, 10},
+		{15, 20},
+	}
 
-    builder := NewPartialObjectChannelBuilder(file.Name(), ranges)
-    originalContent := []byte {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'}
+	builder := NewPartialObjectChannelBuilder(file.Name(), ranges)
+	originalContent := []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'}
 
-    for _, curRange := range ranges {
-        channel, err := builder.GetChannel(curRange.Start)
-        if err == nil {
-            _, err := channel.Write(originalContent[curRange.Start:curRange.End+1])
-            ds3Testing.AssertNilError(t, err)
-        }
-    }
+	for _, curRange := range ranges {
+		channel, err := builder.GetChannel(curRange.Start)
+		if err == nil {
+			_, err := channel.Write(originalContent[curRange.Start : curRange.End+1])
+			ds3Testing.AssertNilError(t, err)
+		}
+	}
 
-    result, err := ioutil.ReadAll(file)
-    expected := []byte {'b', 'c', 'd', 'e', 'f', 'i', 'j', 'k', 'p', 'q', 'r', 's', 't', 'u'}
-    if !reflect.DeepEqual(expected, result) {
-        t.Errorf("Expected '%s' but got '%s'", string(expected), string(result))
-    }
+	result, err := ioutil.ReadAll(file)
+	expected := []byte{'b', 'c', 'd', 'e', 'f', 'i', 'j', 'k', 'p', 'q', 'r', 's', 't', 'u'}
+	if !reflect.DeepEqual(expected, result) {
+		t.Errorf("Expected '%s' but got '%s'", string(expected), string(result))
+	}
 }

--- a/helpers/conditionalBool.go
+++ b/helpers/conditionalBool.go
@@ -3,41 +3,40 @@ package helpers
 import "sync"
 
 type NotifyBlobDone interface {
-    // Waits for at least one done signal.
-    Wait()
+	// Waits for at least one done signal.
+	Wait()
 
-    // Sends a done signal. Multiple signals have no additional effect.
-    SignalDone()
+	// Sends a done signal. Multiple signals have no additional effect.
+	SignalDone()
 }
 
-
 func NewConditionalBool() *ConditionalBool {
-    conditional :=sync.NewCond(&sync.Mutex{})
-    return &ConditionalBool{
-        conditional: *conditional,
-        Done: false,
-    }
+	conditional := sync.NewCond(&sync.Mutex{})
+	return &ConditionalBool{
+		conditional: *conditional,
+		Done:        false,
+	}
 }
 
 type ConditionalBool struct {
-    conditional sync.Cond
-    Done bool
+	conditional sync.Cond
+	Done        bool
 }
 
 func (conditionalBool *ConditionalBool) Wait() {
-    conditionalBool.conditional.L.Lock()
-    // wait for a done signal to be received
-    for !conditionalBool.Done {
-        conditionalBool.conditional.Wait()
-    }
-    // reset done notifier
-    conditionalBool.Done = false
-    conditionalBool.conditional.L.Unlock()
+	conditionalBool.conditional.L.Lock()
+	// wait for a done signal to be received
+	for !conditionalBool.Done {
+		conditionalBool.conditional.Wait()
+	}
+	// reset done notifier
+	conditionalBool.Done = false
+	conditionalBool.conditional.L.Unlock()
 }
 
 func (conditionalBool *ConditionalBool) SignalDone() {
-    conditionalBool.conditional.L.Lock()
-    conditionalBool.Done = true
-    conditionalBool.conditional.Broadcast()
-    conditionalBool.conditional.L.Unlock()
+	conditionalBool.conditional.L.Lock()
+	conditionalBool.Done = true
+	conditionalBool.conditional.Broadcast()
+	conditionalBool.conditional.L.Unlock()
 }

--- a/helpers/consumer.go
+++ b/helpers/consumer.go
@@ -1,53 +1,53 @@
 package helpers
 
 import (
-    "sync"
+	"sync"
 )
 
 type Consumer interface {
-    run()
+	run()
 }
 
 type consumerImpl struct {
-    queue                   *chan TransferOperation
-    waitGroup               *sync.WaitGroup
-    maxConcurrentOperations uint
+	queue                   *chan TransferOperation
+	waitGroup               *sync.WaitGroup
+	maxConcurrentOperations uint
 
-    // Conditional value that gets triggered when a blob has finished being transferred
-    doneNotifier NotifyBlobDone
+	// Conditional value that gets triggered when a blob has finished being transferred
+	doneNotifier NotifyBlobDone
 }
 
 func newConsumer(queue *chan TransferOperation, waitGroup *sync.WaitGroup, maxConcurrentOperations uint, doneNotifier NotifyBlobDone) Consumer {
-    return &consumerImpl{
-        queue:                   queue,
-        waitGroup:               waitGroup,
-        maxConcurrentOperations: maxConcurrentOperations,
-        doneNotifier:            doneNotifier,
-    }
+	return &consumerImpl{
+		queue:                   queue,
+		waitGroup:               waitGroup,
+		maxConcurrentOperations: maxConcurrentOperations,
+		doneNotifier:            doneNotifier,
+	}
 }
 
 func performTransfer(operation TransferOperation, semaphore *chan int, waitGroup *sync.WaitGroup, doneNotifier NotifyBlobDone) {
-    defer waitGroup.Done()
-    operation()
+	defer waitGroup.Done()
+	operation()
 
-    // send done signal
-    doneNotifier.SignalDone()
+	// send done signal
+	doneNotifier.SignalDone()
 
-    <- *semaphore
+	<-*semaphore
 }
 
 func (consumer *consumerImpl) run() {
-    // semaphore for controlling max number of transfer operations in flight per job
-    semaphore := make(chan int, consumer.maxConcurrentOperations + 1)
+	// semaphore for controlling max number of transfer operations in flight per job
+	semaphore := make(chan int, consumer.maxConcurrentOperations+1)
 
-    for {
-        nextOp, ok := <- *consumer.queue
-        if ok {
-            semaphore <- 1
-            go performTransfer(nextOp, &semaphore, consumer.waitGroup, consumer.doneNotifier)
-        } else {
-            consumer.waitGroup.Done()
-            return
-        }
-    }
+	for {
+		nextOp, ok := <-*consumer.queue
+		if ok {
+			semaphore <- 1
+			go performTransfer(nextOp, &semaphore, consumer.waitGroup, consumer.doneNotifier)
+		} else {
+			consumer.waitGroup.Done()
+			return
+		}
+	}
 }

--- a/helpers/consumer_test.go
+++ b/helpers/consumer_test.go
@@ -1,54 +1,54 @@
 package helpers
 
 import (
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
-    "sync"
-    "testing"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"sync"
+	"testing"
 )
 
 func testTransferBuilder(t *testing.T, i int, resultCount *int, resultMux *sync.Mutex) TransferOperation {
-    return func() {
-        resultMux.Lock()
-        *resultCount++
-        resultMux.Unlock()
+	return func() {
+		resultMux.Lock()
+		*resultCount++
+		resultMux.Unlock()
 
-        t.Logf("Transfer Op: '%d'\n", i)
-    }
+		t.Logf("Transfer Op: '%d'\n", i)
+	}
 }
 
 func TestProducerConsumerModel(t *testing.T) {
-    const numOperations = 10
-    var wg sync.WaitGroup
-    wg.Add(2)
+	const numOperations = 10
+	var wg sync.WaitGroup
+	wg.Add(2)
 
-    resultCount := 0
-    var resultMux sync.Mutex
+	resultCount := 0
+	var resultMux sync.Mutex
 
-    var producer = func(queue *chan TransferOperation) {
-        defer wg.Done()
-        for i := 0; i < numOperations; i++ {
-            wg.Add(1)
+	var producer = func(queue *chan TransferOperation) {
+		defer wg.Done()
+		for i := 0; i < numOperations; i++ {
+			wg.Add(1)
 
-            var transferOf = testTransferBuilder(t, i, &resultCount, &resultMux)
+			var transferOf = testTransferBuilder(t, i, &resultCount, &resultMux)
 
-            t.Logf("Producer: '%d'\n", i)
+			t.Logf("Producer: '%d'\n", i)
 
-            *queue <- transferOf
-        }
-        close(*queue)
-    }
+			*queue <- transferOf
+		}
+		close(*queue)
+	}
 
-    queue := make(chan TransferOperation, 5)
+	queue := make(chan TransferOperation, 5)
 
-    doneNotifier := NewConditionalBool()
+	doneNotifier := NewConditionalBool()
 
-    consumer := newConsumer(&queue, &wg, 5, doneNotifier)
+	consumer := newConsumer(&queue, &wg, 5, doneNotifier)
 
-    go producer(&queue)
-    go consumer.run()
+	go producer(&queue)
+	go consumer.run()
 
-    wg.Wait()
+	wg.Wait()
 
-    ds3Testing.AssertInt(t, "Executed Transfer Operations", numOperations, resultCount)
-    ds3Testing.AssertBool(t, "received done notification", true, doneNotifier.Done)
+	ds3Testing.AssertInt(t, "Executed Transfer Operations", numOperations, resultCount)
+	ds3Testing.AssertBool(t, "received done notification", true, doneNotifier.Done)
 }

--- a/helpers/getProducer.go
+++ b/helpers/getProducer.go
@@ -1,415 +1,415 @@
 package helpers
 
 import (
-    "context"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "github.com/SpectraLogic/ds3_go_sdk/helpers/ranges"
-    "github.com/SpectraLogic/ds3_go_sdk/sdk_log"
-    "io"
-    "sync"
-    "time"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"github.com/SpectraLogic/ds3_go_sdk/helpers/ranges"
+	"github.com/SpectraLogic/ds3_go_sdk/sdk_log"
+	"io"
+	"sync"
+	"time"
 )
 
 const timesToRetryGettingPartialBlob = 5
 
 type getProducer struct {
-    ctx                  context.Context
-    JobMasterObjectList  *ds3Models.MasterObjectList //MOL from put bulk job creation
-    queue                *chan TransferOperation
-    strategy             *ReadTransferStrategy
-    client               *ds3.Client
-    waitGroup            *sync.WaitGroup
-    readObjectMap        map[string]helperModels.GetObject
-    processedBlobTracker blobTracker
-    deferredBlobQueue    BlobDescriptionQueue // queue of blobs whose channels are not yet ready for transfer
-    rangeFinder          ranges.BlobRangeFinder
-    sdk_log.Logger
+	ctx                  context.Context
+	JobMasterObjectList  *ds3Models.MasterObjectList //MOL from put bulk job creation
+	queue                *chan TransferOperation
+	strategy             *ReadTransferStrategy
+	client               *ds3.Client
+	waitGroup            *sync.WaitGroup
+	readObjectMap        map[string]helperModels.GetObject
+	processedBlobTracker blobTracker
+	deferredBlobQueue    BlobDescriptionQueue // queue of blobs whose channels are not yet ready for transfer
+	rangeFinder          ranges.BlobRangeFinder
+	sdk_log.Logger
 
-    // Conditional value that gets triggered when a blob has finished being transferred
-    doneNotifier NotifyBlobDone
+	// Conditional value that gets triggered when a blob has finished being transferred
+	doneNotifier NotifyBlobDone
 }
 
 func newGetProducer(
-    ctx context.Context,
-    jobMasterObjectList *ds3Models.MasterObjectList,
-    getObjects *[]helperModels.GetObject,
-    queue *chan TransferOperation,
-    strategy *ReadTransferStrategy,
-    client *ds3.Client,
-    waitGroup *sync.WaitGroup,
-    doneNotifier NotifyBlobDone) *getProducer {
+	ctx context.Context,
+	jobMasterObjectList *ds3Models.MasterObjectList,
+	getObjects *[]helperModels.GetObject,
+	queue *chan TransferOperation,
+	strategy *ReadTransferStrategy,
+	client *ds3.Client,
+	waitGroup *sync.WaitGroup,
+	doneNotifier NotifyBlobDone) *getProducer {
 
-    return &getProducer{
-        ctx:                  ctx,
-        JobMasterObjectList:  jobMasterObjectList,
-        queue:                queue,
-        strategy:             strategy,
-        client:               client,
-        waitGroup:            waitGroup,
-        readObjectMap:        toReadObjectMap(getObjects),
-        processedBlobTracker: newProcessedBlobTracker(),
-        deferredBlobQueue:    NewBlobDescriptionQueue(),
-        rangeFinder:          ranges.NewBlobRangeFinder(getObjects),
-        Logger:               client.Logger, //use the same logger as the client
-        doneNotifier:         doneNotifier,
-    }
+	return &getProducer{
+		ctx:                  ctx,
+		JobMasterObjectList:  jobMasterObjectList,
+		queue:                queue,
+		strategy:             strategy,
+		client:               client,
+		waitGroup:            waitGroup,
+		readObjectMap:        toReadObjectMap(getObjects),
+		processedBlobTracker: newProcessedBlobTracker(),
+		deferredBlobQueue:    NewBlobDescriptionQueue(),
+		rangeFinder:          ranges.NewBlobRangeFinder(getObjects),
+		Logger:               client.Logger, //use the same logger as the client
+		doneNotifier:         doneNotifier,
+	}
 }
 
 // Creates a map of object name to the GetObject struct
 func toReadObjectMap(getObjects *[]helperModels.GetObject) map[string]helperModels.GetObject {
-    objectMap := make(map[string]helperModels.GetObject)
+	objectMap := make(map[string]helperModels.GetObject)
 
-    if getObjects == nil {
-        return objectMap
-    }
+	if getObjects == nil {
+		return objectMap
+	}
 
-    for _, obj := range *getObjects {
-        objectMap[obj.Name] = obj
-    }
+	for _, obj := range *getObjects {
+		objectMap[obj.Name] = obj
+	}
 
-    return objectMap
+	return objectMap
 }
 
 // Processes all the blobs in a chunk that are ready for transfer from BP
 // Returns the number of blobs queued for process
 func (producer *getProducer) processChunk(curChunk *ds3Models.Objects, bucketName string, jobId string) (int, error) {
-    producer.Debugf("begin chunk processing %s", curChunk.ChunkId)
+	producer.Debugf("begin chunk processing %s", curChunk.ChunkId)
 
-    processedCount := 0
-    // transfer blobs that are ready, and queue those that are waiting for channel
-    for _, curObj := range curChunk.Objects {
-        producer.Debugf("queuing object in waiting to be processed %s offset=%d length=%d", *curObj.Name, curObj.Offset, curObj.Length)
-        blob := helperModels.NewBlobDescription(*curObj.Name, curObj.Offset, curObj.Length)
+	processedCount := 0
+	// transfer blobs that are ready, and queue those that are waiting for channel
+	for _, curObj := range curChunk.Objects {
+		producer.Debugf("queuing object in waiting to be processed %s offset=%d length=%d", *curObj.Name, curObj.Offset, curObj.Length)
+		blob := helperModels.NewBlobDescription(*curObj.Name, curObj.Offset, curObj.Length)
 
-        blobQueued, err := producer.queueBlobForTransfer(&blob, bucketName, jobId)
-        if err != nil {
-            return 0, err
-        }
-        if blobQueued {
-            processedCount++
-        }
-    }
-    return processedCount, nil
+		blobQueued, err := producer.queueBlobForTransfer(&blob, bucketName, jobId)
+		if err != nil {
+			return 0, err
+		}
+		if blobQueued {
+			processedCount++
+		}
+	}
+	return processedCount, nil
 }
 
 // Information required to perform a get operation of a blob with BP as data source and channelBuilder as destination
 type getObjectInfo struct {
-    blob           *helperModels.BlobDescription
-    channelBuilder helperModels.WriteChannelBuilder
-    bucketName     string
-    jobId          string
+	blob           *helperModels.BlobDescription
+	channelBuilder helperModels.WriteChannelBuilder
+	bucketName     string
+	jobId          string
 }
 
 // Creates the transfer operation that will perform the data retrieval of the specified blob from BP
 func (producer *getProducer) transferOperationBuilder(info getObjectInfo) TransferOperation {
-    return func() {
-        // has this file fatally errored while transferring a different blob?
-        if info.channelBuilder.HasFatalError() {
-            // skip performing this blob transfer
-            producer.Warningf("fatal error occurred previously on this file, skipping retrieval of blob objectName='%s' offset=%d", info.blob.Name(), info.blob.Offset())
-            return
-        }
-        blobRanges := producer.rangeFinder.GetRanges(info.blob.Name(), info.blob.Offset(), info.blob.Length())
+	return func() {
+		// has this file fatally errored while transferring a different blob?
+		if info.channelBuilder.HasFatalError() {
+			// skip performing this blob transfer
+			producer.Warningf("fatal error occurred previously on this file, skipping retrieval of blob objectName='%s' offset=%d", info.blob.Name(), info.blob.Offset())
+			return
+		}
+		blobRanges := producer.rangeFinder.GetRanges(info.blob.Name(), info.blob.Offset(), info.blob.Length())
 
-        producer.Debugf("transferring objectName='%s' offset=%d ranges=%v", info.blob.Name(), info.blob.Offset(), blobRanges)
+		producer.Debugf("transferring objectName='%s' offset=%d ranges=%v", info.blob.Name(), info.blob.Offset(), blobRanges)
 
-        getObjRequest := ds3Models.NewGetObjectRequest(info.bucketName, info.blob.Name()).
-            WithOffset(info.blob.Offset()).
-            WithJob(info.jobId)
+		getObjRequest := ds3Models.NewGetObjectRequest(info.bucketName, info.blob.Name()).
+			WithOffset(info.blob.Offset()).
+			WithJob(info.jobId)
 
-        if len(blobRanges) > 0 {
-            getObjRequest = getObjRequest.WithRanges(blobRanges...)
-        }
+		if len(blobRanges) > 0 {
+			getObjRequest = getObjRequest.WithRanges(blobRanges...)
+		}
 
-        getObjResponse, err := producer.client.GetObject(producer.ctx, getObjRequest)
-        if err != nil {
-            producer.strategy.Listeners.Errored(info.blob.Name(), err)
-            info.channelBuilder.SetFatalError(err)
-            producer.Errorf("unable to retrieve object '%s' at offset %d: %s", info.blob.Name(), info.blob.Offset(), err.Error())
-            return
-        }
-        defer func() {
-           err := getObjResponse.Content.Close()
-           if err != nil {
-               producer.Warningf("unable to close response body for object '%s' at offset '%d': %s", info.blob.Name(), info.blob.Offset(), err)
-           }
-        }()
+		getObjResponse, err := producer.client.GetObject(producer.ctx, getObjRequest)
+		if err != nil {
+			producer.strategy.Listeners.Errored(info.blob.Name(), err)
+			info.channelBuilder.SetFatalError(err)
+			producer.Errorf("unable to retrieve object '%s' at offset %d: %s", info.blob.Name(), info.blob.Offset(), err.Error())
+			return
+		}
+		defer func() {
+			err := getObjResponse.Content.Close()
+			if err != nil {
+				producer.Warningf("unable to close response body for object '%s' at offset '%d': %s", info.blob.Name(), info.blob.Offset(), err)
+			}
+		}()
 
-        if len(blobRanges) == 0 {
-            writer, err := info.channelBuilder.GetChannel(info.blob.Offset())
-            if err != nil {
-                producer.strategy.Listeners.Errored(info.blob.Name(), err)
-                info.channelBuilder.SetFatalError(err)
-                producer.Errorf("unable to read contents of object '%s' at offset '%d': %s", info.blob.Name(), info.blob.Offset(), err.Error())
-                return
-            }
-            defer info.channelBuilder.OnDone(writer)
-            bytesWritten, err := io.Copy(writer, getObjResponse.Content) //copy all content from response reader to destination writer
-            if err != nil && err != io.ErrUnexpectedEOF {
-                producer.strategy.Listeners.Errored(info.blob.Name(), err)
-                info.channelBuilder.SetFatalError(err)
-                producer.Errorf("unable to copy content of object '%s' at offset '%d' from source to destination: %s", info.blob.Name(), info.blob.Offset(), err.Error())
-                return
-            }
-            if bytesWritten != info.blob.Length() {
-                producer.Errorf("failed to copy all content of object '%s' at offset '%d': only wrote %d of %d bytes", info.blob.Name(), info.blob.Offset(), bytesWritten, info.blob.Length())
-                err := GetRemainingBlob(producer.ctx, producer.client, info.bucketName, info.blob, bytesWritten, writer, producer.Logger)
-                if err != nil {
-                    producer.strategy.Listeners.Errored(info.blob.Name(), err)
-                    info.channelBuilder.SetFatalError(err)
-                    producer.Errorf("unable to copy content of object '%s' at offset '%d' from source to destination: %s", info.blob.Name(), info.blob.Offset(), err.Error())
-                }
-            }
-            return
-        }
+		if len(blobRanges) == 0 {
+			writer, err := info.channelBuilder.GetChannel(info.blob.Offset())
+			if err != nil {
+				producer.strategy.Listeners.Errored(info.blob.Name(), err)
+				info.channelBuilder.SetFatalError(err)
+				producer.Errorf("unable to read contents of object '%s' at offset '%d': %s", info.blob.Name(), info.blob.Offset(), err.Error())
+				return
+			}
+			defer info.channelBuilder.OnDone(writer)
+			bytesWritten, err := io.Copy(writer, getObjResponse.Content) //copy all content from response reader to destination writer
+			if err != nil && err != io.ErrUnexpectedEOF {
+				producer.strategy.Listeners.Errored(info.blob.Name(), err)
+				info.channelBuilder.SetFatalError(err)
+				producer.Errorf("unable to copy content of object '%s' at offset '%d' from source to destination: %s", info.blob.Name(), info.blob.Offset(), err.Error())
+				return
+			}
+			if bytesWritten != info.blob.Length() {
+				producer.Errorf("failed to copy all content of object '%s' at offset '%d': only wrote %d of %d bytes", info.blob.Name(), info.blob.Offset(), bytesWritten, info.blob.Length())
+				err := GetRemainingBlob(producer.ctx, producer.client, info.bucketName, info.blob, bytesWritten, writer, producer.Logger)
+				if err != nil {
+					producer.strategy.Listeners.Errored(info.blob.Name(), err)
+					info.channelBuilder.SetFatalError(err)
+					producer.Errorf("unable to copy content of object '%s' at offset '%d' from source to destination: %s", info.blob.Name(), info.blob.Offset(), err.Error())
+				}
+			}
+			return
+		}
 
-        // write the content of each range
-        for _, r := range blobRanges {
-            err := writeRangeToDestination(info.channelBuilder, r, getObjResponse.Content)
-            if err != nil {
-                producer.strategy.Listeners.Errored(info.blob.Name(), err)
-                info.channelBuilder.SetFatalError(err)
-                producer.Errorf("unable to write to destination channel for object '%s' with range '%v': %s", info.blob.Name(), r, err.Error())
-            }
-        }
-    }
+		// write the content of each range
+		for _, r := range blobRanges {
+			err := writeRangeToDestination(info.channelBuilder, r, getObjResponse.Content)
+			if err != nil {
+				producer.strategy.Listeners.Errored(info.blob.Name(), err)
+				info.channelBuilder.SetFatalError(err)
+				producer.Errorf("unable to write to destination channel for object '%s' with range '%v': %s", info.blob.Name(), r, err.Error())
+			}
+		}
+	}
 }
 
 func GetRemainingBlob(ctx context.Context, client *ds3.Client, bucketName string, blob *helperModels.BlobDescription, amountAlreadyRetrieved int64, writer io.Writer, logger sdk_log.Logger) error {
-    logger.Debugf("starting retry for fetching partial blob '%s' at offset '%d': amount to retrieve %d", blob.Name(), blob.Offset(), blob.Length() - amountAlreadyRetrieved)
-    bytesRetrievedSoFar := amountAlreadyRetrieved
-    timesRetried := 0
-    rangeEnd := blob.Offset() + blob.Length() -1
-    for bytesRetrievedSoFar < blob.Length() && timesRetried < timesToRetryGettingPartialBlob {
-        rangeStart := blob.Offset() + bytesRetrievedSoFar
-        bytesRetrievedThisRound, err := RetryGettingBlobRange(ctx, client, bucketName, blob.Name(), blob.Offset(), rangeStart, rangeEnd, writer, logger)
-        if err != nil {
-            logger.Errorf("failed to get object '%s' at offset '%d', range %d=%d attempt %d: %s", blob.Name(), blob.Offset(), rangeStart, rangeEnd, timesRetried, err.Error())
-        }
-        bytesRetrievedSoFar+= bytesRetrievedThisRound
-        timesRetried++
-    }
+	logger.Debugf("starting retry for fetching partial blob '%s' at offset '%d': amount to retrieve %d", blob.Name(), blob.Offset(), blob.Length()-amountAlreadyRetrieved)
+	bytesRetrievedSoFar := amountAlreadyRetrieved
+	timesRetried := 0
+	rangeEnd := blob.Offset() + blob.Length() - 1
+	for bytesRetrievedSoFar < blob.Length() && timesRetried < timesToRetryGettingPartialBlob {
+		rangeStart := blob.Offset() + bytesRetrievedSoFar
+		bytesRetrievedThisRound, err := RetryGettingBlobRange(ctx, client, bucketName, blob.Name(), blob.Offset(), rangeStart, rangeEnd, writer, logger)
+		if err != nil {
+			logger.Errorf("failed to get object '%s' at offset '%d', range %d=%d attempt %d: %s", blob.Name(), blob.Offset(), rangeStart, rangeEnd, timesRetried, err.Error())
+		}
+		bytesRetrievedSoFar += bytesRetrievedThisRound
+		timesRetried++
+	}
 
-    if bytesRetrievedSoFar < blob.Length() {
-        return fmt.Errorf("failed to copy all content of object '%s' at offset '%d': only wrote %d of %d bytes", blob.Name(), blob.Offset(), bytesRetrievedSoFar, blob.Length())
-    }
-    return nil
+	if bytesRetrievedSoFar < blob.Length() {
+		return fmt.Errorf("failed to copy all content of object '%s' at offset '%d': only wrote %d of %d bytes", blob.Name(), blob.Offset(), bytesRetrievedSoFar, blob.Length())
+	}
+	return nil
 }
 
 func RetryGettingBlobRange(ctx context.Context, client *ds3.Client, bucketName string, objectName string, blobOffset int64, rangeStart int64, rangeEnd int64, writer io.Writer, logger sdk_log.Logger) (int64, error) {
-    // perform a naked get call for the rest of the blob that we originally failed to get
-    partOfBlobToFetch := ds3Models.Range{
-        Start: rangeStart,
-        End:   rangeEnd,
-    }
-    getObjRequest := ds3Models.NewGetObjectRequest(bucketName, objectName).
-        WithOffset(blobOffset).
-        WithRanges(partOfBlobToFetch)
+	// perform a naked get call for the rest of the blob that we originally failed to get
+	partOfBlobToFetch := ds3Models.Range{
+		Start: rangeStart,
+		End:   rangeEnd,
+	}
+	getObjRequest := ds3Models.NewGetObjectRequest(bucketName, objectName).
+		WithOffset(blobOffset).
+		WithRanges(partOfBlobToFetch)
 
-    getObjResponse, err := client.GetObject(ctx, getObjRequest)
-    if err != nil {
-        return 0, err
-    }
-    defer func() {
-        err := getObjResponse.Content.Close()
-        if err != nil {
-            logger.Warningf("failed to close response body for get object '%s' with range %d-%d: %v", objectName, rangeStart, rangeEnd, err)
-        }
-    }()
+	getObjResponse, err := client.GetObject(ctx, getObjRequest)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		err := getObjResponse.Content.Close()
+		if err != nil {
+			logger.Warningf("failed to close response body for get object '%s' with range %d-%d: %v", objectName, rangeStart, rangeEnd, err)
+		}
+	}()
 
-    bytesWritten, err := io.Copy(writer, getObjResponse.Content) //copy all content from response reader to destination writer
-    return bytesWritten, err
+	bytesWritten, err := io.Copy(writer, getObjResponse.Content) //copy all content from response reader to destination writer
+	return bytesWritten, err
 }
 
 // Writes a range of a blob to its destination channel
 func writeRangeToDestination(channelBuilder helperModels.WriteChannelBuilder, blobRange ds3Models.Range, content io.Reader) error {
-    writer, err := channelBuilder.GetChannel(blobRange.Start)
-    if err != nil {
-        return err
-    }
-    defer channelBuilder.OnDone(writer)
+	writer, err := channelBuilder.GetChannel(blobRange.Start)
+	if err != nil {
+		return err
+	}
+	defer channelBuilder.OnDone(writer)
 
-    _, err = io.CopyN(writer, content, blobRange.End - blobRange.Start + 1) // copies the range from response reader into destination writer
+	_, err = io.CopyN(writer, content, blobRange.End-blobRange.Start+1) // copies the range from response reader into destination writer
 
-    return err
+	return err
 }
 
 // Attempts to transfer a single blob from the BP to the client. If the blob is not ready for transfer,
 // then it is added to the waiting to transfer queue
 // Returns whether or not the blob was queued for transfer
 func (producer *getProducer) queueBlobForTransfer(blob *helperModels.BlobDescription, bucketName string, jobId string) (bool, error) {
-    if producer.processedBlobTracker.IsProcessed(*blob) {
-        return false, nil // already been processed
-    }
+	if producer.processedBlobTracker.IsProcessed(*blob) {
+		return false, nil // already been processed
+	}
 
-    curReadObj, ok := producer.readObjectMap[blob.Name()]
-    if !ok {
-        err := fmt.Errorf("failed to find object associated with blob in object map: %s offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
-        producer.Errorf("unrecoverable error: %v", err)
-        producer.processedBlobTracker.MarkProcessed(*blob)
-        return false, err // fatal error occurred
-    }
+	curReadObj, ok := producer.readObjectMap[blob.Name()]
+	if !ok {
+		err := fmt.Errorf("failed to find object associated with blob in object map: %s offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
+		producer.Errorf("unrecoverable error: %v", err)
+		producer.processedBlobTracker.MarkProcessed(*blob)
+		return false, err // fatal error occurred
+	}
 
-    if curReadObj.ChannelBuilder == nil {
-        err := fmt.Errorf("failed to transfer object, it does not have a channel builder: %s", curReadObj.Name)
-        producer.Errorf("unrecoverable error: %v", err)
-        producer.processedBlobTracker.MarkProcessed(*blob)
-        return false, err // fatal error occurred
-    }
+	if curReadObj.ChannelBuilder == nil {
+		err := fmt.Errorf("failed to transfer object, it does not have a channel builder: %s", curReadObj.Name)
+		producer.Errorf("unrecoverable error: %v", err)
+		producer.processedBlobTracker.MarkProcessed(*blob)
+		return false, err // fatal error occurred
+	}
 
-    if curReadObj.ChannelBuilder.HasFatalError() {
-        // a fatal error happened on a previous blob for this file, skip processing
-        producer.Warningf("fatal error occurred while transferring previous blob on this file, skipping blob '%s' offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
-        producer.processedBlobTracker.MarkProcessed(*blob)
-        return false, nil // not going to process
-    }
+	if curReadObj.ChannelBuilder.HasFatalError() {
+		// a fatal error happened on a previous blob for this file, skip processing
+		producer.Warningf("fatal error occurred while transferring previous blob on this file, skipping blob '%s' offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
+		producer.processedBlobTracker.MarkProcessed(*blob)
+		return false, nil // not going to process
+	}
 
-    if !curReadObj.ChannelBuilder.IsChannelAvailable(blob.Offset()) {
-        producer.Debugf("channel is not currently available for getting blob '%s' offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
-        producer.deferredBlobQueue.Push(blob)
-        return false, nil // not ready to be processed
-    }
+	if !curReadObj.ChannelBuilder.IsChannelAvailable(blob.Offset()) {
+		producer.Debugf("channel is not currently available for getting blob '%s' offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
+		producer.deferredBlobQueue.Push(blob)
+		return false, nil // not ready to be processed
+	}
 
-    producer.Debugf("channel is available for getting blob '%s' offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
+	producer.Debugf("channel is available for getting blob '%s' offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
 
-    // Create transfer operation
-    objInfo := getObjectInfo{
-        blob:           blob,
-        channelBuilder: curReadObj.ChannelBuilder,
-        bucketName:     bucketName,
-        jobId:          jobId,
-    }
+	// Create transfer operation
+	objInfo := getObjectInfo{
+		blob:           blob,
+		channelBuilder: curReadObj.ChannelBuilder,
+		bucketName:     bucketName,
+		jobId:          jobId,
+	}
 
-    transfer := producer.transferOperationBuilder(objInfo)
+	transfer := producer.transferOperationBuilder(objInfo)
 
-    // Increment wait group, and enqueue transfer operation
-    producer.waitGroup.Add(1)
-    *producer.queue <- transfer
+	// Increment wait group, and enqueue transfer operation
+	producer.waitGroup.Add(1)
+	*producer.queue <- transfer
 
-    // Mark blob as processed
-    producer.processedBlobTracker.MarkProcessed(*blob)
+	// Mark blob as processed
+	producer.processedBlobTracker.MarkProcessed(*blob)
 
-    return true, nil
+	return true, nil
 }
 
 // Attempts to process all blobs whose channels were not available for transfer.
 // Blobs whose channels are still not available are placed back on the queue.
 // Returns the number of blobs queued for processing.
 func (producer *getProducer) processWaitingBlobs(bucketName string, jobId string) (int, error) {
-    processedCount := 0
+	processedCount := 0
 
-    // attempt to process all blobs in waiting to be transferred
-    waitingBlobs := producer.deferredBlobQueue.Size()
-    for i := 0; i < waitingBlobs; i++ {
-        //attempt transfer
-        curBlob, err := producer.deferredBlobQueue.Pop()
-        if err != nil {
-            //should not be possible to get here
-            producer.Errorf(err.Error())
-            break
-        }
-        producer.Debugf("attempting to process '%s' offset=%d length=%d", curBlob.Name(), curBlob.Offset(), curBlob.Length())
-        blobQueued, err := producer.queueBlobForTransfer(curBlob, bucketName, jobId)
-        if err != nil {
-            return 0, err
-        }
-        if blobQueued {
-            processedCount++
-        }
-    }
-    return processedCount, nil
+	// attempt to process all blobs in waiting to be transferred
+	waitingBlobs := producer.deferredBlobQueue.Size()
+	for i := 0; i < waitingBlobs; i++ {
+		//attempt transfer
+		curBlob, err := producer.deferredBlobQueue.Pop()
+		if err != nil {
+			//should not be possible to get here
+			producer.Errorf(err.Error())
+			break
+		}
+		producer.Debugf("attempting to process '%s' offset=%d length=%d", curBlob.Name(), curBlob.Offset(), curBlob.Length())
+		blobQueued, err := producer.queueBlobForTransfer(curBlob, bucketName, jobId)
+		if err != nil {
+			return 0, err
+		}
+		if blobQueued {
+			processedCount++
+		}
+	}
+	return processedCount, nil
 }
 
 // This initiates the production of the transfer operations which will be consumed by a consumer running in a separate go routine.
 // Each transfer operation will retrieve one blob of content from the BP.
 // Once all blobs have been queued to be transferred, the producer will finish, even if all operations have not been consumed yet.
 func (producer *getProducer) run() error {
-    defer close(*producer.queue)
+	defer close(*producer.queue)
 
-    // determine number of blobs to be processed
-    var totalBlobCount = producer.totalBlobCount()
-    producer.Debugf("job status totalBlobs=%d processedBlobs=%d", totalBlobCount, producer.processedBlobTracker.NumberOfProcessedBlobs())
+	// determine number of blobs to be processed
+	var totalBlobCount = producer.totalBlobCount()
+	producer.Debugf("job status totalBlobs=%d processedBlobs=%d", totalBlobCount, producer.processedBlobTracker.NumberOfProcessedBlobs())
 
-    // process all chunks and make sure all blobs are queued for transfer
-    for producer.hasMoreToProcess(totalBlobCount) {
-        processedCount, err := producer.queueBlobsReadyForTransfer(totalBlobCount)
-        if err != nil {
-            return err
-        }
+	// process all chunks and make sure all blobs are queued for transfer
+	for producer.hasMoreToProcess(totalBlobCount) {
+		processedCount, err := producer.queueBlobsReadyForTransfer(totalBlobCount)
+		if err != nil {
+			return err
+		}
 
-        // If the last operation processed blobs, then wait for something to finish
-        if processedCount > 0 {
-            producer.doneNotifier.Wait()
-        } else if producer.hasMoreToProcess(totalBlobCount) {
-            // nothing could be processed, cache is probably full, wait a bit before trying again
-            select {
-            case <-producer.ctx.Done():
-                return producer.ctx.Err()
-            case <-time.After(producer.strategy.BlobStrategy.delay()):
-            }
-        }
-    }
-    return nil
+		// If the last operation processed blobs, then wait for something to finish
+		if processedCount > 0 {
+			producer.doneNotifier.Wait()
+		} else if producer.hasMoreToProcess(totalBlobCount) {
+			// nothing could be processed, cache is probably full, wait a bit before trying again
+			select {
+			case <-producer.ctx.Done():
+				return producer.ctx.Err()
+			case <-time.After(producer.strategy.BlobStrategy.delay()):
+			}
+		}
+	}
+	return nil
 }
 
 func (producer *getProducer) hasMoreToProcess(totalBlobCount int64) bool {
-    return producer.processedBlobTracker.NumberOfProcessedBlobs() < totalBlobCount || producer.deferredBlobQueue.Size() > 0
+	return producer.processedBlobTracker.NumberOfProcessedBlobs() < totalBlobCount || producer.deferredBlobQueue.Size() > 0
 }
 
 // Returns the number of blobs that have been queued for transfer
 func (producer *getProducer) queueBlobsReadyForTransfer(totalBlobCount int64) (int, error) {
-    // Attempt to transfer waiting blobs
-    processedCount, err := producer.processWaitingBlobs(*producer.JobMasterObjectList.BucketName, producer.JobMasterObjectList.JobId)
-    if err != nil {
-        return 0, err
-    }
+	// Attempt to transfer waiting blobs
+	processedCount, err := producer.processWaitingBlobs(*producer.JobMasterObjectList.BucketName, producer.JobMasterObjectList.JobId)
+	if err != nil {
+		return 0, err
+	}
 
-    // Check if we need to query the BP for allocated blobs, or if we already know everything is allocated.
-    if int64(producer.deferredBlobQueue.Size()) + producer.processedBlobTracker.NumberOfProcessedBlobs() >= totalBlobCount {
-        // Everything is already allocated, no need to query BP for allocated chunks
-        return processedCount, nil
-    }
+	// Check if we need to query the BP for allocated blobs, or if we already know everything is allocated.
+	if int64(producer.deferredBlobQueue.Size())+producer.processedBlobTracker.NumberOfProcessedBlobs() >= totalBlobCount {
+		// Everything is already allocated, no need to query BP for allocated chunks
+		return processedCount, nil
+	}
 
-    // Get the list of available chunks that the server can receive. The server may
-    // not be able to receive everything, so not all chunks will necessarily be
-    // returned
-    chunksReady := ds3Models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(producer.JobMasterObjectList.JobId)
-    chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(producer.ctx, chunksReady)
-    if err != nil {
-        producer.Errorf("unrecoverable error: %v", err)
-        return processedCount, err
-    }
+	// Get the list of available chunks that the server can receive. The server may
+	// not be able to receive everything, so not all chunks will necessarily be
+	// returned
+	chunksReady := ds3Models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(producer.JobMasterObjectList.JobId)
+	chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(producer.ctx, chunksReady)
+	if err != nil {
+		producer.Errorf("unrecoverable error: %v", err)
+		return processedCount, err
+	}
 
-    // Check to see if any chunks can be processed
-    numberOfChunks := len(chunksReadyResponse.MasterObjectList.Objects)
-    if numberOfChunks > 0 {
-        // Loop through all the chunks that are available for processing, and send
-        // the files that are contained within them.
-        for _, curChunk := range chunksReadyResponse.MasterObjectList.Objects {
-            justProcessedCount, err := producer.processChunk(&curChunk, *chunksReadyResponse.MasterObjectList.BucketName, chunksReadyResponse.MasterObjectList.JobId)
-            if err != nil {
-                return 0, err
-            }
-            processedCount += justProcessedCount
-        }
-    }
-    return processedCount, nil
+	// Check to see if any chunks can be processed
+	numberOfChunks := len(chunksReadyResponse.MasterObjectList.Objects)
+	if numberOfChunks > 0 {
+		// Loop through all the chunks that are available for processing, and send
+		// the files that are contained within them.
+		for _, curChunk := range chunksReadyResponse.MasterObjectList.Objects {
+			justProcessedCount, err := producer.processChunk(&curChunk, *chunksReadyResponse.MasterObjectList.BucketName, chunksReadyResponse.MasterObjectList.JobId)
+			if err != nil {
+				return 0, err
+			}
+			processedCount += justProcessedCount
+		}
+	}
+	return processedCount, nil
 }
 
 // Determines the number of blobs to be transferred.
 func (producer *getProducer) totalBlobCount() int64 {
-    if producer.JobMasterObjectList.Objects == nil || len(producer.JobMasterObjectList.Objects) == 0 {
-        return 0
-    }
+	if producer.JobMasterObjectList.Objects == nil || len(producer.JobMasterObjectList.Objects) == 0 {
+		return 0
+	}
 
-    var count int64 = 0
-    for _, chunk := range producer.JobMasterObjectList.Objects {
-        for range chunk.Objects {
-            count++
-        }
-    }
-    return count
+	var count int64 = 0
+	for _, chunk := range producer.JobMasterObjectList.Objects {
+		for range chunk.Objects {
+			count++
+		}
+	}
+	return count
 }

--- a/helpers/getTransfernator.go
+++ b/helpers/getTransfernator.go
@@ -1,136 +1,136 @@
 package helpers
 
 import (
-    "context"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "net/http"
-    "sync"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"net/http"
+	"sync"
 )
 
 type getTransceiver struct {
-    BucketName  string
-    ReadObjects *[]helperModels.GetObject
-    Strategy    *ReadTransferStrategy
-    Client      *ds3.Client
+	BucketName  string
+	ReadObjects *[]helperModels.GetObject
+	Strategy    *ReadTransferStrategy
+	Client      *ds3.Client
 }
 
 func newGetTransceiver(bucketName string, readObjects *[]helperModels.GetObject, strategy *ReadTransferStrategy, client *ds3.Client) *getTransceiver {
-    return &getTransceiver{
-        BucketName:  bucketName,
-        ReadObjects: readObjects,
-        Strategy:    strategy,
-        Client:      client,
-    }
+	return &getTransceiver{
+		BucketName:  bucketName,
+		ReadObjects: readObjects,
+		Strategy:    strategy,
+		Client:      client,
+	}
 }
 
 // Creates the bulk get request from the list of write objects and get bulk job options
 func newBulkGetRequest(bucketName string, readObjects *[]helperModels.GetObject, options ReadBulkJobOptions) *ds3Models.GetBulkJobSpectraS3Request {
-    var getObjects []ds3Models.Ds3GetObject
-    for _, obj := range *readObjects {
-        getObjects = append(getObjects, createPartialGetObjects(obj)...)
-    }
+	var getObjects []ds3Models.Ds3GetObject
+	for _, obj := range *readObjects {
+		getObjects = append(getObjects, createPartialGetObjects(obj)...)
+	}
 
-    bulkGet := ds3Models.NewGetBulkJobSpectraS3RequestWithPartialObjects(bucketName, getObjects)
-    if options.Aggregating != nil {
-        bulkGet.WithAggregating(*options.Aggregating)
-    }
-    if options.ChunkClientProcessingOrderGuarantee != ds3Models.UNDEFINED {
-        bulkGet.WithChunkClientProcessingOrderGuarantee(options.ChunkClientProcessingOrderGuarantee)
-    }
-    if options.ImplicitJobIdResolution != nil {
-        bulkGet.WithImplicitJobIdResolution(*options.ImplicitJobIdResolution)
-    }
-    if options.Priority != ds3Models.UNDEFINED {
-        bulkGet.WithPriority(options.Priority)
-    }
-    if options.Name != nil {
-        bulkGet.WithName(*options.Name)
-    }
+	bulkGet := ds3Models.NewGetBulkJobSpectraS3RequestWithPartialObjects(bucketName, getObjects)
+	if options.Aggregating != nil {
+		bulkGet.WithAggregating(*options.Aggregating)
+	}
+	if options.ChunkClientProcessingOrderGuarantee != ds3Models.UNDEFINED {
+		bulkGet.WithChunkClientProcessingOrderGuarantee(options.ChunkClientProcessingOrderGuarantee)
+	}
+	if options.ImplicitJobIdResolution != nil {
+		bulkGet.WithImplicitJobIdResolution(*options.ImplicitJobIdResolution)
+	}
+	if options.Priority != ds3Models.UNDEFINED {
+		bulkGet.WithPriority(options.Priority)
+	}
+	if options.Name != nil {
+		bulkGet.WithName(*options.Name)
+	}
 
-    return bulkGet
+	return bulkGet
 }
 
 // Converts a GetObject into its corresponding Ds3GetObjects for use in bulk get request building.
 func createPartialGetObjects(getObject helperModels.GetObject) []ds3Models.Ds3GetObject {
-    // handle getting the entire object
-    if len(getObject.Ranges) == 0 {
-        return []ds3Models.Ds3GetObject { { Name:getObject.Name } }
-    }
-    // handle partial object retrieval
-    var partialObjects []ds3Models.Ds3GetObject
-    for _, r := range getObject.Ranges {
-        offset := r.Start
-        length := r.End - r.Start + 1
-        partialObjects = append(partialObjects, ds3Models.Ds3GetObject{Name:getObject.Name, Offset:&offset, Length:&length})
-    }
-    return partialObjects
+	// handle getting the entire object
+	if len(getObject.Ranges) == 0 {
+		return []ds3Models.Ds3GetObject{{Name: getObject.Name}}
+	}
+	// handle partial object retrieval
+	var partialObjects []ds3Models.Ds3GetObject
+	for _, r := range getObject.Ranges {
+		offset := r.Start
+		length := r.End - r.Start + 1
+		partialObjects = append(partialObjects, ds3Models.Ds3GetObject{Name: getObject.Name, Offset: &offset, Length: &length})
+	}
+	return partialObjects
 }
 
 func (transceiver *getTransceiver) createBulkGetJob(ctx context.Context) (*ds3Models.GetBulkJobSpectraS3Response, *[]helperModels.GetObject, error) {
-    // attempt to create a bulk get of all objects
-    bulkGet := newBulkGetRequest(transceiver.BucketName, transceiver.ReadObjects, transceiver.Strategy.Options)
-    bulkGetResponse, err := transceiver.Client.GetBulkJobSpectraS3(ctx, bulkGet)
-    if err == nil {
-        return bulkGetResponse, transceiver.ReadObjects, nil
-    }
+	// attempt to create a bulk get of all objects
+	bulkGet := newBulkGetRequest(transceiver.BucketName, transceiver.ReadObjects, transceiver.Strategy.Options)
+	bulkGetResponse, err := transceiver.Client.GetBulkJobSpectraS3(ctx, bulkGet)
+	if err == nil {
+		return bulkGetResponse, transceiver.ReadObjects, nil
+	}
 
-    badStatusErr, ok := err.(*ds3Models.BadStatusCodeError)
-    if !ok || badStatusErr.ActualStatusCode != http.StatusNotFound{
-        // failed to create bulk get for reason other than 404
-        return nil, nil, err
-    }
+	badStatusErr, ok := err.(*ds3Models.BadStatusCodeError)
+	if !ok || badStatusErr.ActualStatusCode != http.StatusNotFound {
+		// failed to create bulk get for reason other than 404
+		return nil, nil, err
+	}
 
-    // head each item and try again for all objects that exist in the bucket
-    var objectsThatExist []helperModels.GetObject
-    for _, obj := range *transceiver.ReadObjects {
-        _, err := transceiver.Client.HeadObject(ctx, ds3Models.NewHeadObjectRequest(transceiver.BucketName, obj.Name))
-        if err != nil {
-            // mark file as having a fatal error
-            readableErr := fmt.Errorf("failed HeadObject call on %s: %v", obj.Name, err)
-            obj.ChannelBuilder.SetFatalError(readableErr)
-            transceiver.Strategy.Listeners.Errored(obj.Name, readableErr)
-        } else {
-            objectsThatExist = append(objectsThatExist, obj)
-        }
-    }
-    if len(objectsThatExist) <= 0 {
-        return nil, nil, err
-    }
+	// head each item and try again for all objects that exist in the bucket
+	var objectsThatExist []helperModels.GetObject
+	for _, obj := range *transceiver.ReadObjects {
+		_, err := transceiver.Client.HeadObject(ctx, ds3Models.NewHeadObjectRequest(transceiver.BucketName, obj.Name))
+		if err != nil {
+			// mark file as having a fatal error
+			readableErr := fmt.Errorf("failed HeadObject call on %s: %v", obj.Name, err)
+			obj.ChannelBuilder.SetFatalError(readableErr)
+			transceiver.Strategy.Listeners.Errored(obj.Name, readableErr)
+		} else {
+			objectsThatExist = append(objectsThatExist, obj)
+		}
+	}
+	if len(objectsThatExist) <= 0 {
+		return nil, nil, err
+	}
 
-    // create bulk get job for all objects that exist in the bucket
-    bulkGet = newBulkGetRequest(transceiver.BucketName, &objectsThatExist, transceiver.Strategy.Options)
-    bulkGetResponse, err = transceiver.Client.GetBulkJobSpectraS3(ctx, bulkGet)
-    if err != nil {
-        return nil, nil, err
-    } else {
-        return bulkGetResponse, &objectsThatExist, nil
-    }
+	// create bulk get job for all objects that exist in the bucket
+	bulkGet = newBulkGetRequest(transceiver.BucketName, &objectsThatExist, transceiver.Strategy.Options)
+	bulkGetResponse, err = transceiver.Client.GetBulkJobSpectraS3(ctx, bulkGet)
+	if err != nil {
+		return nil, nil, err
+	} else {
+		return bulkGetResponse, &objectsThatExist, nil
+	}
 }
 
 func (transceiver *getTransceiver) transfer(ctx context.Context) (string, error) {
-    // create bulk get job
-    bulkGetResponse, objectsToRetrieve, err := transceiver.createBulkGetJob(ctx)
-    if err != nil {
-        return "", err
-    }
+	// create bulk get job
+	bulkGetResponse, objectsToRetrieve, err := transceiver.createBulkGetJob(ctx)
+	if err != nil {
+		return "", err
+	}
 
-    // init queue, producer and consumer
-    var waitGroup sync.WaitGroup
+	// init queue, producer and consumer
+	var waitGroup sync.WaitGroup
 
-    doneNotifier := NewConditionalBool()
+	doneNotifier := NewConditionalBool()
 
-    queue := newOperationQueue(transceiver.Strategy.BlobStrategy.maxWaitingTransfers(), transceiver.Client.Logger)
-    producer := newGetProducer(ctx, &bulkGetResponse.MasterObjectList, objectsToRetrieve, &queue, transceiver.Strategy, transceiver.Client, &waitGroup, doneNotifier)
-    consumer := newConsumer(&queue, &waitGroup, transceiver.Strategy.BlobStrategy.maxConcurrentTransfers(), doneNotifier)
+	queue := newOperationQueue(transceiver.Strategy.BlobStrategy.maxWaitingTransfers(), transceiver.Client.Logger)
+	producer := newGetProducer(ctx, &bulkGetResponse.MasterObjectList, objectsToRetrieve, &queue, transceiver.Strategy, transceiver.Client, &waitGroup, doneNotifier)
+	consumer := newConsumer(&queue, &waitGroup, transceiver.Strategy.BlobStrategy.maxConcurrentTransfers(), doneNotifier)
 
-    // Wait for completion of producer-consumer goroutines
-    waitGroup.Add(1)  // adding producer and consumer goroutines to wait group
-    go consumer.run()
-    err = producer.run() // producer will add to waitGroup for every blob retrieval added to queue, and each transfer performed will decrement from waitGroup
-    waitGroup.Wait()
+	// Wait for completion of producer-consumer goroutines
+	waitGroup.Add(1) // adding producer and consumer goroutines to wait group
+	go consumer.run()
+	err = producer.run() // producer will add to waitGroup for every blob retrieval added to queue, and each transfer performed will decrement from waitGroup
+	waitGroup.Wait()
 
-    return bulkGetResponse.MasterObjectList.JobId, err
+	return bulkGetResponse.MasterObjectList.JobId, err
 }

--- a/helpers/helpersImpl.go
+++ b/helpers/helpersImpl.go
@@ -1,48 +1,48 @@
 package helpers
 
 import (
-    "context"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "github.com/SpectraLogic/ds3_go_sdk/helpers/ranges"
-    "net/http"
-    "sort"
-    "strings"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"github.com/SpectraLogic/ds3_go_sdk/helpers/ranges"
+	"net/http"
+	"sort"
+	"strings"
 )
 
 type HelperInterface interface {
-    //ListObjectsFromBucket(bucketName string) []ds3Models.S3Object
-    //ListObjectsFromDirectory(directoryName string) []helperModels.PutObject
+	//ListObjectsFromBucket(bucketName string) []ds3Models.S3Object
+	//ListObjectsFromDirectory(directoryName string) []helperModels.PutObject
 
-    // Puts the specified list of objects on the Black Pearl in the specified bucket.
-    // Returns the Black Pearl bulk put Job ID and any errors that may have occurred.
-    // A job ID will be returned if a BP job was successfully created, regardless of
-    // whether additional errors occur. Cancelling ctx aborts in-flight requests and
-    // stops the producer between attempts.
-    PutObjects(ctx context.Context, bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (string, error)
+	// Puts the specified list of objects on the Black Pearl in the specified bucket.
+	// Returns the Black Pearl bulk put Job ID and any errors that may have occurred.
+	// A job ID will be returned if a BP job was successfully created, regardless of
+	// whether additional errors occur. Cancelling ctx aborts in-flight requests and
+	// stops the producer between attempts.
+	PutObjects(ctx context.Context, bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (string, error)
 
-    // Retrieves the list of objects from the specified bucket on the Black Pearl.
-    // Returns the Black Pearl bulk get Job ID and any errors that may have occurred.
-    // A job ID will be returned if a BP job was successfully created, regardless of
-    // whether additional errors occur. Cancelling ctx aborts in-flight requests and
-    // stops the producer between attempts.
-    GetObjects(ctx context.Context, bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (string, error)
+	// Retrieves the list of objects from the specified bucket on the Black Pearl.
+	// Returns the Black Pearl bulk get Job ID and any errors that may have occurred.
+	// A job ID will be returned if a BP job was successfully created, regardless of
+	// whether additional errors occur. Cancelling ctx aborts in-flight requests and
+	// stops the producer between attempts.
+	GetObjects(ctx context.Context, bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (string, error)
 
-    // Retrieves the list of objects from the specified bucket on the Black Pearl.
-    // If a get job cannot be created due to insufficient cache space to fulfill an
-    // IN_ORDER processing guarantee, then the job is split across multiple BP jobs.
-    // This allows for the IN_ORDER retrieval of objects that exceed available cache space.
-    GetObjectsSpanningJobs(ctx context.Context, bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) ([]string, error)
+	// Retrieves the list of objects from the specified bucket on the Black Pearl.
+	// If a get job cannot be created due to insufficient cache space to fulfill an
+	// IN_ORDER processing guarantee, then the job is split across multiple BP jobs.
+	// This allows for the IN_ORDER retrieval of objects that exceed available cache space.
+	GetObjectsSpanningJobs(ctx context.Context, bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) ([]string, error)
 }
 
 type HelperImpl struct {
-     client *ds3.Client
+	client *ds3.Client
 }
 
 func NewHelpers(client *ds3.Client) HelperInterface {
-    return &HelperImpl{client:client}
+	return &HelperImpl{client: client}
 }
 
 /*
@@ -56,127 +56,127 @@ func (helper *HelperImpl) ListObjectsFromDirectory(directoryName string) []helpe
 */
 
 func (helper *HelperImpl) PutObjects(ctx context.Context, bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (string, error) {
-    transceiver := newPutTransceiver(bucketName, &objects, &strategy, helper.client)
-    return transceiver.transfer(ctx)
+	transceiver := newPutTransceiver(bucketName, &objects, &strategy, helper.client)
+	return transceiver.transfer(ctx)
 }
 
 func (helper *HelperImpl) GetObjects(ctx context.Context, bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (string, error) {
-    transceiver := newGetTransceiver(bucketName, &objects, &strategy, helper.client)
-    return transceiver.transfer(ctx)
+	transceiver := newGetTransceiver(bucketName, &objects, &strategy, helper.client)
+	return transceiver.transfer(ctx)
 }
 
 func (helper *HelperImpl) GetObjectsSpanningJobs(ctx context.Context, bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) ([]string, error) {
-    // Attempt to send the entire job at once
-    jobId, err := helper.GetObjects(ctx, bucketName, objects, strategy)
-    if err == nil {
-        // success
-        return []string{jobId}, nil
-    } else if !helper.isCannotPreAllocateError(err) {
-        // error not related to pre-allocation
-        return nil, err
-    }
+	// Attempt to send the entire job at once
+	jobId, err := helper.GetObjects(ctx, bucketName, objects, strategy)
+	if err == nil {
+		// success
+		return []string{jobId}, nil
+	} else if !helper.isCannotPreAllocateError(err) {
+		// error not related to pre-allocation
+		return nil, err
+	}
 
-    // Retrieve each file individually
-    var jobIds []string
-    for _, getObject := range objects {
-        fileJobIds := helper.retrieveIndividualFile(ctx, bucketName, getObject, strategy)
-        jobIds = append(jobIds, fileJobIds...)
-    }
-    return jobIds, nil
+	// Retrieve each file individually
+	var jobIds []string
+	for _, getObject := range objects {
+		fileJobIds := helper.retrieveIndividualFile(ctx, bucketName, getObject, strategy)
+		jobIds = append(jobIds, fileJobIds...)
+	}
+	return jobIds, nil
 }
 
 func (helper *HelperImpl) isCannotPreAllocateError(err error) bool {
-    badStatusErr, ok := err.(*models.BadStatusCodeError)
-    if !ok || badStatusErr.ActualStatusCode != http.StatusServiceUnavailable {
-        // failed to create bulk get for reason other than 503
-        return false
-    }
+	badStatusErr, ok := err.(*models.BadStatusCodeError)
+	if !ok || badStatusErr.ActualStatusCode != http.StatusServiceUnavailable {
+		// failed to create bulk get for reason other than 503
+		return false
+	}
 
-    if strings.Contains(badStatusErr.Error(), "GET jobs that have a chunkClientProcessingOrderGuarantee of IN_ORDER must be entirely pre-allocated.  Cannot pre-allocate") {
-        return true
-    }
-    return false
+	if strings.Contains(badStatusErr.Error(), "GET jobs that have a chunkClientProcessingOrderGuarantee of IN_ORDER must be entirely pre-allocated.  Cannot pre-allocate") {
+		return true
+	}
+	return false
 }
 
 func (helper *HelperImpl) retrieveIndividualFile(ctx context.Context, bucketName string, getObject helperModels.GetObject, strategy ReadTransferStrategy) []string {
-    // Get the blob offsets
-    headObject, err := helper.client.HeadObject(ctx, models.NewHeadObjectRequest(bucketName, getObject.Name))
-    if err != nil {
-        getObject.ChannelBuilder.SetFatalError(err)
-        return nil
-    }
-    var offsets []int64
-    for offset := range headObject.BlobChecksums {
-        offsets = append(offsets, offset)
-    }
+	// Get the blob offsets
+	headObject, err := helper.client.HeadObject(ctx, models.NewHeadObjectRequest(bucketName, getObject.Name))
+	if err != nil {
+		getObject.ChannelBuilder.SetFatalError(err)
+		return nil
+	}
+	var offsets []int64
+	for offset := range headObject.BlobChecksums {
+		offsets = append(offsets, offset)
+	}
 
-    sort.Slice(offsets, func(i, j int) bool {
-        return offsets[i] < offsets[j]
-    })
+	sort.Slice(offsets, func(i, j int) bool {
+		return offsets[i] < offsets[j]
+	})
 
-    // Get the object size
-    objectsDetails, err := helper.client.GetObjectsWithFullDetailsSpectraS3(
-        ctx,
-        models.NewGetObjectsWithFullDetailsSpectraS3Request().
-            WithBucketId(bucketName).WithName(getObject.Name).
-            WithLatest(true))
+	// Get the object size
+	objectsDetails, err := helper.client.GetObjectsWithFullDetailsSpectraS3(
+		ctx,
+		models.NewGetObjectsWithFullDetailsSpectraS3Request().
+			WithBucketId(bucketName).WithName(getObject.Name).
+			WithLatest(true))
 
-    if err != nil {
-        getObject.ChannelBuilder.SetFatalError(err)
-        return nil
-    } else if len(objectsDetails.DetailedS3ObjectList.DetailedS3Objects) < 1 {
-        getObject.ChannelBuilder.SetFatalError(fmt.Errorf("failed to get object details"))
-        return nil
-    }
+	if err != nil {
+		getObject.ChannelBuilder.SetFatalError(err)
+		return nil
+	} else if len(objectsDetails.DetailedS3ObjectList.DetailedS3Objects) < 1 {
+		getObject.ChannelBuilder.SetFatalError(fmt.Errorf("failed to get object details"))
+		return nil
+	}
 
-    // Retrieve the object one blob at a time in order
-    objectCopy := getObject
-    objectEnd := objectsDetails.DetailedS3ObjectList.DetailedS3Objects[0].Size - 1
-    if len(objectCopy.Ranges) == 0 {
-        // If the user didn't specify a range, add a range that covers the entire file
-        // so that we can use the blobRangeFinder to tell us what ranges to specify.
-        objectCopy.Ranges = append(objectCopy.Ranges, models.Range{Start: 0, End: objectEnd})
-    }
-    blobFinder := ranges.NewBlobRangeFinder(&[]helperModels.GetObject{objectCopy})
+	// Retrieve the object one blob at a time in order
+	objectCopy := getObject
+	objectEnd := objectsDetails.DetailedS3ObjectList.DetailedS3Objects[0].Size - 1
+	if len(objectCopy.Ranges) == 0 {
+		// If the user didn't specify a range, add a range that covers the entire file
+		// so that we can use the blobRangeFinder to tell us what ranges to specify.
+		objectCopy.Ranges = append(objectCopy.Ranges, models.Range{Start: 0, End: objectEnd})
+	}
+	blobFinder := ranges.NewBlobRangeFinder(&[]helperModels.GetObject{objectCopy})
 
-    var jobIds []string
-    for i, offset := range offsets {
-        var blobEnd int64
-        if i+1 < len(offsets) {
-            blobEnd = offsets[i+1]-1
-        } else {
-            blobEnd = objectEnd
-        }
-        length := blobEnd - offset + 1
-        blobRanges := blobFinder.GetRanges(objectCopy.Name, offset, length)
-        if len(blobRanges) == 0 {
-            // This blob does not need to be retrieved
-            continue
-        }
+	var jobIds []string
+	for i, offset := range offsets {
+		var blobEnd int64
+		if i+1 < len(offsets) {
+			blobEnd = offsets[i+1] - 1
+		} else {
+			blobEnd = objectEnd
+		}
+		length := blobEnd - offset + 1
+		blobRanges := blobFinder.GetRanges(objectCopy.Name, offset, length)
+		if len(blobRanges) == 0 {
+			// This blob does not need to be retrieved
+			continue
+		}
 
-        jobId, err := helper.retrieveBlob(ctx, bucketName, getObject, blobRanges, strategy)
-        if err != nil {
-            getObject.ChannelBuilder.SetFatalError(err)
-            return nil
-        }
-        jobIds = append(jobIds, jobId)
+		jobId, err := helper.retrieveBlob(ctx, bucketName, getObject, blobRanges, strategy)
+		if err != nil {
+			getObject.ChannelBuilder.SetFatalError(err)
+			return nil
+		}
+		jobIds = append(jobIds, jobId)
 
-        if objectCopy.ChannelBuilder.HasFatalError() {
-            // Failed to retrieve a portion of the file, don't bother with the rest
-            break
-        }
-    }
-    return jobIds
+		if objectCopy.ChannelBuilder.HasFatalError() {
+			// Failed to retrieve a portion of the file, don't bother with the rest
+			break
+		}
+	}
+	return jobIds
 }
 
 func (helper *HelperImpl) retrieveBlob(ctx context.Context, bucketName string, getObject helperModels.GetObject, blobRanges []models.Range, strategy ReadTransferStrategy) (string, error) {
-    // Since there is only one blob being retrieved, create the job with Order-Guarantee=None so that the
-    // job will wait if cache needs to be reclaimed on the BP before the chunk can be allocated.
-    getObjectBlob := getObject
-    getObjectBlob.Ranges = blobRanges
+	// Since there is only one blob being retrieved, create the job with Order-Guarantee=None so that the
+	// job will wait if cache needs to be reclaimed on the BP before the chunk can be allocated.
+	getObjectBlob := getObject
+	getObjectBlob.Ranges = blobRanges
 
-    strategyCopy := strategy
-    strategyCopy.Options.ChunkClientProcessingOrderGuarantee = models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_NONE
+	strategyCopy := strategy
+	strategyCopy.Options.ChunkClientProcessingOrderGuarantee = models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_NONE
 
-    return helper.GetObjects(ctx, bucketName, []helperModels.GetObject{getObjectBlob}, strategyCopy)
+	return helper.GetObjects(ctx, bucketName, []helperModels.GetObject{getObjectBlob}, strategyCopy)
 }

--- a/helpers/helpersImpl_test.go
+++ b/helpers/helpersImpl_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 type randomDataReader struct {
-	curRead int
-	maxRead int
-	mutex sync.Mutex
+	curRead       int
+	maxRead       int
+	mutex         sync.Mutex
 	totalFileHash hash.Hash
-	rangesHash hash.Hash
-	ranges []ds3Models.Range
+	rangesHash    hash.Hash
+	ranges        []ds3Models.Range
 }
 
 func (reader *randomDataReader) Read(p []byte) (int, error) {
@@ -78,7 +78,7 @@ type randomDataReadChannelBuilder struct {
 }
 
 func (builder *randomDataReadChannelBuilder) IsChannelAvailable(offset int64) bool {
-	 return int64(builder.randomDataReader.curRead) == offset
+	return int64(builder.randomDataReader.curRead) == offset
 }
 
 func (builder *randomDataReadChannelBuilder) GetChannel(_ int64) (io.ReadCloser, error) {
@@ -90,8 +90,8 @@ func (builder *randomDataReadChannelBuilder) OnDone(reader io.ReadCloser) {
 }
 
 type consumeWriter struct {
-	size int64
-	hash hash.Hash
+	size  int64
+	hash  hash.Hash
 	mutex sync.Mutex
 }
 
@@ -134,7 +134,7 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 	const minCache = 1073741824
 	const objectSize = minCache + 100
 
-	testRanges := []ds3Models.Range{{Start: 2, End: 10}, {Start: 30, End: 40}, {Start: 50, End: 60}, {Start: 80, End: objectSize-1}}
+	testRanges := []ds3Models.Range{{Start: 2, End: 10}, {Start: 30, End: 40}, {Start: 50, End: 60}, {Start: 80, End: objectSize - 1}}
 
 	bucketName := fmt.Sprintf("testBucket-%d", time.Now().UnixNano())
 	objectName := fmt.Sprintf("testObject-%d", time.Now().UnixNano())
@@ -178,11 +178,11 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 
 	objReader := randomDataReader{
 		maxRead: objectSize,
-		ranges: testRanges,
+		ranges:  testRanges,
 	}
 
 	putObject := models.PutObject{
-		PutObject:      ds3Models.Ds3PutObject{
+		PutObject: ds3Models.Ds3PutObject{
 			Name: objectName,
 			Size: int64(objectSize),
 		},
@@ -194,12 +194,12 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 
 	writeStrategy := WriteTransferStrategy{
 		BlobStrategy: &SimpleBlobStrategy{
-			Delay: time.Millisecond * 10,
+			Delay:                  time.Millisecond * 10,
 			MaxConcurrentTransfers: 5,
-			MaxWaitingTransfers: 1,
+			MaxWaitingTransfers:    1,
 		},
-		Options:      WriteBulkJobOptions{MaxUploadSize: &MinUploadSize},
-		Listeners:    ListenerStrategy{
+		Options: WriteBulkJobOptions{MaxUploadSize: &MinUploadSize},
+		Listeners: ListenerStrategy{
 			ErrorCallback: func(objectName string, err error) {
 				t.Errorf("unexpected error on '%s': %v", objectName, err)
 			},
@@ -216,12 +216,12 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 		}
 	}()
 
-	testCases := []struct{
-		name string
+	testCases := []struct {
+		name   string
 		ranges []ds3Models.Range
-	} {
-		{ name: "retrieve entire file", ranges: nil },
-		{ name: "retrieve ranges", ranges: testRanges},
+	}{
+		{name: "retrieve entire file", ranges: nil},
+		{name: "retrieve ranges", ranges: testRanges},
 	}
 
 	for _, testCase := range testCases {
@@ -232,12 +232,12 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 
 			readStrategy := ReadTransferStrategy{
 				BlobStrategy: &SimpleBlobStrategy{
-					Delay: time.Millisecond * 10,
+					Delay:                  time.Millisecond * 10,
 					MaxConcurrentTransfers: 5,
-					MaxWaitingTransfers: 1,
+					MaxWaitingTransfers:    1,
 				},
-				Options:      ReadBulkJobOptions{ChunkClientProcessingOrderGuarantee: ds3Models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER},
-				Listeners:    ListenerStrategy{
+				Options: ReadBulkJobOptions{ChunkClientProcessingOrderGuarantee: ds3Models.JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER},
+				Listeners: ListenerStrategy{
 					ErrorCallback: func(objectName string, err error) {
 						t.Errorf("unexpected error on '%s': %v", objectName, err)
 					},
@@ -249,7 +249,7 @@ func TestRetrievingObjectLargerThanCacheInOrder(t *testing.T) {
 				Name:   objectName,
 				Ranges: testCase.ranges,
 				ChannelBuilder: &consumerWriteChannelBuilder{
-					writer: &objWriter,
+					writer:            &objWriter,
 					FatalErrorHandler: channels.FatalErrorHandler{},
 				},
 			}

--- a/helpers/ioReaderWithSIzeDecorator.go
+++ b/helpers/ioReaderWithSIzeDecorator.go
@@ -5,18 +5,18 @@ import "io"
 // Defines a simple wrapper for an io.Reader and io.Closer which specifies size
 // Implements ReaderWithSizeDecorator.
 type IoReaderWithSizeDecorator struct {
-    reader io.Reader
-    size int64
+	reader io.Reader
+	size   int64
 }
 
 func NewIoReaderWithSizeDecorator(reader io.Reader, size int64) *IoReaderWithSizeDecorator {
-    return &IoReaderWithSizeDecorator{reader:reader, size:size}
+	return &IoReaderWithSizeDecorator{reader: reader, size: size}
 }
 
 func (sizedReader *IoReaderWithSizeDecorator) Read(bytes []byte) (int, error) {
-    return sizedReader.reader.Read(bytes)
+	return sizedReader.reader.Read(bytes)
 }
 
 func (sizedReader *IoReaderWithSizeDecorator) Size() (int64, error) {
-    return sizedReader.size, nil
+	return sizedReader.size, nil
 }

--- a/helpers/listeners.go
+++ b/helpers/listeners.go
@@ -1,13 +1,13 @@
 package helpers
 
 type ListenerStrategy struct {
-    // Called when an error occurred during transfer of an object.
-    // This must be a thread safe function.
-    ErrorCallback func(objectName string, err error)
+	// Called when an error occurred during transfer of an object.
+	// This must be a thread safe function.
+	ErrorCallback func(objectName string, err error)
 }
 
 func (listener *ListenerStrategy) Errored(objectName string, err error) {
-    if listener.ErrorCallback != nil {
-        listener.ErrorCallback(objectName, err)
-    }
+	if listener.ErrorCallback != nil {
+		listener.ErrorCallback(objectName, err)
+	}
 }

--- a/helpers/models/blobDescription.go
+++ b/helpers/models/blobDescription.go
@@ -2,27 +2,27 @@ package models
 
 // Describes a blob
 type BlobDescription struct {
-    name   string
-    offset int64
-    length int64
+	name   string
+	offset int64
+	length int64
 }
 
 func NewBlobDescription(name string, offset int64, length int64) BlobDescription {
-    return BlobDescription{
-        name:   name,
-        offset: offset,
-        length: length,
-    }
+	return BlobDescription{
+		name:   name,
+		offset: offset,
+		length: length,
+	}
 }
 
 func (d *BlobDescription) Name() string {
-    return d.name
+	return d.name
 }
 
 func (d *BlobDescription) Offset() int64 {
-    return d.offset
+	return d.offset
 }
 
 func (d *BlobDescription) Length() int64 {
-    return d.length
+	return d.length
 }

--- a/helpers/models/channelBuilder.go
+++ b/helpers/models/channelBuilder.go
@@ -3,21 +3,20 @@ package models
 import "io"
 
 type ChannelErrorHandler interface {
-    HasFatalError() bool // Determines if a fatal error has happened while transferring a file, i.e. don't transfer more blobs for this file.
-    SetFatalError(err error) // Sets a fatal error for the associated file. This will stop future blobs from being sent from this channel.
+	HasFatalError() bool     // Determines if a fatal error has happened while transferring a file, i.e. don't transfer more blobs for this file.
+	SetFatalError(err error) // Sets a fatal error for the associated file. This will stop future blobs from being sent from this channel.
 }
 
 type ReadChannelBuilder interface {
-    IsChannelAvailable(offset int64) bool
-    GetChannel(offset int64) (io.ReadCloser, error)
-    OnDone(reader io.ReadCloser) // Determines what a given blob does when it finishes transferring
-    ChannelErrorHandler
+	IsChannelAvailable(offset int64) bool
+	GetChannel(offset int64) (io.ReadCloser, error)
+	OnDone(reader io.ReadCloser) // Determines what a given blob does when it finishes transferring
+	ChannelErrorHandler
 }
 
 type WriteChannelBuilder interface {
-    IsChannelAvailable(offset int64) bool
-    GetChannel(offset int64) (io.WriteCloser, error)
-    OnDone(writer io.WriteCloser) // Determines what a given blob does when it finishes transferring
-    ChannelErrorHandler
+	IsChannelAvailable(offset int64) bool
+	GetChannel(offset int64) (io.WriteCloser, error)
+	OnDone(writer io.WriteCloser) // Determines what a given blob does when it finishes transferring
+	ChannelErrorHandler
 }
-

--- a/helpers/models/objects.go
+++ b/helpers/models/objects.go
@@ -6,22 +6,22 @@ import (
 )
 
 type GetObject struct {
-    Name string
-    Ranges []models.Range
-    ChannelBuilder WriteChannelBuilder
+	Name           string
+	Ranges         []models.Range
+	ChannelBuilder WriteChannelBuilder
 }
 
 type PutObject struct {
-    PutObject      models.Ds3PutObject
-    ChannelBuilder ReadChannelBuilder
-	Metadata map[string]string
+	PutObject      models.Ds3PutObject
+	ChannelBuilder ReadChannelBuilder
+	Metadata       map[string]string
 }
 
 func (putObject *PutObject) WithMetaData(key string, values ...string) interface{} {
 	if strings.HasPrefix(strings.ToLower(key), models.AMZ_META_HEADER) {
 		putObject.Metadata[key] = strings.Join(values, ",")
 	} else {
-		putObject.Metadata[strings.ToLower(models.AMZ_META_HEADER + key)] = strings.Join(values, ",")
+		putObject.Metadata[strings.ToLower(models.AMZ_META_HEADER+key)] = strings.Join(values, ",")
 	}
 
 	return putObject

--- a/helpers/operationQueue.go
+++ b/helpers/operationQueue.go
@@ -1,7 +1,7 @@
 package helpers
 
 import (
-    "github.com/SpectraLogic/ds3_go_sdk/sdk_log"
+	"github.com/SpectraLogic/ds3_go_sdk/sdk_log"
 )
 
 type TransferOperation func() // transfer operation that sends/gets stuff from BP
@@ -10,17 +10,17 @@ const MinQueueSize uint = 1
 const MaxQueueSize uint = 100
 
 func newOperationQueue(size uint, logger sdk_log.Logger) chan TransferOperation {
-    var queue chan TransferOperation
+	var queue chan TransferOperation
 
-    if size > MaxQueueSize {
-        logger.Warningf("invalid operation queue size: specified value '%d' which exceeds the maximum, defaulting to '%d'", size, MaxQueueSize)
-        queue = make(chan TransferOperation, MaxQueueSize)
-    } else if size < MinQueueSize {
-        logger.Warningf("invalid operation queue size: specified value '%d' which is below the minimum, defaulting to '%d'", size, MinQueueSize)
-        queue = make(chan TransferOperation, MinQueueSize)
-    } else {
-        queue = make(chan TransferOperation, size)
-    }
+	if size > MaxQueueSize {
+		logger.Warningf("invalid operation queue size: specified value '%d' which exceeds the maximum, defaulting to '%d'", size, MaxQueueSize)
+		queue = make(chan TransferOperation, MaxQueueSize)
+	} else if size < MinQueueSize {
+		logger.Warningf("invalid operation queue size: specified value '%d' which is below the minimum, defaulting to '%d'", size, MinQueueSize)
+		queue = make(chan TransferOperation, MinQueueSize)
+	} else {
+		queue = make(chan TransferOperation, size)
+	}
 
-    return queue
+	return queue
 }

--- a/helpers/producer.go
+++ b/helpers/producer.go
@@ -3,5 +3,5 @@ package helpers
 import "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 
 type Producer interface {
-    run(error *models.AggregateError)
+	run(error *models.AggregateError)
 }

--- a/helpers/putProducer.go
+++ b/helpers/putProducer.go
@@ -1,116 +1,116 @@
 package helpers
 
 import (
-    "context"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "github.com/SpectraLogic/ds3_go_sdk/sdk_log"
-    "sync"
-    "time"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"github.com/SpectraLogic/ds3_go_sdk/sdk_log"
+	"sync"
+	"time"
 )
 
 type putProducer struct {
-    ctx                  context.Context
-    JobMasterObjectList  *ds3Models.MasterObjectList //MOL from put bulk job creation
-    WriteObjects         *[]helperModels.PutObject
-    queue                *chan TransferOperation
-    strategy             *WriteTransferStrategy
-    client               *ds3.Client
-    waitGroup            *sync.WaitGroup
-    writeObjectMap       map[string]helperModels.PutObject
-    processedBlobTracker blobTracker
-    deferredBlobQueue    BlobDescriptionQueue // queue of blobs whose channels are not yet ready for transfer
-    sdk_log.Logger
+	ctx                  context.Context
+	JobMasterObjectList  *ds3Models.MasterObjectList //MOL from put bulk job creation
+	WriteObjects         *[]helperModels.PutObject
+	queue                *chan TransferOperation
+	strategy             *WriteTransferStrategy
+	client               *ds3.Client
+	waitGroup            *sync.WaitGroup
+	writeObjectMap       map[string]helperModels.PutObject
+	processedBlobTracker blobTracker
+	deferredBlobQueue    BlobDescriptionQueue // queue of blobs whose channels are not yet ready for transfer
+	sdk_log.Logger
 
-    // Conditional value that gets triggered when a blob has finished being transferred
-    doneNotifier NotifyBlobDone
+	// Conditional value that gets triggered when a blob has finished being transferred
+	doneNotifier NotifyBlobDone
 }
 
 func newPutProducer(
-    ctx context.Context,
-    jobMasterObjectList *ds3Models.MasterObjectList,
-    putObjects *[]helperModels.PutObject,
-    queue *chan TransferOperation,
-    strategy *WriteTransferStrategy,
-    client *ds3.Client,
-    waitGroup *sync.WaitGroup,
-    doneNotifier NotifyBlobDone) *putProducer {
+	ctx context.Context,
+	jobMasterObjectList *ds3Models.MasterObjectList,
+	putObjects *[]helperModels.PutObject,
+	queue *chan TransferOperation,
+	strategy *WriteTransferStrategy,
+	client *ds3.Client,
+	waitGroup *sync.WaitGroup,
+	doneNotifier NotifyBlobDone) *putProducer {
 
-    return &putProducer{
-        ctx:                  ctx,
-        JobMasterObjectList:  jobMasterObjectList,
-        WriteObjects:         putObjects,
-        queue:                queue,
-        strategy:             strategy,
-        client:               client,
-        waitGroup:            waitGroup,
-        writeObjectMap:       toWriteObjectMap(putObjects),
-        deferredBlobQueue:    NewBlobDescriptionQueue(),
-        processedBlobTracker: newProcessedBlobTracker(),
-        Logger:               client.Logger, // use the same logger as the client
-        doneNotifier:         doneNotifier,
-    }
+	return &putProducer{
+		ctx:                  ctx,
+		JobMasterObjectList:  jobMasterObjectList,
+		WriteObjects:         putObjects,
+		queue:                queue,
+		strategy:             strategy,
+		client:               client,
+		waitGroup:            waitGroup,
+		writeObjectMap:       toWriteObjectMap(putObjects),
+		deferredBlobQueue:    NewBlobDescriptionQueue(),
+		processedBlobTracker: newProcessedBlobTracker(),
+		Logger:               client.Logger, // use the same logger as the client
+		doneNotifier:         doneNotifier,
+	}
 }
 
 // Creates a map of object name to PutObject struct
 func toWriteObjectMap(putObjects *[]helperModels.PutObject) map[string]helperModels.PutObject {
-    objectMap := make(map[string]helperModels.PutObject)
+	objectMap := make(map[string]helperModels.PutObject)
 
-    if putObjects == nil {
-        return objectMap
-    }
+	if putObjects == nil {
+		return objectMap
+	}
 
-    for _, obj := range *putObjects {
-        objectMap[obj.PutObject.Name] = obj
-    }
+	for _, obj := range *putObjects {
+		objectMap[obj.PutObject.Name] = obj
+	}
 
-    return objectMap
+	return objectMap
 }
 
 // Information required to perform a put operation of a blob using the source channelBuilder to BP destination
 type putObjectInfo struct {
-    blob           helperModels.BlobDescription
-    channelBuilder helperModels.ReadChannelBuilder
-    bucketName     string
-    jobId          string
+	blob           helperModels.BlobDescription
+	channelBuilder helperModels.ReadChannelBuilder
+	bucketName     string
+	jobId          string
 }
 
 // Creates the transfer operation that will perform the data upload of the specified blob to BP
 func (producer *putProducer) transferOperationBuilder(info putObjectInfo) TransferOperation {
-    return func() {
-        // has this file fatally errored while transferring a different blob?
-        if info.channelBuilder.HasFatalError() {
-            // skip performing this blob transfer
-            producer.Warningf("fatal error occurred previously on this file, skipping sending blob name='%s' offset=%d length=%d", info.blob.Name(), info.blob.Offset(), info.blob.Length())
-            return
-        }
-        reader, err := info.channelBuilder.GetChannel(info.blob.Offset())
-        if err != nil {
-            producer.strategy.Listeners.Errored(info.blob.Name(), err)
+	return func() {
+		// has this file fatally errored while transferring a different blob?
+		if info.channelBuilder.HasFatalError() {
+			// skip performing this blob transfer
+			producer.Warningf("fatal error occurred previously on this file, skipping sending blob name='%s' offset=%d length=%d", info.blob.Name(), info.blob.Offset(), info.blob.Length())
+			return
+		}
+		reader, err := info.channelBuilder.GetChannel(info.blob.Offset())
+		if err != nil {
+			producer.strategy.Listeners.Errored(info.blob.Name(), err)
 
-            info.channelBuilder.SetFatalError(err)
-            producer.Errorf("could not get reader for object with name='%s' offset=%d length=%d: %v", info.blob.Name(), info.blob.Offset(), info.blob.Length(), err)
-            return
-        }
-        defer info.channelBuilder.OnDone(reader)
+			info.channelBuilder.SetFatalError(err)
+			producer.Errorf("could not get reader for object with name='%s' offset=%d length=%d: %v", info.blob.Name(), info.blob.Offset(), info.blob.Length(), err)
+			return
+		}
+		defer info.channelBuilder.OnDone(reader)
 
-        sizedReader := NewIoReaderWithSizeDecorator(reader, info.blob.Length())
-        putObjRequest := ds3Models.NewPutObjectRequest(info.bucketName, info.blob.Name(), sizedReader).
-            WithJob(info.jobId).
-            WithOffset(info.blob.Offset())
+		sizedReader := NewIoReaderWithSizeDecorator(reader, info.blob.Length())
+		putObjRequest := ds3Models.NewPutObjectRequest(info.bucketName, info.blob.Name(), sizedReader).
+			WithJob(info.jobId).
+			WithOffset(info.blob.Offset())
 
 		producer.maybeAddMetadata(info, putObjRequest)
 
-        _, err = producer.client.PutObject(producer.ctx, putObjRequest)
-        if err != nil {
-            producer.strategy.Listeners.Errored(info.blob.Name(), err)
+		_, err = producer.client.PutObject(producer.ctx, putObjRequest)
+		if err != nil {
+			producer.strategy.Listeners.Errored(info.blob.Name(), err)
 
-            info.channelBuilder.SetFatalError(err)
-            producer.Errorf("problem during transfer of %s: %s", info.blob.Name(), err.Error())
-        }
-    }
+			info.channelBuilder.SetFatalError(err)
+			producer.Errorf("problem during transfer of %s: %s", info.blob.Name(), err.Error())
+		}
+	}
 }
 
 func (producer *putProducer) maybeAddMetadata(info putObjectInfo, putObjRequest *ds3Models.PutObjectRequest) {
@@ -142,201 +142,201 @@ func (producer *putProducer) metadataFrom(info putObjectInfo) map[string]string 
 // If a blob is not ready for transfer, then it is added to the waiting to be transferred queue.
 // Returns the number of  blobs added to queue.
 func (producer *putProducer) processChunk(curChunk *ds3Models.Objects, bucketName string, jobId string) (int, error) {
-    processedCount := 0
-    producer.Debugf("begin chunk processing %s", curChunk.ChunkId)
+	processedCount := 0
+	producer.Debugf("begin chunk processing %s", curChunk.ChunkId)
 
-    // transfer blobs that are ready, and queue those that are waiting for channel
-    for _, curObj := range curChunk.Objects {
-        producer.Debugf("queuing object in waiting to be processed %s offset=%d length=%d", *curObj.Name, curObj.Offset, curObj.Length)
-        blob := helperModels.NewBlobDescription(*curObj.Name, curObj.Offset, curObj.Length)
-        blobQueued, err := producer.queueBlobForTransfer(&blob, bucketName, jobId)
-        if err != nil {
-            return 0, err
-        }
-        if blobQueued {
-            processedCount++
-        }
-    }
-    return processedCount, nil
+	// transfer blobs that are ready, and queue those that are waiting for channel
+	for _, curObj := range curChunk.Objects {
+		producer.Debugf("queuing object in waiting to be processed %s offset=%d length=%d", *curObj.Name, curObj.Offset, curObj.Length)
+		blob := helperModels.NewBlobDescription(*curObj.Name, curObj.Offset, curObj.Length)
+		blobQueued, err := producer.queueBlobForTransfer(&blob, bucketName, jobId)
+		if err != nil {
+			return 0, err
+		}
+		if blobQueued {
+			processedCount++
+		}
+	}
+	return processedCount, nil
 }
 
 // Iterates through blobs that are waiting to be transferred and attempts to transfer.
 // If successful, blob is removed from queue. Else, it is re-queued.
 // Returns the number of blobs added to queue.
 func (producer *putProducer) processWaitingBlobs(bucketName string, jobId string) (int, error) {
-    processedCount := 0
+	processedCount := 0
 
-    // attempt to process all blobs in waiting to be transferred
-    waitingBlobs := producer.deferredBlobQueue.Size()
-    for i := 0; i < waitingBlobs; i++ {
-        //attempt transfer
-        curBlob, err := producer.deferredBlobQueue.Pop()
-        if err != nil {
-            //should not be possible to get here
-            producer.Errorf("problem when getting next blob to be transferred: %s", err.Error())
-            break
-        }
-        producer.Debugf("attempting to process %s offset=%d length=%d", curBlob.Name(), curBlob.Offset(), curBlob.Length())
-        blobQueued, err := producer.queueBlobForTransfer(curBlob, bucketName, jobId)
-        if err != nil {
-            return 0, err
-        }
-        if blobQueued {
-            processedCount++
-        }
-    }
+	// attempt to process all blobs in waiting to be transferred
+	waitingBlobs := producer.deferredBlobQueue.Size()
+	for i := 0; i < waitingBlobs; i++ {
+		//attempt transfer
+		curBlob, err := producer.deferredBlobQueue.Pop()
+		if err != nil {
+			//should not be possible to get here
+			producer.Errorf("problem when getting next blob to be transferred: %s", err.Error())
+			break
+		}
+		producer.Debugf("attempting to process %s offset=%d length=%d", curBlob.Name(), curBlob.Offset(), curBlob.Length())
+		blobQueued, err := producer.queueBlobForTransfer(curBlob, bucketName, jobId)
+		if err != nil {
+			return 0, err
+		}
+		if blobQueued {
+			processedCount++
+		}
+	}
 
-    return processedCount, nil
+	return processedCount, nil
 }
 
 // Attempts to transfer a single blob. If the blob is not ready for transfer,
 // it is added to the waiting to transfer queue.
 // Returns whether or not the blob was queued for transfer.
 func (producer *putProducer) queueBlobForTransfer(blob *helperModels.BlobDescription, bucketName string, jobId string) (bool, error) {
-    if producer.processedBlobTracker.IsProcessed(*blob) {
-        return false, nil // this was already processed
-    }
+	if producer.processedBlobTracker.IsProcessed(*blob) {
+		return false, nil // this was already processed
+	}
 
-    curWriteObj, ok := producer.writeObjectMap[blob.Name()]
-    if !ok {
-        err := fmt.Errorf("failed to find object associated with blob in object map: %s offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
-        producer.Errorf("unrecoverable error: %v", err)
-        producer.processedBlobTracker.MarkProcessed(*blob)
-        return false, err // fatal error occurred
-    }
+	curWriteObj, ok := producer.writeObjectMap[blob.Name()]
+	if !ok {
+		err := fmt.Errorf("failed to find object associated with blob in object map: %s offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
+		producer.Errorf("unrecoverable error: %v", err)
+		producer.processedBlobTracker.MarkProcessed(*blob)
+		return false, err // fatal error occurred
+	}
 
-    if curWriteObj.ChannelBuilder == nil {
-        err := fmt.Errorf("failed to transfer object, it does not have a channel builder: %s", curWriteObj.PutObject.Name)
-        producer.Errorf("unrecoverable error: %v", err)
-        producer.processedBlobTracker.MarkProcessed(*blob)
-        return false, err // fatal error occurred
-    }
+	if curWriteObj.ChannelBuilder == nil {
+		err := fmt.Errorf("failed to transfer object, it does not have a channel builder: %s", curWriteObj.PutObject.Name)
+		producer.Errorf("unrecoverable error: %v", err)
+		producer.processedBlobTracker.MarkProcessed(*blob)
+		return false, err // fatal error occurred
+	}
 
-    if curWriteObj.ChannelBuilder.HasFatalError() {
-        // a fatal error happened on a previous blob for this file, skip processing
-        producer.Warningf("fatal error occurred while transferring previous blob on this file, skipping blob %s offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
-        producer.processedBlobTracker.MarkProcessed(*blob)
-        return false, nil // not actually transferring this blob
-    }
+	if curWriteObj.ChannelBuilder.HasFatalError() {
+		// a fatal error happened on a previous blob for this file, skip processing
+		producer.Warningf("fatal error occurred while transferring previous blob on this file, skipping blob %s offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
+		producer.processedBlobTracker.MarkProcessed(*blob)
+		return false, nil // not actually transferring this blob
+	}
 
-    if !curWriteObj.ChannelBuilder.IsChannelAvailable(blob.Offset()) {
-        producer.Debugf("channel is not currently available for blob %s offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
-        // Not ready to be transferred
-        producer.deferredBlobQueue.Push(blob)
-        return false, nil // not ready to be sent
-    }
+	if !curWriteObj.ChannelBuilder.IsChannelAvailable(blob.Offset()) {
+		producer.Debugf("channel is not currently available for blob %s offset=%d length=%d", blob.Name(), blob.Offset(), blob.Length())
+		// Not ready to be transferred
+		producer.deferredBlobQueue.Push(blob)
+		return false, nil // not ready to be sent
+	}
 
-    producer.Debugf("channel is available for blob %s offset=%d length=%d", curWriteObj.PutObject.Name, blob.Offset(), blob.Length())
-    // Blob ready to be transferred
+	producer.Debugf("channel is available for blob %s offset=%d length=%d", curWriteObj.PutObject.Name, blob.Offset(), blob.Length())
+	// Blob ready to be transferred
 
-    // Create transfer operation
-    objInfo := putObjectInfo{
-        blob:           *blob,
-        channelBuilder: curWriteObj.ChannelBuilder,
-        bucketName:     bucketName,
-        jobId:          jobId,
-    }
+	// Create transfer operation
+	objInfo := putObjectInfo{
+		blob:           *blob,
+		channelBuilder: curWriteObj.ChannelBuilder,
+		bucketName:     bucketName,
+		jobId:          jobId,
+	}
 
-    transfer := producer.transferOperationBuilder(objInfo)
+	transfer := producer.transferOperationBuilder(objInfo)
 
-    // Increment wait group, and enqueue transfer operation
-    producer.waitGroup.Add(1)
-    *producer.queue <- transfer
+	// Increment wait group, and enqueue transfer operation
+	producer.waitGroup.Add(1)
+	*producer.queue <- transfer
 
-    // Mark blob as processed
-    producer.processedBlobTracker.MarkProcessed(*blob)
+	// Mark blob as processed
+	producer.processedBlobTracker.MarkProcessed(*blob)
 
-    return true, nil
+	return true, nil
 }
 
 // This initiates the production of the transfer operations which will be consumed by a consumer running in a separate go routine.
 // Each transfer operation will put one blob of content to the BP.
 // Once all blobs have been queued to be transferred, the producer will finish, even if all operations have not been consumed yet.
 func (producer *putProducer) run() error {
-    defer close(*producer.queue)
+	defer close(*producer.queue)
 
-    // determine number of blobs to be processed
-    totalBlobCount := producer.totalBlobCount()
-    producer.Debugf("job status totalBlobs=%d processedBlobs=%d", totalBlobCount, producer.processedBlobTracker.NumberOfProcessedBlobs())
+	// determine number of blobs to be processed
+	totalBlobCount := producer.totalBlobCount()
+	producer.Debugf("job status totalBlobs=%d processedBlobs=%d", totalBlobCount, producer.processedBlobTracker.NumberOfProcessedBlobs())
 
-    // process all chunks and make sure all blobs are queued for transfer
-    for producer.hasMoreToProcess(totalBlobCount) {
-        processedCount, err := producer.queueBlobsReadyForTransfer(totalBlobCount)
-        if err != nil {
-            return err
-        }
+	// process all chunks and make sure all blobs are queued for transfer
+	for producer.hasMoreToProcess(totalBlobCount) {
+		processedCount, err := producer.queueBlobsReadyForTransfer(totalBlobCount)
+		if err != nil {
+			return err
+		}
 
-        // If the last operation processed blobs, then wait for something to finish
-        if processedCount > 0 {
-            // wait for a done signal to be received
-            producer.doneNotifier.Wait()
-        } else if producer.hasMoreToProcess(totalBlobCount) {
-            // nothing could be processed, cache is probably full, wait a bit before trying again
-            select {
-            case <-producer.ctx.Done():
-                return producer.ctx.Err()
-            case <-time.After(producer.strategy.BlobStrategy.delay()):
-            }
-        }
-    }
-    return nil
+		// If the last operation processed blobs, then wait for something to finish
+		if processedCount > 0 {
+			// wait for a done signal to be received
+			producer.doneNotifier.Wait()
+		} else if producer.hasMoreToProcess(totalBlobCount) {
+			// nothing could be processed, cache is probably full, wait a bit before trying again
+			select {
+			case <-producer.ctx.Done():
+				return producer.ctx.Err()
+			case <-time.After(producer.strategy.BlobStrategy.delay()):
+			}
+		}
+	}
+	return nil
 }
 
 func (producer *putProducer) hasMoreToProcess(totalBlobCount int64) bool {
-    return producer.processedBlobTracker.NumberOfProcessedBlobs() < totalBlobCount || producer.deferredBlobQueue.Size() > 0
+	return producer.processedBlobTracker.NumberOfProcessedBlobs() < totalBlobCount || producer.deferredBlobQueue.Size() > 0
 }
 
 // Returns the number of items queued for work.
 func (producer *putProducer) queueBlobsReadyForTransfer(totalBlobCount int64) (int, error) {
-    // Attempt to transfer waiting blobs
-    processedCount, err := producer.processWaitingBlobs(*producer.JobMasterObjectList.BucketName, producer.JobMasterObjectList.JobId)
-    if err != nil {
-        return 0, err
-    }
+	// Attempt to transfer waiting blobs
+	processedCount, err := producer.processWaitingBlobs(*producer.JobMasterObjectList.BucketName, producer.JobMasterObjectList.JobId)
+	if err != nil {
+		return 0, err
+	}
 
-    // Check if we need to query the BP for allocated blobs, or if we already know everything is allocated.
-    if int64(producer.deferredBlobQueue.Size()) + producer.processedBlobTracker.NumberOfProcessedBlobs() >= totalBlobCount {
-        // Everything is already allocated, no need to query BP for allocated chunks
-        return processedCount, nil
-    }
+	// Check if we need to query the BP for allocated blobs, or if we already know everything is allocated.
+	if int64(producer.deferredBlobQueue.Size())+producer.processedBlobTracker.NumberOfProcessedBlobs() >= totalBlobCount {
+		// Everything is already allocated, no need to query BP for allocated chunks
+		return processedCount, nil
+	}
 
-    // Get the list of available chunks that the server can receive. The server may
-    // not be able to receive everything, so not all chunks will necessarily be
-    // returned
-    chunksReady := ds3Models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(producer.JobMasterObjectList.JobId)
-    chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(producer.ctx, chunksReady)
-    if err != nil {
-        producer.Errorf("unrecoverable error: %v", err)
-        return processedCount, err
-    }
+	// Get the list of available chunks that the server can receive. The server may
+	// not be able to receive everything, so not all chunks will necessarily be
+	// returned
+	chunksReady := ds3Models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(producer.JobMasterObjectList.JobId)
+	chunksReadyResponse, err := producer.client.GetJobChunksReadyForClientProcessingSpectraS3(producer.ctx, chunksReady)
+	if err != nil {
+		producer.Errorf("unrecoverable error: %v", err)
+		return processedCount, err
+	}
 
-    // Check to see if any chunks can be processed
-    numberOfChunks := len(chunksReadyResponse.MasterObjectList.Objects)
-    if numberOfChunks > 0 {
-        // Loop through all the chunks that are available for processing, and send
-        // the files that are contained within them.
-        for _, curChunk := range chunksReadyResponse.MasterObjectList.Objects {
-            justProcessedCount, err := producer.processChunk(&curChunk, *chunksReadyResponse.MasterObjectList.BucketName, chunksReadyResponse.MasterObjectList.JobId)
-            if err != nil {
-                return 0, err
-            }
-            processedCount += justProcessedCount
-        }
-    }
-    return processedCount, nil
+	// Check to see if any chunks can be processed
+	numberOfChunks := len(chunksReadyResponse.MasterObjectList.Objects)
+	if numberOfChunks > 0 {
+		// Loop through all the chunks that are available for processing, and send
+		// the files that are contained within them.
+		for _, curChunk := range chunksReadyResponse.MasterObjectList.Objects {
+			justProcessedCount, err := producer.processChunk(&curChunk, *chunksReadyResponse.MasterObjectList.BucketName, chunksReadyResponse.MasterObjectList.JobId)
+			if err != nil {
+				return 0, err
+			}
+			processedCount += justProcessedCount
+		}
+	}
+	return processedCount, nil
 }
 
 // Determines the number of blobs to be transferred.
 func (producer *putProducer) totalBlobCount() int64 {
-    if producer.JobMasterObjectList.Objects == nil || len(producer.JobMasterObjectList.Objects) == 0 {
-        return 0
-    }
+	if producer.JobMasterObjectList.Objects == nil || len(producer.JobMasterObjectList.Objects) == 0 {
+		return 0
+	}
 
-    var count int64 = 0
-    for _, chunk := range producer.JobMasterObjectList.Objects {
-        for range chunk.Objects {
-            count++
-        }
-    }
-    return count
+	var count int64 = 0
+	for _, chunk := range producer.JobMasterObjectList.Objects {
+		for range chunk.Objects {
+			count++
+		}
+	}
+	return count
 }

--- a/helpers/putTransceiver.go
+++ b/helpers/putTransceiver.go
@@ -1,96 +1,96 @@
 package helpers
 
 import (
-    "context"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "sync"
+	"context"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"sync"
 )
 
 type putTransceiver struct {
-    BucketName   string
-    WriteObjects *[]helperModels.PutObject
-    Strategy     *WriteTransferStrategy
-    Client       *ds3.Client
+	BucketName   string
+	WriteObjects *[]helperModels.PutObject
+	Strategy     *WriteTransferStrategy
+	Client       *ds3.Client
 }
 
 func newPutTransceiver(bucketName string, writeObjects *[]helperModels.PutObject, strategy *WriteTransferStrategy, client *ds3.Client) *putTransceiver {
-    return &putTransceiver{
-        BucketName:   bucketName,
-        WriteObjects: writeObjects,
-        Strategy:     strategy,
-        Client:       client,
-    }
+	return &putTransceiver{
+		BucketName:   bucketName,
+		WriteObjects: writeObjects,
+		Strategy:     strategy,
+		Client:       client,
+	}
 }
 
 // Creates the bulk put request from the list of write objects and put bulk job options
 func newBulkPutRequest(bucketName string, writeObjects *[]helperModels.PutObject, options WriteBulkJobOptions) *ds3Models.PutBulkJobSpectraS3Request {
-    var putObjects []ds3Models.Ds3PutObject
-    for _, obj := range *writeObjects {
-        putObjects = append(putObjects, obj.PutObject)
-    }
+	var putObjects []ds3Models.Ds3PutObject
+	for _, obj := range *writeObjects {
+		putObjects = append(putObjects, obj.PutObject)
+	}
 
-    bulkPut := ds3Models.NewPutBulkJobSpectraS3Request(bucketName, putObjects)
-    if options.Aggregating != nil {
-        bulkPut = bulkPut.WithAggregating(*options.Aggregating)
-    }
-    if options.ImplicitJobIdResolution != nil {
-        bulkPut = bulkPut.WithImplicitJobIdResolution(*options.ImplicitJobIdResolution)
-    }
-    if options.MaxUploadSize != nil {
-        bulkPut = bulkPut.WithMaxUploadSize(*options.MaxUploadSize)
-    }
-    if options.MinimizeSpanningAcrossMedia != nil {
-        bulkPut = bulkPut.WithMinimizeSpanningAcrossMedia(*options.MinimizeSpanningAcrossMedia)
-    }
-    if options.Priority != nil {
-        bulkPut = bulkPut.WithPriority(*options.Priority)
-    }
-    if options.VerifyAfterWrite != nil {
-        bulkPut = bulkPut.WithVerifyAfterWrite(*options.VerifyAfterWrite)
-    }
-    if options.Name != nil {
-        bulkPut = bulkPut.WithName(*options.Name)
-    }
-    if options.Force != nil && *options.Force {
-        bulkPut = bulkPut.WithForce()
-    }
-    if options.IgnoreNamingConflicts != nil && *options.IgnoreNamingConflicts {
-        bulkPut = bulkPut.WithIgnoreNamingConflicts()
-    }
-    if options.Protected != nil {
-        bulkPut = bulkPut.WithProtected(*options.Protected)
-    }
-    return bulkPut
+	bulkPut := ds3Models.NewPutBulkJobSpectraS3Request(bucketName, putObjects)
+	if options.Aggregating != nil {
+		bulkPut = bulkPut.WithAggregating(*options.Aggregating)
+	}
+	if options.ImplicitJobIdResolution != nil {
+		bulkPut = bulkPut.WithImplicitJobIdResolution(*options.ImplicitJobIdResolution)
+	}
+	if options.MaxUploadSize != nil {
+		bulkPut = bulkPut.WithMaxUploadSize(*options.MaxUploadSize)
+	}
+	if options.MinimizeSpanningAcrossMedia != nil {
+		bulkPut = bulkPut.WithMinimizeSpanningAcrossMedia(*options.MinimizeSpanningAcrossMedia)
+	}
+	if options.Priority != nil {
+		bulkPut = bulkPut.WithPriority(*options.Priority)
+	}
+	if options.VerifyAfterWrite != nil {
+		bulkPut = bulkPut.WithVerifyAfterWrite(*options.VerifyAfterWrite)
+	}
+	if options.Name != nil {
+		bulkPut = bulkPut.WithName(*options.Name)
+	}
+	if options.Force != nil && *options.Force {
+		bulkPut = bulkPut.WithForce()
+	}
+	if options.IgnoreNamingConflicts != nil && *options.IgnoreNamingConflicts {
+		bulkPut = bulkPut.WithIgnoreNamingConflicts()
+	}
+	if options.Protected != nil {
+		bulkPut = bulkPut.WithProtected(*options.Protected)
+	}
+	return bulkPut
 }
 
 func (transceiver *putTransceiver) transfer(ctx context.Context) (string, error) {
-    // create bulk put job
-    bulkPut := newBulkPutRequest(transceiver.BucketName, transceiver.WriteObjects, transceiver.Strategy.Options)
+	// create bulk put job
+	bulkPut := newBulkPutRequest(transceiver.BucketName, transceiver.WriteObjects, transceiver.Strategy.Options)
 
-    bulkPutResponse, err := transceiver.Client.PutBulkJobSpectraS3(ctx, bulkPut)
-    if err != nil {
-        return "", err
-    }
+	bulkPutResponse, err := transceiver.Client.PutBulkJobSpectraS3(ctx, bulkPut)
+	if err != nil {
+		return "", err
+	}
 
-    // init queue, producer and consumer
-    var waitGroup sync.WaitGroup
+	// init queue, producer and consumer
+	var waitGroup sync.WaitGroup
 
-    doneNotifier := NewConditionalBool()
+	doneNotifier := NewConditionalBool()
 
-    queue := newOperationQueue(transceiver.Strategy.BlobStrategy.maxWaitingTransfers(), transceiver.Client.Logger)
-    producer := newPutProducer(ctx, &bulkPutResponse.MasterObjectList, transceiver.WriteObjects, &queue, transceiver.Strategy, transceiver.Client, &waitGroup, doneNotifier)
-    consumer := newConsumer(&queue, &waitGroup, transceiver.Strategy.BlobStrategy.maxConcurrentTransfers(), doneNotifier)
+	queue := newOperationQueue(transceiver.Strategy.BlobStrategy.maxWaitingTransfers(), transceiver.Client.Logger)
+	producer := newPutProducer(ctx, &bulkPutResponse.MasterObjectList, transceiver.WriteObjects, &queue, transceiver.Strategy, transceiver.Client, &waitGroup, doneNotifier)
+	consumer := newConsumer(&queue, &waitGroup, transceiver.Strategy.BlobStrategy.maxConcurrentTransfers(), doneNotifier)
 
-    // Wait for completion of producer-consumer goroutines
-    waitGroup.Add(1)  // adding producer and consumer goroutines to wait group
+	// Wait for completion of producer-consumer goroutines
+	waitGroup.Add(1) // adding producer and consumer goroutines to wait group
 
-    go consumer.run()
-    err = producer.run() // producer will add to waitGroup for every blob added to queue, and each transfer performed will decrement from waitGroup
-    waitGroup.Wait()
+	go consumer.run()
+	err = producer.run() // producer will add to waitGroup for every blob added to queue, and each transfer performed will decrement from waitGroup
+	waitGroup.Wait()
 
-    return bulkPutResponse.MasterObjectList.JobId, err
+	return bulkPutResponse.MasterObjectList.JobId, err
 }
 
 /*

--- a/helpers/ranges/rangeHelper.go
+++ b/helpers/ranges/rangeHelper.go
@@ -1,9 +1,9 @@
 package ranges
 
 import (
-    ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "sort"
+	ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"sort"
 )
 
 // Used to sort a slice of Range objects in ascending order.
@@ -11,123 +11,123 @@ import (
 type Ranges []ds3Models.Range
 
 func (ranges Ranges) Len() int {
-    return len(ranges)
+	return len(ranges)
 }
 
 func (ranges Ranges) Swap(i, j int) {
-    ranges[i], ranges[j] = ranges[j], ranges[i]
+	ranges[i], ranges[j] = ranges[j], ranges[i]
 }
 
 // compares Start and then End
 func (ranges Ranges) Less(i, j int) bool {
-    if ranges[i].Start == ranges[j].Start {
-        return ranges[i].End < ranges[j].End
-    }
-    return ranges[i].Start < ranges[j].Start
+	if ranges[i].Start == ranges[j].Start {
+		return ranges[i].End < ranges[j].End
+	}
+	return ranges[i].Start < ranges[j].Start
 }
 
 type RangeCollapser interface {
-    // Collapses a set of ranges. Any duplicates or sub-ranges are removed.
-    // The original range slice must remain unmodified.
-    Collapse(ranges []ds3Models.Range) []ds3Models.Range
+	// Collapses a set of ranges. Any duplicates or sub-ranges are removed.
+	// The original range slice must remain unmodified.
+	Collapse(ranges []ds3Models.Range) []ds3Models.Range
 }
 
-type RangeCollapserImpl struct { }
+type RangeCollapserImpl struct{}
 
 // Creates a slice of ranges that contain the collapsed ranges provided.
 // The original range slice remains unmodified.
 func (RangeCollapserImpl) Collapse(ranges []ds3Models.Range) []ds3Models.Range {
-    rangeCopy := make([]ds3Models.Range, len(ranges))
-    copy(rangeCopy, ranges)
+	rangeCopy := make([]ds3Models.Range, len(ranges))
+	copy(rangeCopy, ranges)
 
-    // sorts ranges in ascending order
-    sort.Sort(Ranges(rangeCopy))
+	// sorts ranges in ascending order
+	sort.Sort(Ranges(rangeCopy))
 
-    // collapse ranges
-    for i, j := 0, 1; j < len(rangeCopy); {
-        if rangeCopy[i] == rangeCopy[j] {
-            // if they are the same delete the second item
-            rangeCopy = append(rangeCopy[:j], rangeCopy[j+1:]...)
-        } else if rangeCopy[i].End + 1 >= rangeCopy[j].Start {
-            // if overlapping ranges, collapse into single entry
-            if rangeCopy[i].End < rangeCopy[j].End {
-                rangeCopy[i].End = rangeCopy[j].End //update i entry to encompass both
-            }
-            rangeCopy = append(rangeCopy[:j], rangeCopy[j+1:]...) //delete j entry
-        } else {
-            i++
-            j++
-        }
-    }
-    return rangeCopy
+	// collapse ranges
+	for i, j := 0, 1; j < len(rangeCopy); {
+		if rangeCopy[i] == rangeCopy[j] {
+			// if they are the same delete the second item
+			rangeCopy = append(rangeCopy[:j], rangeCopy[j+1:]...)
+		} else if rangeCopy[i].End+1 >= rangeCopy[j].Start {
+			// if overlapping ranges, collapse into single entry
+			if rangeCopy[i].End < rangeCopy[j].End {
+				rangeCopy[i].End = rangeCopy[j].End //update i entry to encompass both
+			}
+			rangeCopy = append(rangeCopy[:j], rangeCopy[j+1:]...) //delete j entry
+		} else {
+			i++
+			j++
+		}
+	}
+	return rangeCopy
 }
 
 type BlobRangeFinder interface {
-    // Retrieves the ranges associated with a given blob.
-    GetRanges(name string, offset int64, length int64) []ds3Models.Range
+	// Retrieves the ranges associated with a given blob.
+	GetRanges(name string, offset int64, length int64) []ds3Models.Range
 }
 
 type BlobRangeFinderImpl struct {
-    // Map of objects to ranges to be retrieved from object.
-    // Ranges are collapsed.
-    rangeMap map[string][]ds3Models.Range
-    collapser RangeCollapser
+	// Map of objects to ranges to be retrieved from object.
+	// Ranges are collapsed.
+	rangeMap  map[string][]ds3Models.Range
+	collapser RangeCollapser
 }
 
 // Creates a BlobRangeFinderImpl which is populated with the provided getObjects
 func NewBlobRangeFinder(getObjects *[]helperModels.GetObject) BlobRangeFinder {
-    rangeMap := toRangeMap(getObjects)
-    return &BlobRangeFinderImpl{
-        rangeMap: *rangeMap,
-        collapser: RangeCollapserImpl{},
-    }
+	rangeMap := toRangeMap(getObjects)
+	return &BlobRangeFinderImpl{
+		rangeMap:  *rangeMap,
+		collapser: RangeCollapserImpl{},
+	}
 }
 
 func toRangeMap(getObjects *[]helperModels.GetObject) *map[string][]ds3Models.Range {
-    rangeMap := make(map[string][]ds3Models.Range)
+	rangeMap := make(map[string][]ds3Models.Range)
 
-    if getObjects == nil {
-        return &rangeMap
-    }
+	if getObjects == nil {
+		return &rangeMap
+	}
 
-    collapser := RangeCollapserImpl{}
-    for _, obj := range *getObjects {
-        rangeMap[obj.Name] = collapser.Collapse(obj.Ranges)
-    }
-    return &rangeMap
+	collapser := RangeCollapserImpl{}
+	for _, obj := range *getObjects {
+		rangeMap[obj.Name] = collapser.Collapse(obj.Ranges)
+	}
+	return &rangeMap
 }
 
 func (rangeFinder *BlobRangeFinderImpl) GetRanges(name string, offset int64, length int64) []ds3Models.Range {
-    objectRanges := rangeFinder.rangeMap[name]
+	objectRanges := rangeFinder.rangeMap[name]
 
-    // get the subset of ranges that intersect the blob boundary
-    var blobRanges []ds3Models.Range
-    for _, r := range objectRanges {
-        if rangeFinder.isIntersection(r, offset, length) {
-            blobRanges = append(blobRanges, rangeFinder.getIntersection(r, offset, length))
-        }
-    }
+	// get the subset of ranges that intersect the blob boundary
+	var blobRanges []ds3Models.Range
+	for _, r := range objectRanges {
+		if rangeFinder.isIntersection(r, offset, length) {
+			blobRanges = append(blobRanges, rangeFinder.getIntersection(r, offset, length))
+		}
+	}
 
-    return blobRanges
+	return blobRanges
 }
 
 func (BlobRangeFinderImpl) isIntersection(r ds3Models.Range, offset int64, length int64) bool {
-    return !(r.Start > offset + length - 1 || r.End < offset)
+	return !(r.Start > offset+length-1 || r.End < offset)
 }
 
 // Returns the intersection of the range and the portion of the file assuming that said range exists
 func (BlobRangeFinderImpl) getIntersection(r ds3Models.Range, offset int64, length int64) ds3Models.Range {
-    var intersection ds3Models.Range
-    if r.Start < offset {
-        intersection.Start = offset
-    } else {
-        intersection.Start = r.Start
-    }
+	var intersection ds3Models.Range
+	if r.Start < offset {
+		intersection.Start = offset
+	} else {
+		intersection.Start = r.Start
+	}
 
-    if r.End < offset + length - 1 {
-        intersection.End = r.End
-    } else {
-        intersection.End = offset + length - 1
-    }
-    return intersection
+	if r.End < offset+length-1 {
+		intersection.End = r.End
+	} else {
+		intersection.End = offset + length - 1
+	}
+	return intersection
 }

--- a/helpers/ranges/ranges_test.go
+++ b/helpers/ranges/ranges_test.go
@@ -1,120 +1,120 @@
 package ranges
 
 import (
-    "testing"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "sort"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
-    "fmt"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"sort"
+	"testing"
 )
 
 func getTestRanges() []models.Range {
-    return []models.Range {
-        {1, 3},
-        {0, 2}, // not in order regarding start position
-        {5, 7},
-        {5, 6}, // not in order regarding end position
-        {10, 11},
-        {10, 11}, // duplicate
-        {12, 15},
-        {13, 14},
-        {20, 25},
-        {21, 22}, // subset of other range
-        {30, 31}, // shared boundary
-        {31, 32},
-    }
+	return []models.Range{
+		{1, 3},
+		{0, 2}, // not in order regarding start position
+		{5, 7},
+		{5, 6}, // not in order regarding end position
+		{10, 11},
+		{10, 11}, // duplicate
+		{12, 15},
+		{13, 14},
+		{20, 25},
+		{21, 22}, // subset of other range
+		{30, 31}, // shared boundary
+		{31, 32},
+	}
 }
 
 func verifyRangeLists(first []models.Range, second []models.Range) bool {
-    if len(first) != len(second) {
-        return false
-    }
+	if len(first) != len(second) {
+		return false
+	}
 
-    for i := 0; i < len(first); i++ {
-        if first[i] != second[i] {
-            return false
-        }
-    }
-    return true
+	for i := 0; i < len(first); i++ {
+		if first[i] != second[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestSortingRanges(t *testing.T) {
-    ranges := getTestRanges()
+	ranges := getTestRanges()
 
-    sort.Sort(Ranges(ranges))
+	sort.Sort(Ranges(ranges))
 
-    expected := []models.Range {
-        {0, 2},
-        {1, 3},
-        {5, 6},
-        {5, 7},
-        {10, 11},
-        {10, 11},
-        {12, 15},
-        {13, 14},
-        {20, 25},
-        {21, 22},
-        {30, 31},
-        {31, 32},
-    }
-    ds3Testing.AssertBool(t, "sorted list is correct", true, verifyRangeLists(ranges, expected))
+	expected := []models.Range{
+		{0, 2},
+		{1, 3},
+		{5, 6},
+		{5, 7},
+		{10, 11},
+		{10, 11},
+		{12, 15},
+		{13, 14},
+		{20, 25},
+		{21, 22},
+		{30, 31},
+		{31, 32},
+	}
+	ds3Testing.AssertBool(t, "sorted list is correct", true, verifyRangeLists(ranges, expected))
 }
 
 func TestCollapsingRanges(t *testing.T) {
-    ranges := Ranges(getTestRanges())
+	ranges := Ranges(getTestRanges())
 
-    collapser := RangeCollapserImpl{}
-    newRanges := collapser.Collapse(ranges)
+	collapser := RangeCollapserImpl{}
+	newRanges := collapser.Collapse(ranges)
 
-    ds3Testing.AssertBool(t, "original list is unmodified", true, verifyRangeLists(ranges, getTestRanges()))
+	ds3Testing.AssertBool(t, "original list is unmodified", true, verifyRangeLists(ranges, getTestRanges()))
 
-    expected := []models.Range {
-        {0, 3},
-        {5, 7},
-        {10, 15},
-        {20, 25},
-        {30, 32},
-    }
-    ds3Testing.AssertBool(t, "collapsed list is correct", true, verifyRangeLists(newRanges, expected))
+	expected := []models.Range{
+		{0, 3},
+		{5, 7},
+		{10, 15},
+		{20, 25},
+		{30, 32},
+	}
+	ds3Testing.AssertBool(t, "collapsed list is correct", true, verifyRangeLists(newRanges, expected))
 }
 
 func TestIsIntersection(t *testing.T) {
-    rangeFinder := BlobRangeFinderImpl{}
+	rangeFinder := BlobRangeFinderImpl{}
 
-    ds3Testing.AssertBool(t, "intersection 0-3, 5-9", false, rangeFinder.isIntersection(models.Range{0, 3}, 5, 5))
-    ds3Testing.AssertBool(t, "intersection 3-4, 5-9", false, rangeFinder.isIntersection(models.Range{3, 4}, 5, 5))
+	ds3Testing.AssertBool(t, "intersection 0-3, 5-9", false, rangeFinder.isIntersection(models.Range{0, 3}, 5, 5))
+	ds3Testing.AssertBool(t, "intersection 3-4, 5-9", false, rangeFinder.isIntersection(models.Range{3, 4}, 5, 5))
 
-    ds3Testing.AssertBool(t, "intersection 3-5, 5-9", true, rangeFinder.isIntersection(models.Range{3, 5}, 5, 5))
-    ds3Testing.AssertBool(t, "intersection 5-7, 5-9", true, rangeFinder.isIntersection(models.Range{5, 7}, 5, 5))
-    ds3Testing.AssertBool(t, "intersection 6-7, 5-9", true, rangeFinder.isIntersection(models.Range{6, 7}, 5, 5))
-    ds3Testing.AssertBool(t, "intersection 8-10, 5-9", true, rangeFinder.isIntersection(models.Range{8, 10}, 5, 5))
-    ds3Testing.AssertBool(t, "intersection 9-11, 5-9", true, rangeFinder.isIntersection(models.Range{9, 11}, 5, 5))
-    ds3Testing.AssertBool(t, "intersection 3-11, 5-9", true, rangeFinder.isIntersection(models.Range{3, 11}, 5, 5))
+	ds3Testing.AssertBool(t, "intersection 3-5, 5-9", true, rangeFinder.isIntersection(models.Range{3, 5}, 5, 5))
+	ds3Testing.AssertBool(t, "intersection 5-7, 5-9", true, rangeFinder.isIntersection(models.Range{5, 7}, 5, 5))
+	ds3Testing.AssertBool(t, "intersection 6-7, 5-9", true, rangeFinder.isIntersection(models.Range{6, 7}, 5, 5))
+	ds3Testing.AssertBool(t, "intersection 8-10, 5-9", true, rangeFinder.isIntersection(models.Range{8, 10}, 5, 5))
+	ds3Testing.AssertBool(t, "intersection 9-11, 5-9", true, rangeFinder.isIntersection(models.Range{9, 11}, 5, 5))
+	ds3Testing.AssertBool(t, "intersection 3-11, 5-9", true, rangeFinder.isIntersection(models.Range{3, 11}, 5, 5))
 
-    ds3Testing.AssertBool(t, "intersection 10-12, 5-9", false, rangeFinder.isIntersection(models.Range{10, 12}, 5, 5))
-    ds3Testing.AssertBool(t, "intersection 11-15, 5-9", false, rangeFinder.isIntersection(models.Range{11, 15}, 5, 5))
+	ds3Testing.AssertBool(t, "intersection 10-12, 5-9", false, rangeFinder.isIntersection(models.Range{10, 12}, 5, 5))
+	ds3Testing.AssertBool(t, "intersection 11-15, 5-9", false, rangeFinder.isIntersection(models.Range{11, 15}, 5, 5))
 }
 
 func TestGetIntersection(t *testing.T) {
-    input := []models.Range {
-        {3, 7},
-        {6, 7},
-        {7, 12},
-        {3, 12},
-    }
+	input := []models.Range{
+		{3, 7},
+		{6, 7},
+		{7, 12},
+		{3, 12},
+	}
 
-    expected := []models.Range {
-        {5, 7},
-        {6, 7},
-        {7, 9},
-        {5, 9},
-    }
+	expected := []models.Range{
+		{5, 7},
+		{6, 7},
+		{7, 9},
+		{5, 9},
+	}
 
-    rangeFinder := BlobRangeFinderImpl{}
+	rangeFinder := BlobRangeFinderImpl{}
 
-    for i := 0; i < len(input); i++ {
-        result := rangeFinder.getIntersection(input[i], 5, 5)
-        ds3Testing.AssertInt64(t, fmt.Sprintf("Input%v.Start", input[i]), expected[i].Start, result.Start)
-        ds3Testing.AssertInt64(t, fmt.Sprintf("Input%v.End", input[i]), expected[i].End, result.End)
-    }
+	for i := 0; i < len(input); i++ {
+		result := rangeFinder.getIntersection(input[i], 5, 5)
+		ds3Testing.AssertInt64(t, fmt.Sprintf("Input%v.Start", input[i]), expected[i].Start, result.Start)
+		ds3Testing.AssertInt64(t, fmt.Sprintf("Input%v.End", input[i]), expected[i].End, result.End)
+	}
 }

--- a/helpers/readTransferStrategy.go
+++ b/helpers/readTransferStrategy.go
@@ -3,21 +3,21 @@ package helpers
 import "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 
 type ReadTransferStrategy struct {
-    BlobStrategy ReadBlobStrategy
-    Options      ReadBulkJobOptions
-    Listeners    ListenerStrategy
+	BlobStrategy ReadBlobStrategy
+	Options      ReadBulkJobOptions
+	Listeners    ListenerStrategy
 }
 
 // Defines the options to use on the get bulk job
 type ReadBulkJobOptions struct {
-    Aggregating *bool
-    ChunkClientProcessingOrderGuarantee models.JobChunkClientProcessingOrderGuarantee
-    ImplicitJobIdResolution *bool
-    Name *string
-    Priority models.Priority
+	Aggregating                         *bool
+	ChunkClientProcessingOrderGuarantee models.JobChunkClientProcessingOrderGuarantee
+	ImplicitJobIdResolution             *bool
+	Name                                *string
+	Priority                            models.Priority
 }
 
 // Strategy for how to blob objects for writing
 type ReadBlobStrategy interface {
-    BlobStrategy
+	BlobStrategy
 }

--- a/helpers/transceiver.go
+++ b/helpers/transceiver.go
@@ -1,6 +1,6 @@
 package helpers
 
 type Transceiver interface {
-    transfer() error
-    //cancel()
+	transfer() error
+	//cancel()
 }

--- a/helpers/writeTransferStrategy.go
+++ b/helpers/writeTransferStrategy.go
@@ -1,33 +1,33 @@
 package helpers
 
 import (
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
 )
 
 var MinUploadSize int64 = 10485760
 
 // Defines strategy for how to perform write transfers
 type WriteTransferStrategy struct {
-    BlobStrategy WriteBlobStrategy
-    Options      WriteBulkJobOptions
-    Listeners    ListenerStrategy
+	BlobStrategy WriteBlobStrategy
+	Options      WriteBulkJobOptions
+	Listeners    ListenerStrategy
 }
 
 // Defines the options to use on the put bulk job
 type WriteBulkJobOptions struct {
-    Aggregating *bool
-    ImplicitJobIdResolution *bool
-    MaxUploadSize *int64
-    MinimizeSpanningAcrossMedia *bool
-    Priority *models.Priority
-    VerifyAfterWrite *bool
-    Name *string
-    Force *bool
-    IgnoreNamingConflicts *bool
-    Protected *bool
+	Aggregating                 *bool
+	ImplicitJobIdResolution     *bool
+	MaxUploadSize               *int64
+	MinimizeSpanningAcrossMedia *bool
+	Priority                    *models.Priority
+	VerifyAfterWrite            *bool
+	Name                        *string
+	Force                       *bool
+	IgnoreNamingConflicts       *bool
+	Protected                   *bool
 }
 
 // Strategy for how to blob objects for writing
 type WriteBlobStrategy interface {
-    BlobStrategy
+	BlobStrategy
 }

--- a/helpers_integration/helpersImpl_test.go
+++ b/helpers_integration/helpersImpl_test.go
@@ -1,26 +1,26 @@
 package helpers_integration
 
 import (
-    "bytes"
-    "context"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_integration/utils"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
-    "github.com/SpectraLogic/ds3_go_sdk/helpers"
-    "github.com/SpectraLogic/ds3_go_sdk/helpers/channels"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "github.com/SpectraLogic/ds3_go_sdk/samples/utils"
-    "io"
-    "io/ioutil"
-    "log"
-    "os"
-    "strings"
-    "sync"
-    "sync/atomic"
-    "testing"
-    "time"
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_integration/utils"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_utils/ds3Testing"
+	"github.com/SpectraLogic/ds3_go_sdk/helpers"
+	"github.com/SpectraLogic/ds3_go_sdk/helpers/channels"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"github.com/SpectraLogic/ds3_go_sdk/samples/utils"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
 )
 
 var client *ds3.Client
@@ -29,729 +29,729 @@ var envTestNameSpace = "GoHelperTest"
 var defaultUser = "Administrator"
 
 func TestMain(m *testing.M) {
-    var err error
-    var exitVal int
-    var ids *testutils.TestIds
-    client, ids, err = testutils.SetupTestEnv(testBucket, defaultUser, envTestNameSpace)
-    if err != nil {
-        log.Printf("Unable to setup test environment '%s'.", err.Error())
-        exitVal = 1
-    } else {
-        exitVal = m.Run()
-    }
-    testutils.TeardownTestEnv(client, ids, testBucket)
-    os.Exit(exitVal)
+	var err error
+	var exitVal int
+	var ids *testutils.TestIds
+	client, ids, err = testutils.SetupTestEnv(testBucket, defaultUser, envTestNameSpace)
+	if err != nil {
+		log.Printf("Unable to setup test environment '%s'.", err.Error())
+		exitVal = 1
+	} else {
+		exitVal = m.Run()
+	}
+	testutils.TeardownTestEnv(client, ids, testBucket)
+	os.Exit(exitVal)
 }
 
 func TestPutBulk(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
-    helper := helpers.NewHelpers(client)
+	defer testutils.DeleteBucketContents(client, testBucket)
+	helper := helpers.NewHelpers(client)
 
-    strategy := newTestTransferStrategy(t)
+	strategy := newTestTransferStrategy(t)
 
-    writeObjects, err := getTestBooksAsWriteObjects()
-    ds3Testing.AssertNilError(t, err)
+	writeObjects, err := getTestBooksAsWriteObjects()
+	ds3Testing.AssertNilError(t, err)
 
-    jobId, err := helper.PutObjects(context.Background(), testBucket, *writeObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    if jobId == "" {
-        t.Error("expected to get a BP job ID, but instead got nothing")
-    }
+	jobId, err := helper.PutObjects(context.Background(), testBucket, *writeObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	if jobId == "" {
+		t.Error("expected to get a BP job ID, but instead got nothing")
+	}
 
-    // verify all books are on BP
-    getBucket, getBucketErr := client.GetBucket(context.Background(), ds3Models.NewGetBucketRequest(testBucket))
-    ds3Testing.AssertNilError(t, getBucketErr)
-    if len(getBucket.ListBucketResult.Objects) != len(*writeObjects) {
-        t.Fatalf("Expected '%d' objects in bucket '%s', but found '%d'.", len(*writeObjects), testBucket, len(getBucket.ListBucketResult.Objects))
-    }
-    for i, obj := range getBucket.ListBucketResult.Objects {
-        ds3Testing.AssertNonNilStringPtr(t, "BookName", testutils.BookTitles[i], obj.Key)
-    }
+	// verify all books are on BP
+	getBucket, getBucketErr := client.GetBucket(context.Background(), ds3Models.NewGetBucketRequest(testBucket))
+	ds3Testing.AssertNilError(t, getBucketErr)
+	if len(getBucket.ListBucketResult.Objects) != len(*writeObjects) {
+		t.Fatalf("Expected '%d' objects in bucket '%s', but found '%d'.", len(*writeObjects), testBucket, len(getBucket.ListBucketResult.Objects))
+	}
+	for i, obj := range getBucket.ListBucketResult.Objects {
+		ds3Testing.AssertNonNilStringPtr(t, "BookName", testutils.BookTitles[i], obj.Key)
+	}
 
-    testutils.VerifyFilesOnBP(t, testBucket, testutils.BookTitles, testutils.BookPath, client)
+	testutils.VerifyFilesOnBP(t, testBucket, testutils.BookTitles, testutils.BookPath, client)
 }
 
 func TestPutBulkBlobSpanningChunksRandomAccess(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    helper := helpers.NewHelpers(client)
+	helper := helpers.NewHelpers(client)
 
-    strategy := newTestTransferStrategy(t)
+	strategy := newTestTransferStrategy(t)
 
-    writeObj, err := getTestWriteObjectRandomAccess(LargeBookTitle, LargeBookPath+LargeBookTitle)
+	writeObj, err := getTestWriteObjectRandomAccess(LargeBookTitle, LargeBookPath+LargeBookTitle)
 
-    var writeObjects []helperModels.PutObject
-    writeObjects = append(writeObjects, *writeObj)
+	var writeObjects []helperModels.PutObject
+	writeObjects = append(writeObjects, *writeObj)
 
-    ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertNilError(t, err)
 
-    jobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    if jobId == "" {
-        t.Error("expected to get a BP job ID, but instead got nothing")
-    }
+	jobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	if jobId == "" {
+		t.Error("expected to get a BP job ID, but instead got nothing")
+	}
 
-    testutils.VerifyFilesOnBP(t, testBucket, []string{LargeBookTitle}, LargeBookPath, client)
+	testutils.VerifyFilesOnBP(t, testBucket, []string{LargeBookTitle}, LargeBookPath, client)
 }
 
 func TestPutBulkBlobSpanningChunksStreamAccess(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    helper := helpers.NewHelpers(client)
+	helper := helpers.NewHelpers(client)
 
-    strategy := newTestTransferStrategy(t)
+	strategy := newTestTransferStrategy(t)
 
-    writeObj, err := getTestWriteObjectStreamAccess(LargeBookTitle, LargeBookPath+LargeBookTitle)
+	writeObj, err := getTestWriteObjectStreamAccess(LargeBookTitle, LargeBookPath+LargeBookTitle)
 
-    var writeObjects []helperModels.PutObject
-    writeObjects = append(writeObjects, *writeObj)
+	var writeObjects []helperModels.PutObject
+	writeObjects = append(writeObjects, *writeObj)
 
-    ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertNilError(t, err)
 
-    jobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    if jobId == "" {
-        t.Error("expected to get a BP job ID, but instead got nothing")
-    }
+	jobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	if jobId == "" {
+		t.Error("expected to get a BP job ID, but instead got nothing")
+	}
 
-    testutils.VerifyFilesOnBP(t, testBucket, []string{LargeBookTitle}, LargeBookPath, client)
+	testutils.VerifyFilesOnBP(t, testBucket, []string{LargeBookTitle}, LargeBookPath, client)
 }
 
 // GOSDK-26: On archive helpers can hang indefinitely using streaming strategy if blob fails.
 // Test validates the above jira is fixed.
 func TestPutBulkBlobSpanningChunksStreamAccessDoesNotExist(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    helper := helpers.NewHelpers(client)
+	helper := helpers.NewHelpers(client)
 
-    errorCallbackCalled := false
-    var mutex sync.Mutex
-    errorCallback := func(objectName string, err error) {
-        mutex.Lock()
-        errorCallbackCalled = true
-        mutex.Unlock()
+	errorCallbackCalled := false
+	var mutex sync.Mutex
+	errorCallback := func(objectName string, err error) {
+		mutex.Lock()
+		errorCallbackCalled = true
+		mutex.Unlock()
 
-        ds3Testing.AssertString(t, "object name", LargeBookTitle, objectName)
-    }
+		ds3Testing.AssertString(t, "object name", LargeBookTitle, objectName)
+	}
 
-    strategy := helpers.WriteTransferStrategy{
-        BlobStrategy: newTestBlobStrategy(),
-        Options:      helpers.WriteBulkJobOptions{MaxUploadSize: &helpers.MinUploadSize},
-        Listeners:    helpers.ListenerStrategy{ErrorCallback: errorCallback},
-    }
+	strategy := helpers.WriteTransferStrategy{
+		BlobStrategy: newTestBlobStrategy(),
+		Options:      helpers.WriteBulkJobOptions{MaxUploadSize: &helpers.MinUploadSize},
+		Listeners:    helpers.ListenerStrategy{ErrorCallback: errorCallback},
+	}
 
-    // open a file but lie that its bigger than it is
-    f, err := os.Open(testutils.BookPath + testutils.BookTitles[0])
-    writeObj := helperModels.PutObject{
-        PutObject:      ds3Models.Ds3PutObject{Name: LargeBookTitle, Size: 20 * 1024 * 1024},
-        ChannelBuilder: &testStreamAccessReadChannelBuilder{f: f},
-    }
+	// open a file but lie that its bigger than it is
+	f, err := os.Open(testutils.BookPath + testutils.BookTitles[0])
+	writeObj := helperModels.PutObject{
+		PutObject:      ds3Models.Ds3PutObject{Name: LargeBookTitle, Size: 20 * 1024 * 1024},
+		ChannelBuilder: &testStreamAccessReadChannelBuilder{f: f},
+	}
 
-    var writeObjects []helperModels.PutObject
-    writeObjects = append(writeObjects, writeObj)
+	var writeObjects []helperModels.PutObject
+	writeObjects = append(writeObjects, writeObj)
 
-    ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertNilError(t, err)
 
-    _, err = helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertBool(t, "error callback called", true, errorCallbackCalled)
+	_, err = helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertBool(t, "error callback called", true, errorCallbackCalled)
 }
 
 func TestGetBulk(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
-    err := testutils.PutTestBooks(client, testBucket)
-    ds3Testing.AssertNilError(t, err)
+	defer testutils.DeleteBucketContents(client, testBucket)
+	err := testutils.PutTestBooks(client, testBucket)
+	ds3Testing.AssertNilError(t, err)
 
-    helper := helpers.NewHelpers(client)
+	helper := helpers.NewHelpers(client)
 
-    strategy := helpers.ReadTransferStrategy{
-        Options:      helpers.ReadBulkJobOptions{}, // use default job options
-        BlobStrategy: newTestBlobStrategy(),
-        Listeners:    newErrorOnErrorListenerStrategy(t),
-    }
+	strategy := helpers.ReadTransferStrategy{
+		Options:      helpers.ReadBulkJobOptions{}, // use default job options
+		BlobStrategy: newTestBlobStrategy(),
+		Listeners:    newErrorOnErrorListenerStrategy(t),
+	}
 
-    file0, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file0.Close()
-    defer os.Remove(file0.Name())
+	file0, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file0.Close()
+	defer os.Remove(file0.Name())
 
-    file1, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file1.Close()
-    defer os.Remove(file1.Name())
+	file1, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file1.Close()
+	defer os.Remove(file1.Name())
 
-    file2, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file2.Close()
-    defer os.Remove(file2.Name())
+	file2, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file2.Close()
+	defer os.Remove(file2.Name())
 
-    file3, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file3.Close()
-    defer os.Remove(file3.Name())
+	file3, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file3.Close()
+	defer os.Remove(file3.Name())
 
-    readObjects := []helperModels.GetObject{
-        {Name: testutils.BookTitles[0], ChannelBuilder: channels.NewWriteChannelBuilder(file0.Name())},
-        {Name: testutils.BookTitles[1], ChannelBuilder: channels.NewWriteChannelBuilder(file1.Name())},
-        {Name: testutils.BookTitles[2], ChannelBuilder: channels.NewWriteChannelBuilder(file2.Name())},
-        {Name: testutils.BookTitles[3], ChannelBuilder: channels.NewWriteChannelBuilder(file3.Name())},
-    }
+	readObjects := []helperModels.GetObject{
+		{Name: testutils.BookTitles[0], ChannelBuilder: channels.NewWriteChannelBuilder(file0.Name())},
+		{Name: testutils.BookTitles[1], ChannelBuilder: channels.NewWriteChannelBuilder(file1.Name())},
+		{Name: testutils.BookTitles[2], ChannelBuilder: channels.NewWriteChannelBuilder(file2.Name())},
+		{Name: testutils.BookTitles[3], ChannelBuilder: channels.NewWriteChannelBuilder(file3.Name())},
+	}
 
-    jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    if jobId == "" {
-        t.Error("expected to get a BP job ID, but instead got nothing")
-    }
+	jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	if jobId == "" {
+		t.Error("expected to get a BP job ID, but instead got nothing")
+	}
 
-    utils.VerifyBookContent(testutils.BookTitles[0], file0)
-    utils.VerifyBookContent(testutils.BookTitles[1], file1)
-    utils.VerifyBookContent(testutils.BookTitles[2], file2)
-    utils.VerifyBookContent(testutils.BookTitles[3], file3)
+	utils.VerifyBookContent(testutils.BookTitles[0], file0)
+	utils.VerifyBookContent(testutils.BookTitles[1], file1)
+	utils.VerifyBookContent(testutils.BookTitles[2], file2)
+	utils.VerifyBookContent(testutils.BookTitles[3], file3)
 }
 
 func TestGetBulkBlobSpanningChunksRandomAccess(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    LoadLargeFile(t, testBucket, client)
+	LoadLargeFile(t, testBucket, client)
 
-    helper := helpers.NewHelpers(client)
+	helper := helpers.NewHelpers(client)
 
-    strategy := helpers.ReadTransferStrategy{
-        Options:      helpers.ReadBulkJobOptions{}, // use default job options
-        BlobStrategy: newTestBlobStrategy(),
-        Listeners:    newErrorOnErrorListenerStrategy(t),
-    }
+	strategy := helpers.ReadTransferStrategy{
+		Options:      helpers.ReadBulkJobOptions{}, // use default job options
+		BlobStrategy: newTestBlobStrategy(),
+		Listeners:    newErrorOnErrorListenerStrategy(t),
+	}
 
-    file, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file.Close()
-    defer os.Remove(file.Name())
+	file, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file.Close()
+	defer os.Remove(file.Name())
 
-    readObjects := []helperModels.GetObject{
-        {Name: LargeBookTitle, ChannelBuilder: channels.NewWriteChannelBuilder(file.Name())},
-    }
+	readObjects := []helperModels.GetObject{
+		{Name: LargeBookTitle, ChannelBuilder: channels.NewWriteChannelBuilder(file.Name())},
+	}
 
-    jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    if jobId == "" {
-        t.Error("expected to get a BP job ID, but instead got nothing")
-    }
+	jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	if jobId == "" {
+		t.Error("expected to get a BP job ID, but instead got nothing")
+	}
 
-    err = VerifyLargeBookContent(file)
-    ds3Testing.AssertNilError(t, err)
+	err = VerifyLargeBookContent(file)
+	ds3Testing.AssertNilError(t, err)
 }
 
 func TestGetBulkBlobSpanningChunksStreaming(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    LoadLargeFile(t, testBucket, client)
+	LoadLargeFile(t, testBucket, client)
 
-    helper := helpers.NewHelpers(client)
+	helper := helpers.NewHelpers(client)
 
-    strategy := helpers.ReadTransferStrategy{
-        Options:      helpers.ReadBulkJobOptions{}, // use default job options
-        BlobStrategy: newTestBlobStrategy(),
-        Listeners:    newErrorOnErrorListenerStrategy(t),
-    }
+	strategy := helpers.ReadTransferStrategy{
+		Options:      helpers.ReadBulkJobOptions{}, // use default job options
+		BlobStrategy: newTestBlobStrategy(),
+		Listeners:    newErrorOnErrorListenerStrategy(t),
+	}
 
-    file, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file.Close()
-    defer os.Remove(file.Name())
+	file, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file.Close()
+	defer os.Remove(file.Name())
 
-    fileWriter, err := os.OpenFile(file.Name(), os.O_WRONLY|os.O_CREATE, os.ModePerm)
-    defer fileWriter.Close()
+	fileWriter, err := os.OpenFile(file.Name(), os.O_WRONLY|os.O_CREATE, os.ModePerm)
+	defer fileWriter.Close()
 
-    readObjects := []helperModels.GetObject{
-        {Name: LargeBookTitle, ChannelBuilder: &testStreamAccessWriteChannelBuilder{f: fileWriter}},
-    }
+	readObjects := []helperModels.GetObject{
+		{Name: LargeBookTitle, ChannelBuilder: &testStreamAccessWriteChannelBuilder{f: fileWriter}},
+	}
 
-    jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    if jobId == "" {
-        t.Error("expected to get a BP job ID, but instead got nothing")
-    }
+	jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	if jobId == "" {
+		t.Error("expected to get a BP job ID, but instead got nothing")
+	}
 
-    err = VerifyLargeBookContent(file)
-    ds3Testing.AssertNilError(t, err)
+	err = VerifyLargeBookContent(file)
+	ds3Testing.AssertNilError(t, err)
 }
 
 func TestGetBulkBlobSpanningChunksStreamingFailBlob(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    LoadLargeFile(t, testBucket, client)
+	LoadLargeFile(t, testBucket, client)
 
-    helper := helpers.NewHelpers(client)
+	helper := helpers.NewHelpers(client)
 
-    errorCallbackCalled := false
-    var mutex sync.Mutex
-    errorCallback := func(objectName string, err error) {
-        mutex.Lock()
-        errorCallbackCalled = true
-        mutex.Unlock()
+	errorCallbackCalled := false
+	var mutex sync.Mutex
+	errorCallback := func(objectName string, err error) {
+		mutex.Lock()
+		errorCallbackCalled = true
+		mutex.Unlock()
 
-        ds3Testing.AssertString(t, "object name", LargeBookTitle, objectName)
-    }
+		ds3Testing.AssertString(t, "object name", LargeBookTitle, objectName)
+	}
 
-    strategy := helpers.ReadTransferStrategy{
-        Options:      helpers.ReadBulkJobOptions{}, // use default job options
-        BlobStrategy: newTestBlobStrategy(),
-        Listeners: helpers.ListenerStrategy{
-            ErrorCallback: errorCallback,
-        },
-    }
+	strategy := helpers.ReadTransferStrategy{
+		Options:      helpers.ReadBulkJobOptions{}, // use default job options
+		BlobStrategy: newTestBlobStrategy(),
+		Listeners: helpers.ListenerStrategy{
+			ErrorCallback: errorCallback,
+		},
+	}
 
-    file, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file.Close()
-    defer os.Remove(file.Name())
+	file, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file.Close()
+	defer os.Remove(file.Name())
 
-    readObjects := []helperModels.GetObject{
-        {Name: LargeBookTitle, ChannelBuilder: &testStreamAccessWriteFailOnFirstBlob{}},
-    }
+	readObjects := []helperModels.GetObject{
+		{Name: LargeBookTitle, ChannelBuilder: &testStreamAccessWriteFailOnFirstBlob{}},
+	}
 
-    _, err = helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertBool(t, "error callback called", true, errorCallbackCalled)
+	_, err = helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertBool(t, "error callback called", true, errorCallbackCalled)
 }
 
 func TestGetBulkPartialObjectRandomAccess(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    LoadLargeFile(t, testBucket, client)
+	LoadLargeFile(t, testBucket, client)
 
-    helper := helpers.NewHelpers(client)
+	helper := helpers.NewHelpers(client)
 
-    strategy := helpers.ReadTransferStrategy{
-        Options:      helpers.ReadBulkJobOptions{}, // use default job options
-        BlobStrategy: newTestBlobStrategy(),
-        Listeners:    newErrorOnErrorListenerStrategy(t),
-    }
+	strategy := helpers.ReadTransferStrategy{
+		Options:      helpers.ReadBulkJobOptions{}, // use default job options
+		BlobStrategy: newTestBlobStrategy(),
+		Listeners:    newErrorOnErrorListenerStrategy(t),
+	}
 
-    file, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file.Close()
-    defer os.Remove(file.Name())
+	file, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file.Close()
+	defer os.Remove(file.Name())
 
-    ranges := []ds3Models.Range{
-        {0, 100},
-        {200, 300},
-        {301, 400},
-        {500, 600},
-    }
+	ranges := []ds3Models.Range{
+		{0, 100},
+		{200, 300},
+		{301, 400},
+		{500, 600},
+	}
 
-    readObjects := []helperModels.GetObject{
-        {Name: LargeBookTitle, ChannelBuilder: channels.NewPartialObjectChannelBuilder(file.Name(), ranges), Ranges: ranges},
-    }
+	readObjects := []helperModels.GetObject{
+		{Name: LargeBookTitle, ChannelBuilder: channels.NewPartialObjectChannelBuilder(file.Name(), ranges), Ranges: ranges},
+	}
 
-    jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    if jobId == "" {
-        t.Error("expected to get a BP job ID, but instead got nothing")
-    }
+	jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	if jobId == "" {
+		t.Error("expected to get a BP job ID, but instead got nothing")
+	}
 
-    file.Seek(0, io.SeekStart)
-    testutils.VerifyPartialFile(t, LargeBookPath+LargeBookTitle, 101, 0, file)
-    testutils.VerifyPartialFile(t, LargeBookPath+LargeBookTitle, 201, 200, file)
-    testutils.VerifyPartialFile(t, LargeBookPath+LargeBookTitle, 101, 500, file)
+	file.Seek(0, io.SeekStart)
+	testutils.VerifyPartialFile(t, LargeBookPath+LargeBookTitle, 101, 0, file)
+	testutils.VerifyPartialFile(t, LargeBookPath+LargeBookTitle, 201, 200, file)
+	testutils.VerifyPartialFile(t, LargeBookPath+LargeBookTitle, 101, 500, file)
 }
 
 func TestPutObjectDoesNotExist(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
-    helper := helpers.NewHelpers(client)
-    const testObjectName = "does-not-exist"
+	defer testutils.DeleteBucketContents(client, testBucket)
+	helper := helpers.NewHelpers(client)
+	const testObjectName = "does-not-exist"
 
-    errorCallbackCalled := false
-    var mutex sync.Mutex
-    errorCallback := func(objectName string, err error) {
-        mutex.Lock()
-        errorCallbackCalled = true
-        mutex.Unlock()
+	errorCallbackCalled := false
+	var mutex sync.Mutex
+	errorCallback := func(objectName string, err error) {
+		mutex.Lock()
+		errorCallbackCalled = true
+		mutex.Unlock()
 
-        ds3Testing.AssertString(t, "errored object name", testObjectName, objectName)
-        ds3Testing.AssertBool(t, "error expected to by of type NotExist", true, os.IsNotExist(err))
-    }
+		ds3Testing.AssertString(t, "errored object name", testObjectName, objectName)
+		ds3Testing.AssertBool(t, "error expected to by of type NotExist", true, os.IsNotExist(err))
+	}
 
-    strategy := helpers.WriteTransferStrategy{
-        BlobStrategy: newTestBlobStrategy(),
-        Options:      helpers.WriteBulkJobOptions{MaxUploadSize: &helpers.MinUploadSize},
-        Listeners:    helpers.ListenerStrategy{ErrorCallback: errorCallback},
-    }
+	strategy := helpers.WriteTransferStrategy{
+		BlobStrategy: newTestBlobStrategy(),
+		Options:      helpers.WriteBulkJobOptions{MaxUploadSize: &helpers.MinUploadSize},
+		Listeners:    helpers.ListenerStrategy{ErrorCallback: errorCallback},
+	}
 
-    channelBuilder := channels.NewReadChannelBuilder(testObjectName)
-    nonExistentPutObj := helperModels.PutObject{
-        PutObject:      ds3Models.Ds3PutObject{Name: testObjectName, Size: 10},
-        ChannelBuilder: channelBuilder,
-    }
+	channelBuilder := channels.NewReadChannelBuilder(testObjectName)
+	nonExistentPutObj := helperModels.PutObject{
+		PutObject:      ds3Models.Ds3PutObject{Name: testObjectName, Size: 10},
+		ChannelBuilder: channelBuilder,
+	}
 
-    writeObjects := []helperModels.PutObject{nonExistentPutObj}
+	writeObjects := []helperModels.PutObject{nonExistentPutObj}
 
-    _, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
+	_, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
 
-    ds3Testing.AssertBool(t, "error callback was called", true, errorCallbackCalled)
+	ds3Testing.AssertBool(t, "error callback was called", true, errorCallbackCalled)
 }
 
 type closeWrapper struct {
-    io.Reader
+	io.Reader
 }
 
 func (wrapper *closeWrapper) Close() error {
-    return nil
+	return nil
 }
 
 type emptyReadChannelBuilder struct {
-    channels.FatalErrorHandler
+	channels.FatalErrorHandler
 }
 
 func (builder *emptyReadChannelBuilder) GetChannel(_ int64) (io.ReadCloser, error) {
-    reader := bytes.NewReader([]byte{})
-    return &closeWrapper{Reader: reader}, nil
+	reader := bytes.NewReader([]byte{})
+	return &closeWrapper{Reader: reader}, nil
 }
 
 func (builder *emptyReadChannelBuilder) IsChannelAvailable(_ int64) bool {
-    return true
+	return true
 }
 
 func (builder *emptyReadChannelBuilder) OnDone(reader io.ReadCloser) {
-    reader.Close()
+	reader.Close()
 }
 
 type emptyWriteCloser struct{}
 
 func (writer *emptyWriteCloser) Write(p []byte) (n int, err error) {
-    return len(p), nil
+	return len(p), nil
 }
 
 func (writer *emptyWriteCloser) Close() error {
-    return nil
+	return nil
 }
 
 type emptyWriteChannelBuilder struct {
-    channels.FatalErrorHandler
+	channels.FatalErrorHandler
 }
 
 func (builder *emptyWriteChannelBuilder) GetChannel(_ int64) (io.WriteCloser, error) {
-    return &emptyWriteCloser{}, nil
+	return &emptyWriteCloser{}, nil
 }
 
 func (builder *emptyWriteChannelBuilder) IsChannelAvailable(_ int64) bool {
-    return true
+	return true
 }
 
 func (builder *emptyWriteChannelBuilder) OnDone(writer io.WriteCloser) {
-    writer.Close()
+	writer.Close()
 }
 
 func TestBulkPutAndGetLotsOfFiles(t *testing.T) {
-    defer func() {
-        // force delete the bucket because its faster than deleting all the files
-        testutils.DeleteBucket(client, testBucket)
-        // re-creating the bucket after force delete because other tests expect it to exist
-        testutils.PutBucket(client, testBucket)
-    }()
-    helper := helpers.NewHelpers(client)
+	defer func() {
+		// force delete the bucket because its faster than deleting all the files
+		testutils.DeleteBucket(client, testBucket)
+		// re-creating the bucket after force delete because other tests expect it to exist
+		testutils.PutBucket(client, testBucket)
+	}()
+	helper := helpers.NewHelpers(client)
 
-    // put a bunch of files
-    var writeObjects []helperModels.PutObject
+	// put a bunch of files
+	var writeObjects []helperModels.PutObject
 
-    const numObjects = 18650
-    for i := 0; i < numObjects; i++ {
-        objName := fmt.Sprintf("file-%d.txt", i)
-        curWriteObj := helperModels.PutObject{
-            PutObject:      ds3Models.Ds3PutObject{Name: objName, Size: 0},
-            ChannelBuilder: &emptyReadChannelBuilder{},
-        }
-        writeObjects = append(writeObjects, curWriteObj)
-    }
+	const numObjects = 18650
+	for i := 0; i < numObjects; i++ {
+		objName := fmt.Sprintf("file-%d.txt", i)
+		curWriteObj := helperModels.PutObject{
+			PutObject:      ds3Models.Ds3PutObject{Name: objName, Size: 0},
+			ChannelBuilder: &emptyReadChannelBuilder{},
+		}
+		writeObjects = append(writeObjects, curWriteObj)
+	}
 
-    writeStrategy := helpers.WriteTransferStrategy{
-        BlobStrategy: &helpers.SimpleBlobStrategy{
-            Delay:                  time.Second * 30,
-            MaxConcurrentTransfers: 10,
-        },
-        Options:   helpers.WriteBulkJobOptions{MaxUploadSize: &helpers.MinUploadSize},
-        Listeners: newErrorOnErrorListenerStrategy(t),
-    }
+	writeStrategy := helpers.WriteTransferStrategy{
+		BlobStrategy: &helpers.SimpleBlobStrategy{
+			Delay:                  time.Second * 30,
+			MaxConcurrentTransfers: 10,
+		},
+		Options:   helpers.WriteBulkJobOptions{MaxUploadSize: &helpers.MinUploadSize},
+		Listeners: newErrorOnErrorListenerStrategy(t),
+	}
 
-    jobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, writeStrategy)
-    ds3Testing.AssertNilError(t, err)
-    if jobId == "" {
-        t.Error("expected to get a BP job ID, but instead got nothing")
-    }
+	jobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, writeStrategy)
+	ds3Testing.AssertNilError(t, err)
+	if jobId == "" {
+		t.Error("expected to get a BP job ID, but instead got nothing")
+	}
 
-    // retrieve said files
-    var readObjects []helperModels.GetObject
-    for _, writeObj := range writeObjects {
-        curGetObj := helperModels.GetObject{
-            Name:           writeObj.PutObject.Name,
-            ChannelBuilder: &emptyWriteChannelBuilder{},
-        }
-        readObjects = append(readObjects, curGetObj)
-    }
+	// retrieve said files
+	var readObjects []helperModels.GetObject
+	for _, writeObj := range writeObjects {
+		curGetObj := helperModels.GetObject{
+			Name:           writeObj.PutObject.Name,
+			ChannelBuilder: &emptyWriteChannelBuilder{},
+		}
+		readObjects = append(readObjects, curGetObj)
+	}
 
-    readStrategy := helpers.ReadTransferStrategy{
-        Options: helpers.ReadBulkJobOptions{}, // use default job options
-        BlobStrategy: &helpers.SimpleBlobStrategy{
-            Delay:                  time.Second * 30,
-            MaxConcurrentTransfers: 10,
-        },
-        Listeners: newErrorOnErrorListenerStrategy(t),
-    }
+	readStrategy := helpers.ReadTransferStrategy{
+		Options: helpers.ReadBulkJobOptions{}, // use default job options
+		BlobStrategy: &helpers.SimpleBlobStrategy{
+			Delay:                  time.Second * 30,
+			MaxConcurrentTransfers: 10,
+		},
+		Listeners: newErrorOnErrorListenerStrategy(t),
+	}
 
-    jobId, err = helper.GetObjects(context.Background(), testBucket, readObjects, readStrategy)
-    ds3Testing.AssertNilError(t, err)
+	jobId, err = helper.GetObjects(context.Background(), testBucket, readObjects, readStrategy)
+	ds3Testing.AssertNilError(t, err)
 
-    if jobId == "" {
-        t.Errorf("expected to get a BP job ID, but instead got nothing")
-    }
+	if jobId == "" {
+		t.Errorf("expected to get a BP job ID, but instead got nothing")
+	}
 }
 
 func TestRetryGettingBlobRange(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    helper := helpers.NewHelpers(client)
-    strategy := newTestTransferStrategy(t)
+	helper := helpers.NewHelpers(client)
+	strategy := newTestTransferStrategy(t)
 
-    // Put a blobbed object to BP
-    const bigFilePath = LargeBookPath + LargeBookTitle
-    writeObj, err := getTestWriteObjectRandomAccess(LargeBookTitle, bigFilePath)
-    ds3Testing.AssertNilError(t, err)
+	// Put a blobbed object to BP
+	const bigFilePath = LargeBookPath + LargeBookTitle
+	writeObj, err := getTestWriteObjectRandomAccess(LargeBookTitle, bigFilePath)
+	ds3Testing.AssertNilError(t, err)
 
-    var writeObjects []helperModels.PutObject
-    writeObjects = append(writeObjects, *writeObj)
+	var writeObjects []helperModels.PutObject
+	writeObjects = append(writeObjects, *writeObj)
 
-    putJobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    if putJobId == "" {
-        t.Error("expected to get a BP job ID, but instead got nothing")
-    }
+	putJobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	if putJobId == "" {
+		t.Error("expected to get a BP job ID, but instead got nothing")
+	}
 
-    // Try to get some data from each blob
-    getJob, err := client.GetJobSpectraS3(context.Background(), ds3Models.NewGetJobSpectraS3Request(putJobId))
-    ds3Testing.AssertNilError(t, err)
+	// Try to get some data from each blob
+	getJob, err := client.GetJobSpectraS3(context.Background(), ds3Models.NewGetJobSpectraS3Request(putJobId))
+	ds3Testing.AssertNilError(t, err)
 
-    blobsChecked := 0
-    for _, curObj := range getJob.MasterObjectList.Objects {
-        for _, blob := range curObj.Objects {
-            func() {
-                // create a temp file for writing the blob to
-                tempFile, err := ioutil.TempFile("", "go-sdk-test-")
-                ds3Testing.AssertNilError(t, err)
-                defer func() {
-                    tempFile.Close()
-                    os.Remove(tempFile.Name())
-                }()
+	blobsChecked := 0
+	for _, curObj := range getJob.MasterObjectList.Objects {
+		for _, blob := range curObj.Objects {
+			func() {
+				// create a temp file for writing the blob to
+				tempFile, err := ioutil.TempFile("", "go-sdk-test-")
+				ds3Testing.AssertNilError(t, err)
+				defer func() {
+					tempFile.Close()
+					os.Remove(tempFile.Name())
+				}()
 
-                // get a range of the blob
-                startRange := blob.Offset + 10 // retrieve subset of blob
-                endRange := blob.Length + blob.Offset - 1
-                bytesWritten, err := helpers.RetryGettingBlobRange(context.Background(), client, testBucket, writeObj.PutObject.Name, blob.Offset, startRange, endRange, tempFile, client.Logger)
-                ds3Testing.AssertNilError(t, err)
-                ds3Testing.AssertInt64(t, "bytes written", endRange-startRange+1, bytesWritten)
+				// get a range of the blob
+				startRange := blob.Offset + 10 // retrieve subset of blob
+				endRange := blob.Length + blob.Offset - 1
+				bytesWritten, err := helpers.RetryGettingBlobRange(context.Background(), client, testBucket, writeObj.PutObject.Name, blob.Offset, startRange, endRange, tempFile, client.Logger)
+				ds3Testing.AssertNilError(t, err)
+				ds3Testing.AssertInt64(t, "bytes written", endRange-startRange+1, bytesWritten)
 
-                // verify that retrieved partial blob is correct
-                err = tempFile.Sync()
-                ds3Testing.AssertNilError(t, err)
+				// verify that retrieved partial blob is correct
+				err = tempFile.Sync()
+				ds3Testing.AssertNilError(t, err)
 
-                tempFile.Seek(0, 0)
-                length := endRange - startRange
-                testutils.VerifyPartialFile(t, bigFilePath, length, startRange, tempFile)
-            }()
-            blobsChecked++
-        }
-    }
-    if blobsChecked == 0 {
-        t.Fatalf("didn't verify any blobs")
-    }
+				tempFile.Seek(0, 0)
+				length := endRange - startRange
+				testutils.VerifyPartialFile(t, bigFilePath, length, startRange, tempFile)
+			}()
+			blobsChecked++
+		}
+	}
+	if blobsChecked == 0 {
+		t.Fatalf("didn't verify any blobs")
+	}
 }
 
 func TestGetRemainingBlob(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
+	defer testutils.DeleteBucketContents(client, testBucket)
 
-    helper := helpers.NewHelpers(client)
-    strategy := newTestTransferStrategy(t)
+	helper := helpers.NewHelpers(client)
+	strategy := newTestTransferStrategy(t)
 
-    // Put a blobbed object to BP
-    const bigFilePath = LargeBookPath + LargeBookTitle
-    writeObj, err := getTestWriteObjectRandomAccess(LargeBookTitle, bigFilePath)
-    ds3Testing.AssertNilError(t, err)
+	// Put a blobbed object to BP
+	const bigFilePath = LargeBookPath + LargeBookTitle
+	writeObj, err := getTestWriteObjectRandomAccess(LargeBookTitle, bigFilePath)
+	ds3Testing.AssertNilError(t, err)
 
-    var writeObjects []helperModels.PutObject
-    writeObjects = append(writeObjects, *writeObj)
+	var writeObjects []helperModels.PutObject
+	writeObjects = append(writeObjects, *writeObj)
 
-    putJobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    if putJobId == "" {
-        t.Error("expected to get a BP job ID, but instead got nothing")
-    }
+	putJobId, err := helper.PutObjects(context.Background(), testBucket, writeObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	if putJobId == "" {
+		t.Error("expected to get a BP job ID, but instead got nothing")
+	}
 
-    // Try to get some data from each blob
-    getJob, err := client.GetJobSpectraS3(context.Background(), ds3Models.NewGetJobSpectraS3Request(putJobId))
-    ds3Testing.AssertNilError(t, err)
+	// Try to get some data from each blob
+	getJob, err := client.GetJobSpectraS3(context.Background(), ds3Models.NewGetJobSpectraS3Request(putJobId))
+	ds3Testing.AssertNilError(t, err)
 
-    blobsChecked := 0
-    for _, curObj := range getJob.MasterObjectList.Objects {
-        for _, blob := range curObj.Objects {
-            func() {
-                // create a temp file for writing the blob to
-                tempFile, err := ioutil.TempFile("", "go-sdk-test-")
-                ds3Testing.AssertNilError(t, err)
-                defer func() {
-                    tempFile.Close()
-                    os.Remove(tempFile.Name())
-                }()
+	blobsChecked := 0
+	for _, curObj := range getJob.MasterObjectList.Objects {
+		for _, blob := range curObj.Objects {
+			func() {
+				// create a temp file for writing the blob to
+				tempFile, err := ioutil.TempFile("", "go-sdk-test-")
+				ds3Testing.AssertNilError(t, err)
+				defer func() {
+					tempFile.Close()
+					os.Remove(tempFile.Name())
+				}()
 
-                // get the remainder of the blob after skipping some bytes
-                blob := helperModels.NewBlobDescription(*blob.Name, blob.Offset, blob.Length)
-                var amountToSkip int64 = 10
-                err = helpers.GetRemainingBlob(context.Background(), client, testBucket, &blob, amountToSkip, tempFile, client.Logger)
-                ds3Testing.AssertNilError(t, err)
+				// get the remainder of the blob after skipping some bytes
+				blob := helperModels.NewBlobDescription(*blob.Name, blob.Offset, blob.Length)
+				var amountToSkip int64 = 10
+				err = helpers.GetRemainingBlob(context.Background(), client, testBucket, &blob, amountToSkip, tempFile, client.Logger)
+				ds3Testing.AssertNilError(t, err)
 
-                // verify that retrieved partial blob is correct
-                err = tempFile.Sync()
-                ds3Testing.AssertNilError(t, err)
+				// verify that retrieved partial blob is correct
+				err = tempFile.Sync()
+				ds3Testing.AssertNilError(t, err)
 
-                tempFile.Seek(0, 0)
-                length := blob.Length() - amountToSkip
-                testutils.VerifyPartialFile(t, bigFilePath, length, blob.Offset()+amountToSkip, tempFile)
-            }()
-            blobsChecked++
-        }
-    }
-    if blobsChecked == 0 {
-        t.Fatalf("didn't verify any blobs")
-    }
+				tempFile.Seek(0, 0)
+				length := blob.Length() - amountToSkip
+				testutils.VerifyPartialFile(t, bigFilePath, length, blob.Offset()+amountToSkip, tempFile)
+			}()
+			blobsChecked++
+		}
+	}
+	if blobsChecked == 0 {
+		t.Fatalf("didn't verify any blobs")
+	}
 }
 
 func TestRetryGetObjectsWhenSomeObjectsDoNotExist(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
-    err := testutils.PutTestBooks(client, testBucket)
-    ds3Testing.AssertNilError(t, err)
+	defer testutils.DeleteBucketContents(client, testBucket)
+	err := testutils.PutTestBooks(client, testBucket)
+	ds3Testing.AssertNilError(t, err)
 
-    helper := helpers.NewHelpers(client)
+	helper := helpers.NewHelpers(client)
 
-    perObjectErrCount := int64(0)
-    errListener := helpers.ListenerStrategy{
-        ErrorCallback: func(objectName string, err error) {
-            atomic.AddInt64(&perObjectErrCount, 1)
-        },
-    }
+	perObjectErrCount := int64(0)
+	errListener := helpers.ListenerStrategy{
+		ErrorCallback: func(objectName string, err error) {
+			atomic.AddInt64(&perObjectErrCount, 1)
+		},
+	}
 
-    strategy := helpers.ReadTransferStrategy{
-        Options:      helpers.ReadBulkJobOptions{}, // use default job options
-        BlobStrategy: newTestBlobStrategy(),
-        Listeners:    errListener,
-    }
+	strategy := helpers.ReadTransferStrategy{
+		Options:      helpers.ReadBulkJobOptions{}, // use default job options
+		BlobStrategy: newTestBlobStrategy(),
+		Listeners:    errListener,
+	}
 
-    file0, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file0.Close()
-    defer os.Remove(file0.Name())
+	file0, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file0.Close()
+	defer os.Remove(file0.Name())
 
-    file1, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file1.Close()
-    defer os.Remove(file1.Name())
+	file1, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file1.Close()
+	defer os.Remove(file1.Name())
 
-    file2, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file2.Close()
-    defer os.Remove(file2.Name())
+	file2, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file2.Close()
+	defer os.Remove(file2.Name())
 
-    file3, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    defer file3.Close()
-    defer os.Remove(file3.Name())
+	file3, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	defer file3.Close()
+	defer os.Remove(file3.Name())
 
-    doesNotExist1, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertNilError(t, doesNotExist1.Close())
-    defer os.Remove(doesNotExist1.Name())
+	doesNotExist1, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertNilError(t, doesNotExist1.Close())
+	defer os.Remove(doesNotExist1.Name())
 
-    doesNotExist2, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertNilError(t, doesNotExist2.Close())
-    defer os.Remove(doesNotExist2.Name())
+	doesNotExist2, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertNilError(t, doesNotExist2.Close())
+	defer os.Remove(doesNotExist2.Name())
 
-    doesNotExistChannelBuilder1 := channels.NewWriteChannelBuilder(doesNotExist1.Name())
-    doesNotExistChannelBuilder2 := channels.NewWriteChannelBuilder(doesNotExist2.Name())
-    readObjects := []helperModels.GetObject{
-        {Name: testutils.BookTitles[0], ChannelBuilder: channels.NewWriteChannelBuilder(file0.Name())},
-        {Name: testutils.BookTitles[1], ChannelBuilder: channels.NewWriteChannelBuilder(file1.Name())},
-        {Name: testutils.BookTitles[2], ChannelBuilder: channels.NewWriteChannelBuilder(file2.Name())},
-        {Name: testutils.BookTitles[3], ChannelBuilder: channels.NewWriteChannelBuilder(file3.Name())},
-        {Name: "doesNotExist1", ChannelBuilder: doesNotExistChannelBuilder1},
-        {Name: "doesNotExist2", ChannelBuilder: doesNotExistChannelBuilder2},
-    }
+	doesNotExistChannelBuilder1 := channels.NewWriteChannelBuilder(doesNotExist1.Name())
+	doesNotExistChannelBuilder2 := channels.NewWriteChannelBuilder(doesNotExist2.Name())
+	readObjects := []helperModels.GetObject{
+		{Name: testutils.BookTitles[0], ChannelBuilder: channels.NewWriteChannelBuilder(file0.Name())},
+		{Name: testutils.BookTitles[1], ChannelBuilder: channels.NewWriteChannelBuilder(file1.Name())},
+		{Name: testutils.BookTitles[2], ChannelBuilder: channels.NewWriteChannelBuilder(file2.Name())},
+		{Name: testutils.BookTitles[3], ChannelBuilder: channels.NewWriteChannelBuilder(file3.Name())},
+		{Name: "doesNotExist1", ChannelBuilder: doesNotExistChannelBuilder1},
+		{Name: "doesNotExist2", ChannelBuilder: doesNotExistChannelBuilder2},
+	}
 
-    jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
-    ds3Testing.AssertNilError(t, err)
-    if jobId == "" {
-        t.Error("expected to get a BP job ID, but instead got nothing")
-    }
+	jobId, err := helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
+	ds3Testing.AssertNilError(t, err)
+	if jobId == "" {
+		t.Error("expected to get a BP job ID, but instead got nothing")
+	}
 
-    utils.VerifyBookContent(testutils.BookTitles[0], file0)
-    utils.VerifyBookContent(testutils.BookTitles[1], file1)
-    utils.VerifyBookContent(testutils.BookTitles[2], file2)
-    utils.VerifyBookContent(testutils.BookTitles[3], file3)
+	utils.VerifyBookContent(testutils.BookTitles[0], file0)
+	utils.VerifyBookContent(testutils.BookTitles[1], file1)
+	utils.VerifyBookContent(testutils.BookTitles[2], file2)
+	utils.VerifyBookContent(testutils.BookTitles[3], file3)
 
-    ds3Testing.AssertInt64(t, "per-object error count", 2, perObjectErrCount)
+	ds3Testing.AssertInt64(t, "per-object error count", 2, perObjectErrCount)
 
-    doesNotExistStat, err := os.Stat(doesNotExist1.Name())
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertInt64(t, "size of file", 0, doesNotExistStat.Size())
+	doesNotExistStat, err := os.Stat(doesNotExist1.Name())
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertInt64(t, "size of file", 0, doesNotExistStat.Size())
 
-    doesNotExistStat, err = os.Stat(doesNotExist2.Name())
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertInt64(t, "size of file", 0, doesNotExistStat.Size())
+	doesNotExistStat, err = os.Stat(doesNotExist2.Name())
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertInt64(t, "size of file", 0, doesNotExistStat.Size())
 
-    ds3Testing.AssertBool(t, "has fatal error", true, doesNotExistChannelBuilder1.HasFatalError())
-    ds3Testing.AssertBool(t, "has fatal error", true, doesNotExistChannelBuilder2.HasFatalError())
+	ds3Testing.AssertBool(t, "has fatal error", true, doesNotExistChannelBuilder1.HasFatalError())
+	ds3Testing.AssertBool(t, "has fatal error", true, doesNotExistChannelBuilder2.HasFatalError())
 }
 
 func TestRetryGetObjectsWhenNoObjectExist(t *testing.T) {
-    defer testutils.DeleteBucketContents(client, testBucket)
-    err := testutils.PutTestBooks(client, testBucket)
-    ds3Testing.AssertNilError(t, err)
+	defer testutils.DeleteBucketContents(client, testBucket)
+	err := testutils.PutTestBooks(client, testBucket)
+	ds3Testing.AssertNilError(t, err)
 
-    helper := helpers.NewHelpers(client)
+	helper := helpers.NewHelpers(client)
 
-    perObjectErrCount := int64(0)
-    errListener := helpers.ListenerStrategy{
-        ErrorCallback: func(objectName string, err error) {
-            atomic.AddInt64(&perObjectErrCount, 1)
-        },
-    }
+	perObjectErrCount := int64(0)
+	errListener := helpers.ListenerStrategy{
+		ErrorCallback: func(objectName string, err error) {
+			atomic.AddInt64(&perObjectErrCount, 1)
+		},
+	}
 
-    strategy := helpers.ReadTransferStrategy{
-        Options:      helpers.ReadBulkJobOptions{}, // use default job options
-        BlobStrategy: newTestBlobStrategy(),
-        Listeners:    errListener,
-    }
+	strategy := helpers.ReadTransferStrategy{
+		Options:      helpers.ReadBulkJobOptions{}, // use default job options
+		BlobStrategy: newTestBlobStrategy(),
+		Listeners:    errListener,
+	}
 
-    doesNotExist1, err := ioutil.TempFile(os.TempDir(), "goTest")
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertNilError(t, doesNotExist1.Close())
-    defer os.Remove(doesNotExist1.Name())
+	doesNotExist1, err := ioutil.TempFile(os.TempDir(), "goTest")
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertNilError(t, doesNotExist1.Close())
+	defer os.Remove(doesNotExist1.Name())
 
-    doesNotExistChannelBuilder1 := channels.NewWriteChannelBuilder(doesNotExist1.Name())
-    readObjects := []helperModels.GetObject{
-        {Name: "doesNotExist1", ChannelBuilder: doesNotExistChannelBuilder1},
-    }
+	doesNotExistChannelBuilder1 := channels.NewWriteChannelBuilder(doesNotExist1.Name())
+	readObjects := []helperModels.GetObject{
+		{Name: "doesNotExist1", ChannelBuilder: doesNotExistChannelBuilder1},
+	}
 
-    _, err = helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
-    if err == nil {
-        t.Fatalf("expected error when creating GET job")
-    } else if !strings.Contains(err.Error(), "Could not find requested blobs for") {
-        t.Fatalf("expected '404 Could not find requested blobs' error but got %v", err)
-    }
+	_, err = helper.GetObjects(context.Background(), testBucket, readObjects, strategy)
+	if err == nil {
+		t.Fatalf("expected error when creating GET job")
+	} else if !strings.Contains(err.Error(), "Could not find requested blobs for") {
+		t.Fatalf("expected '404 Could not find requested blobs' error but got %v", err)
+	}
 
-    ds3Testing.AssertInt64(t, "per-object error count", 1, perObjectErrCount)
+	ds3Testing.AssertInt64(t, "per-object error count", 1, perObjectErrCount)
 
-    doesNotExistStat, err := os.Stat(doesNotExist1.Name())
-    ds3Testing.AssertNilError(t, err)
-    ds3Testing.AssertInt64(t, "size of file", 0, doesNotExistStat.Size())
+	doesNotExistStat, err := os.Stat(doesNotExist1.Name())
+	ds3Testing.AssertNilError(t, err)
+	ds3Testing.AssertInt64(t, "size of file", 0, doesNotExistStat.Size())
 
-    ds3Testing.AssertBool(t, "has fatal error", true, doesNotExistChannelBuilder1.HasFatalError())
+	ds3Testing.AssertBool(t, "has fatal error", true, doesNotExistChannelBuilder1.HasFatalError())
 }

--- a/helpers_integration/largeFileTestUtil.go
+++ b/helpers_integration/largeFileTestUtil.go
@@ -1,16 +1,16 @@
 package helpers_integration
 
 import (
-    "context"
-    "io"
-    "bytes"
-    "fmt"
-    "io/ioutil"
-    "errors"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
-    "github.com/SpectraLogic/ds3_go_sdk/helpers"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "testing"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/helpers"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"io"
+	"io/ioutil"
+	"testing"
 )
 
 const LargeBookPath = "./resources/bigfiles/"
@@ -19,37 +19,37 @@ const LargeBookTitle = "lesmis-copies.txt"
 
 // Verifies the content of a ReadCloser matches the content of the specified book.
 func VerifyLargeBookContent(content io.ReadCloser) error {
-    expected, err := ioutil.ReadFile(LargeBookPath + LargeBookTitle)
-    if err != nil {
-        return err
-    }
+	expected, err := ioutil.ReadFile(LargeBookPath + LargeBookTitle)
+	if err != nil {
+		return err
+	}
 
-    actual, err := ioutil.ReadAll(content)
-    if err != nil {
-        return err
-    }
+	actual, err := ioutil.ReadAll(content)
+	if err != nil {
+		return err
+	}
 
-    if bytes.Compare(expected, actual) != 0 {
-        return errors.New(fmt.Sprintf("Mismatched content for expected and received object. Expected size %d, actual size %d.",
-            len(expected),
-            len(actual)))
-    }
-    return nil
+	if bytes.Compare(expected, actual) != 0 {
+		return errors.New(fmt.Sprintf("Mismatched content for expected and received object. Expected size %d, actual size %d.",
+			len(expected),
+			len(actual)))
+	}
+	return nil
 }
 
 func LoadLargeFile(t *testing.T, bucket string, client *ds3.Client) error {
-    fmt.Printf("Loading large file to BP")
-    defer fmt.Printf("Finished loading large file to BP")
-    helper := helpers.NewHelpers(client)
+	fmt.Printf("Loading large file to BP")
+	defer fmt.Printf("Finished loading large file to BP")
+	helper := helpers.NewHelpers(client)
 
-    writeObj, err := getTestWriteObjectRandomAccess(LargeBookTitle, LargeBookPath + LargeBookTitle)
-    if err != nil {
-        return err
-    }
+	writeObj, err := getTestWriteObjectRandomAccess(LargeBookTitle, LargeBookPath+LargeBookTitle)
+	if err != nil {
+		return err
+	}
 
-    var writeObjects []helperModels.PutObject
-    writeObjects = append(writeObjects, *writeObj)
+	var writeObjects []helperModels.PutObject
+	writeObjects = append(writeObjects, *writeObj)
 
-    _, err = helper.PutObjects(context.Background(), bucket, writeObjects, newTestTransferStrategy(t))
-    return err
+	_, err = helper.PutObjects(context.Background(), bucket, writeObjects, newTestTransferStrategy(t))
+	return err
 }

--- a/helpers_integration/testReadChannels.go
+++ b/helpers_integration/testReadChannels.go
@@ -1,69 +1,69 @@
 package helpers_integration
 
 import (
-    "github.com/SpectraLogic/ds3_go_sdk/helpers/channels"
-    "sync"
-    "io"
-    "log"
-    "os"
-    "errors"
+	"errors"
+	"github.com/SpectraLogic/ds3_go_sdk/helpers/channels"
+	"io"
+	"log"
+	"os"
+	"sync"
 )
 
 // Channel builder for a test file simulating stream access
 type testStreamAccessReadChannelBuilder struct {
-    f *os.File
-    channelCounter channelCounter
-    channels.FatalErrorHandler
+	f              *os.File
+	channelCounter channelCounter
+	channels.FatalErrorHandler
 }
 
 // Used as a thread safe counter to keep track of the current number of channels in use for a given ReadChannelBuilder
 type channelCounter struct {
-    mux sync.RWMutex
-    numChan int
+	mux     sync.RWMutex
+	numChan int
 }
 
 func (counter *channelCounter) currentCount() int {
-    counter.mux.RLock()
-    defer counter.mux.RUnlock()
-    return counter.numChan
+	counter.mux.RLock()
+	defer counter.mux.RUnlock()
+	return counter.numChan
 }
 
 func (counter *channelCounter) increment() {
-    counter.mux.Lock()
-    defer counter.mux.Unlock()
-    counter.numChan++
+	counter.mux.Lock()
+	defer counter.mux.Unlock()
+	counter.numChan++
 }
 
 func (counter *channelCounter) decrement() {
-    counter.mux.Lock()
-    defer counter.mux.Unlock()
-    counter.numChan--
+	counter.mux.Lock()
+	defer counter.mux.Unlock()
+	counter.numChan--
 }
 
 func (builder *testStreamAccessReadChannelBuilder) GetChannel(offset int64) (io.ReadCloser, error) {
-    if builder.channelCounter.currentCount() > 0 {
-        return nil, errors.New("ERROR: channel is not currently available")
-    }
-    log.Printf("DEBUG: incrementing channel semaphore with length %d", builder.channelCounter.currentCount())
-    builder.channelCounter.increment()
-    return builder.f, nil
+	if builder.channelCounter.currentCount() > 0 {
+		return nil, errors.New("ERROR: channel is not currently available")
+	}
+	log.Printf("DEBUG: incrementing channel semaphore with length %d", builder.channelCounter.currentCount())
+	builder.channelCounter.increment()
+	return builder.f, nil
 }
 
 func (builder *testStreamAccessReadChannelBuilder) IsChannelAvailable(offset int64) bool {
-    curOffset, _ := builder.f.Seek(0, io.SeekCurrent)
-    if curOffset != offset || builder.channelCounter.currentCount() > 0 {
-        log.Printf("DEBUG: channel is not available. Offset expected=%d actual=%d. Semaphore expected=0 actual=%d", offset, curOffset, builder.channelCounter.currentCount())
-        return false
-    }
-    log.Print("DEBUG: channel deamed available\n")
-    return true
+	curOffset, _ := builder.f.Seek(0, io.SeekCurrent)
+	if curOffset != offset || builder.channelCounter.currentCount() > 0 {
+		log.Printf("DEBUG: channel is not available. Offset expected=%d actual=%d. Semaphore expected=0 actual=%d", offset, curOffset, builder.channelCounter.currentCount())
+		return false
+	}
+	log.Print("DEBUG: channel deamed available\n")
+	return true
 }
 
 func (builder *testStreamAccessReadChannelBuilder) OnDone(reader io.ReadCloser) {
-    if builder.channelCounter.currentCount() == 0 {
-        log.Printf("ERROR: cannot perform OnDone as no channels currently allocated")
-        return
-    }
-    log.Printf("DEBUG: Decrementing semaphore with current usage %d", builder.channelCounter.currentCount())
-    builder.channelCounter.decrement() // decrement semaphore
+	if builder.channelCounter.currentCount() == 0 {
+		log.Printf("ERROR: cannot perform OnDone as no channels currently allocated")
+		return
+	}
+	log.Printf("DEBUG: Decrementing semaphore with current usage %d", builder.channelCounter.currentCount())
+	builder.channelCounter.decrement() // decrement semaphore
 }

--- a/helpers_integration/testStrategyUtils.go
+++ b/helpers_integration/testStrategyUtils.go
@@ -1,82 +1,82 @@
 package helpers_integration
 
 import (
-    "os"
-    "testing"
-    "time"
-    "github.com/SpectraLogic/ds3_go_sdk/helpers"
-    ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3_integration/utils"
-    "github.com/SpectraLogic/ds3_go_sdk/helpers/channels"
+	ds3Models "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3_integration/utils"
+	"github.com/SpectraLogic/ds3_go_sdk/helpers"
+	"github.com/SpectraLogic/ds3_go_sdk/helpers/channels"
+	helperModels "github.com/SpectraLogic/ds3_go_sdk/helpers/models"
+	"os"
+	"testing"
+	"time"
 )
 
 func getTestWriteObjectStreamAccess(objectName string, path string) (*helperModels.PutObject, error) {
-    fileInfo, err := os.Stat(path)
-    if err != nil {
-        return nil, err
-    }
-    size := fileInfo.Size()
-    f, err := os.Open(path)
-    if err != nil {
-        return nil, err
-    }
-    curWriteObj := helperModels.PutObject{
-        PutObject:      ds3Models.Ds3PutObject{Name:objectName,Size:size},
-        ChannelBuilder: &testStreamAccessReadChannelBuilder{f:f},
-    }
-    return &curWriteObj, nil
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	size := fileInfo.Size()
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	curWriteObj := helperModels.PutObject{
+		PutObject:      ds3Models.Ds3PutObject{Name: objectName, Size: size},
+		ChannelBuilder: &testStreamAccessReadChannelBuilder{f: f},
+	}
+	return &curWriteObj, nil
 }
 
 // Retrieves a file with the specified path, and creates a PutObject using the specified name
 func getTestWriteObjectRandomAccess(objectName string, path string) (*helperModels.PutObject, error) {
-    channelBuilder := channels.NewReadChannelBuilder(path)
-    fileInfo, err := os.Stat(path)
-    if err != nil {
-        return nil, err
-    }
-    size := fileInfo.Size()
-    curWriteObj := helperModels.PutObject{
-        PutObject:      ds3Models.Ds3PutObject{Name:objectName,Size:size},
-        ChannelBuilder: channelBuilder,
-    }
-    return &curWriteObj, nil
+	channelBuilder := channels.NewReadChannelBuilder(path)
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	size := fileInfo.Size()
+	curWriteObj := helperModels.PutObject{
+		PutObject:      ds3Models.Ds3PutObject{Name: objectName, Size: size},
+		ChannelBuilder: channelBuilder,
+	}
+	return &curWriteObj, nil
 }
 
 // Retrieves the test books as write objects with random access
 func getTestBooksAsWriteObjects() (*[]helperModels.PutObject, error) {
-    var writeObjects []helperModels.PutObject
-    for _, book := range testutils.BookTitles {
-        curWriteObj, err := getTestWriteObjectRandomAccess(book, testutils.BookPath+book)
-        if err != nil {
-            return nil, err
-        }
+	var writeObjects []helperModels.PutObject
+	for _, book := range testutils.BookTitles {
+		curWriteObj, err := getTestWriteObjectRandomAccess(book, testutils.BookPath+book)
+		if err != nil {
+			return nil, err
+		}
 
-        writeObjects = append(writeObjects, *curWriteObj)
-    }
-    return &writeObjects, nil
+		writeObjects = append(writeObjects, *curWriteObj)
+	}
+	return &writeObjects, nil
 }
 
 // Creates a simple transfer strategy for testing
-func newTestTransferStrategy(t * testing.T) helpers.WriteTransferStrategy {
-    return helpers.WriteTransferStrategy{
-        BlobStrategy: newTestBlobStrategy(),
-        Options:      helpers.WriteBulkJobOptions{MaxUploadSize: &helpers.MinUploadSize},
-        Listeners:    newErrorOnErrorListenerStrategy(t),
-    }
+func newTestTransferStrategy(t *testing.T) helpers.WriteTransferStrategy {
+	return helpers.WriteTransferStrategy{
+		BlobStrategy: newTestBlobStrategy(),
+		Options:      helpers.WriteBulkJobOptions{MaxUploadSize: &helpers.MinUploadSize},
+		Listeners:    newErrorOnErrorListenerStrategy(t),
+	}
 }
 
 func newErrorOnErrorListenerStrategy(t *testing.T) helpers.ListenerStrategy {
-    return helpers.ListenerStrategy{
-        ErrorCallback: func(objectName string, err error) {
-            t.Errorf("unexpected error on '%s': %v", objectName, err)
-        },
-    }
+	return helpers.ListenerStrategy{
+		ErrorCallback: func(objectName string, err error) {
+			t.Errorf("unexpected error on '%s': %v", objectName, err)
+		},
+	}
 }
 
 // Creates a simple blob strategy for testing
 func newTestBlobStrategy() *helpers.SimpleBlobStrategy {
-    var delay time.Duration = time.Second * 5
-    var maxTransferGoroutines uint = 5
-    return &helpers.SimpleBlobStrategy{Delay:delay, MaxConcurrentTransfers:maxTransferGoroutines}
+	var delay time.Duration = time.Second * 5
+	var maxTransferGoroutines uint = 5
+	return &helpers.SimpleBlobStrategy{Delay: delay, MaxConcurrentTransfers: maxTransferGoroutines}
 }

--- a/helpers_integration/testWriteChannels.go
+++ b/helpers_integration/testWriteChannels.go
@@ -1,69 +1,69 @@
 package helpers_integration
 
 import (
-    "errors"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/helpers/channels"
-    "io"
-    "log"
-    "os"
+	"errors"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/helpers/channels"
+	"io"
+	"log"
+	"os"
 )
 
 type testStreamAccessWriteChannelBuilder struct {
-    f *os.File
-    channelCounter channelCounter
-    channels.FatalErrorHandler
+	f              *os.File
+	channelCounter channelCounter
+	channels.FatalErrorHandler
 }
 
 func (builder *testStreamAccessWriteChannelBuilder) IsChannelAvailable(offset int64) bool {
-    curOffset, _ := builder.f.Seek(0, io.SeekCurrent)
-    if curOffset != offset || builder.channelCounter.currentCount() > 0 {
-        log.Printf("DEBUG: channel is not available. Offset expected Offset expected=%d actual=%d. Semaphore expected=0 actual=%d\n", offset, curOffset, builder.channelCounter.currentCount())
-        return false
-    }
-    log.Printf("DEBUG: channel is available\n")
-    return true
+	curOffset, _ := builder.f.Seek(0, io.SeekCurrent)
+	if curOffset != offset || builder.channelCounter.currentCount() > 0 {
+		log.Printf("DEBUG: channel is not available. Offset expected Offset expected=%d actual=%d. Semaphore expected=0 actual=%d\n", offset, curOffset, builder.channelCounter.currentCount())
+		return false
+	}
+	log.Printf("DEBUG: channel is available\n")
+	return true
 }
 
 func (builder *testStreamAccessWriteChannelBuilder) GetChannel(offset int64) (io.WriteCloser, error) {
-    if builder.channelCounter.currentCount() > 0 {
-        return nil, errors.New("ERROR: channel is not currently available")
-    }
-    builder.channelCounter.increment()
-    return builder.f, nil
+	if builder.channelCounter.currentCount() > 0 {
+		return nil, errors.New("ERROR: channel is not currently available")
+	}
+	builder.channelCounter.increment()
+	return builder.f, nil
 }
 
 func (builder *testStreamAccessWriteChannelBuilder) OnDone(writer io.WriteCloser) {
-    if builder.channelCounter.currentCount() == 0 {
-        log.Printf("ERROR: cannot perform OnDone as no channels currently allocated")
-        return
-    }
-    builder.channelCounter.decrement()
+	if builder.channelCounter.currentCount() == 0 {
+		log.Printf("ERROR: cannot perform OnDone as no channels currently allocated")
+		return
+	}
+	builder.channelCounter.decrement()
 }
 
 // test channel that will fail to get channel
 type testStreamAccessWriteFailOnFirstBlob struct {
-    channelCounter
-    channels.FatalErrorHandler
+	channelCounter
+	channels.FatalErrorHandler
 }
 
 func (builder *testStreamAccessWriteFailOnFirstBlob) IsChannelAvailable(offset int64) bool {
-    if offset != 0 {
-        log.Printf("DEBUG: channel is not available at offset=%d. Semaphore expected=0 actual=%d\n", offset, builder.channelCounter.currentCount())
-        return false
-    }
-    log.Printf("DEBUG: channel is available\n")
-    return true
+	if offset != 0 {
+		log.Printf("DEBUG: channel is not available at offset=%d. Semaphore expected=0 actual=%d\n", offset, builder.channelCounter.currentCount())
+		return false
+	}
+	log.Printf("DEBUG: channel is available\n")
+	return true
 }
 
 func (builder testStreamAccessWriteFailOnFirstBlob) GetChannel(offset int64) (io.WriteCloser, error) {
-    return nil, fmt.Errorf("unable to get channel")
+	return nil, fmt.Errorf("unable to get channel")
 }
 
 func (builder *testStreamAccessWriteFailOnFirstBlob) OnDone(writer io.WriteCloser) {
-    if builder.channelCounter.currentCount() == 0 {
-        log.Printf("ERROR: cannot perform OnDone as no channels currently allocated")
-        return
-    }
-    builder.channelCounter.decrement()
+	if builder.channelCounter.currentCount() == 0 {
+		log.Printf("ERROR: cannot perform OnDone as no channels currently allocated")
+		return
+	}
+	builder.channelCounter.decrement()
 }

--- a/samples/functions/getBucketSample.go
+++ b/samples/functions/getBucketSample.go
@@ -12,44 +12,44 @@
 package functions
 
 import (
-    "context"
-    "log"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/samples/utils"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/samples/utils"
+	"log"
 )
 
 // Demonstrates how to get a list of S3 objects in a bucket. Assumes that the target
 // bucket already exists and has files, i.e. run putBulkSample.go first.
 func GetBucketSample() {
-    fmt.Println("---- Get Bucket Sample ----")
+	fmt.Println("---- Get Bucket Sample ----")
 
-    // Create the client from environment variables.
-    client, err := buildclient.FromEnv()
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Create the client from environment variables.
+	client, err := buildclient.FromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // Create the get bucket request.
-    bucketRequest := models.NewGetBucketRequest(utils.BucketName)
+	// Create the get bucket request.
+	bucketRequest := models.NewGetBucketRequest(utils.BucketName)
 
-    // Perform the Get Bucket call by using the client and invoking the desired command.
-    bucketResponse, err := client.GetBucket(context.Background(), bucketRequest)
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Perform the Get Bucket call by using the client and invoking the desired command.
+	bucketResponse, err := client.GetBucket(context.Background(), bucketRequest)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    if len(bucketResponse.ListBucketResult.Objects) == 0 {
-        fmt.Printf("There are no objects in bucket '%s'.\n", utils.BucketName)
-        return
-    }
+	if len(bucketResponse.ListBucketResult.Objects) == 0 {
+		fmt.Printf("There are no objects in bucket '%s'.\n", utils.BucketName)
+		return
+	}
 
-    fmt.Printf("Objects in bucket '%s'\n", utils.BucketName)
-    for i, obj := range bucketResponse.ListBucketResult.Objects {
-        fmt.Printf("%d) Object: '%s' created on '%s'\n",
-            i,
-            utils.ToSafeString(obj.Key),
-            utils.ToSafeString(obj.LastModified))
-    }
+	fmt.Printf("Objects in bucket '%s'\n", utils.BucketName)
+	for i, obj := range bucketResponse.ListBucketResult.Objects {
+		fmt.Printf("%d) Object: '%s' created on '%s'\n",
+			i,
+			utils.ToSafeString(obj.Key),
+			utils.ToSafeString(obj.LastModified))
+	}
 }

--- a/samples/functions/getBulkSample.go
+++ b/samples/functions/getBulkSample.go
@@ -12,93 +12,93 @@
 package functions
 
 import (
-    "context"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
-    "log"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/samples/utils"
-    "time"
-    "fmt"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/samples/utils"
+	"log"
+	"time"
 )
 
 // Demonstrates how to perform a bulk get. Assumes that the target bucket already exists
 // and has files, i.e. run putBulkSample.go first.
 func GetBulkSample() {
-    fmt.Println("---- Get Bulk Sample ----")
+	fmt.Println("---- Get Bulk Sample ----")
 
-    // Create a client from environment variables.
-    client, err := buildclient.FromEnv()
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Create a client from environment variables.
+	client, err := buildclient.FromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // Get a list of all objects in the target bucket.
-    bucketResponse, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(utils.BucketName))
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Get a list of all objects in the target bucket.
+	bucketResponse, err := client.GetBucket(context.Background(), models.NewGetBucketRequest(utils.BucketName))
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    objectList := bucketResponse.ListBucketResult.Objects
+	objectList := bucketResponse.ListBucketResult.Objects
 
-    // Convert object list returned from get bucket into a list of object names.
-    var objectNames []string
-    for _, obj := range objectList {
-        objectNames = append(objectNames, *obj.Key)
-    }
+	// Convert object list returned from get bucket into a list of object names.
+	var objectNames []string
+	for _, obj := range objectList {
+		objectNames = append(objectNames, *obj.Key)
+	}
 
-    // Initialize the bulk get request.
-    bulkGetRequest := models.NewGetBulkJobSpectraS3Request(utils.BucketName, objectNames)
+	// Initialize the bulk get request.
+	bulkGetRequest := models.NewGetBulkJobSpectraS3Request(utils.BucketName, objectNames)
 
-    // Send the bulk get request to the server. Note that this creates the bulk get job,
-    // but does not retrieve the objects.
-    bulkGetResponse, err := client.GetBulkJobSpectraS3(context.Background(), bulkGetRequest)
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Send the bulk get request to the server. Note that this creates the bulk get job,
+	// but does not retrieve the objects.
+	bulkGetResponse, err := client.GetBulkJobSpectraS3(context.Background(), bulkGetRequest)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // Bulk jobs are split into multiple chunks which then need to be transferred.
-    totalChunkCount := len(bulkGetResponse.MasterObjectList.Objects)
-    curChunkCount := 0
+	// Bulk jobs are split into multiple chunks which then need to be transferred.
+	totalChunkCount := len(bulkGetResponse.MasterObjectList.Objects)
+	curChunkCount := 0
 
-    for curChunkCount < totalChunkCount {
-        // Get the chunks that the server can send. The server may need to retrieve
-        // objects into cache from the tape.
-        chunksReady := models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(bulkGetResponse.MasterObjectList.JobId)
-        chunksReadyResponse, err := client.GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), chunksReady)
-        if err != nil {
-            log.Fatal(err)
-        }
+	for curChunkCount < totalChunkCount {
+		// Get the chunks that the server can send. The server may need to retrieve
+		// objects into cache from the tape.
+		chunksReady := models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(bulkGetResponse.MasterObjectList.JobId)
+		chunksReadyResponse, err := client.GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), chunksReady)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-        // Check to see if any chunks can be processed.
-        numberOfChunks := len(chunksReadyResponse.MasterObjectList.Objects)
-        if numberOfChunks > 0 {
-            // Loop through all the chunks that are available for processing, and get
-            // the files that are contained within them.
-            for _, curChunk := range chunksReadyResponse.MasterObjectList.Objects {
+		// Check to see if any chunks can be processed.
+		numberOfChunks := len(chunksReadyResponse.MasterObjectList.Objects)
+		if numberOfChunks > 0 {
+			// Loop through all the chunks that are available for processing, and get
+			// the files that are contained within them.
+			for _, curChunk := range chunksReadyResponse.MasterObjectList.Objects {
 
-                for _, curObj := range curChunk.Objects {
+				for _, curObj := range curChunk.Objects {
 
-                    getObjRequest := models.NewGetObjectRequest(utils.BucketName, *curObj.Name).
-                        WithJob(bulkGetResponse.MasterObjectList.JobId).
-                        WithOffset(curObj.Offset)
+					getObjRequest := models.NewGetObjectRequest(utils.BucketName, *curObj.Name).
+						WithJob(bulkGetResponse.MasterObjectList.JobId).
+						WithOffset(curObj.Offset)
 
-                    getObjResponse, err := client.GetObject(context.Background(), getObjRequest)
-                    if err != nil {
-                        log.Fatal(err)
-                    }
+					getObjResponse, err := client.GetObject(context.Background(), getObjRequest)
+					if err != nil {
+						log.Fatal(err)
+					}
 
-                    err = utils.VerifyBookContent(*curObj.Name, getObjResponse.Content)
-                    if err != nil {
-                        log.Fatal(err)
-                    }
-                    fmt.Printf("Retrived: %s offset=%d length%d\n", *curObj.Name, curObj.Offset, curObj.Length)
-                }
-                curChunkCount++
-            }
-        } else {
-            // When no chunks are returned we need to sleep to allow for cache space to
-            // be freed.
-            time.Sleep(time.Second * 5)
-        }
-    }
+					err = utils.VerifyBookContent(*curObj.Name, getObjResponse.Content)
+					if err != nil {
+						log.Fatal(err)
+					}
+					fmt.Printf("Retrived: %s offset=%d length%d\n", *curObj.Name, curObj.Offset, curObj.Length)
+				}
+				curChunkCount++
+			}
+		} else {
+			// When no chunks are returned we need to sleep to allow for cache space to
+			// be freed.
+			time.Sleep(time.Second * 5)
+		}
+	}
 }

--- a/samples/functions/getObjectSample.go
+++ b/samples/functions/getObjectSample.go
@@ -12,34 +12,34 @@
 package functions
 
 import (
-    "context"
-    "log"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
-    "github.com/SpectraLogic/ds3_go_sdk/samples/utils"
-    "fmt"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/samples/utils"
+	"log"
 )
 
 // Demonstrates how to get an object within a bucket. Assumes that the
 // target bucket already exists and has the specified file.
 // i.e. run putBulkSample.go first.
 func GetObjectSample() {
-    fmt.Println("---- Get Object Sample ----")
+	fmt.Println("---- Get Object Sample ----")
 
-    // Create the client from environment variables.
-    client, err := buildclient.FromEnv()
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Create the client from environment variables.
+	client, err := buildclient.FromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // Grab the first book defined in utils.BookNames
-    getObjRequest := models.NewGetObjectRequest(utils.BucketName, utils.BookNames[0])
-    getObjResponse, err := client.GetObject(context.Background(), getObjRequest)
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Grab the first book defined in utils.BookNames
+	getObjRequest := models.NewGetObjectRequest(utils.BucketName, utils.BookNames[0])
+	getObjResponse, err := client.GetObject(context.Background(), getObjRequest)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // Verify that the contents of the book were retrieved correctly.
-    utils.VerifyBookContent(utils.BookNames[0], getObjResponse.Content)
-    fmt.Printf("Retrieved: %s\n", utils.BookNames[0])
+	// Verify that the contents of the book were retrieved correctly.
+	utils.VerifyBookContent(utils.BookNames[0], getObjResponse.Content)
+	fmt.Printf("Retrieved: %s\n", utils.BookNames[0])
 }

--- a/samples/functions/getServiceSample.go
+++ b/samples/functions/getServiceSample.go
@@ -12,35 +12,35 @@
 package functions
 
 import (
-    "context"
-    "log"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/samples/utils"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/samples/utils"
+	"log"
 )
 
 func GetServiceSample() {
-    fmt.Println("---- Get Service Sample ----")
+	fmt.Println("---- Get Service Sample ----")
 
-    // Create the client from environment variables.
-    client, err := buildclient.FromEnv()
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Create the client from environment variables.
+	client, err := buildclient.FromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // Create the get service request. All requests to a DS3 appliance start this way.
-    request := models.NewGetServiceRequest()
+	// Create the get service request. All requests to a DS3 appliance start this way.
+	request := models.NewGetServiceRequest()
 
-    // Perform the Get Service call by using the client and invoking the desired command.
-    response, err := client.GetService(context.Background(), request)
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Perform the Get Service call by using the client and invoking the desired command.
+	response, err := client.GetService(context.Background(), request)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // Printing contents of get service.
-    fmt.Println("Buckets:")
-    for i, bucket := range response.ListAllMyBucketsResult.Buckets {
-        fmt.Printf("%d) Name: %s; CreationDate: %s\n", i + 1, utils.ToSafeString(bucket.Name), utils.ToSafeString(bucket.CreationDate))
-    }
+	// Printing contents of get service.
+	fmt.Println("Buckets:")
+	for i, bucket := range response.ListAllMyBucketsResult.Buckets {
+		fmt.Printf("%d) Name: %s; CreationDate: %s\n", i+1, utils.ToSafeString(bucket.Name), utils.ToSafeString(bucket.CreationDate))
+	}
 }

--- a/samples/functions/putBucketSample.go
+++ b/samples/functions/putBucketSample.go
@@ -12,11 +12,11 @@
 package functions
 
 import (
-    "context"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
-    "log"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"log"
 )
 
 // Demonstrates how to create a bucket in two ways.
@@ -25,39 +25,39 @@ import (
 //
 // This assumes that the BP credentials are stored in environment variables.
 func PutBucketSample() {
-    fmt.Println("---- Put Bucket Sample ----")
-    client, err := buildclient.FromEnv()
-    if err != nil {
-        log.Fatal(err)
-    }
+	fmt.Println("---- Put Bucket Sample ----")
+	client, err := buildclient.FromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // 1) Create a bucket using the default data policy. Note that there must already exist a
-    //    default data policy on the specified BP for this to work.
+	// 1) Create a bucket using the default data policy. Note that there must already exist a
+	//    default data policy on the specified BP for this to work.
 
-    bucket1Name := "bucket1Sample"
+	bucket1Name := "bucket1Sample"
 
-    // Create the put bucket request
-    bucket1Request := models.NewPutBucketRequest(bucket1Name)
+	// Create the put bucket request
+	bucket1Request := models.NewPutBucketRequest(bucket1Name)
 
-    // Perform the put bucket call by using the client and invoking the command
-    _, err = client.PutBucket(context.Background(), bucket1Request)
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Perform the put bucket call by using the client and invoking the command
+	_, err = client.PutBucket(context.Background(), bucket1Request)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // 2) Create a bucket while specifying the specific data policy to be assigned to the bucket
-    // This assumes that the data policy "Dual Copy on Tape" already exists on the BP
+	// 2) Create a bucket while specifying the specific data policy to be assigned to the bucket
+	// This assumes that the data policy "Dual Copy on Tape" already exists on the BP
 
-    dataPolicyName := "Dual Copy on Tape"
-    bucket2Name := "bucket2Sample"
+	dataPolicyName := "Dual Copy on Tape"
+	bucket2Name := "bucket2Sample"
 
-    // Create the spectra S3 put bucket request and specify the desired data policy. Note that
-    // you can use either the data policy's name or its UUID
-    bucket2Request := models.NewPutBucketSpectraS3Request(bucket2Name).WithDataPolicyId(dataPolicyName)
+	// Create the spectra S3 put bucket request and specify the desired data policy. Note that
+	// you can use either the data policy's name or its UUID
+	bucket2Request := models.NewPutBucketSpectraS3Request(bucket2Name).WithDataPolicyId(dataPolicyName)
 
-    // Perform the spectra S3 put bucket call by using the client and invoking the command
-    _, err = client.PutBucketSpectraS3(context.Background(), bucket2Request)
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Perform the spectra S3 put bucket call by using the client and invoking the command
+	_, err = client.PutBucketSpectraS3(context.Background(), bucket2Request)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/samples/functions/putBulkSample.go
+++ b/samples/functions/putBulkSample.go
@@ -12,101 +12,101 @@
 package functions
 
 import (
-    "context"
-    "log"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
-    "os"
-    "time"
-    "github.com/SpectraLogic/ds3_go_sdk/samples/utils"
-    "fmt"
+	"context"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/buildclient"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/samples/utils"
+	"log"
+	"os"
+	"time"
 )
 
 func PutBulkSample() {
-    fmt.Println("---- Put Bulk Sample ----")
+	fmt.Println("---- Put Bulk Sample ----")
 
-    // Create a client from environment variables.
-    client, err := buildclient.FromEnv()
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Create a client from environment variables.
+	client, err := buildclient.FromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // Create a bucket where our files will be stored.
-    _, err = client.PutBucket(context.Background(), models.NewPutBucketRequest(utils.BucketName))
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Create a bucket where our files will be stored.
+	_, err = client.PutBucket(context.Background(), models.NewPutBucketRequest(utils.BucketName))
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // Create the list of Ds3PutObjects to be put to the Black Pearl via the bulk put
-    // command. For each object we need its name and size.
-    var ds3PutObjects []models.Ds3PutObject
-    for _, book := range utils.BookNames {
-        fi, err := os.Stat(utils.ResourceFolder + book)
-        if err != nil {
-            log.Fatal(err)
-        }
-        curObj := models.Ds3PutObject{ Name:book, Size:fi.Size()}
-        ds3PutObjects = append(ds3PutObjects, curObj)
-    }
+	// Create the list of Ds3PutObjects to be put to the Black Pearl via the bulk put
+	// command. For each object we need its name and size.
+	var ds3PutObjects []models.Ds3PutObject
+	for _, book := range utils.BookNames {
+		fi, err := os.Stat(utils.ResourceFolder + book)
+		if err != nil {
+			log.Fatal(err)
+		}
+		curObj := models.Ds3PutObject{Name: book, Size: fi.Size()}
+		ds3PutObjects = append(ds3PutObjects, curObj)
+	}
 
-    // Create the bulk put request.
-    putBulkRequest := models.NewPutBulkJobSpectraS3Request(utils.BucketName, ds3PutObjects)
+	// Create the bulk put request.
+	putBulkRequest := models.NewPutBulkJobSpectraS3Request(utils.BucketName, ds3PutObjects)
 
-    // Send the bulk put request to the server. This creates the job, but does not
-    // directly send the data.
-    putBulkResponse, err := client.PutBulkJobSpectraS3(context.Background(), putBulkRequest)
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Send the bulk put request to the server. This creates the job, but does not
+	// directly send the data.
+	putBulkResponse, err := client.PutBulkJobSpectraS3(context.Background(), putBulkRequest)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // The bulk request will split the files over several chunks if it needs to.
-    // We then need to ask what chunks we can send, and then send them making sure
-    // we don't resend the same chunks.
+	// The bulk request will split the files over several chunks if it needs to.
+	// We then need to ask what chunks we can send, and then send them making sure
+	// we don't resend the same chunks.
 
-    // The bulk job is split into multiple chunks, which then need to be transferred.
-    totalChunkCount := len(putBulkResponse.MasterObjectList.Objects)
-    curChunkCount := 0
+	// The bulk job is split into multiple chunks, which then need to be transferred.
+	totalChunkCount := len(putBulkResponse.MasterObjectList.Objects)
+	curChunkCount := 0
 
-    for curChunkCount < totalChunkCount {
-        // Get the list of available chunks that the server can receive. The server may
-        // not be able to receive everything, so not all chunks will necessarily be
-        // returned
-        chunksReady := models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(putBulkResponse.MasterObjectList.JobId)
-        chunksReadyResponse, err := client.GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), chunksReady)
-        if err != nil {
-            log.Fatal(err)
-        }
+	for curChunkCount < totalChunkCount {
+		// Get the list of available chunks that the server can receive. The server may
+		// not be able to receive everything, so not all chunks will necessarily be
+		// returned
+		chunksReady := models.NewGetJobChunksReadyForClientProcessingSpectraS3Request(putBulkResponse.MasterObjectList.JobId)
+		chunksReadyResponse, err := client.GetJobChunksReadyForClientProcessingSpectraS3(context.Background(), chunksReady)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-        // Check to see if any chunks can be processed
-        numberOfChunks := len(chunksReadyResponse.MasterObjectList.Objects)
-        if numberOfChunks > 0 {
-            // Loop through all the chunks that are available for processing, and send
-            // the files that are contained within them.
-            for _, curChunk := range chunksReadyResponse.MasterObjectList.Objects  {
+		// Check to see if any chunks can be processed
+		numberOfChunks := len(chunksReadyResponse.MasterObjectList.Objects)
+		if numberOfChunks > 0 {
+			// Loop through all the chunks that are available for processing, and send
+			// the files that are contained within them.
+			for _, curChunk := range chunksReadyResponse.MasterObjectList.Objects {
 
-                for _, curObj := range curChunk.Objects {
+				for _, curObj := range curChunk.Objects {
 
-                    reader, err := utils.LoadBook(*curObj.Name)
-                    if err != nil {
-                        log.Fatal(err)
-                    }
+					reader, err := utils.LoadBook(*curObj.Name)
+					if err != nil {
+						log.Fatal(err)
+					}
 
-                    putObjRequest := models.NewPutObjectRequest(utils.BucketName, *curObj.Name, reader).
-                        WithJob(chunksReadyResponse.MasterObjectList.JobId).
-                        WithOffset(curObj.Offset)
+					putObjRequest := models.NewPutObjectRequest(utils.BucketName, *curObj.Name, reader).
+						WithJob(chunksReadyResponse.MasterObjectList.JobId).
+						WithOffset(curObj.Offset)
 
-                    _, err = client.PutObject(context.Background(), putObjRequest)
-                    if err != nil {
-                        log.Fatal(err)
-                    }
-                    fmt.Printf("Sent: %s offset=%d length=%d\n", *curObj.Name, curObj.Offset, curObj.Length)
-                }
-                curChunkCount++
-            }
-        } else {
-            // When no chunks are returned we need to sleep to allow for cache space to
-            // be freed.
-            time.Sleep(time.Second * 5)
-        }
-    }
+					_, err = client.PutObject(context.Background(), putObjRequest)
+					if err != nil {
+						log.Fatal(err)
+					}
+					fmt.Printf("Sent: %s offset=%d length=%d\n", *curObj.Name, curObj.Offset, curObj.Length)
+				}
+				curChunkCount++
+			}
+		} else {
+			// When no chunks are returned we need to sleep to allow for cache space to
+			// be freed.
+			time.Sleep(time.Second * 5)
+		}
+	}
 }

--- a/samples/samples.go
+++ b/samples/samples.go
@@ -16,27 +16,27 @@ import "github.com/SpectraLogic/ds3_go_sdk/samples/functions"
 // Runs the various sample code. Each sample is self contained and can be run separately.
 func main() {
 
-    // Lists all existing buckets on the BP.
-    // Source code: getServiceSample.go
-    functions.GetServiceSample()
+	// Lists all existing buckets on the BP.
+	// Source code: getServiceSample.go
+	functions.GetServiceSample()
 
-    // Creates a bucket on the BP and puts sample files in the bucket.
-    // Source code: putBulkSample.go
-    functions.PutBulkSample()
+	// Creates a bucket on the BP and puts sample files in the bucket.
+	// Source code: putBulkSample.go
+	functions.PutBulkSample()
 
-    // Gets a list of S3 objects in a bucket.
-    // Source code: getBucketSample.go
-    functions.GetBucketSample()
+	// Gets a list of S3 objects in a bucket.
+	// Source code: getBucketSample.go
+	functions.GetBucketSample()
 
-    // Retrieve an object from a bucket.
-    // Source code: getObjectSample.go
-    functions.GetObjectSample()
+	// Retrieve an object from a bucket.
+	// Source code: getObjectSample.go
+	functions.GetObjectSample()
 
-    // Retrieves several objects from a bucket on the BP.
-    // Source code: getBulkSample.go
-    functions.GetBulkSample()
+	// Retrieves several objects from a bucket on the BP.
+	// Source code: getBulkSample.go
+	functions.GetBulkSample()
 
-    // Creates some buckets on the BP
-    // Source code: putBucketSample.go
-    functions.PutBucketSample()
+	// Creates some buckets on the BP
+	// Source code: putBucketSample.go
+	functions.PutBucketSample()
 }

--- a/samples/utils/sampleUtils.go
+++ b/samples/utils/sampleUtils.go
@@ -12,55 +12,56 @@
 package utils
 
 import (
-    "io/ioutil"
-    "io"
-    "bytes"
-    "errors"
-    "fmt"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"io"
+	"io/ioutil"
 )
 
 const BucketName = "GoPutBulkBucket"
 const ResourceFolder = "./samples/resources/"
+
 var BookNames = []string{"beowulf.txt", "sherlock_holmes.txt", "tale_of_two_cities.txt", "ulysses.txt"}
 
 // Loads a book from resources folder.
 func LoadBook(book string) (models.ReaderWithSizeDecorator, error) {
-    content, err := ioutil.ReadFile(ResourceFolder + book)
-    if err != nil {
-        return nil, err
-    }
+	content, err := ioutil.ReadFile(ResourceFolder + book)
+	if err != nil {
+		return nil, err
+	}
 
-    reader := ds3.BuildByteReaderWithSizeDecorator(content)
-    return reader, nil
+	reader := ds3.BuildByteReaderWithSizeDecorator(content)
+	return reader, nil
 }
 
 // Converts a string pointer into a string. If null, returns empty. Used to
 // print string pointers.
 func ToSafeString(str *string) string {
-    if str == nil {
-        return ""
-    }
-    return *str
+	if str == nil {
+		return ""
+	}
+	return *str
 }
 
 // Verifies the content of a ReadCloser matches the content of the specified book.
 func VerifyBookContent(bookName string, content io.ReadCloser) error {
-    expected, err := ioutil.ReadFile(ResourceFolder + bookName)
-    if err != nil {
-        return err
-    }
+	expected, err := ioutil.ReadFile(ResourceFolder + bookName)
+	if err != nil {
+		return err
+	}
 
-    actual, err := ioutil.ReadAll(content)
-    if err != nil {
-        return err
-    }
+	actual, err := ioutil.ReadAll(content)
+	if err != nil {
+		return err
+	}
 
-    if bytes.Compare(expected, actual) != 0 {
-        errors.New(fmt.Sprintf("Mismatched content for expected and received object. Expected size %d, actual size %d.",
-            len(expected),
-            len(actual)))
-    }
-    return nil
+	if bytes.Compare(expected, actual) != 0 {
+		errors.New(fmt.Sprintf("Mismatched content for expected and received object. Expected size %d, actual size %d.",
+			len(expected),
+			len(actual)))
+	}
+	return nil
 }

--- a/sdk_log/logger.go
+++ b/sdk_log/logger.go
@@ -1,8 +1,8 @@
 package sdk_log
 
 type Logger interface {
-    Infof(format string, args ...interface{})
-    Debugf(format string, args ...interface{})
-    Warningf(format string, args ...interface{})
-    Errorf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Debugf(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
 }

--- a/sdk_log/null_logger.go
+++ b/sdk_log/null_logger.go
@@ -1,24 +1,24 @@
 package sdk_log
 
 func NewNullLogger() Logger {
-    return &NullLogger{}
+	return &NullLogger{}
 }
 
 // A logger which does nothing.
-type NullLogger struct {}
+type NullLogger struct{}
 
 func (NullLogger) Infof(format string, args ...interface{}) {
-    // do nothing
+	// do nothing
 }
 
 func (NullLogger) Debugf(format string, args ...interface{}) {
-    // do nothing
+	// do nothing
 }
 
 func (NullLogger) Warningf(format string, args ...interface{}) {
-    // do nothing
+	// do nothing
 }
 
 func (NullLogger) Errorf(format string, args ...interface{}) {
-    // do nothing
+	// do nothing
 }

--- a/sdk_log/simple_logger.go
+++ b/sdk_log/simple_logger.go
@@ -1,28 +1,28 @@
 package sdk_log
 
 import (
-    "log"
+	"log"
 )
 
 // A logger which prints everything to log.Printf with the level as a prefix.
 func NewSimpleLogger() Logger {
-    return &SimpleLogger{}
+	return &SimpleLogger{}
 }
 
-type SimpleLogger struct {}
+type SimpleLogger struct{}
 
 func (SimpleLogger) Infof(format string, args ...interface{}) {
-    log.Printf("INFO " + format, args...)
+	log.Printf("INFO "+format, args...)
 }
 
 func (SimpleLogger) Debugf(format string, args ...interface{}) {
-    log.Printf("DEBUG " + format, args...)
+	log.Printf("DEBUG "+format, args...)
 }
 
 func (SimpleLogger) Warningf(format string, args ...interface{}) {
-    log.Printf("WARNING " + format, args...)
+	log.Printf("WARNING "+format, args...)
 }
 
 func (SimpleLogger) Errorf(format string, args ...interface{}) {
-    log.Printf("ERROR " + format, args...)
+	log.Printf("ERROR "+format, args...)
 }


### PR DESCRIPTION
This changes all Go code to follow current Go conventions. By far the
biggest change is converting spaces to tabs. Here's exactly what
was done:
1. go fmt ./...
2. Run a newer version of ds3_autogen to regenerate ds3/ using the same 5.8 contract. This newer version of ds3_autogen has similar changes so it generates "go fmt"'d code. This was diff'd against what step 1 generated. The only differences were a few unnecessary newline characters in the step 1 version, which have been removed; this is because "go fmt" doesn't remove these but the new ds3_autogen doesn't add them either.